### PR TITLE
p2p: Save ID Key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ test_data/
 /bin
 chaindata/
 *.wasm
+node.key

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@
 language: go
 
 go:
-  - 1.12.x
+  - 1.13.x
 
 env:
   global:

--- a/p2p/bootstrap_test.go
+++ b/p2p/bootstrap_test.go
@@ -63,7 +63,7 @@ func TestBootstrapConnect(t *testing.T) {
 	bootnodeCfg := &Config{
 		BootstrapNodes: nil,
 		Port:           7000,
-		RandSeed:       0,
+		RandSeed:       1,
 		NoBootstrap:    true,
 		NoMdns:         true,
 	}
@@ -75,7 +75,7 @@ func TestBootstrapConnect(t *testing.T) {
 	nodeCfg := &Config{
 		BootstrapNodes: []string{bootnodeAddr.String()},
 		Port:           7001,
-		RandSeed:       1,
+		RandSeed:       2,
 		NoBootstrap:    false,
 		NoMdns:         true,
 	}

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -17,15 +17,21 @@
 package p2p
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	mrand "math/rand"
+	"path"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	ma "github.com/multiformats/go-multiaddr"
 )
+
+const KeyFile = "node.key"
 
 // Config is used to configure a p2p service
 type Config struct {
@@ -33,21 +39,34 @@ type Config struct {
 	BootstrapNodes []string
 	// Listening port
 	Port uint32
-	// If 0, random host ID will be generated; If non-0, deterministic ID will be produced
+	// If 0, random host ID will be generated; If non-0, deterministic ID will be produced, keys will not be loaded from data dir
 	RandSeed int64
 	// Disable bootstrapping altogether. BootstrapNodes has no effect over this.
 	NoBootstrap bool
 	// Disables MDNS discovery
 	NoMdns bool
+	// Global data directory
+	DataDir string
+	// Identity key for node
+	privateKey crypto.PrivKey
 }
 
 func (c *Config) buildOpts() ([]libp2p.Option, error) {
 	ip := "0.0.0.0"
 
-	priv, err := generateKey(c.RandSeed)
-	if err != nil {
-		return nil, err
+	if c.RandSeed == 0 {
+		err := c.setupPrivKey()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		key, err := generateKey(c.RandSeed, c.DataDir)
+		if err != nil {
+			return nil, err
+		}
+		c.privateKey = key
 	}
+
 
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, c.Port))
 	if err != nil {
@@ -59,18 +78,50 @@ func (c *Config) buildOpts() ([]libp2p.Option, error) {
 	return []libp2p.Option{
 		libp2p.ListenAddrs(addr),
 		libp2p.DisableRelay(),
-		libp2p.Identity(priv),
+		libp2p.Identity(c.privateKey),
 		libp2p.NATPortMap(),
 		libp2p.Ping(true),
 		libp2p.ConnectionManager(connMgr),
 	}, nil
 }
 
-// generateKey generates a libp2p private key which is used for secure messaging
-func generateKey(seed int64) (crypto.PrivKey, error) {
-	// If the seed is zero, use real cryptographic randomness. Otherwise, use a
-	// deterministic randomness source to make generated keys stay the same
-	// across multiple runs
+// setupPrivKey will attempt to load the nodes private key, if that fails it will create one
+func (c *Config) setupPrivKey() error {
+	// If key exists, load it
+	key, err := tryLoadPrivKey(c.DataDir)
+	if err != nil {
+		return err
+	}
+	// Otherwise, create a key
+	if key == nil {
+		log.Debug("No existing p2p key, generating a new one")
+		key, err = generateKey(c.RandSeed, c.DataDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	c.privateKey = key
+	return nil
+}
+
+// tryLoadPrivkey will attempt to load the private key from the provided path
+func tryLoadPrivKey(fp string) (crypto.PrivKey, error){
+	keyData, err := ioutil.ReadFile(path.Join(fp, KeyFile))
+	if err != nil {
+		return nil, nil
+	}
+
+	return crypto.UnmarshalEd25519PrivateKey(keyData)
+}
+
+
+// generateKey generates an ed25519 private key and writes it to the data directory
+// If the seed is zero, we use real cryptographic randomness. Otherwise, we use a
+// deterministic randomness source to make generated keys stay the same
+// across multiple runs
+func generateKey(seed int64, fp string) (crypto.PrivKey, error) {
+
 	var r io.Reader
 	if seed == 0 {
 		r = rand.Reader
@@ -80,10 +131,16 @@ func generateKey(seed int64) (crypto.PrivKey, error) {
 
 	// Generate a key pair for this host. We will use it at least
 	// to obtain a valid host ID.
-	priv, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, r)
+	_, priv, err := ed25519.GenerateKey(r)
 	if err != nil {
 		return nil, err
 	}
 
-	return priv, nil
+	err = ioutil.WriteFile(path.Join(fp, KeyFile), priv, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+
+	return crypto.UnmarshalEd25519PrivateKey(priv)
 }

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	mrand "math/rand"
 	"path"
+	"path/filepath"
 
 	log "github.com/ChainSafe/log15"
 	"github.com/libp2p/go-libp2p"
@@ -67,7 +68,6 @@ func (c *Config) buildOpts() ([]libp2p.Option, error) {
 		c.privateKey = key
 	}
 
-
 	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, c.Port))
 	if err != nil {
 		return nil, err
@@ -106,15 +106,14 @@ func (c *Config) setupPrivKey() error {
 }
 
 // tryLoadPrivkey will attempt to load the private key from the provided path
-func tryLoadPrivKey(fp string) (crypto.PrivKey, error){
-	keyData, err := ioutil.ReadFile(path.Join(fp, KeyFile))
+func tryLoadPrivKey(fp string) (crypto.PrivKey, error) {
+	keyData, err := ioutil.ReadFile(path.Join(filepath.Clean(fp), KeyFile))
 	if err != nil {
 		return nil, nil
 	}
 
 	return crypto.UnmarshalEd25519PrivateKey(keyData)
 }
-
 
 // generateKey generates an ed25519 private key and writes it to the data directory
 // If the seed is zero, we use real cryptographic randomness. Otherwise, we use a
@@ -136,11 +135,10 @@ func generateKey(seed int64, fp string) (crypto.PrivKey, error) {
 		return nil, err
 	}
 
-	err = ioutil.WriteFile(path.Join(fp, KeyFile), priv, 0600)
+	err = ioutil.WriteFile(path.Join(filepath.Clean(fp), KeyFile), priv, 0600)
 	if err != nil {
 		return nil, err
 	}
-
 
 	return crypto.UnmarshalEd25519PrivateKey(priv)
 }

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -45,15 +45,17 @@ func startNewService(t *testing.T, cfg *Config) *Service {
 	return node
 }
 
-
 func TestBuildOpts(t *testing.T) {
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "p2p-test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	testCfgA := &Config{
 		BootstrapNodes: []string{},
 		Port:           7001,
-		DataDir: tmpDir,
+		DataDir:        tmpDir,
 	}
 
 	_, err = testCfgA.buildOpts()
@@ -68,7 +70,7 @@ func TestBuildOpts(t *testing.T) {
 	testCfgB := &Config{
 		BootstrapNodes: []string{},
 		Port:           7001,
-		DataDir: tmpDir,
+		DataDir:        tmpDir,
 	}
 
 	_, err = testCfgB.buildOpts()
@@ -85,7 +87,7 @@ func TestService_PeerCount(t *testing.T) {
 	testServiceConfigA := &Config{
 		NoBootstrap: true,
 		Port:        7002,
-		RandSeed: 1,
+		RandSeed:    1,
 	}
 
 	sa, err := NewService(testServiceConfigA, nil)
@@ -103,7 +105,7 @@ func TestService_PeerCount(t *testing.T) {
 	testServiceConfigB := &Config{
 		NoBootstrap: true,
 		Port:        7003,
-		RandSeed: 2,
+		RandSeed:    2,
 	}
 
 	sb, err := NewService(testServiceConfigB, nil)
@@ -139,7 +141,7 @@ func TestSend(t *testing.T) {
 	testServiceConfigA := &Config{
 		NoBootstrap: true,
 		Port:        7004,
-		RandSeed: 1,
+		RandSeed:    1,
 	}
 
 	sa, err := NewService(testServiceConfigA, nil)
@@ -157,7 +159,7 @@ func TestSend(t *testing.T) {
 	testServiceConfigB := &Config{
 		NoBootstrap: true,
 		Port:        7005,
-		RandSeed: 2,
+		RandSeed:    2,
 	}
 
 	msgChan := make(chan []byte)
@@ -233,7 +235,7 @@ func TestGossiping(t *testing.T) {
 		Port:           7000,
 		NoBootstrap:    true,
 		NoMdns:         true,
-		RandSeed: 1,
+		RandSeed:       1,
 	}
 
 	nodeA, err := NewService(nodeConfigA, nil)
@@ -250,8 +252,8 @@ func TestGossiping(t *testing.T) {
 		BootstrapNodes: []string{
 			nodeA_Addr.String(),
 		},
-		Port:   7001,
-		NoMdns: true,
+		Port:     7001,
+		NoMdns:   true,
 		RandSeed: 2,
 	}
 
@@ -276,8 +278,8 @@ func TestGossiping(t *testing.T) {
 		BootstrapNodes: []string{
 			nodeB_Addr.String(),
 		},
-		Port:   7002,
-		NoMdns: true,
+		Port:     7002,
+		NoMdns:   true,
 		RandSeed: 3,
 	}
 


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Load p2p identity key from data dir if it exists
- Bump travis Go version (project is already 1.13)

Note: Currently the data dir path cannot be set properly, implementing #347 will solve this. If you try running the node it will create the key in the current directory

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test ./p2p
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: closes #335 