### PR TITLE
Update Makefile and add license headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(GOLANGCI):
 ## lint: Lints project files, go gets golangci-lint if missing. Runs `golangci-lint` on project files.
 .PHONY: lint
 lint: $(GOLANGCI)
-	golangci-lint run ./...
+	golangci-lint run ./... -c .golangci.yml
 
 ## test: Runs `go test` on project test files.
 test:
@@ -38,6 +38,15 @@ build:
 start:
 	@echo "  >  \033[32mStarting server...\033[0m "
 	./bin/gossamer
+
+$(ADDLICENSE):
+	go get -u github.com/google/addlicense
+
+## license: Adds license header to missing files, go gets addLicense if missing. Runs `addlicense -c gossamer -f ./copyright.txt -y 2019 .` on project files.
+.PHONY: license
+license: $(ADDLICENSE)
+	@echo "  >  \033[32mAdding license headers...\033[0m "
+	addlicense -c gossamer -f ./copyright.txt -y 2019 .
 
 docker:
 	@echo "  >  \033[32mBuilding Docker Container...\033[0m "

--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package babe
 
 import (

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package babe
 
 import (

--- a/consensus/babe/runtime.go
+++ b/consensus/babe/runtime.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package babe
 
 import (

--- a/consensus/babe/types.go
+++ b/consensus/babe/types.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package babe
 
 // TODO: change to Schnorrkel keys

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,0 +1,15 @@
+Copyright 2019 ChainSafe Systems (ON) Corp.
+This file is part of gossamer.
+
+The gossamer library is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+The gossamer library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package runtime
 
 // #include <stdlib.h>

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2019 ChainSafe Systems (ON) Corp.
+# This file is part of gossamer.
+#
+# The gossamer library is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# The gossamer library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
 echo ">> Running tests..."
 go test -short -coverprofile c.out ./...


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->

I noticed some of the `babe` files were merged without a license header so I decided to add the command to the Makefile. Now we can easily add license headers to our files prior to being merged. 
  
## Changes
- Adds the command `make license` to `Makefile` which adds license header to missing files
- Adds `copyright.txt` to repo which is our license header 
- Adds license header to missing files
- `make lint` now uses the configuration set in `.golangci.yml`

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```

```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: