### PR TITLE
p2p, add Block Announce Network Message

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -177,7 +177,7 @@ type BlockHeaderMessage common.BlockHeader
 
 // string formats a BlockHeaderMessage as a string
 func (bhm *BlockHeaderMessage) String() string {
-	return fmt.Sprintf("BlockHeaderMessage ParentHash=%x Number=%d StateRoot=%x ExtrinsicsRoot=%x Digest=%x",
+	return fmt.Sprintf("BlockHeaderMessage ParentHash=0x%x Number=%d StateRoot=0x%x ExtrinsicsRoot=0x%x Digest=0x%x",
 		bhm.ParentHash,
 		bhm.Number,
 		bhm.StateRoot,

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -256,7 +256,6 @@ func (bm *BlockRequestMessage) Decode(r io.Reader) error {
 	return nil
 }
 
-
 type BlockHeaderMessage common.BlockHeader
 
 // string formats a BlockHeaderMessage as a string

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -20,10 +20,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
-
 	scale "github.com/ChainSafe/gossamer/codec"
-	common "github.com/ChainSafe/gossamer/common"
+	"github.com/ChainSafe/gossamer/common"
+	"io"
 )
 
 const (
@@ -171,4 +170,25 @@ func (bm *BlockRequestMessage) Encode() ([]byte, error) {
 // Decodes the message into a BlockRequestMessage, it assumes the type byte has been removed
 func (bm *BlockRequestMessage) Decode(msg []byte) error {
 	return nil
+}
+
+
+type BlockHeaderMessage common.BlockHeader
+
+// string formats a BlockHeaderMessage as a string
+func (bhm *BlockHeaderMessage) String() string {
+	return fmt.Sprintf("BlockHeaderMessage ParentHash=%x Number=%d StateRoot=%x ExtrinsicsRoot=%x Digest=%x",
+		bhm.ParentHash,
+		bhm.Number,
+		bhm.StateRoot,
+		bhm.ExtrinsicsRoot,
+		bhm.Digest)
+}
+
+func (bhm *BlockHeaderMessage) Encode() ([]byte, error) {
+	enc, err := scale.Encode(bhm)
+	if err != nil {
+		return enc, err
+	}
+	return append([]byte{BlockAnnounceMsg}, enc...), nil
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -20,9 +20,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
+
 	scale "github.com/ChainSafe/gossamer/codec"
 	"github.com/ChainSafe/gossamer/common"
-	"io"
 )
 
 const (
@@ -172,7 +173,6 @@ func (bm *BlockRequestMessage) Decode(msg []byte) error {
 	return nil
 }
 
-
 type BlockHeaderMessage common.BlockHeader
 
 // string formats a BlockHeaderMessage as a string
@@ -191,4 +191,10 @@ func (bhm *BlockHeaderMessage) Encode() ([]byte, error) {
 		return enc, err
 	}
 	return append([]byte{BlockAnnounceMsg}, enc...), nil
+}
+
+//Decodes the message into a BlockHeaderMessage, it assumes the type byte has been removed
+func (bhm *BlockHeaderMessage) Decode(msg []byte) error {
+	_, err := scale.Decode(msg, bhm)
+	return err
 }

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -274,7 +274,7 @@ func (bhm *BlockHeaderMessage) Encode() ([]byte, error) {
 	if err != nil {
 		return enc, err
 	}
-	return append([]byte{BlockAnnounceMsg}, enc...), nil
+	return append([]byte{BlockAnnounceMsgType}, enc...), nil
 }
 
 //Decodes the message into a BlockHeaderMessage, it assumes the type byte has been removed

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -288,14 +288,51 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 	}
 
 	bhm := &BlockHeaderMessage{
-		ParentHash: parentHash,
-		Number: big.NewInt(1),
-		StateRoot: stateRoot,
+		ParentHash:     parentHash,
+		Number:         big.NewInt(1),
+		StateRoot:      stateRoot,
 		ExtrinsicsRoot: extrinsicsRoot,
-		Digest: []byte{},
+		Digest:         []byte{},
 	}
 	encMsg, err := bhm.Encode()
 	if !bytes.Equal(encMsg, expected) {
 		t.Fatalf("Fail: got %x expected %x", encMsg, expected)
+	}
+}
+
+func TestDecodeBlockAnnounceMessage(t *testing.T) {
+	announceMessage, err := common.HexToBytes("0x454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bhm := new(BlockHeaderMessage)
+	err = bhm.Decode(announceMessage)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parentHash, err := common.HexToHash("0x4545454545454545454545454545454545454545454545454545454545454545")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateRoot, err := common.HexToHash("0xb3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	extrinsicsRoot, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := &BlockHeaderMessage{
+		ParentHash:     parentHash,
+		Number:         big.NewInt(1),
+		StateRoot:      stateRoot,
+		ExtrinsicsRoot: extrinsicsRoot,
+		Digest:         []byte{},
+	}
+
+	if !reflect.DeepEqual(bhm, expected) {
+		t.Fatalf("Fail: got %v expected %v", bhm, expected)
 	}
 }

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -295,6 +295,9 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 		Digest:         []byte{},
 	}
 	encMsg, err := bhm.Encode()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(encMsg, expected) {
 		t.Fatalf("Fail: got %x expected %x", encMsg, expected)
 	}

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -344,9 +344,9 @@ func TestDecodeBlockRequestMessage_NoOptionals(t *testing.T) {
 
 	if err != nil {
 		t.Fatal(err)
-	}  
+	}
 
-  buf := &bytes.Buffer{}
+	buf := &bytes.Buffer{}
 	buf.Write(encMsg)
 
 	m, err := DecodeMessage(buf)
@@ -373,14 +373,14 @@ func TestDecodeBlockRequestMessage_NoOptionals(t *testing.T) {
 		t.Fatalf("Fail: got %v expected %v", bm, expected)
 	}
 }
-    
+
 func TestEncodeBlockResponseMessage(t *testing.T) {
 	expected, err := common.HexToBytes("0x02070000000000000000")
 
 	if err != nil {
 		t.Fatal(err)
 	}
-  
+
 	bm := &BlockResponseMessage{
 		Id:   7,
 		Data: []byte{0},
@@ -395,13 +395,13 @@ func TestEncodeBlockResponseMessage(t *testing.T) {
 		t.Fatalf("Fail: got %x expected %x", encMsg, expected)
 	}
 }
-    
+
 func TestDecodeBlockResponseMessage(t *testing.T) {
 	encMsg, err := common.HexToBytes("0x070000000000000000")
 	if err != nil {
 		t.Fatal(err)
 	}
-  
+
 	buf := &bytes.Buffer{}
 	buf.Write(encMsg)
 
@@ -435,7 +435,7 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-  
+
 	parentHash, err := common.HexToHash("0x4545454545454545454545454545454545454545454545454545454545454545")
 	if err != nil {
 		t.Fatal(err)
@@ -445,7 +445,7 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 	extrinsicsRoot, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-  if err != nil {
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -460,7 +460,7 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-  if !bytes.Equal(encMsg, expected) {
+	if !bytes.Equal(encMsg, expected) {
 		t.Fatalf("Fail: got %x expected %x", encMsg, expected)
 	}
 }
@@ -499,5 +499,5 @@ func TestDecodeBlockAnnounceMessage(t *testing.T) {
 
 	if !reflect.DeepEqual(bhm, expected) {
 		t.Fatalf("Fail: got %v expected %v", bhm, expected)
-  }
+	}
 }

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -18,6 +18,7 @@ package p2p
 
 import (
 	"bytes"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -253,6 +254,47 @@ func TestEncodeBlockRequestMessage_NoOptionals(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if !bytes.Equal(encMsg, expected) {
+		t.Fatalf("Fail: got %x expected %x", encMsg, expected)
+	}
+}
+
+func TestEncodeBlockAnnounceMessage(t *testing.T) {
+	// this value is a concatenation of:
+	//  message type:  byte(3)
+	//  ParentHash: Hash: 0x4545454545454545454545454545454545454545454545454545454545454545
+	//	Number: *big.Int // block number: 1
+	//	StateRoot:  Hash: 0xb3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe0
+	//	ExtrinsicsRoot: Hash: 0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314
+	//	Digest: []byte
+
+	//                                        mtparenthash                                                      bnstateroot                                                       extrinsicsroot                                                  di
+	expected, err := common.HexToBytes("0x03454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parentHash, err := common.HexToHash("0x4545454545454545454545454545454545454545454545454545454545454545")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateRoot, err := common.HexToHash("0xb3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	extrinsicsRoot, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bhm := &BlockHeaderMessage{
+		ParentHash: parentHash,
+		Number: big.NewInt(1),
+		StateRoot: stateRoot,
+		ExtrinsicsRoot: extrinsicsRoot,
+		Digest: []byte{},
+	}
+	encMsg, err := bhm.Encode()
 	if !bytes.Equal(encMsg, expected) {
 		t.Fatalf("Fail: got %x expected %x", encMsg, expected)
 	}


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->
Code to handle Encoding and Decoding Block Announce Network Message. Palkadot Runtime Environment Specification section E.1.4.
<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Added `BlockHeaderMessage` type
- Created `Encode` function for `BlockHeaderMessage`
- Created `Decode` function for `BlockHeaderMessage`
- Created `String` function for `BlockHeaderMessage`
- Created `TestEncodeBlockAnnounceMessage` test
- Created `TestDecodeBlockAnnounceMessage` test

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test -v ./p2p/...
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues:
closes #256 