### PR TITLE
Remove CLI Flag Migration

### DIFF
--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -62,7 +62,7 @@ var (
 		Description: `The dumpconfig command shows configuration values.`,
 	}
 	initCommand = cli.Command{
-		Action:    MigrateFlags(initNode),
+		Action:    initNode,
 		Name:      "init",
 		Usage:     "Initialize node genesis state",
 		ArgsUsage: "",
@@ -136,21 +136,6 @@ func initNode(ctx *cli.Context) error {
 
 	log.Info("🕸\t Finished initializing node!")
 	return nil
-}
-
-// MigrateFlags sets the global flag from a local flag when it's set.
-func MigrateFlags(action func(ctx *cli.Context) error) func(*cli.Context) error {
-	return func(ctx *cli.Context) error {
-		for _, name := range ctx.FlagNames() {
-			if ctx.IsSet(name) {
-				err := ctx.GlobalSet(name, ctx.String(name))
-				if err != nil {
-					return nil
-				}
-			}
-		}
-		return action(ctx)
-	}
 }
 
 // gossamer is the main entrypoint into the gossamer system


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Removes `MigrateFlags` method as it is no longer required.

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
go test -v ./cmd/....
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: Only my OCD.