### PR TITLE
trie: improve generation of random tests

### DIFF
--- a/trie/database_test.go
+++ b/trie/database_test.go
@@ -46,7 +46,7 @@ func TestWriteToDB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rt := generateRandTest(20000)
+	rt := generateRandomTests(20000)
 	var val []byte
 	for _, test := range rt {
 		err = trie.Put(test.key, test.value)

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -219,7 +219,7 @@ func TestEncodeRoot(t *testing.T) {
 	trie := newEmpty()
 
 	for i := 0; i < 20; i++ {
-		rt := generateRandTest(16)
+		rt := generateRandomTests(16)
 		for _, test := range rt {
 			err := trie.Put(test.key, test.value)
 			if err != nil {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -94,32 +94,38 @@ type trieTest struct {
 	op    int
 }
 
-func generateRandTest(size int) []trieTest {
+func generateRandomTests(size int) []trieTest {
 	rt := make([]trieTest, size)
-	r := *rand.New(rand.NewSource(rand.Int63()))
-	for i := range rt {
-		rt[i] = trieTest{}
-		buf := make([]byte, r.Intn(379)+1)
-		r.Read(buf)
-		if !keyExists(rt[0:i], buf) {
-			rt[i].key = buf
+	kv := make(map[string][]byte)
 
-			buf = make([]byte, r.Intn(128))
-			r.Read(buf)
-			rt[i].value = buf
-		}
+	for i := range rt {
+		test := generateRandomTest(kv)
+		rt[i] = test
+		kv[string(test.key)] = rt[i].value
 	}
+
 	return rt
 }
 
-func keyExists(rt []trieTest, key []byte) bool {
-	for _, test := range rt {
-		if bytes.Equal(test.key, key) {
-			return true
+func generateRandomTest(kv map[string][]byte) trieTest {
+	r := *rand.New(rand.NewSource(rand.Int63()))
+	test := trieTest{}
+
+	for {
+		buf := make([]byte, r.Intn(379)+1)
+		r.Read(buf)
+		key := string(buf)	
+
+		if kv[key] == nil {
+			test.key = buf
+
+			buf = make([]byte, r.Intn(128))
+			r.Read(buf)
+			test.value = buf
+
+			return test
 		}
 	}
-
-	return false
 }
 
 func hexDecode(in string) []byte {
@@ -243,7 +249,7 @@ func TestPutAndGetOddKeyLengths(t *testing.T) {
 func TestPutAndGet(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		trie := newEmpty()
-		rt := generateRandTest(1000)
+		rt := generateRandomTests(10000)
 		for _, test := range rt {
 			err := trie.Put(test.key, test.value)
 			if err != nil {
@@ -474,7 +480,7 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 func TestDelete(t *testing.T) {
 	trie := newEmpty()
 
-	rt := generateRandTest(1000)
+	rt := generateRandomTests(10000)
 	for _, test := range rt {
 		err := trie.Put(test.key, test.value)
 		if err != nil {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -114,9 +114,8 @@ func generateRandomTest(kv map[string][]byte) trieTest {
 	for {
 		buf := make([]byte, r.Intn(379)+1)
 		r.Read(buf)
-		key := string(buf)	
 
-		if kv[key] == nil {
+		if kv[string(buf)] == nil {
 			test.key = buf
 
 			buf = make([]byte, r.Intn(128))


### PR DESCRIPTION
## Changes
- this improvement came to me at 6am this morning when I was half awake
- to prevent duplicate keys being randomly generated we store the previous keys created in that test in a mapping
- previously it was just a list which was slow, tests run quite a bit faster now

## Tests:
```
go test ./trie/
```