### PR TITLE
runtime: ext_secp256k1_ecdsa_recover

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/dgraph-io/badger v1.6.0-rc1
 	github.com/disiqueira/gotree v1.0.0
+	github.com/ethereum/go-ethereum v1.9.6
 	github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4
 github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/ethereum/go-ethereum v1.9.6 h1:EacwxMGKZezZi+m3in0Tlyk0veDQgnfZ9BjQqHAaQLM=
+github.com/ethereum/go-ethereum v1.9.6/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543 h1:aMJGfgqe1QDhAVwxRg5fjCRF533xHidiKsugk7Vvzug=
 github.com/filecoin-project/go-leb128 v0.0.0-20190212224330-8d79a5489543/go.mod h1:mjrHv1cDGJWDlGmC0eDc1E5VJr8DmL9XMUcaFwiuKg8=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -67,9 +67,9 @@ import (
 	trie "github.com/ChainSafe/gossamer/trie"
 	log "github.com/ChainSafe/log15"
 	xxhash "github.com/OneOfOne/xxhash"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 	ed25519 "golang.org/x/crypto/ed25519"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 var registry map[int]RuntimeCtx
@@ -507,7 +507,7 @@ func ext_secp256k1_ecdsa_recover(context unsafe.Pointer, msgData, sigData, pubke
 		return 0
 	}
 
-	copy(memory[pubkeyData : pubkeyData+65], pub)
+	copy(memory[pubkeyData:pubkeyData+65], pub)
 	return 1
 }
 

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -69,6 +69,7 @@ import (
 	xxhash "github.com/OneOfOne/xxhash"
 	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 	ed25519 "golang.org/x/crypto/ed25519"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 )
 
 var registry map[int]RuntimeCtx
@@ -492,7 +493,22 @@ func ext_ed25519_verify(context unsafe.Pointer, msgData, msgLen, sigData, pubkey
 //export ext_secp256k1_ecdsa_recover
 func ext_secp256k1_ecdsa_recover(context unsafe.Pointer, msgData, sigData, pubkeyData int32) int32 {
 	log.Debug("[ext_secp256k1_ecdsa_recover] executing...")
-	return 0
+	instanceContext := wasm.IntoInstanceContext(context)
+	memory := instanceContext.Memory().Data()
+
+	// msg must be the 32-byte hash of the message to be signed.
+	// sig must be a 65-byte compact ECDSA signature containing the
+	// recovery id as the last element.
+	msg := memory[msgData : msgData+32]
+	sig := memory[sigData : sigData+65]
+
+	pub, err := secp256k1.RecoverPubkey(msg, sig)
+	if err != nil {
+		return 0
+	}
+
+	copy(memory[pubkeyData : pubkeyData+65], pub)
+	return 1
 }
 
 //export ext_is_validator


### PR DESCRIPTION
## Changes
- implement ext_secp256k1_ecdsa_recover
- uses a go-ethereum library, this seems to be our best bet for a "go" implementation unless we want to use cgo

## Tests:
```
go test ./runtime/... -v
```

### Issues:
closes #274 