### PR TITLE
Services Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 # Sublime
 *.sublime*
 
-trie/test_data
+test_data/
 /bin
 chaindata/
 *.wasm

--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -83,13 +83,11 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	srvcs = append(srvcs, p2pSrvc)
 
 	// DB
-	// Create database dir and initialize stateDB and blockDB
 	dataDir := getDatabaseDir(ctx, fig)
 	dbSrv, err := polkadb.NewDbService(dataDir)
 	if err != nil {
 		return nil, nil, err
 	}
-	// append DBs to services registrar
 	srvcs = append(srvcs, dbSrv)
 
 	// API

--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -85,7 +85,7 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	// DB
 	// Create database dir and initialize stateDB and blockDB
 	dataDir := getDatabaseDir(ctx, fig)
-	dbSrv, err := polkadb.NewDatabaseService(dataDir)
+	dbSrv, err := polkadb.NewDbService(dataDir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/netsim/main.go
+++ b/cmd/netsim/main.go
@@ -91,8 +91,8 @@ func main() {
 	//}()
 
 	for _, node := range sim.Nodes {
-		e := node.Start()
-		if <-e != nil {
+		err := node.Start()
+		if err != nil {
 			log.Warn("main", "start err", err)
 		}
 	}

--- a/core/service.go
+++ b/core/service.go
@@ -87,7 +87,9 @@ func (s *Service) start(e chan error) {
 }
 
 func (s *Service) Stop() error {
-	s.rt.Stop()
+	if s.rt != nil{
+		s.rt.Stop()
+	}
 	return nil
 }
 

--- a/core/service.go
+++ b/core/service.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"github.com/ChainSafe/gossamer/internal/services"
 	log "github.com/ChainSafe/log15"
 
 	scale "github.com/ChainSafe/gossamer/codec"
@@ -26,6 +27,8 @@ import (
 	"github.com/ChainSafe/gossamer/p2p"
 	"github.com/ChainSafe/gossamer/runtime"
 )
+
+var _ services.Service = &Service{}
 
 // Service is a overhead layer that allows for communication between the runtime, BABE, and the p2p layer.
 // It deals with the validation of transactions and blocks by calling their respective validation functions
@@ -47,10 +50,10 @@ func NewService(rt *runtime.Runtime, b *babe.Session, msgChan <-chan p2p.Message
 }
 
 // Start begins the service. This begins watching the message channel for new block or transaction messages.
-func (s *Service) Start() <-chan error {
+func (s *Service) Start() error {
 	e := make(chan error)
 	go s.start(e)
-	return e
+	return <-e
 }
 
 func (s *Service) start(e chan error) {
@@ -73,10 +76,9 @@ func (s *Service) start(e chan error) {
 	e <- nil
 }
 
-func (s *Service) Stop() <-chan error {
-	e := make(chan error)
-
-	return e
+func (s *Service) Stop() error {
+	s.rt.Stop()
+	return nil
 }
 
 // ProcessTransaction attempts to validates the transaction

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -97,8 +97,7 @@ func TestNewService_Start(t *testing.T) {
 
 	mgr := NewService(rt, b, msgChan)
 
-	e := mgr.Start()
-	err := <-e
+	err := mgr.Start()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -183,9 +183,6 @@ func TestHandleMsg_Transaction(t *testing.T) {
 
 	// wait for message to be handled
 	time.Sleep(time.Second)
-	if err := <-e; err != nil {
-		t.Fatal(err)
-	}
 
 	// check if in babe tx queue
 	tx := b.PeekFromTxQueue()
@@ -201,7 +198,8 @@ func TestHandleMsg_BlockResponse(t *testing.T) {
 	b := babe.NewSession([32]byte{}, [64]byte{}, rt)
 	msgChan := make(chan []byte)
 	mgr := NewService(rt, b, msgChan)
-	e := mgr.Start()
+	e := make(chan error)
+	go mgr.start(e)
 	if err := <-e; err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +212,6 @@ func TestHandleMsg_BlockResponse(t *testing.T) {
 
 	// wait for message to be handled
 	time.Sleep(time.Second)
-
 	if err := <-e; err != nil {
 		t.Fatal(err)
 	}

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -169,8 +169,8 @@ func TestHandleMsg_Transaction(t *testing.T) {
 	b := babe.NewSession([32]byte{}, [64]byte{}, rt)
 	msgChan := make(chan []byte)
 	mgr := NewService(rt, b, msgChan)
-	e := mgr.Start()
-	if err := <-e; err != nil {
+	err := mgr.Start()
+	if err != nil {
 		t.Fatal(err)
 	}
 

--- a/dot/dot_test.go
+++ b/dot/dot_test.go
@@ -39,7 +39,7 @@ func createTestDot(t *testing.T) *Dot {
 
 	// DB
 	dataDir := "../test_data"
-	dbSrv, err := polkadb.NewDatabaseService(dataDir)
+	dbSrv, err := polkadb.NewDbService(dataDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dot/dot_test.go
+++ b/dot/dot_test.go
@@ -71,11 +71,6 @@ func TestDot_Start(t *testing.T) {
 		if s == nil {
 			t.Fatalf("error getting service: %T", srvc)
 		}
-
-		e := dot.Services.Err(srvc)
-		if e == nil {
-			t.Fatalf("error getting error channel for service: %T", srvc)
-		}
 	}
 
 	dot.Stop()

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -16,12 +16,16 @@
 
 package api
 
-import apiModule "github.com/ChainSafe/gossamer/internal/api/modules"
+import (
+	apiModule "github.com/ChainSafe/gossamer/internal/api/modules"
+	"github.com/ChainSafe/gossamer/internal/services"
+)
+
+var _ services.Service = &Service{}
 
 // Service couples all components required for the API.
 type Service struct {
 	Api *Api
-	err <-chan error
 }
 
 // Api contains all the available modules
@@ -43,16 +47,14 @@ func NewApiService(p2p apiModule.P2pApi, rt apiModule.RuntimeApi) *Service {
 			RuntimeModule: &apiModule.RuntimeModule{
 				Rt: rt,
 			},
-		}, nil,
+		},
 	}
 }
 
-// Start creates, stores and returns an error channel
-func (s *Service) Start() <-chan error {
-	s.err = make(chan error)
-	return s.err
+func (s *Service) Start() error {
+	return nil
 }
 
-func (s *Service) Stop() <-chan error {
+func (s *Service) Stop() error {
 	return nil
 }

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -25,31 +25,31 @@ type MockSrvcA struct {
 	running bool
 }
 
-func (s *MockSrvcA) Start() <-chan error {
+func (s *MockSrvcA) Start() error {
 	s.running = true
-	return make(chan error)
+	return nil
 }
-func (s *MockSrvcA) Stop() <-chan error {
+func (s *MockSrvcA) Stop() error {
 	s.running = false
-	return make(chan error)
+	return nil
 }
 
 type MockSrvcB struct {
 	running bool
 }
 
-func (s *MockSrvcB) Start() <-chan error {
+func (s *MockSrvcB) Start() error {
 	s.running = true
-	return make(chan error)
+	return nil
 }
-func (s *MockSrvcB) Stop() <-chan error {
+func (s *MockSrvcB) Stop() error {
 	s.running = false
-	return make(chan error)
+	return nil
 }
 
 type FakeService struct{}
 
-func (s *FakeService) Start() <-chan error { return *new(<-chan error) }
+func (s *FakeService) Start() error { return nil }
 func (s *FakeService) Stop()               {}
 
 // --------------------------------------------------------
@@ -100,20 +100,22 @@ func TestServiceRegistry_Get_Err(t *testing.T) {
 	r.RegisterService(a)
 	r.RegisterService(b)
 
-	r.StartAll()
-
-	if r.Get(a) == nil || r.Err(a) == nil {
+	if r.Get(a) == nil {
 		t.Fatalf("Failed to fetch service: %T", a)
 	}
-	if r.Get(b) == nil || r.Err(a) == nil {
+	if err := r.Get(a).Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	if r.Get(b) == nil {
 		t.Fatalf("Failed to fetch service: %T", b)
+	}
+	if err := r.Get(b).Start(); err != nil {
+		t.Fatal(err)
 	}
 
 	f := &FakeService{}
 	if s := r.Get(f); s != nil {
 		t.Fatalf("Expected nil. Fetched service: %T", s)
-	}
-	if e := r.Err(f); e != nil {
-		t.Fatalf("Expected nil. Got: %T", e)
 	}
 }

--- a/p2p/bootstrap_test.go
+++ b/p2p/bootstrap_test.go
@@ -106,8 +106,7 @@ func TestNoBootstrap(t *testing.T) {
 
 	defer sa.Stop()
 
-	e := sa.Start()
-	err = <-e
+	err = sa.Start()
 	if err != nil {
 		t.Errorf("Start error: %s", err)
 	}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ChainSafe/gossamer/common"
+	"github.com/ChainSafe/gossamer/internal/services"
 	log "github.com/ChainSafe/log15"
 	ds "github.com/ipfs/go-datastore"
 	dsync "github.com/ipfs/go-datastore/sync"
@@ -40,6 +41,8 @@ import (
 
 const ProtocolPrefix = "/substrate/dot/2"
 const mdnsPeriod = time.Minute
+
+var _ services.Service = &Service{}
 
 // Service describes a p2p service, including host and dht
 type Service struct {
@@ -122,10 +125,10 @@ func NewService(conf *Config, msgChan chan<- Message) (*Service, error) {
 }
 
 // Start begins the p2p Service, including discovery
-func (s *Service) Start() <-chan error {
+func (s *Service) Start() error {
 	e := make(chan error)
 	go s.start(e)
-	return e
+	return <-e
 }
 
 // start begins the p2p Service, including discovery. start does not terminate once called.
@@ -168,21 +171,19 @@ func (s *Service) start(e chan error) {
 }
 
 // Stop stops the p2p service
-func (s *Service) Stop() <-chan error {
-	e := make(chan error)
-
+func (s *Service) Stop() error {
 	//Stop the host & IpfsDHT
 	err := s.host.Close()
 	if err != nil {
-		e <- err
+		return err
 	}
 
 	err = s.dht.Close()
 	if err != nil {
-		e <- err
+		return err
 	}
 
-	return e
+	return nil
 }
 
 // Broadcast sends a message to all peers

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -36,8 +36,7 @@ func startNewService(t *testing.T, cfg *Config) *Service {
 		t.Fatal(err)
 	}
 
-	e := node.Start()
-	err = <-e
+	err = node.Start()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,8 +85,7 @@ func TestService_PeerCount(t *testing.T) {
 
 	defer sa.Stop()
 
-	e := sa.Start()
-	err = <-e
+	err = sa.Start()
 	if err != nil {
 		t.Errorf("Start error: %s", err)
 	}
@@ -139,8 +137,7 @@ func TestSend(t *testing.T) {
 
 	defer sa.Stop()
 
-	e := sa.Start()
-	err = <-e
+	err = sa.Start()
 	if err != nil {
 		t.Errorf("Start error: %s", err)
 	}
@@ -174,8 +171,7 @@ func TestSend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e = sb.Start()
-	err = <-e
+	err = sb.Start()
 	if err != nil {
 		t.Errorf("Start error: %s", err)
 	}

--- a/polkadb/database_test.go
+++ b/polkadb/database_test.go
@@ -41,7 +41,7 @@ func testSetup() []data {
 }
 
 func TestBadgerDB_PutGetDel(t *testing.T) {
-	db, remove := newTestDBService()
+	db, remove := newTestDBService(t)
 	defer remove()
 
 	testPutGetter(db.StateDB.Db, t)
@@ -133,7 +133,7 @@ func testGetPath(db Database, t *testing.T) {
 }
 
 func TestBadgerDB_Batch(t *testing.T) {
-	db, remove := newTestDBService()
+	db, remove := newTestDBService(t)
 	defer remove()
 	testBatchPut(db.StateDB.Db, t)
 }
@@ -177,7 +177,7 @@ func testBatchPut(db Database, t *testing.T) {
 }
 
 func TestBadgerDB_Iterator(t *testing.T) {
-	db, remove := newTestDBService()
+	db, remove := newTestDBService(t)
 	defer remove()
 
 	testNewIterator(db.StateDB.Db, t)

--- a/polkadb/dbService.go
+++ b/polkadb/dbService.go
@@ -15,8 +15,8 @@ type DbService struct {
 	BlockDB *BlockDB
 }
 
-// NewDatabaseService opens and returns a new DB object
-func NewDatabaseService(path string) (*DbService, error) {
+// NewDbService opens and returns a new DB object
+func NewDbService(path string) (*DbService, error) {
 	return &DbService{
 		path: path,
 		StateDB: nil,

--- a/polkadb/dbService.go
+++ b/polkadb/dbService.go
@@ -2,55 +2,67 @@ package polkadb
 
 import (
 	"path/filepath"
+
+	"github.com/ChainSafe/gossamer/internal/services"
 )
 
+var _ services.Service = &DbService{}
+
+// DbService contains both databases for service registry
+type DbService struct {
+	path string
+	StateDB *StateDB
+	BlockDB *BlockDB
+
+	err chan<- error
+}
+
+// NewDatabaseService opens and returns a new DB object
+func NewDatabaseService(path string) (*DbService, error) {
+	return &DbService{
+		path: path,
+		StateDB: nil,
+		BlockDB: nil,
+		err:     nil,
+	}, nil
+}
+
 // Start...
-func (dbService *DbService) Start() <-chan error {
-	dbService.err = make(<-chan error)
-	return dbService.err
+func (s *DbService) Start() <-chan error {
+	ch := make(chan error)
+	s.err = ch
+	stateDataDir := filepath.Join(s.path, "state")
+	blockDataDir := filepath.Join(s.path, "block")
+
+	stateDb, err := NewStateDB(stateDataDir)
+	if err != nil {
+		s.err <- err
+	}
+
+	blockDb, err := NewBlockDB(blockDataDir)
+	if err != nil {
+		s.err <- err
+	}
+
+	s.BlockDB = blockDb
+	s.StateDB = stateDb
+
+	return ch
 }
 
 // Stop kills running BlockDB and StateDB instances
-func (dbService *DbService) Stop() <-chan error {
+func (s *DbService) Stop() <-chan error {
 	e := make(chan error)
 	// Closing Badger Databases
-	err := dbService.StateDB.Db.Close()
+	err := s.StateDB.Db.Close()
 	if err != nil {
 		e <- err
 	}
 
-	err = dbService.BlockDB.Db.Close()
+	err = s.BlockDB.Db.Close()
 	if err != nil {
 		e <- err
 	}
 	return e
 }
 
-// DbService contains both databases for service registry
-type DbService struct {
-	StateDB *StateDB
-	BlockDB *BlockDB
-
-	err <-chan error
-}
-
-// NewDatabaseService opens and returns a new DB object
-func NewDatabaseService(file string) (*DbService, error) {
-	stateDataDir := filepath.Join(file, "state")
-	blockDataDir := filepath.Join(file, "block")
-
-	stateDb, err := NewStateDB(stateDataDir)
-	if err != nil {
-		return nil, err
-	}
-
-	blockDb, err := NewBlockDB(blockDataDir)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DbService{
-		StateDB: stateDb,
-		BlockDB: blockDb,
-	}, nil
-}

--- a/polkadb/dbService.go
+++ b/polkadb/dbService.go
@@ -13,8 +13,6 @@ type DbService struct {
 	path string
 	StateDB *StateDB
 	BlockDB *BlockDB
-
-	err chan<- error
 }
 
 // NewDatabaseService opens and returns a new DB object
@@ -23,46 +21,43 @@ func NewDatabaseService(path string) (*DbService, error) {
 		path: path,
 		StateDB: nil,
 		BlockDB: nil,
-		err:     nil,
 	}, nil
 }
 
 // Start...
-func (s *DbService) Start() <-chan error {
-	ch := make(chan error)
-	s.err = ch
+func (s *DbService) Start() error {
+
 	stateDataDir := filepath.Join(s.path, "state")
 	blockDataDir := filepath.Join(s.path, "block")
 
 	stateDb, err := NewStateDB(stateDataDir)
 	if err != nil {
-		s.err <- err
+		return err
 	}
 
 	blockDb, err := NewBlockDB(blockDataDir)
 	if err != nil {
-		s.err <- err
+		return err
 	}
 
 	s.BlockDB = blockDb
 	s.StateDB = stateDb
 
-	return ch
+	return nil
 }
 
 // Stop kills running BlockDB and StateDB instances
-func (s *DbService) Stop() <-chan error {
-	e := make(chan error)
+func (s *DbService) Stop() error {
 	// Closing Badger Databases
 	err := s.StateDB.Db.Close()
 	if err != nil {
-		e <- err
+		return err
 	}
 
 	err = s.BlockDB.Db.Close()
 	if err != nil {
-		e <- err
+		return err
 	}
-	return e
+	return nil
 }
 

--- a/polkadb/dbService_test.go
+++ b/polkadb/dbService_test.go
@@ -7,14 +7,15 @@ import (
 	"testing"
 )
 
-func newTestDBService() (*DbService, func()) {
+// Returns started dbService
+func newTestDBService(t *testing.T) (*DbService, func()) {
 	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
 	if err != nil {
-		panic("failed to create test file: " + err.Error())
+		t.Fatal("failed to create test file: " + err.Error())
 	}
 	db, err := NewDatabaseService(dir)
 	if err != nil {
-		panic("failed to create test database: " + err.Error())
+		t.Fatal("failed to create test database: " + err.Error())
 	}
 	db.Start()
 	return db, func() {
@@ -26,26 +27,17 @@ func newTestDBService() (*DbService, func()) {
 }
 
 func TestDbService_Start(t *testing.T) {
-	db, remove := newTestDBService()
-	defer remove()
-
-	err := db.Start()
-	if e := <- err; e != nil {
-		t.Fatal(e)
-	}
-
-	err = db.Stop()
-	if e := <- err; e != nil {
-		t.Fatal(e)
-	}
-}
-
-func TestDb_Close(t *testing.T) {
-	db, remove := newTestDBService()
-	defer remove()
-
-	err := db.StateDB.Db.Close()
+	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
 	if err != nil {
-		t.Fatalf("get returned wrong result, got %v", err)
+		t.Fatal("failed to create test file: " + err.Error())
+	}
+	db, err := NewDatabaseService(dir)
+	if err != nil {
+		t.Fatal("failed to create test database: " + err.Error())
+	}
+
+	err = db.Start()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/polkadb/dbService_test.go
+++ b/polkadb/dbService_test.go
@@ -13,7 +13,7 @@ func newTestDBService(t *testing.T) (*DbService, func()) {
 	if err != nil {
 		t.Fatal("failed to create test file: " + err.Error())
 	}
-	db, err := NewDatabaseService(dir)
+	db, err := NewDbService(dir)
 	if err != nil {
 		t.Fatal("failed to create test database: " + err.Error())
 	}
@@ -31,7 +31,7 @@ func TestDbService_Start(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create test file: " + err.Error())
 	}
-	db, err := NewDatabaseService(dir)
+	db, err := NewDbService(dir)
 	if err != nil {
 		t.Fatal("failed to create test database: " + err.Error())
 	}

--- a/polkadb/dbService_test.go
+++ b/polkadb/dbService_test.go
@@ -16,6 +16,7 @@ func newTestDBService() (*DbService, func()) {
 	if err != nil {
 		panic("failed to create test database: " + err.Error())
 	}
+	db.Start()
 	return db, func() {
 		db.Stop()
 		if err := os.RemoveAll(dir); err != nil {
@@ -29,8 +30,13 @@ func TestDbService_Start(t *testing.T) {
 	defer remove()
 
 	err := db.Start()
-	if err == nil {
-		t.Fatalf("get returned wrong result, got %v", err)
+	if e := <- err; e != nil {
+		t.Fatal(e)
+	}
+
+	err = db.Stop()
+	if e := <- err; e != nil {
+		t.Fatal(e)
 	}
 }
 

--- a/polkadb/dbService_test.go
+++ b/polkadb/dbService_test.go
@@ -11,11 +11,11 @@ import (
 func newTestDBService(t *testing.T) (*DbService, func()) {
 	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
 	if err != nil {
-		t.Fatal("failed to create test file: " + err.Error())
+		t.Fatal("failed to create temp dir: " + err.Error())
 	}
 	db, err := NewDbService(dir)
 	if err != nil {
-		t.Fatal("failed to create test database: " + err.Error())
+		t.Fatal("failed to create test dbService: " + err.Error())
 	}
 	db.Start()
 	return db, func() {
@@ -29,11 +29,11 @@ func newTestDBService(t *testing.T) (*DbService, func()) {
 func TestDbService_Start(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
 	if err != nil {
-		t.Fatal("failed to create test file: " + err.Error())
+		t.Fatal("failed to create temp dir: " + err.Error())
 	}
 	db, err := NewDbService(dir)
 	if err != nil {
-		t.Fatal("failed to create test database: " + err.Error())
+		t.Fatal("failed to create test dbService: " + err.Error())
 	}
 
 	err = db.Start()

--- a/polkadb/table_test.go
+++ b/polkadb/table_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBadgerDB_TablePrefixOps(t *testing.T) {
-	db, remove := newTestDBService()
+	db, remove := newTestDBService(t)
 	defer remove()
 
 	testPutTablesWithPrefix(db.StateDB.Db, t)
@@ -93,7 +93,7 @@ func testNewTableBatch(db Database, t *testing.T) {
 }
 
 func TestBadgerDB_TableBatchWithPrefix(t *testing.T) {
-	db, remove := newTestDBService()
+	db, remove := newTestDBService(t)
 	defer remove()
 	testBatchTablePutWithPrefix(db.StateDB.Db, t)
 }


### PR DESCRIPTION
The main change here is the removal of error channels from the `Start()` and `Stop()` functions of the interface `Service` in favour of just returning errors. There seems to be no real need to return the errors through a channel, and we presently have no way of reading these errors. 

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Service return types
- dbService now creates dbs inside `Start()`
- Rename `NewDatabaseService` to `NewDbService` to match struct name

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test -v ./...
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: