### PR TITLE
Fix Failing Tests On Development

### DIFF
--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -380,7 +380,7 @@ func TestGossiping(t *testing.T) {
 		if !reflect.DeepEqual(bmEnc, res) {
 			t.Fatalf("Didn't receive the correct message")
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatalf("Did not receive message from %s", nodeB.host.hostAddr)
 	}
 


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->

I suspect the failure it due to the test timing out prematurely. It shouldn't happen in the real world but since we have multiple nodes on the same machine it seems reasonable to expect unusual processing times. 

<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Increases `TestGossiping` timeout to 30 secs (from 10)


<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test ./p2p
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: