### PR TITLE
Elizabeth/trie fix header

### DIFF
--- a/trie/hash.go
+++ b/trie/hash.go
@@ -17,7 +17,6 @@
 package trie
 
 import (
-	"encoding/hex"
 	"hash"
 
 	"github.com/ChainSafe/gossamer/common"
@@ -30,12 +29,7 @@ type Hasher struct {
 }
 
 func newHasher() (*Hasher, error) {
-	key, err := hex.DecodeString("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
-	if err != nil {
-		return nil, err
-	}
-
-	h, err := blake2s.New256(key)
+	h, err := blake2s.New256(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/trie/node.go
+++ b/trie/node.go
@@ -129,17 +129,17 @@ func (l *leaf) Encode() ([]byte, error) {
 func (b *branch) header() []byte {
 	var header byte
 	if b.value == nil {
-		header = 2
+		header = 2 << 6
 	} else {
-		header = 3
+		header = 3 << 6
 	}
 	var encodePkLen []byte
 
-	if len(b.key) > 62 {
-		header = header | 0xfc
+	if len(b.key) >= 63 {
+		header = header | 0x3f
 		encodePkLen = encodeExtraPartialKeyLength(len(b.key))
 	} else {
-		header = header | (byte(len(b.key)) << 2)
+		header = header | byte(len(b.key))
 	}
 
 	fullHeader := append([]byte{header}, encodePkLen...)
@@ -147,14 +147,14 @@ func (b *branch) header() []byte {
 }
 
 func (l *leaf) header() []byte {
-	var header byte = 1
+	var header byte = 1 << 6
 	var encodePkLen []byte
 
-	if len(l.key) > 62 {
-		header = header | 0xfc
+	if len(l.key) >= 63 {
+		header = header | 0x3f
 		encodePkLen = encodeExtraPartialKeyLength(len(l.key))
 	} else {
-		header = header | (byte(len(l.key)) << 2)
+		header = header | byte(len(l.key))
 	}
 
 	fullHeader := append([]byte{header}, encodePkLen...)

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -64,24 +64,24 @@ func TestBranchHeader(t *testing.T) {
 		br     *branch
 		header []byte
 	}{
-		{&branch{nil, [16]node{}, nil}, []byte{0x80}},
-		{&branch{[]byte{0x00}, [16]node{}, nil}, []byte{0x81}},
-		{&branch{[]byte{0x00, 0x00, 0xf, 0x3}, [16]node{}, nil}, []byte{0x84}},
+		{&branch{nil, [16]node{}, nil, true}, []byte{0x80}},
+		{&branch{[]byte{0x00}, [16]node{}, nil, true}, []byte{0x81}},
+		{&branch{[]byte{0x00, 0x00, 0xf, 0x3}, [16]node{}, nil, true}, []byte{0x84}},
 
-		{&branch{nil, [16]node{}, []byte{0x01}}, []byte{0xc0}},
-		{&branch{[]byte{0x00}, [16]node{}, []byte{0x01}}, []byte{0xc1}},
-		{&branch{[]byte{0x00, 0x00}, [16]node{}, []byte{0x01}}, []byte{0xc2}},
-		{&branch{[]byte{0x00, 0x00, 0xf}, [16]node{}, []byte{0x01}}, []byte{0xc3}},
+		{&branch{nil, [16]node{}, []byte{0x01}, true}, []byte{0xc0}},
+		{&branch{[]byte{0x00}, [16]node{}, []byte{0x01}, true}, []byte{0xc1}},
+		{&branch{[]byte{0x00, 0x00}, [16]node{}, []byte{0x01}, true}, []byte{0xc2}},
+		{&branch{[]byte{0x00, 0x00, 0xf}, [16]node{}, []byte{0x01}, true}, []byte{0xc3}},
 
-		{&branch{byteArray(62), [16]node{}, nil}, []byte{0xbe}},
-		{&branch{byteArray(62), [16]node{}, []byte{0x00}}, []byte{0xfe}},
-		{&branch{byteArray(63), [16]node{}, nil}, []byte{0xbf, 0}},
-		{&branch{byteArray(64), [16]node{}, nil}, []byte{0xbf, 1}},
-		{&branch{byteArray(64), [16]node{}, []byte{0x01}}, []byte{0xff, 1}},
+		{&branch{byteArray(62), [16]node{}, nil, true}, []byte{0xbe}},
+		{&branch{byteArray(62), [16]node{}, []byte{0x00}, true}, []byte{0xfe}},
+		{&branch{byteArray(63), [16]node{}, nil, true}, []byte{0xbf, 0}},
+		{&branch{byteArray(64), [16]node{}, nil, true}, []byte{0xbf, 1}},
+		{&branch{byteArray(64), [16]node{}, []byte{0x01}, true}, []byte{0xff, 1}},
 
-		{&branch{byteArray(317), [16]node{}, []byte{0x01}}, []byte{255, 254}},
-		{&branch{byteArray(318), [16]node{}, []byte{0x01}}, []byte{255, 255, 0}},
-		{&branch{byteArray(573), [16]node{}, []byte{0x01}}, []byte{255, 255, 255, 0}},
+		{&branch{byteArray(317), [16]node{}, []byte{0x01}, true}, []byte{255, 254}},
+		{&branch{byteArray(318), [16]node{}, []byte{0x01}, true}, []byte{255, 255, 0}},
+		{&branch{byteArray(573), [16]node{}, []byte{0x01}, true}, []byte{255, 255, 255, 0}},
 	}
 
 	for _, test := range tests {
@@ -97,15 +97,15 @@ func TestLeafHeader(t *testing.T) {
 		br     *leaf
 		header []byte
 	}{
-		{&leaf{nil, nil}, []byte{0x40}},
-		{&leaf{[]byte{0x00}, nil}, []byte{0x41}},
-		{&leaf{[]byte{0x00, 0x00, 0xf, 0x3}, nil}, []byte{0x44}},
-		{&leaf{byteArray(62), nil}, []byte{0x7e}},
-		{&leaf{byteArray(63), nil}, []byte{0x7f, 0}},
-		{&leaf{byteArray(64), []byte{0x01}}, []byte{0x7f, 1}},
+		{&leaf{nil, nil, true}, []byte{0x40}},
+		{&leaf{[]byte{0x00}, nil, true}, []byte{0x41}},
+		{&leaf{[]byte{0x00, 0x00, 0xf, 0x3}, nil, true}, []byte{0x44}},
+		{&leaf{byteArray(62), nil, true}, []byte{0x7e}},
+		{&leaf{byteArray(63), nil, true}, []byte{0x7f, 0}},
+		{&leaf{byteArray(64), []byte{0x01}, true}, []byte{0x7f, 1}},
 
-		{&leaf{byteArray(318), []byte{0x01}}, []byte{0x7f, 0xff, 0}},
-		{&leaf{byteArray(573), []byte{0x01}}, []byte{0x7f, 0xff, 0xff, 0}},
+		{&leaf{byteArray(318), []byte{0x01}, true}, []byte{0x7f, 0xff, 0}},
+		{&leaf{byteArray(573), []byte{0x01}, true}, []byte{0x7f, 0xff, 0xff, 0}},
 	}
 
 	for _, test := range tests {

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -64,20 +64,20 @@ func TestBranchHeader(t *testing.T) {
 		br     *branch
 		header []byte
 	}{
-		{&branch{nil, [16]node{}, nil}, []byte{2}},
-		{&branch{[]byte{0x00}, [16]node{}, nil}, []byte{6}},
-		{&branch{[]byte{0x00, 0x00, 0xf, 0x3}, [16]node{}, nil}, []byte{18}},
+		{&branch{nil, [16]node{}, nil}, []byte{0x80}},
+		{&branch{[]byte{0x00}, [16]node{}, nil}, []byte{0x81}},
+		{&branch{[]byte{0x00, 0x00, 0xf, 0x3}, [16]node{}, nil}, []byte{0x84}},
 
-		{&branch{nil, [16]node{}, []byte{0x01}}, []byte{3}},
-		{&branch{[]byte{0x00}, [16]node{}, []byte{0x01}}, []byte{7}},
-		{&branch{[]byte{0x00, 0x00}, [16]node{}, []byte{0x01}}, []byte{11}},
-		{&branch{[]byte{0x00, 0x00, 0xf}, [16]node{}, []byte{0x01}}, []byte{15}},
+		{&branch{nil, [16]node{}, []byte{0x01}}, []byte{0xc0}},
+		{&branch{[]byte{0x00}, [16]node{}, []byte{0x01}}, []byte{0xc1}},
+		{&branch{[]byte{0x00, 0x00}, [16]node{}, []byte{0x01}}, []byte{0xc2}},
+		{&branch{[]byte{0x00, 0x00, 0xf}, [16]node{}, []byte{0x01}}, []byte{0xc3}},
 
-		{&branch{byteArray(62), [16]node{}, nil}, []byte{0xfa}},
-		{&branch{byteArray(62), [16]node{}, []byte{0x00}}, []byte{0xfb}},
-		{&branch{byteArray(63), [16]node{}, nil}, []byte{254, 0}},
-		{&branch{byteArray(64), [16]node{}, nil}, []byte{254, 1}},
-		{&branch{byteArray(64), [16]node{}, []byte{0x01}}, []byte{255, 1}},
+		{&branch{byteArray(62), [16]node{}, nil}, []byte{0xbe}},
+		{&branch{byteArray(62), [16]node{}, []byte{0x00}}, []byte{0xfe}},
+		{&branch{byteArray(63), [16]node{}, nil}, []byte{0xbf, 0}},
+		{&branch{byteArray(64), [16]node{}, nil}, []byte{0xbf, 1}},
+		{&branch{byteArray(64), [16]node{}, []byte{0x01}}, []byte{0xff, 1}},
 
 		{&branch{byteArray(317), [16]node{}, []byte{0x01}}, []byte{255, 254}},
 		{&branch{byteArray(318), [16]node{}, []byte{0x01}}, []byte{255, 255, 0}},
@@ -97,15 +97,15 @@ func TestLeafHeader(t *testing.T) {
 		br     *leaf
 		header []byte
 	}{
-		{&leaf{nil, nil}, []byte{1}},
-		{&leaf{[]byte{0x00}, nil}, []byte{5}},
-		{&leaf{[]byte{0x00, 0x00, 0xf, 0x3}, nil}, []byte{17}},
-		{&leaf{byteArray(62), nil}, []byte{0xf9}},
-		{&leaf{byteArray(63), nil}, []byte{253, 0}},
-		{&leaf{byteArray(64), []byte{0x01}}, []byte{253, 1}},
+		{&leaf{nil, nil}, []byte{0x40}},
+		{&leaf{[]byte{0x00}, nil}, []byte{0x41}},
+		{&leaf{[]byte{0x00, 0x00, 0xf, 0x3}, nil}, []byte{0x44}},
+		{&leaf{byteArray(62), nil}, []byte{0x7e}},
+		{&leaf{byteArray(63), nil}, []byte{0x7f, 0}},
+		{&leaf{byteArray(64), []byte{0x01}}, []byte{0x7f, 1}},
 
-		{&leaf{byteArray(318), []byte{0x01}}, []byte{253, 255, 0}},
-		{&leaf{byteArray(573), []byte{0x01}}, []byte{253, 255, 255, 0}},
+		{&leaf{byteArray(318), []byte{0x01}}, []byte{0x7f, 0xff, 0}},
+		{&leaf{byteArray(573), []byte{0x01}}, []byte{0x7f, 0xff, 0xff, 0}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Changes
- changed node header encoding to match the spec. previously, the node prefix was at the least two significant bits when it should have been at the two most significant bits.
- updated tests to reflect changes

## Tests:
```
go test ./trie/...
```

### Fixes:
closes #113 