### PR TITLE
trie pk encoding fix

### DIFF
--- a/trie/node.go
+++ b/trie/node.go
@@ -109,8 +109,8 @@ func Encode(n node) ([]byte, error) {
 // Encode encodes a branch with the following format:
 // NodeHeader | Extra partial key length | Partial Key | Value
 // where NodeHeader is a byte:
-// bottom two bits of first byte: 10 if branch w/o value, 11 if branch w/ value
-// top six bits of first byte: if len(key) > 62, 0xff, otherwise len(key)
+// most significant two bits of first byte: 10 if branch w/o value, 11 if branch w/ value
+// least significant six bits of first byte: if len(key) > 62, 0x3f, otherwise len(key)
 // where Extra partial key length is included if len(key) > 63:
 // consists of the remaining key length
 // Partial Key is the branch's key

--- a/trie/node.go
+++ b/trie/node.go
@@ -18,6 +18,7 @@ package trie
 
 import (
 	"bytes"
+	"errors"
 
 	scale "github.com/ChainSafe/gossamer/codec"
 	"github.com/ChainSafe/gossamer/common"
@@ -116,7 +117,11 @@ func Encode(n node) ([]byte, error) {
 // Value is:
 // Children Bitmap | Enc(Child[i_1]) | Enc(Child[i_2]) | ... | Enc(Child[i_n]) | SCALE Branch Node Value
 func (b *branch) Encode() ([]byte, error) {
-	encoding := b.header()
+	encoding, err := b.header()
+	if err != nil {
+		return nil, err
+	}
+
 	encoding = append(encoding, nibblesToKey(b.key)...)
 	encoding = append(encoding, common.Uint16ToBytes(b.childrenBitmap())...)
 
@@ -132,7 +137,7 @@ func (b *branch) Encode() ([]byte, error) {
 
 	buffer := bytes.Buffer{}
 	se := scale.Encoder{Writer: &buffer}
-	_, err := se.Encode(b.value)
+	_, err = se.Encode(b.value)
 	if err != nil {
 		return encoding, err
 	}
@@ -144,19 +149,23 @@ func (b *branch) Encode() ([]byte, error) {
 // Encode encodes a leaf with the following format:
 // NodeHeader | Extra partial key length | Partial Key | Value
 // where NodeHeader is a byte:
-// bottom two bits of first byte: 01
-// top six bits of first byte: if len(key) > 62, 0xff, otherwise len(key)
+// most significant two bits of first byte: 01
+// least signficant six bits of first byte: if len(key) > 62, 0x3f, otherwise len(key)
 // where Extra partial key length is included if len(key) > 63:
 // consists of the remaining key length
 // Partial Key is the leaf's key
 // Value is the leaf's SCALE encoded value
 func (l *leaf) Encode() ([]byte, error) {
-	encoding := l.header()
+	encoding, err := l.header()
+	if err != nil {
+		return nil, err
+	}
+
 	encoding = append(encoding, nibblesToKey(l.key)...)
 
 	buffer := bytes.Buffer{}
 	se := scale.Encoder{Writer: &buffer}
-	_, err := se.Encode(l.value)
+	_, err = se.Encode(l.value)
 	if err != nil {
 		return encoding, err
 	}
@@ -165,7 +174,7 @@ func (l *leaf) Encode() ([]byte, error) {
 	return encoding, nil
 }
 
-func (b *branch) header() []byte {
+func (b *branch) header() ([]byte, error) {
 	var header byte
 	if b.value == nil {
 		header = 2 << 6
@@ -173,37 +182,50 @@ func (b *branch) header() []byte {
 		header = 3 << 6
 	}
 	var encodePkLen []byte
+	var err error
 
 	if len(b.key) >= 63 {
 		header = header | 0x3f
-		encodePkLen = encodeExtraPartialKeyLength(len(b.key))
+		encodePkLen, err = encodeExtraPartialKeyLength(len(b.key))
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		header = header | byte(len(b.key))
 	}
 
 	fullHeader := append([]byte{header}, encodePkLen...)
-	return fullHeader
+	return fullHeader, nil
 }
 
-func (l *leaf) header() []byte {
+func (l *leaf) header() ([]byte, error) {
 	var header byte = 1 << 6
 	var encodePkLen []byte
+	var err error
 
 	if len(l.key) >= 63 {
 		header = header | 0x3f
-		encodePkLen = encodeExtraPartialKeyLength(len(l.key))
+		encodePkLen, err = encodeExtraPartialKeyLength(len(l.key))
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		header = header | byte(len(l.key))
 	}
 
 	fullHeader := append([]byte{header}, encodePkLen...)
-	return fullHeader
+	return fullHeader, nil
 }
 
-func encodeExtraPartialKeyLength(pkLen int) []byte {
+func encodeExtraPartialKeyLength(pkLen int) ([]byte, error) {
 	pkLen -= 63
 	fullHeader := []byte{}
-	for i := 0; i < 317; i++ {
+
+	if pkLen > 1<<16 {
+		return nil, errors.New("partial key length > 2^16")
+	}
+
+	for i := 0; i < 1<<16; i++ {
 		if pkLen < 255 {
 			fullHeader = append(fullHeader, byte(pkLen))
 			break
@@ -213,5 +235,5 @@ func encodeExtraPartialKeyLength(pkLen int) []byte {
 		}
 	}
 
-	return fullHeader
+	return fullHeader, nil
 }

--- a/trie/node.go
+++ b/trie/node.go
@@ -222,7 +222,7 @@ func encodeExtraPartialKeyLength(pkLen int) ([]byte, error) {
 	fullHeader := []byte{}
 
 	if pkLen >= 1<<16 {
-		return nil, errors.New("partial key length exceeds 2^16")
+		return nil, errors.New("partial key length greater than or equal to 2^16")
 	}
 
 	for i := 0; i < 1<<16; i++ {

--- a/trie/node.go
+++ b/trie/node.go
@@ -221,8 +221,8 @@ func encodeExtraPartialKeyLength(pkLen int) ([]byte, error) {
 	pkLen -= 63
 	fullHeader := []byte{}
 
-	if pkLen > 1<<16 {
-		return nil, errors.New("partial key length > 2^16")
+	if pkLen >= 1<<16 {
+		return nil, errors.New("partial key length exceeds 2^16")
 	}
 
 	for i := 0; i < 1<<16; i++ {

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -85,8 +85,10 @@ func TestBranchHeader(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res := test.br.header()
-		if !bytes.Equal(res, test.header) {
+		res, err := test.br.header()
+		if err != nil {
+			t.Fatalf("Error when encoding header: %s", err)
+		} else if !bytes.Equal(res, test.header) {
 			t.Errorf("Branch header fail case %v: got %x expected %x", test.br, res, test.header)
 		}
 	}
@@ -109,8 +111,10 @@ func TestLeafHeader(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res := test.br.header()
-		if !bytes.Equal(res, test.header) {
+		res, err := test.br.header()
+		if err != nil {
+			t.Fatalf("Error when encoding header: %s", err)
+		} else if !bytes.Equal(res, test.header) {
 			t.Errorf("Leaf header fail: got %x expected %x", res, test.header)
 		}
 	}
@@ -124,7 +128,12 @@ func TestBranchEncode(t *testing.T) {
 		b := &branch{key: testKey, children: [16]node{}, value: randVals[i]}
 		expected := []byte{}
 
-		expected = append(expected, b.header()...)
+		header, err := b.header()
+		if err != nil {
+			t.Fatalf("Error when encoding header: %s", err)
+		}
+
+		expected = append(expected, header...)
 		expected = append(expected, nibblesToKey(b.key)...)
 
 		expected = append(expected, common.Uint16ToBytes(b.childrenBitmap())...)
@@ -141,7 +150,7 @@ func TestBranchEncode(t *testing.T) {
 
 		buf := bytes.Buffer{}
 		encoder := &scale.Encoder{Writer: &buf}
-		_, err := encoder.Encode(b.value)
+		_, err = encoder.Encode(b.value)
 		if err != nil {
 			t.Fatalf("Fail when encoding value with scale: %s", err)
 		}
@@ -165,12 +174,16 @@ func TestLeafEncode(t *testing.T) {
 		l := &leaf{key: testKey, value: randVals[i]}
 		expected := []byte{}
 
-		expected = append(expected, l.header()...)
+		header, err := l.header()
+		if err != nil {
+			t.Fatalf("Error when encoding header: %s", err)
+		}
+		expected = append(expected, header...)
 		expected = append(expected, nibblesToKey(l.key)...)
 
 		buf := bytes.Buffer{}
 		encoder := &scale.Encoder{Writer: &buf}
-		_, err := encoder.Encode(l.value)
+		_, err = encoder.Encode(l.value)
 		if err != nil {
 			t.Fatalf("Fail when encoding value with scale: %s", err)
 		}

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -94,6 +94,22 @@ func TestBranchHeader(t *testing.T) {
 	}
 }
 
+func TestFailingPk(t *testing.T) {
+	tests := []struct {
+		br     *branch
+		header []byte
+	}{
+		{&branch{byteArray(2<<16), [16]node{}, []byte{0x01}, true}, []byte{255, 254}},
+	}
+
+	for _, test := range tests {
+		_, err := test.br.header()
+		if err == nil {
+			t.Fatalf("should error when encoding node w pk length > 2^16")
+		} 
+	}
+}
+
 func TestLeafHeader(t *testing.T) {
 	tests := []struct {
 		br     *leaf


### PR DESCRIPTION
## Changes
- as @amerameen pointed out, the partial key length is not limited to 317 but to 2^16
- update function to conform to spec, now errors if len(pk) > 2^16
- also update some comments

## Tests:
```
go test ./trie/
```