### PR TITLE
move keyEncode to common and rename to swapNibbles

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -43,3 +43,20 @@ func AppendZeroes(input []byte, size int) []byte {
 		}
 	}
 }
+
+// SwapByteNibbles swaps the two nibbles of a byte
+func SwapByteNibbles(b byte) byte {
+	b1 := (uint(b) & 240) >> 4
+	b2 := (uint(b) & 15) << 4
+
+	return byte(b1 | b2)
+}
+
+// SwapNibbles swaps the nibbles for each byte in the byte array
+func SwapNibbles(k []byte) []byte {
+	result := make([]byte, len(k))
+	for i, b := range k {
+		result[i] = SwapByteNibbles(b)
+	}
+	return result
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -61,3 +61,45 @@ func TestUint16ToBytes(t *testing.T) {
 		}
 	}
 }
+
+func TestSwapByteNibbles(t *testing.T) {
+	tests := []struct {
+		input    byte
+		expected byte
+	}{
+		{byte(0xA0), byte(0x0A)},
+		{byte(0), byte(0)},
+		{byte(0x24), byte(0x42)},
+	}
+
+	for _, test := range tests {
+		res := SwapByteNibbles(test.input)
+		if res != test.expected {
+			t.Fatalf("got: %x; expected: %x", res, test.expected)
+		}
+	}
+}
+
+func TestSwapNibbles(t *testing.T) {
+	tests := []struct {
+		key        []byte
+		encodedKey []byte
+	}{
+		{[]byte{0x01, 0x02, 0x03, 0x04, 0x05}, []byte{0x10, 0x20, 0x30, 0x40, 0x50}},
+		{[]byte{0xff, 0x0, 0xAA, 0x81}, []byte{0xff, 0x00, 0xAA, 0x18}},
+		{[]byte{0xAC, 0x19, 0x15}, []byte{0xCA, 0x91, 0x51}},
+	}
+
+	for _, test := range tests {
+		res := SwapNibbles(test.key)
+		if !bytes.Equal(res, test.encodedKey) {
+			t.Fatalf("got: %x, expected: %x", res, test.encodedKey)
+		}
+
+		res = SwapNibbles(res)
+		if !bytes.Equal(res, test.key) {
+			t.Fatalf("Re-encoding failed. got: %x expected: %x", res, test.key)
+		}
+	}
+
+}

--- a/trie/codec.go
+++ b/trie/codec.go
@@ -16,24 +16,6 @@
 
 package trie
 
-// keyEncodeByte swaps the two nibbles of a byte to result in 'LE'
-func keyEncodeByte(b byte) byte {
-	b1 := (uint(b) & 240) >> 4
-	b2 := (uint(b) & 15) << 4
-
-	return byte(b1 | b2)
-}
-
-// KeyEncode encodes the key by placing in in little endian nibble format
-func KeyEncode(k []byte) []byte {
-	result := make([]byte, len(k))
-	// Encode each byte
-	for i, b := range k {
-		result[i] = keyEncodeByte(b)
-	}
-	return result
-}
-
 // keyToNibbles turns bytes into nibbles
 // does not rearrange the nibbles; assumes they are already ordered in LE
 // if the last nibble is zero, it is removed and the length of the output is odd

--- a/trie/codec_test.go
+++ b/trie/codec_test.go
@@ -21,48 +21,6 @@ import (
 	"testing"
 )
 
-func TestKeyEncodeByte(t *testing.T) {
-	tests := []struct {
-		input    byte
-		expected byte
-	}{
-		{byte(0xA0), byte(0x0A)},
-		{byte(0), byte(0)},
-		{byte(0x24), byte(0x42)},
-	}
-
-	for _, test := range tests {
-		res := keyEncodeByte(test.input)
-		if res != test.expected {
-			t.Fatalf("got: %x; expected: %x", res, test.expected)
-		}
-	}
-}
-
-func TestKeyEncode(t *testing.T) {
-	tests := []struct {
-		key        []byte
-		encodedKey []byte
-	}{
-		{[]byte{0x01, 0x02, 0x03, 0x04, 0x05}, []byte{0x10, 0x20, 0x30, 0x40, 0x50}},
-		{[]byte{0xff, 0x0, 0xAA, 0x81}, []byte{0xff, 0x00, 0xAA, 0x18}},
-		{[]byte{0xAC, 0x19, 0x15}, []byte{0xCA, 0x91, 0x51}},
-	}
-
-	for _, test := range tests {
-		res := KeyEncode(test.key)
-		if !bytes.Equal(res, test.encodedKey) {
-			t.Fatalf("got: %x, expected: %x", res, test.encodedKey)
-		}
-
-		res = KeyEncode(res)
-		if !bytes.Equal(res, test.key) {
-			t.Fatalf("Re-encoding failed. got: %x expected: %x", res, test.key)
-		}
-	}
-
-}
-
 func TestKeyToNibbles(t *testing.T) {
 	tests := []struct {
 		input    []byte


### PR DESCRIPTION
## Changes
- as pointed out by @drskalman the KeyEncode function wasn't used in the trie package
- ended up using keyToNibbles to split the key into nibbles
- as such I've moved KeyEncode to the common package and renamed it SwapNibbles as I feel that's more descriptive of what it does

## Tests:
```
go test ./common/ ./trie/
```