### PR TITLE
Fixed p2p TestStringsToPeerInfos test

### DIFF
--- a/p2p/bootstrap_test.go
+++ b/p2p/bootstrap_test.go
@@ -32,14 +32,13 @@ func TestStringToPeerInfo(t *testing.T) {
 }
 
 func TestStringsToPeerInfos(t *testing.T) {
-	for _, str := range IPFS_PEERS {
-		pi, err := stringToPeerInfo(str)
-		if err != nil {
-			t.Error(err)
-		}
-
-		if pi.ID.Pretty() != str[len(str)-46:] {
-			t.Errorf("StringToPeerInfo error: got %s expected %s", pi.ID.Pretty(), str)
+	pi, err := stringsToPeerInfos(IPFS_PEERS)
+	if err != nil {
+		t.Error(err)
+	}
+	for k, pi := range pi {
+		if pi.ID.Pretty() != IPFS_PEERS[k][len(IPFS_PEERS[k])-46:] {
+			t.Errorf("StringToPeerInfo error: got %s expected %s", pi.ID.Pretty(), IPFS_PEERS[k])
 		}
 	}
 }


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

The original `TestStringsToPeerInfos` test was not calling `stringsToPeerInfos` but rather calling `stringToPeerInfo`
<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Fixed `stringsToPeerInfos` test
- 
- 

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test ./p2p -run TestStringsToPeerInfos -v 
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Fixes: