### PR TITLE
[🔔main, blocktree, core, dot, polkadb, trie🔔] BlockDB and StateDB

### DIFF
--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -83,20 +83,12 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	dbSrv := &polkadb.ChainDB{
+		StateDB: stateDB,
+		BlockDB: blockDB,
+	}
 	// append DBs to services registrar
-	srvcs = append(srvcs, stateDB)
-	srvcs = append(srvcs, blockDB)
-
-	// pass DBs to their respected components
-	//state := &trie.Database{
-	//	StateDB : stateDB,
-	//}
-	//_ = trie.NewEmptyTrie(state)
-	//
-	//b := & blocktree.BlockTree{
-	//	BlockDB: blockDB,
-	//}
-	//bt := blocktree.NewBlockTreeFromGenesis(gen, blockDB)
+	srvcs = append(srvcs, dbSrv)
 
 	// API
 	apiSrvc := api.NewApiService(p2pSrvc, nil)

--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -17,8 +17,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/ChainSafe/gossamer/core/blocktree"
-	"github.com/ChainSafe/gossamer/trie"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -72,29 +70,33 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	srvcs = append(srvcs, p2pSrvc)
 
 	// DB
+	// Create database dir and initialize stateDB and blockDB
 	dataDir := getDatabaseDir(ctx, fig)
+
 	stateDataDir := filepath.Join(dataDir, "state")
 	stateDB, err := polkadb.NewBadgerService(stateDataDir)
 	if err != nil {
 		return nil, nil, err
 	}
-	state := &trie.Database{
-		StateDB : stateDB,
-	}
-	srvcs = append(srvcs, stateDB)
-
-	_ = trie.NewEmptyTrie(state)
-
 	blockDataDir := filepath.Join(dataDir, "block")
 	blockDB, err := polkadb.NewBadgerService(blockDataDir)
 	if err != nil {
 		return nil, nil, err
 	}
-	b := & blocktree.BlockTree{
-		BlockDB: blockDB,
-	}
-
+	// append DBs to services registrar
+	srvcs = append(srvcs, stateDB)
 	srvcs = append(srvcs, blockDB)
+
+	// pass DBs to their respected components
+	//state := &trie.Database{
+	//	StateDB : stateDB,
+	//}
+	//_ = trie.NewEmptyTrie(state)
+	//
+	//b := & blocktree.BlockTree{
+	//	BlockDB: blockDB,
+	//}
+	//bt := blocktree.NewBlockTreeFromGenesis(gen, blockDB)
 
 	// API
 	apiSrvc := api.NewApiService(p2pSrvc, nil)

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -18,8 +18,9 @@ package blocktree
 
 import (
 	"fmt"
-	"github.com/ChainSafe/gossamer/polkadb"
 	"math/big"
+
+	"github.com/ChainSafe/gossamer/polkadb"
 
 	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/core"
@@ -34,11 +35,11 @@ type BlockTree struct {
 	head            *node
 	leaves          leafMap
 	finalizedBlocks []*node
-	BlockDB polkadb.Database
+	BlockDB         polkadb.Database
 }
 
 // NewBlockTreeFromGenesis initializes a blocktree with a genesis block.
-func NewBlockTreeFromGenesis(genesis core.Block) *BlockTree {
+func NewBlockTreeFromGenesis(genesis core.Block, db polkadb.Database) *BlockTree {
 	head := &node{
 		hash:     genesis.Header.Hash,
 		number:   genesis.Header.Number,
@@ -50,6 +51,7 @@ func NewBlockTreeFromGenesis(genesis core.Block) *BlockTree {
 		head:            head,
 		finalizedBlocks: []*node{},
 		leaves:          leafMap{head.hash: head},
+		BlockDB:         db,
 	}
 }
 
@@ -60,7 +62,7 @@ func (bt *BlockTree) AddBlock(block core.Block) {
 	// Check if it already exists
 	// TODO: Can shortcut this by checking DB
 	// bt.BlockDB
-	
+
 	n := bt.GetNode(block.Header.Hash)
 	if n != nil {
 		log.Debug("Attempted to add block to tree that already exists", "hash", n.hash)

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -61,14 +61,8 @@ func (bt *BlockTree) AddBlock(block core.Block) {
 	parent := bt.GetNode(block.Header.ParentHash)
 	// Check if it already exists
 	// TODO: Can shortcut this by checking DB
-	// TODO: Write blockData to db and getter functions
-
-	//blockNum := block.Header.Number
-	//bestNum  := bt.BlockDB.Get()
-	//if (bestNum < blockNum) {
-	//	store block
-	//  bt.BlockDB.Put()
-	//}
+	// TODO: Write blockData to db
+	// TODO: Create getter functions to check if blockNum is greater than best block stored
 
 	n := bt.GetNode(block.Header.Hash)
 	if n != nil {

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -61,7 +61,14 @@ func (bt *BlockTree) AddBlock(block core.Block) {
 	parent := bt.GetNode(block.Header.ParentHash)
 	// Check if it already exists
 	// TODO: Can shortcut this by checking DB
-	// bt.BlockDB
+	// TODO: Write blockData to db and getter functions
+
+	//blockNum := block.Header.Number
+	//bestNum  := bt.BlockDB.Get()
+	//if (bestNum < blockNum) {
+	//	store block
+	//  bt.BlockDB.Put()
+	//}
 
 	n := bt.GetNode(block.Header.Hash)
 	if n != nil {

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -18,6 +18,7 @@ package blocktree
 
 import (
 	"fmt"
+	"github.com/ChainSafe/gossamer/polkadb"
 	"math/big"
 
 	"github.com/ChainSafe/gossamer/common"
@@ -33,6 +34,7 @@ type BlockTree struct {
 	head            *node
 	leaves          leafMap
 	finalizedBlocks []*node
+	BlockDB polkadb.Database
 }
 
 // NewBlockTreeFromGenesis initializes a blocktree with a genesis block.
@@ -57,6 +59,8 @@ func (bt *BlockTree) AddBlock(block core.Block) {
 	parent := bt.GetNode(block.Header.ParentHash)
 	// Check if it already exists
 	// TODO: Can shortcut this by checking DB
+	// bt.BlockDB
+	
 	n := bt.GetNode(block.Header.Hash)
 	if n != nil {
 		log.Debug("Attempted to add block to tree that already exists", "hash", n.hash)

--- a/core/blocktree/blocktree_test.go
+++ b/core/blocktree/blocktree_test.go
@@ -18,13 +18,31 @@ package blocktree
 
 import (
 	"math/big"
+	"os"
 	"strconv"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/core"
+	db "github.com/ChainSafe/gossamer/polkadb"
 	log "github.com/ChainSafe/log15"
 )
+
+var blockDB *db.BadgerService
+
+func TestMain(m *testing.M) {
+	dbSrv, err := db.NewBadgerService("./gossamer_data/block")
+	if err != nil {
+		log.Crit("database was not created ", "error ", err)
+	}
+	blockDB = dbSrv
+	exitVal := m.Run()
+	dbSrv.Close()
+	if err := os.RemoveAll("./gossamer_data/"); err != nil {
+		log.Warn("removal of temp directory badger-test failed", "error", err)
+	}
+	os.Exit(exitVal)
+}
 
 var zeroHash, _ = common.HexToHash("0x00")
 
@@ -52,7 +70,7 @@ func intToHashable(in int) string {
 }
 
 func createFlatTree(t *testing.T, depth int) *BlockTree {
-	bt := NewBlockTreeFromGenesis(createGenesisBlock())
+	bt := NewBlockTreeFromGenesis(createGenesisBlock(), blockDB)
 
 	previousHash := bt.head.hash
 

--- a/core/types.go
+++ b/core/types.go
@@ -25,3 +25,13 @@ type BlockHeader struct {
 
 // BlockBody is the extrinsics inside a state block
 type BlockBody []byte
+
+/// Blockdata is stored within the BlockDB
+type Blockdata struct {
+	Hash common.Hash
+	Header BlockHeader
+	Body BlockBody
+	// Receipt
+	// MessageQueue
+	// Justification
+}

--- a/core/types.go
+++ b/core/types.go
@@ -28,9 +28,9 @@ type BlockBody []byte
 
 /// Blockdata is stored within the BlockDB
 type Blockdata struct {
-	Hash common.Hash
+	Hash   common.Hash
 	Header BlockHeader
-	Body BlockBody
+	Body   BlockBody
 	// Receipt
 	// MessageQueue
 	// Justification

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,7 @@ require (
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
 	github.com/ipfs/go-datastore v0.0.5
-	github.com/ipfs/go-ipfs v0.4.22-0.20190703233353-70e499afbc16
-	github.com/ipfs/go-ipfs-config v0.0.6
+	github.com/ipfs/go-ipfs v0.4.22-0.20190703233353-70e499afbc16 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libp2p/go-libp2p v0.2.0
 	github.com/libp2p/go-libp2p-core v0.0.6
@@ -21,7 +20,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.0.4
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.1
-	github.com/pkg/errors v0.8.1
 	github.com/urfave/cli v1.20.0
 	github.com/wasmerio/go-ext-wasm v0.0.0-20190716093451-605a12aad995
 	golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,7 @@ github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUn
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4To=
 github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -591,7 +592,9 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190222223459-a17d461953aa/go.mod h1:2RVY1rIf+2J2o/IM9+vPq9RzmHDSseB7FoXiSNIUsoU=
 github.com/sourcegraph/go-diff v0.5.1/go.mod h1:j2dHj3m8aZgQO8lMTcTnBcXkRRRqi34cd2MNlA9u1mE=
+github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a h1:/eS3yfGjQKG+9kayBkj0ip1BGhq6zJ3eaVksphxAaek=
 github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
+github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/polkadb/database.go
+++ b/polkadb/database.go
@@ -17,11 +17,11 @@
 package polkadb
 
 import (
-	"log"
+	"os"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/dgraph-io/badger"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 )
 
 // BadgerService contains directory path to data and db instance
@@ -79,10 +79,12 @@ func (db *BadgerService) Stop() <-chan error {
 // NewBadgerService opens and returns a new DB object
 func NewBadgerService(file string) (*BadgerService, error) {
 	opts := badger.DefaultOptions(file)
-
+	if err := os.MkdirAll(file, os.ModePerm); err != nil {
+		log.Crit("err creating directory for DB ", err)
+	}
 	db, err := badger.Open(opts)
 	if err != nil {
-		log.Fatal(err)
+		log.Crit("err opening DB directory", err)
 		return nil, err
 	}
 
@@ -163,9 +165,9 @@ func (db *BadgerService) Del(key []byte) error {
 func (db *BadgerService) Close() {
 	err := db.db.Close()
 	if err == nil {
-		log.Println("Database closed")
+		log.Info("Database closed")
 	} else {
-		log.Fatal("Failed to close database", "err", err)
+		log.Crit("Failed to close database", "err", err)
 	}
 }
 
@@ -215,7 +217,7 @@ func (i *Iterable) Seek(key []byte) {
 func (i *Iterable) Key() []byte {
 	ret, err := snappy.Decode(nil, i.iter.Item().Key())
 	if err != nil {
-		log.Printf("%+v", errors.Wrap(err, "key retrieval error"))
+		log.Warn("key retrieval error ", "error", err)
 	}
 	return ret
 }
@@ -224,11 +226,11 @@ func (i *Iterable) Key() []byte {
 func (i *Iterable) Value() []byte {
 	val, err := i.iter.Item().ValueCopy(nil)
 	if err != nil {
-		log.Printf("%+v", errors.Wrap(err, "value retrieval error"))
+		log.Warn("value retrieval error ", "error", err)
 	}
 	ret, err := snappy.Decode(nil, val)
 	if err != nil {
-		log.Printf("%+v", errors.Wrap(err, "value decoding error"))
+		log.Warn("value decoding error ", "error", err)
 	}
 	return ret
 }
@@ -250,11 +252,11 @@ func (b *batchWriter) Write() error {
 	for k, v := range b.b {
 		err := wb.Set([]byte(k), v)
 		if err != nil {
-			log.Printf("%+v", errors.Wrap(err, "error writing batch txs"))
+			log.Warn("error writing batch txs ", "error", err)
 		}
 	}
 	if err := wb.Flush(); err != nil {
-		log.Printf("%+v", errors.Wrap(err, "error stored by writeBatch"))
+		log.Warn("error stored by write batch ", "error", err)
 	}
 	return nil
 }
@@ -268,7 +270,7 @@ func (b *batchWriter) ValueSize() int {
 func (b *batchWriter) Delete(key []byte) error {
 	err := b.db.db.NewWriteBatch().Delete(key)
 	if err != nil {
-		log.Printf("%+v", errors.Wrap(err, "error batch deleting key"))
+		log.Warn("error batch deleting key ", "error", err)
 	}
 	b.size++
 	return nil

--- a/trie/database.go
+++ b/trie/database.go
@@ -24,7 +24,7 @@ import (
 
 // Database is a wrapper around a polkadb
 type Database struct {
-	Db     polkadb.Database
+	StateDB     polkadb.Database
 	Batch  polkadb.Batch
 	Lock   sync.RWMutex
 	Hasher *Hasher
@@ -35,7 +35,7 @@ type Database struct {
 // This does not actually write to the db, just to the batch writer
 // Commit must be called afterwards to finish writing to the db
 func (t *Trie) WriteToDB() error {
-	t.db.Batch = t.db.Db.NewBatch()
+	t.db.Batch = t.db.StateDB.NewBatch()
 	return t.writeToDB(t.root)
 }
 

--- a/trie/database.go
+++ b/trie/database.go
@@ -24,10 +24,10 @@ import (
 
 // Database is a wrapper around a polkadb
 type Database struct {
-	StateDB     polkadb.Database
-	Batch  polkadb.Batch
-	Lock   sync.RWMutex
-	Hasher *Hasher
+	StateDB polkadb.Database
+	Batch   polkadb.Batch
+	Lock    sync.RWMutex
+	Hasher  *Hasher
 }
 
 // WriteToDB writes the trie to the underlying database batch writer

--- a/trie/database_test.go
+++ b/trie/database_test.go
@@ -15,15 +15,15 @@ func newTrie() (*Trie, error) {
 		return nil, err
 	}
 
-	db, err := db.NewBadgerService("./gossamer_data")
+	stateDB, err := db.NewBadgerService("./gossamer_data/state")
 	if err != nil {
 		return nil, err
 	}
 
 	trie := &Trie{
 		db: &Database{
-			StateDB:     db,
-			Hasher: hasher,
+			StateDB: stateDB,
+			Hasher:  hasher,
 		},
 		root: nil,
 	}

--- a/trie/database_test.go
+++ b/trie/database_test.go
@@ -22,19 +22,19 @@ func newTrie() (*Trie, error) {
 
 	trie := &Trie{
 		db: &Database{
-			Db:     db,
+			StateDB:     db,
 			Hasher: hasher,
 		},
 		root: nil,
 	}
 
-	trie.db.Batch = trie.db.Db.NewBatch()
+	trie.db.Batch = trie.db.StateDB.NewBatch()
 
 	return trie, nil
 }
 
 func (t *Trie) closeDb() {
-	t.db.Db.Close()
+	t.db.StateDB.Close()
 	if err := os.RemoveAll("./gossamer_data"); err != nil {
 		fmt.Println("removal of temp directory gossamer_data failed")
 	}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -19,6 +19,7 @@ package trie
 import (
 	"bytes"
 	"errors"
+
 	"github.com/ChainSafe/gossamer/common"
 )
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -69,7 +69,7 @@ var (
 
 func newEmpty() *Trie {
 	db := &Database{
-		Db: polkadb.NewMemDatabase(),
+		StateDB: polkadb.NewMemDatabase(),
 	}
 	t := NewEmptyTrie(db)
 	return t
@@ -84,7 +84,7 @@ func TestNewEmptyTrie(t *testing.T) {
 
 func TestNewTrie(t *testing.T) {
 	db := &Database{
-		Db: polkadb.NewMemDatabase(),
+		StateDB: polkadb.NewMemDatabase(),
 	}
 	trie := NewTrie(db, &leaf{key: []byte{0}, value: []byte{17}})
 	if trie == nil {


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->

This PR does not include writing the appropriate `blockData` to the `BlockDB` but rather changes how the databases are initialized and available to each of their respected components. A subsequent PR will be made with write and read data operations for the `BlockDB`.

## Changes
- Creates two `badgerServices` one for `stateDB`, the other for `blockDB` 
- DataDir will be appended with `state` or `block`
- `ChainDB` holds both badger instances and registers them accordingly
- Added `Blockdata` struct which contains the fields that will be stored in the `BlockDB`
- Trie database points specifically to `StateDB` while the blocktree points to `BlockDB`
- Updated tests accordingly  

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test ./...
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues:

#203 