### PR TITLE
p2p: use p2p instead of ipfs for host multiaddress

### DIFF
--- a/p2p/host.go
+++ b/p2p/host.go
@@ -235,6 +235,10 @@ func (h *host) close() error {
 // fullAddrs returns all the hosts addresses with their ID append as multiaddrs
 func (h *host) fullAddrs() (maddrs []ma.Multiaddr) {
 	addrs := h.h.Addrs()
+
+	// use "p2p" instead of "ipfs" when creating a multiaddress
+	ma.SwapToP2pMultiaddrs()
+
 	for _, a := range addrs {
 		maddr, err := ma.NewMultiaddr(fmt.Sprintf("%s/p2p/%s", a, h.h.ID().Pretty()))
 		if err != nil {


### PR DESCRIPTION
## Changes:

This pull request makes use of the [`SwapToP2pMultiaddrs`](https://github.com/multiformats/go-multiaddr/blob/64e34154803fd9bd07ef4c6480be117ec72e35fc/protocol.go#L53-L78) configuration method in [go-multiaddr](https://github.com/multiformats/go-multiaddr) in order to use `p2p` instead of `ipfs` when creating a new multiaddress.

## Tests:

```
go test ./p2p
```

## Issues:
closes #367 