### PR TITLE
trie: fix tests

### DIFF
--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -112,7 +112,7 @@ func generateRandomTest(kv map[string][]byte) trieTest {
 	test := trieTest{}
 
 	for {
-		buf := make([]byte, r.Intn(379)+1)
+		buf := make([]byte, r.Intn(379)+2)
 		r.Read(buf)
 
 		if kv[string(buf)] == nil {
@@ -479,7 +479,7 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 func TestDelete(t *testing.T) {
 	trie := newEmpty()
 
-	rt := generateRandomTests(10000)
+	rt := generateRandomTests(50000)
 	for _, test := range rt {
 		err := trie.Put(test.key, test.value)
 		if err != nil {


### PR DESCRIPTION
## Changes
- change min key length in random tests to 2
- i think there was a bug with duplicate keys still being created due to converting the byte array into a string then checking if it was created or not, looked like keys of length <2 were still being duplicated

## Tests:
```
go test ./trie/
```