### PR TITLE
cmd,config,dot,rpc: Decouple configs

### DIFF
--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -194,7 +194,6 @@ func TestSetP2pConfig(t *testing.T) {
 			cfg.P2pCfg{
 				BootstrapNodes: cfg.DefaultP2PBootstrap,
 				Port:           cfg.DefaultP2PPort,
-				//RandSeed:       cfg.DefaultP2PRandSeed,
 				NoBootstrap: true,
 				NoMdns:      true,
 			},
@@ -206,7 +205,6 @@ func TestSetP2pConfig(t *testing.T) {
 			cfg.P2pCfg{
 				BootstrapNodes: []string{"1234", "5678"},
 				Port:           cfg.DefaultP2PPort,
-				//RandSeed:       cfg.DefaultP2PRandSeed,
 				NoBootstrap: false,
 				NoMdns:      false,
 			},
@@ -218,7 +216,6 @@ func TestSetP2pConfig(t *testing.T) {
 			cfg.P2pCfg{
 				BootstrapNodes: cfg.DefaultP2PBootstrap,
 				Port:           1337,
-				//RandSeed:       cfg.DefaultP2PRandSeed,
 				NoBootstrap: false,
 				NoMdns:      false,
 			},

--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -194,8 +194,8 @@ func TestSetP2pConfig(t *testing.T) {
 			cfg.P2pCfg{
 				BootstrapNodes: cfg.DefaultP2PBootstrap,
 				Port:           cfg.DefaultP2PPort,
-				NoBootstrap: true,
-				NoMdns:      true,
+				NoBootstrap:    true,
+				NoMdns:         true,
 			},
 		},
 		{
@@ -205,8 +205,8 @@ func TestSetP2pConfig(t *testing.T) {
 			cfg.P2pCfg{
 				BootstrapNodes: []string{"1234", "5678"},
 				Port:           cfg.DefaultP2PPort,
-				NoBootstrap: false,
-				NoMdns:      false,
+				NoBootstrap:    false,
+				NoMdns:         false,
 			},
 		},
 		{
@@ -216,8 +216,8 @@ func TestSetP2pConfig(t *testing.T) {
 			cfg.P2pCfg{
 				BootstrapNodes: cfg.DefaultP2PBootstrap,
 				Port:           1337,
-				NoBootstrap: false,
-				NoMdns:      false,
+				NoBootstrap:    false,
+				NoMdns:         false,
 			},
 		},
 	}

--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/internal/api"
 	"github.com/ChainSafe/gossamer/internal/services"
-	"github.com/ChainSafe/gossamer/p2p"
 	"github.com/ChainSafe/gossamer/rpc"
 
 	"flag"
@@ -107,14 +106,14 @@ func TestGetConfig(t *testing.T) {
 			t.Fatalf("failed to set fig %v", err)
 		}
 
-		r := fmt.Sprintf("%+v", fig.RpcCfg)
-		rpcExp := fmt.Sprintf("%+v", c.expected.RpcCfg)
+		r := fmt.Sprintf("%+v", fig.Rpc)
+		rpcExp := fmt.Sprintf("%+v", c.expected.Rpc)
 
 		db := fmt.Sprintf("%+v", fig.DbCfg)
 		dbExp := fmt.Sprintf("%+v", c.expected.DbCfg)
 
-		peer := fmt.Sprintf("%+v", fig.P2pCfg)
-		p2pExp := fmt.Sprintf("%+v", c.expected.P2pCfg)
+		peer := fmt.Sprintf("%+v", fig.P2p)
+		p2pExp := fmt.Sprintf("%+v", c.expected.P2p)
 
 		if !bytes.Equal([]byte(r), []byte(rpcExp)) {
 			t.Fatalf("test failed: %v, got %+v expected %+v", c.name, r, rpcExp)
@@ -164,7 +163,7 @@ func TestGetDatabaseDir(t *testing.T) {
 
 func TestCreateP2PService(t *testing.T) {
 	_, cfgClone := createTempConfigFile()
-	srv, _ := createP2PService(cfgClone.P2pCfg)
+	srv, _ := createP2PService(*cfgClone)
 
 	if srv == nil {
 		t.Fatalf("failed to create p2p service")
@@ -180,48 +179,48 @@ func TestSetP2pConfig(t *testing.T) {
 		description string
 		flags       []string
 		values      []interface{}
-		expected    p2p.Config
+		expected    cfg.P2pCfg
 	}{
 		{
 			"config file",
 			[]string{"config"},
 			[]interface{}{tempFile.Name()},
-			cfgClone.P2pCfg,
+			cfgClone.P2p,
 		},
 		{
 			"no bootstrap, no mdns",
 			[]string{"nobootstrap", "nomdns"},
 			[]interface{}{true, true},
-			p2p.Config{
+			cfg.P2pCfg{
 				BootstrapNodes: cfg.DefaultP2PBootstrap,
 				Port:           cfg.DefaultP2PPort,
-				RandSeed:       cfg.DefaultP2PRandSeed,
-				NoBootstrap:    true,
-				NoMdns:         true,
+				//RandSeed:       cfg.DefaultP2PRandSeed,
+				NoBootstrap: true,
+				NoMdns:      true,
 			},
 		},
 		{
 			"bootstrap nodes",
 			[]string{"bootnodes"},
 			[]interface{}{"1234,5678"},
-			p2p.Config{
+			cfg.P2pCfg{
 				BootstrapNodes: []string{"1234", "5678"},
 				Port:           cfg.DefaultP2PPort,
-				RandSeed:       cfg.DefaultP2PRandSeed,
-				NoBootstrap:    false,
-				NoMdns:         false,
+				//RandSeed:       cfg.DefaultP2PRandSeed,
+				NoBootstrap: false,
+				NoMdns:      false,
 			},
 		},
 		{
 			"port",
 			[]string{"p2pport"},
 			[]interface{}{uint(1337)},
-			p2p.Config{
+			cfg.P2pCfg{
 				BootstrapNodes: cfg.DefaultP2PBootstrap,
 				Port:           1337,
-				RandSeed:       cfg.DefaultP2PRandSeed,
-				NoBootstrap:    false,
-				NoMdns:         false,
+				//RandSeed:       cfg.DefaultP2PRandSeed,
+				NoBootstrap: false,
+				NoMdns:      false,
 			},
 		},
 	}
@@ -235,10 +234,10 @@ func TestSetP2pConfig(t *testing.T) {
 			}
 
 			input := cfg.DefaultConfig()
-			res := setP2pConfig(context, input.P2pCfg)
+			res := setP2pConfig(context, input.P2p)
 
 			if !reflect.DeepEqual(res, c.expected) {
-				t.Fatalf("\ngot %+v\nexpected %+v", input.P2pCfg, c.expected)
+				t.Fatalf("\ngot %+v\nexpected %+v", input.P2p, c.expected)
 			}
 		})
 	}
@@ -253,19 +252,19 @@ func TestSetRpcConfig(t *testing.T) {
 		description string
 		flags       []string
 		values      []interface{}
-		expected    rpc.Config
+		expected    cfg.RpcCfg
 	}{
 		{
 			"config file",
 			[]string{"config"},
 			[]interface{}{tempFile.Name()},
-			cfgClone.RpcCfg,
+			cfgClone.Rpc,
 		},
 		{
 			"host and port",
 			[]string{"rpchost", "rpcport"},
 			[]interface{}{"someHost", uint(1337)},
-			rpc.Config{
+			cfg.RpcCfg{
 				Port:    1337,
 				Host:    "someHost",
 				Modules: cfg.DefaultRpcModules,
@@ -275,7 +274,7 @@ func TestSetRpcConfig(t *testing.T) {
 			"modules",
 			[]string{"rpcmods"},
 			[]interface{}{"system,state"},
-			rpc.Config{
+			cfg.RpcCfg{
 				Port:    cfg.DefaultRpcHttpPort,
 				Host:    cfg.DefaultRpcHttpHost,
 				Modules: []api.Module{"system", "state"},
@@ -292,10 +291,10 @@ func TestSetRpcConfig(t *testing.T) {
 			}
 
 			input := cfg.DefaultConfig()
-			res := setRpcConfig(context, input.RpcCfg)
+			res := setRpcConfig(context, input.Rpc)
 
 			if !reflect.DeepEqual(res, c.expected) {
-				t.Fatalf("\ngot %+v\nexpected %+v", input.RpcCfg, c.expected)
+				t.Fatalf("\ngot %+v\nexpected %+v", input.Rpc, c.expected)
 			}
 		})
 	}

--- a/config.toml
+++ b/config.toml
@@ -1,19 +1,13 @@
-# filename: config.toml
+[db]
+  DataDir = "/home/d/.gossamer"
 
 [p2p]
-# Alexander testnet bootstrap nodes
-# TODO: move these to alexander genesis file
-BootstrapNodes=[
-			"/ip4/104.211.54.233/tcp/30363/p2p/16Uiu2HAmFWPUx45xYYeCpAryQbvU3dY8PWGdMwS2tLm1dB1CsmCj",
-			"/ip4/104.211.48.51/tcp/30363/p2p/16Uiu2HAmJqVCtF5oMvu1rbJvqWubMMRuWiKJtpoM8KSQ3JNnL5Ec",
-			"/ip4/104.211.48.247/tcp/30363/p2p/16Uiu2HAkyhNWHTPcA2dVKzMnLpFebXqsDQMpkuGnS9SqjJyDyULi",
-			"/ip4/40.117.153.33/tcp/30363/p2p/16Uiu2HAmKXzRnzgyVtSyyp6ozAk5aT9H7PEi2ozkHSzzg7vmX7LV",
-]
-Port= 7001
-RandSeed= 33
-
-[db]
-DataDir="chaindata"
+  bootstrap-nodes = []
+  no-bootstrap = false
+  no-mdns = false
+  port = 7001
 
 [rpc]
-Modules=["system"]
+  host = "localhost"
+  modules = ["system"]
+  port = 8545

--- a/config/config.go
+++ b/config/config.go
@@ -21,17 +21,29 @@ import (
 	"os"
 
 	tml "github.com/BurntSushi/toml"
-	"github.com/ChainSafe/gossamer/p2p"
+	"github.com/ChainSafe/gossamer/internal/api"
 	"github.com/ChainSafe/gossamer/polkadb"
-	"github.com/ChainSafe/gossamer/rpc"
 	log "github.com/ChainSafe/log15"
 )
 
 // Config is a collection of configurations throughout the system
 type Config struct {
-	P2pCfg p2p.Config     `toml:"p2p"`
-	DbCfg  polkadb.Config `toml:"db"`
-	RpcCfg rpc.Config     `toml:"rpc"`
+	P2p   P2pCfg         `toml:"p2p"`
+	DbCfg polkadb.Config `toml:"db"`
+	Rpc   RpcCfg         `toml:"rpc"`
+}
+
+type P2pCfg struct {
+	BootstrapNodes []string `toml:"bootstrap-nodes"`
+	Port           uint32   `toml:"port"`
+	NoBootstrap    bool     `toml:"no-bootstrap"`
+	NoMdns         bool     `toml:"no-mdns"`
+}
+
+type RpcCfg struct {
+	Port    uint32       `toml:"port"`
+	Host    string       `toml:"host"`
+	Modules []api.Module `toml:"modules"`
 }
 
 // ToTOML encodes a state type into a TOML file.

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -23,9 +23,7 @@ import (
 	"runtime"
 
 	"github.com/ChainSafe/gossamer/internal/api"
-	"github.com/ChainSafe/gossamer/p2p"
 	"github.com/ChainSafe/gossamer/polkadb"
-	"github.com/ChainSafe/gossamer/rpc"
 )
 
 const (
@@ -33,8 +31,7 @@ const (
 	DefaultRpcHttpPort = 8545        // Default port for
 
 	// P2P
-	DefaultP2PPort     = 7001
-	DefaultP2PRandSeed = int64(0)
+	DefaultP2PPort = 7001
 
 	DefaultGenesisPath = "./genesis.json"
 )
@@ -45,9 +42,8 @@ var DefaultRpcModules = []api.Module{"system"}
 
 var (
 	// P2P
-	DefaultP2PConfig = p2p.Config{
+	DefaultP2PConfig = P2pCfg{
 		Port:           DefaultP2PPort,
-		RandSeed:       DefaultP2PRandSeed,
 		BootstrapNodes: DefaultP2PBootstrap,
 		NoBootstrap:    false,
 		NoMdns:         false,
@@ -59,7 +55,7 @@ var (
 	}
 
 	// RPC
-	DefaultRpcConfig = rpc.Config{
+	DefaultRpcConfig = RpcCfg{
 		Host:    DefaultRpcHttpHost,
 		Port:    DefaultRpcHttpPort,
 		Modules: DefaultRpcModules,
@@ -69,9 +65,9 @@ var (
 // DefaultConfig is the default settings used when a config.toml file is not passed in during instantiation
 func DefaultConfig() *Config {
 	return &Config{
-		P2pCfg: DefaultP2PConfig,
-		DbCfg:  DefaultDBConfig,
-		RpcCfg: DefaultRpcConfig,
+		P2p:   DefaultP2PConfig,
+		DbCfg: DefaultDBConfig,
+		Rpc:   DefaultRpcConfig,
 	}
 }
 

--- a/dot/dot_test.go
+++ b/dot/dot_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"testing"
 
-	cfg "github.com/ChainSafe/gossamer/config"
 	"github.com/ChainSafe/gossamer/internal/api"
 	"github.com/ChainSafe/gossamer/internal/services"
 	"github.com/ChainSafe/gossamer/p2p"
@@ -31,7 +30,15 @@ import (
 func createTestDot(t *testing.T) *Dot {
 	var services []services.Service
 	// P2P
-	p2pSrvc, err := p2p.NewService(&cfg.DefaultConfig().P2pCfg, nil)
+	p2pCfg := &p2p.Config{
+		BootstrapNodes: []string{},
+		Port:           7000,
+		RandSeed:       1,
+		NoBootstrap:    false,
+		NoMdns:         false,
+		DataDir:        "",
+	}
+	p2pSrvc, err := p2p.NewService(p2pCfg, nil)
 	services = append(services, p2pSrvc)
 	if err != nil {
 		t.Fatal(err)

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -26,16 +26,16 @@ import (
 
 // HttpServer acts as gateway to an RPC server
 type HttpServer struct {
-	Port    uint32       // Listening port
-	Host    string       // Listening hostname
+	Port      uint32  // Listening port
+	Host      string  // Listening hostname
 	rpcServer *Server // Actual RPC call handler
 }
 
 // NewHttpServer creates a new http server and registers an associated rpc server
-func NewHttpServer(api *api.Api, codec Codec, port uint32, host string, modules []api.Module) *HttpServer {
+func NewHttpServer(api *api.Api, codec Codec, host string, port uint32, modules []api.Module) *HttpServer {
 	server := &HttpServer{
-		Port: port,
-		Host: host,
+		Port:      port,
+		Host:      host,
 		rpcServer: NewApiServer(modules, api),
 	}
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -24,24 +24,19 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
-// Config contains eneral RPC configuration options
-type Config struct {
-	Port    uint32       // Listening port
-	Host    string       // Listening hostname
-	Modules []api.Module // Enabled modules
-}
-
 // HttpServer acts as gateway to an RPC server
 type HttpServer struct {
-	cfg       *Config // Associated config
+	Port    uint32       // Listening port
+	Host    string       // Listening hostname
 	rpcServer *Server // Actual RPC call handler
 }
 
 // NewHttpServer creates a new http server and registers an associated rpc server
-func NewHttpServer(api *api.Api, codec Codec, cfg Config) *HttpServer {
+func NewHttpServer(api *api.Api, codec Codec, port uint32, host string, modules []api.Module) *HttpServer {
 	server := &HttpServer{
-		cfg:       &cfg,
-		rpcServer: NewApiServer(cfg.Modules, api),
+		Port: port,
+		Host: host,
+		rpcServer: NewApiServer(modules, api),
 	}
 
 	server.rpcServer.RegisterCodec(codec)
@@ -51,11 +46,11 @@ func NewHttpServer(api *api.Api, codec Codec, cfg Config) *HttpServer {
 
 // Start registers the rpc handler function and starts the server listening on `h.port`
 func (h *HttpServer) Start() {
-	log.Debug("[rpc] Starting HTTP Server...", "port", h.cfg.Port)
+	log.Debug("[rpc] Starting HTTP Server...", "port", h.Port)
 	http.HandleFunc("/rpc", h.rpcServer.ServeHTTP)
 
 	go func() {
-		err := http.ListenAndServe(fmt.Sprintf("%s:%d", h.cfg.Host, h.cfg.Port), nil)
+		err := http.ListenAndServe(fmt.Sprintf("%s:%d", h.Host, h.Port), nil)
 		if err != nil {
 			log.Error("[rpc] http error", "err", err)
 		}


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->
This PR introduces separate config structs for the P2P and RPC services for explicit use in CLI/config file setup.

Prior to these changes we relied on marshalling the toml config file directly to the P2P/RPC configs. This limits the possible functionality of our CLI/Config packages as it forces all exported fields to be included in the TOML file. This introduces further issues when we try to have shared/global config options as it breaks `dumpConfig`.

This unblock #349.

Note: I left the DB config unchanged as it will be removed in #349.
<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Adds `RpcCfg` and `P2pCfg` types specifically for CLI/config usage
- Removes `rpc.Config` as we can just pass the params to the constructor
- Updates tests
- Regenerates example config

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test -v ./...
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: