### PR TITLE
p2p, rename BlockHeaderMessage to BlockAnnounceMessage to conform to spec

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -256,29 +256,29 @@ func (bm *BlockRequestMessage) Decode(r io.Reader) error {
 	return nil
 }
 
-type BlockHeaderMessage common.BlockHeader
+type BlockAnnounceMessage common.BlockHeader
 
-// string formats a BlockHeaderMessage as a string
-func (bhm *BlockHeaderMessage) String() string {
-	return fmt.Sprintf("BlockHeaderMessage ParentHash=0x%x Number=%d StateRoot=0x%x ExtrinsicsRoot=0x%x Digest=0x%x",
-		bhm.ParentHash,
-		bhm.Number,
-		bhm.StateRoot,
-		bhm.ExtrinsicsRoot,
-		bhm.Digest)
+// string formats a BlockAnnounceMessage as a string
+func (bm *BlockAnnounceMessage) String() string {
+	return fmt.Sprintf("BlockAnnounceMessage ParentHash=0x%x Number=%d StateRoot=0x%x ExtrinsicsRoot=0x%x Digest=0x%x",
+		bm.ParentHash,
+		bm.Number,
+		bm.StateRoot,
+		bm.ExtrinsicsRoot,
+		bm.Digest)
 }
 
-func (bhm *BlockHeaderMessage) Encode() ([]byte, error) {
-	enc, err := scale.Encode(bhm)
+func (bm *BlockAnnounceMessage) Encode() ([]byte, error) {
+	enc, err := scale.Encode(bm)
 	if err != nil {
 		return enc, err
 	}
 	return append([]byte{BlockAnnounceMsgType}, enc...), nil
 }
 
-//Decodes the message into a BlockHeaderMessage, it assumes the type byte has been removed
-func (bhm *BlockHeaderMessage) Decode(msg []byte) error {
-	_, err := scale.Decode(msg, bhm)
+//Decodes the message into a BlockAnnounceMessage, it assumes the type byte has been removed
+func (bm *BlockAnnounceMessage) Decode(msg []byte) error {
+	_, err := scale.Decode(msg, bm)
 	return err
 }
 

--- a/p2p/message_test.go
+++ b/p2p/message_test.go
@@ -449,7 +449,7 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bhm := &BlockHeaderMessage{
+	bhm := &BlockAnnounceMessage{
 		ParentHash:     parentHash,
 		Number:         big.NewInt(1),
 		StateRoot:      stateRoot,
@@ -471,7 +471,7 @@ func TestDecodeBlockAnnounceMessage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bhm := new(BlockHeaderMessage)
+	bhm := new(BlockAnnounceMessage)
 	err = bhm.Decode(announceMessage)
 	if err != nil {
 		t.Fatal(err)
@@ -489,7 +489,7 @@ func TestDecodeBlockAnnounceMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := &BlockHeaderMessage{
+	expected := &BlockAnnounceMessage{
 		ParentHash:     parentHash,
 		Number:         big.NewInt(1),
 		StateRoot:      stateRoot,


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->
Renamed `BlockHeaderMessage` to `BlockAnnounceMessage` so that it conforms to the name specified in section E.1.4 of the PRE spec.
<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Renamed struct `BlockHeaderMessage` to `BlockAnnounceMessage`
- Renamed test that use BlockAnnounceMessage
- 

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test -v ./p2p/...
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: