### PR TITLE
crypto, runtime: ext_ public keys, sign

### DIFF
--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -9,6 +9,11 @@ import (
 	"github.com/ChainSafe/gossamer/common"
 )
 
+const Ed25519PublicKeyLength int = 32
+const Ed25519SeedLength int = 32
+const Ed25519PrivateKeyLength int = 64
+const Ed25519SignatureLength int = 64
+
 // Ed25519Keypair is a ed25519 public-private keypair
 type Ed25519Keypair struct {
 	public  *Ed25519PublicKey
@@ -29,7 +34,7 @@ func NewEd25519Keypair(priv ed25519.PrivateKey) *Ed25519Keypair {
 }
 
 func NewEd25519KeypairFromSeed(seed []byte) (*Ed25519Keypair, error) {
-	if len(seed) != SeedLength {
+	if len(seed) != Ed25519SeedLength {
 		return nil, fmt.Errorf("cannot generate key from seed: seed is not 32 bytes long")
 	}
 	edpriv := ed25519.NewKeyFromSeed(seed)
@@ -38,7 +43,7 @@ func NewEd25519KeypairFromSeed(seed []byte) (*Ed25519Keypair, error) {
 
 // GenerateEd25519Keypair returns a new ed25519 keypair
 func GenerateEd25519Keypair() (*Ed25519Keypair, error) {
-	buf := make([]byte, SeedLength)
+	buf := make([]byte, Sr25519SeedLength)
 	_, err := rand.Read(buf)
 	if err != nil {
 		return nil, err
@@ -52,7 +57,7 @@ func GenerateEd25519Keypair() (*Ed25519Keypair, error) {
 // NewEd25519PublicKey returns an ed25519 public key that consists of the input bytes
 // Input length must be 32 bytes
 func NewEd25519PublicKey(in []byte) (*Ed25519PublicKey, error) {
-	if len(in) != PublicKeyLength {
+	if len(in) != Ed25519PublicKeyLength {
 		return nil, fmt.Errorf("cannot create public key: input is not 32 bytes")
 	}
 
@@ -73,7 +78,7 @@ func NewEd25519PrivateKey(in []byte) (*Ed25519PrivateKey, error) {
 
 // Verify returns true if the signature is valid for the given message and public key, false otherwise
 func Ed25519Verify(pub *Ed25519PublicKey, msg, sig []byte) bool {
-	if len(sig) != SignatureLength {
+	if len(sig) != Ed25519SignatureLength {
 		return false
 	}
 
@@ -124,7 +129,7 @@ func (k *Ed25519PrivateKey) Decode(in []byte) error {
 
 // Verify checks that Ed25519PublicKey was used to create the signature for the message
 func (k *Ed25519PublicKey) Verify(msg, sig []byte) bool {
-	if len(sig) != SignatureLength {
+	if len(sig) != Ed25519SignatureLength {
 		return false
 	}
 	return ed25519.Verify(ed25519.PublicKey(*k), msg, sig)

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -43,7 +43,7 @@ func NewEd25519KeypairFromSeed(seed []byte) (*Ed25519Keypair, error) {
 
 // GenerateEd25519Keypair returns a new ed25519 keypair
 func GenerateEd25519Keypair() (*Ed25519Keypair, error) {
-	buf := make([]byte, Sr25519SeedLength)
+	buf := make([]byte, Ed25519SeedLength)
 	_, err := rand.Read(buf)
 	if err != nil {
 		return nil, err

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -29,7 +29,7 @@ func NewEd25519Keypair(priv ed25519.PrivateKey) *Ed25519Keypair {
 }
 
 func NewEd25519KeypairFromSeed(seed []byte) (*Ed25519Keypair, error) {
-	if len(seed) != 32 {
+	if len(seed) != SeedLength {
 		return nil, fmt.Errorf("cannot generate key from seed: seed is not 32 bytes long")
 	}
 	edpriv := ed25519.NewKeyFromSeed(seed)
@@ -38,7 +38,7 @@ func NewEd25519KeypairFromSeed(seed []byte) (*Ed25519Keypair, error) {
 
 // GenerateEd25519Keypair returns a new ed25519 keypair
 func GenerateEd25519Keypair() (*Ed25519Keypair, error) {
-	buf := make([]byte, 32)
+	buf := make([]byte, SeedLength)
 	_, err := rand.Read(buf)
 	if err != nil {
 		return nil, err
@@ -52,7 +52,7 @@ func GenerateEd25519Keypair() (*Ed25519Keypair, error) {
 // NewEd25519PublicKey returns an ed25519 public key that consists of the input bytes
 // Input length must be 32 bytes
 func NewEd25519PublicKey(in []byte) (*Ed25519PublicKey, error) {
-	if len(in) != 32 {
+	if len(in) != PublicKeyLength {
 		return nil, fmt.Errorf("cannot create public key: input is not 32 bytes")
 	}
 
@@ -63,7 +63,7 @@ func NewEd25519PublicKey(in []byte) (*Ed25519PublicKey, error) {
 // NewEd25519PrivateKey returns an ed25519 private key that consists of the input bytes
 // Input length must be 64 bytes
 func NewEd25519PrivateKey(in []byte) (*Ed25519PrivateKey, error) {
-	if len(in) != 64 {
+	if len(in) != Ed25519PrivateKeyLength {
 		return nil, fmt.Errorf("cannot create private key: input is not 64 bytes")
 	}
 
@@ -73,6 +73,10 @@ func NewEd25519PrivateKey(in []byte) (*Ed25519PrivateKey, error) {
 
 // Verify returns true if the signature is valid for the given message and public key, false otherwise
 func Ed25519Verify(pub *Ed25519PublicKey, msg, sig []byte) bool {
+	if len(sig) != SignatureLength {
+		return false
+	}
+
 	return ed25519.Verify(ed25519.PublicKey(*pub), msg, sig)
 }
 
@@ -120,6 +124,9 @@ func (k *Ed25519PrivateKey) Decode(in []byte) error {
 
 // Verify checks that Ed25519PublicKey was used to create the signature for the message
 func (k *Ed25519PublicKey) Verify(msg, sig []byte) bool {
+	if len(sig) != SignatureLength {
+		return false
+	}
 	return ed25519.Verify(ed25519.PublicKey(*k), msg, sig)
 }
 

--- a/crypto/keypair.go
+++ b/crypto/keypair.go
@@ -13,12 +13,6 @@ type KeyType = string
 const Ed25519Type KeyType = "ed25519"
 const Sr25519Type KeyType = "sr25519"
 
-const PublicKeyLength int = 32
-const SeedLength int = 32
-const Ed25519PrivateKeyLength int = 64
-const Sr25519PrivateKeyLength int = 32
-const SignatureLength int = 64
-
 type Keypair interface {
 	Sign(msg []byte) ([]byte, error)
 	Public() PublicKey

--- a/crypto/keypair.go
+++ b/crypto/keypair.go
@@ -13,6 +13,12 @@ type KeyType = string
 const Ed25519Type KeyType = "ed25519"
 const Sr25519Type KeyType = "sr25519"
 
+const PublicKeyLength int = 32
+const SeedLength int = 32
+const Ed25519PrivateKeyLength int = 64
+const Sr25519PrivateKeyLength int = 32
+const SignatureLength int = 64
+
 type Keypair interface {
 	Sign(msg []byte) ([]byte, error)
 	Public() PublicKey

--- a/crypto/sr25519.go
+++ b/crypto/sr25519.go
@@ -40,7 +40,7 @@ func NewSr25519Keypair(priv *sr25519.SecretKey) (*Sr25519Keypair, error) {
 
 // NewSr25519KeypairFromSeed returns a new Sr25519Keypair given a seed
 func NewSr25519KeypairFromSeed(seed []byte) (*Sr25519Keypair, error) {
-	buf := [32]byte{}
+	buf := [SeedLength]byte{}
 	msc, err := sr25519.NewMiniSecretKeyFromRaw(buf)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func NewSr25519KeypairFromSeed(seed []byte) (*Sr25519Keypair, error) {
 
 // NewSr25519PrivateKey creates a new private key using the input bytes
 func NewSr25519PrivateKey(in []byte) (*Sr25519PrivateKey, error) {
-	if len(in) != 32 {
+	if len(in) != Sr25519PrivateKeyLength {
 		return nil, errors.New("input to create sr25519 private key is not 32 bytes")
 	}
 	priv := new(Sr25519PrivateKey)
@@ -79,11 +79,11 @@ func GenerateSr25519Keypair() (*Sr25519Keypair, error) {
 }
 
 func NewSr25519PublicKey(in []byte) (*Sr25519PublicKey, error) {
-	if len(in) != 32 {
+	if len(in) != PublicKeyLength {
 		return nil, errors.New("cannot create public key: input is not 32 bytes")
 	}
 
-	buf := [32]byte{}
+	buf := [PublicKeyLength]byte{}
 	copy(buf[:], in)
 	return &Sr25519PublicKey{key: sr25519.NewPublicKey(buf)}, nil
 }
@@ -141,10 +141,10 @@ func (k *Sr25519PrivateKey) Encode() []byte {
 // Decode decodes the input bytes into a private key and sets the receiver the decoded key
 // Input must be 32 bytes, or else this function will error
 func (k *Sr25519PrivateKey) Decode(in []byte) error {
-	if len(in) != 32 {
+	if len(in) != Sr25519PrivateKeyLength {
 		return errors.New("input to sr25519 private key decode is not 32 bytes")
 	}
-	b := [32]byte{}
+	b := [Sr25519PrivateKeyLength]byte{}
 	copy(b[:], in)
 	k.key = &sr25519.SecretKey{}
 	return k.key.Decode(b)
@@ -158,7 +158,11 @@ func (k *Sr25519PublicKey) Verify(msg, sig []byte) bool {
 		return false
 	}
 
-	b := [64]byte{}
+	if len(sig) != SignatureLength {
+		return false
+	}
+
+	b := [SignatureLength]byte{}
 	copy(b[:], sig)
 
 	s := &sr25519.Signature{}
@@ -184,10 +188,10 @@ func (k *Sr25519PublicKey) Encode() []byte {
 // Decode decodes the input bytes into a public key and sets the receiver the decoded key
 // Input must be 32 bytes, or else this function will error
 func (k *Sr25519PublicKey) Decode(in []byte) error {
-	if len(in) != 32 {
+	if len(in) != PublicKeyLength {
 		return errors.New("input to sr25519 public key decode is not 32 bytes")
 	}
-	b := [32]byte{}
+	b := [PublicKeyLength]byte{}
 	copy(b[:], in)
 	k.key = &sr25519.PublicKey{}
 	return k.key.Decode(b)

--- a/crypto/sr25519.go
+++ b/crypto/sr25519.go
@@ -8,6 +8,11 @@ import (
 	"github.com/ChainSafe/gossamer/common"
 )
 
+const Sr25519PublicKeyLength int = 32
+const Sr25519SeedLength int = 32
+const Sr25519PrivateKeyLength int = 32
+const Sr25519SignatureLength int = 64
+
 // SigningContext is the context for signatures used or created with substrate
 var SigningContext = []byte("substrate")
 
@@ -40,7 +45,7 @@ func NewSr25519Keypair(priv *sr25519.SecretKey) (*Sr25519Keypair, error) {
 
 // NewSr25519KeypairFromSeed returns a new Sr25519Keypair given a seed
 func NewSr25519KeypairFromSeed(seed []byte) (*Sr25519Keypair, error) {
-	buf := [SeedLength]byte{}
+	buf := [Sr25519SeedLength]byte{}
 	msc, err := sr25519.NewMiniSecretKeyFromRaw(buf)
 	if err != nil {
 		return nil, err
@@ -79,11 +84,11 @@ func GenerateSr25519Keypair() (*Sr25519Keypair, error) {
 }
 
 func NewSr25519PublicKey(in []byte) (*Sr25519PublicKey, error) {
-	if len(in) != PublicKeyLength {
+	if len(in) != Sr25519PublicKeyLength {
 		return nil, errors.New("cannot create public key: input is not 32 bytes")
 	}
 
-	buf := [PublicKeyLength]byte{}
+	buf := [Sr25519PublicKeyLength]byte{}
 	copy(buf[:], in)
 	return &Sr25519PublicKey{key: sr25519.NewPublicKey(buf)}, nil
 }
@@ -158,11 +163,11 @@ func (k *Sr25519PublicKey) Verify(msg, sig []byte) bool {
 		return false
 	}
 
-	if len(sig) != SignatureLength {
+	if len(sig) != Sr25519SignatureLength {
 		return false
 	}
 
-	b := [SignatureLength]byte{}
+	b := [Sr25519SignatureLength]byte{}
 	copy(b[:], sig)
 
 	s := &sr25519.Signature{}
@@ -188,10 +193,10 @@ func (k *Sr25519PublicKey) Encode() []byte {
 // Decode decodes the input bytes into a public key and sets the receiver the decoded key
 // Input must be 32 bytes, or else this function will error
 func (k *Sr25519PublicKey) Decode(in []byte) error {
-	if len(in) != PublicKeyLength {
+	if len(in) != Sr25519PublicKeyLength {
 		return errors.New("input to sr25519 public key decode is not 32 bytes")
 	}
-	b := [PublicKeyLength]byte{}
+	b := [Sr25519PublicKeyLength]byte{}
 	copy(b[:], in)
 	k.key = &sr25519.PublicKey{}
 	return k.key.Decode(b)

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -32,3 +32,23 @@ func (ks *Keystore) Get(pub common.Address) crypto.Keypair {
 	defer ks.lock.RUnlock()
 	return ks.keys[pub]
 }
+
+func (ks *Keystore) Ed25519PublicKeys() []crypto.PublicKey {
+	edkeys := []crypto.PublicKey{}
+	for _, key := range ks.keys {
+		if _, ok := key.(*crypto.Ed25519Keypair); ok {
+			edkeys = append(edkeys, key.Public())
+		}
+	}
+	return edkeys
+}
+
+func (ks *Keystore) Sr25519PublicKeys() []crypto.PublicKey {
+	srkeys := []crypto.PublicKey{}
+	for _, key := range ks.keys {
+		if _, ok := key.(*crypto.Sr25519Keypair); ok {
+			srkeys = append(srkeys, key.Public())
+		}
+	}
+	return srkeys
+}

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -43,6 +43,16 @@ func (ks *Keystore) Ed25519PublicKeys() []crypto.PublicKey {
 	return edkeys
 }
 
+func (ks *Keystore) Ed25519Keypairs() []crypto.Keypair {
+	edkeys := []crypto.Keypair{}
+	for _, key := range ks.keys {
+		if _, ok := key.(*crypto.Ed25519Keypair); ok {
+			edkeys = append(edkeys, key)
+		}
+	}
+	return edkeys
+}
+
 func (ks *Keystore) Sr25519PublicKeys() []crypto.PublicKey {
 	srkeys := []crypto.PublicKey{}
 	for _, key := range ks.keys {
@@ -51,4 +61,14 @@ func (ks *Keystore) Sr25519PublicKeys() []crypto.PublicKey {
 		}
 	}
 	return srkeys
+}
+
+func (ks *Keystore) Sr25519Keypairs() []crypto.Keypair {
+	edkeys := []crypto.Keypair{}
+	for _, key := range ks.keys {
+		if _, ok := key.(*crypto.Sr25519Keypair); ok {
+			edkeys = append(edkeys, key)
+		}
+	}
+	return edkeys
 }

--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -1,6 +1,7 @@
 package keystore
 
 import (
+	"bytes"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/common"
@@ -71,4 +72,13 @@ func (ks *Keystore) Sr25519Keypairs() []crypto.Keypair {
 		}
 	}
 	return edkeys
+}
+
+func (ks *Keystore) GetKeypair(pub crypto.PublicKey) crypto.Keypair {
+	for _, key := range ks.keys {
+		if bytes.Equal(key.Public().Encode(), pub.Encode()) {
+			return key
+		}
+	}
+	return nil
 }

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -548,16 +548,14 @@ func ext_ed25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLe
 	runtimeCtx := registry[*(*int)(instanceContext.Data())]
 	mutex.RUnlock()
 
-	keys := runtimeCtx.keystore.Ed25519Keypairs()
-
-	pubkey := memory[pubkeyData : pubkeyData+32]
-	var signingKey crypto.Keypair
-	for _, key := range keys {
-		if bytes.Equal(key.Public().Encode(), pubkey) {
-			signingKey = key
-		}
+	pubkeyBytes := memory[pubkeyData : pubkeyData+32]
+	pubkey, err := crypto.NewEd25519PublicKey(pubkeyBytes)
+	if err != nil {
+		log.Error("[ext_ed25519_sign]", "error", err)
+		return 1
 	}
 
+	signingKey := runtimeCtx.keystore.GetKeypair(pubkey)
 	if signingKey == nil {
 		log.Error("[ext_ed25519_sign] could not find key in keystore", "public key", pubkey)
 		return 1
@@ -586,15 +584,14 @@ func ext_sr25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLe
 	runtimeCtx := registry[*(*int)(instanceContext.Data())]
 	mutex.RUnlock()
 
-	keys := runtimeCtx.keystore.Sr25519Keypairs()
-
-	pubkey := memory[pubkeyData : pubkeyData+32]
-	var signingKey crypto.Keypair
-	for _, key := range keys {
-		if bytes.Equal(key.Public().Encode(), pubkey) {
-			signingKey = key
-		}
+	pubkeyBytes := memory[pubkeyData : pubkeyData+32]
+	pubkey, err := crypto.NewSr25519PublicKey(pubkeyBytes)
+	if err != nil {
+		log.Error("[ext_sr25519_sign]", "error", err)
+		return 1
 	}
+
+	signingKey := runtimeCtx.keystore.GetKeypair(pubkey)
 
 	if signingKey == nil {
 		log.Error("[ext_sr25519_sign] could not find key in keystore", "public key", pubkey)

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -563,7 +563,9 @@ func ext_ed25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLe
 		return 1
 	}
 
-	msg := memory[msgData : msgData+msgLen]
+	msgLenBytes := memory[msgLen : msgLen+4]
+	msgLength := binary.LittleEndian.Uint32(msgLenBytes)
+	msg := memory[msgData : msgData+int32(msgLength)]
 	sig, err := signingKey.Sign(msg)
 	if err != nil {
 		log.Error("[ext_ed25519_sign] could not sign message")
@@ -599,7 +601,9 @@ func ext_sr25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLe
 		return 1
 	}
 
-	msg := memory[msgData : msgData+msgLen]
+	msgLenBytes := memory[msgLen : msgLen+4]
+	msgLength := binary.LittleEndian.Uint32(msgLenBytes)
+	msg := memory[msgData : msgData+int32(msgLength)]
 	sig, err := signingKey.Sign(msg)
 	if err != nil {
 		log.Error("[ext_sr25519_sign] could not sign message")

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -485,15 +485,56 @@ func ext_sr25519_generate(context unsafe.Pointer, idData, seed, seedLen, out int
 //export ext_ed25519_public_keys
 func ext_ed25519_public_keys(context unsafe.Pointer, idData, resultLen int32) int32 {
 	log.Trace("[ext_ed25519_public_keys] executing...")
-	log.Warn("[ext_ed25519_public_keys] Not yet implemented.")
-	return 0
+	instanceContext := wasm.IntoInstanceContext(context)
+	memory := instanceContext.Memory().Data()
+
+	mutex.RLock()
+	runtimeCtx := registry[*(*int)(instanceContext.Data())]
+	mutex.RUnlock()
+
+	keys := runtimeCtx.keystore.Ed25519PublicKeys()
+	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys)*32))
+	if err != nil {
+		log.Error("[ext_sr25519_public_keys]", "error", err)
+		return -1
+	}	
+
+	for _, key := range keys {
+		copy(memory[offset:offset+32], key.Encode())
+	}
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(len(keys)))
+	copy(memory[resultLen:resultLen+4], buf)
+	return int32(offset)
 }
 
 //export ext_sr25519_public_keys
 func ext_sr25519_public_keys(context unsafe.Pointer, idData, resultLen int32) int32 {
 	log.Trace("[ext_sr25519_public_keys] executing...")
-	log.Warn("[ext_sr25519_public_keys] Not yet implemented.")
-	return 0
+	instanceContext := wasm.IntoInstanceContext(context)
+	memory := instanceContext.Memory().Data()
+
+	mutex.RLock()
+	runtimeCtx := registry[*(*int)(instanceContext.Data())]
+	mutex.RUnlock()
+
+	keys := runtimeCtx.keystore.Ed25519PublicKeys()
+
+	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys)*32))
+	if err != nil {
+		log.Error("[ext_sr25519_public_keys]", "error", err)
+		return -1
+	}	
+
+	for _, key := range keys {
+		copy(memory[offset:offset+32], key.Encode())
+	}
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, uint32(len(keys)))
+	copy(memory[resultLen:resultLen+4], buf)
+	return int32(offset)
 }
 
 //export ext_ed25519_sign

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -496,7 +496,7 @@ func ext_ed25519_public_keys(context unsafe.Pointer, idData, resultLen int32) in
 	// TODO: when do deallocate?
 	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys) * 32))
 	if err != nil {
-		log.Error("[ext_sr25519_public_keys]", "error", err)
+		log.Error("[ext_ed25519_public_keys]", "error", err)
 		return -1
 	}
 

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -493,14 +493,15 @@ func ext_ed25519_public_keys(context unsafe.Pointer, idData, resultLen int32) in
 	mutex.RUnlock()
 
 	keys := runtimeCtx.keystore.Ed25519PublicKeys()
-	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys)*32))
+	// TODO: when do deallocate?
+	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys) * 32))
 	if err != nil {
 		log.Error("[ext_sr25519_public_keys]", "error", err)
 		return -1
-	}	
+	}
 
-	for _, key := range keys {
-		copy(memory[offset:offset+32], key.Encode())
+	for i, key := range keys {
+		copy(memory[offset+uint32(i*32):offset+uint32((i+1)*32)], key.Encode())
 	}
 
 	buf := make([]byte, 4)
@@ -519,16 +520,16 @@ func ext_sr25519_public_keys(context unsafe.Pointer, idData, resultLen int32) in
 	runtimeCtx := registry[*(*int)(instanceContext.Data())]
 	mutex.RUnlock()
 
-	keys := runtimeCtx.keystore.Ed25519PublicKeys()
+	keys := runtimeCtx.keystore.Sr25519PublicKeys()
 
-	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys)*32))
+	offset, err := runtimeCtx.allocator.Allocate(uint32(len(keys) * 32))
 	if err != nil {
 		log.Error("[ext_sr25519_public_keys]", "error", err)
 		return -1
-	}	
+	}
 
-	for _, key := range keys {
-		copy(memory[offset:offset+32], key.Encode())
+	for i, key := range keys {
+		copy(memory[offset+uint32(i*32):offset+uint32((i+1)*32)], key.Encode())
 	}
 
 	buf := make([]byte, 4)

--- a/runtime/wasmer.go
+++ b/runtime/wasmer.go
@@ -19,7 +19,6 @@ package runtime
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -138,6 +137,7 @@ func (r *Runtime) Load(location, length int32) []byte {
 
 func (r *Runtime) Exec(function string, loc int32, data []byte) ([]byte, error) {
 	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	// Store the data into memory
 	r.Store(data, loc)
@@ -155,12 +155,8 @@ func (r *Runtime) Exec(function string, loc int32, data []byte) ([]byte, error) 
 
 	length := int32(resi >> 32)
 	offset := int32(resi)
-	fmt.Printf("offset %d length %d\n", offset, length)
-	mem := r.vm.Memory.Data()
-	rawdata := make([]byte, length)
-	copy(rawdata, mem[offset:offset+length])
 
-	r.mutex.Unlock()
+	rawdata := r.Load(offset, length)
 
 	return rawdata, err
 }

--- a/runtime/wasmer.go
+++ b/runtime/wasmer.go
@@ -127,9 +127,7 @@ func (r *Runtime) StorageRoot() (common.Hash, error) {
 }
 
 func (r *Runtime) Store(data []byte, location int32) {
-	r.mutex.Lock()
 	mem := r.vm.Memory.Data()
-	r.mutex.Unlock()
 	copy(mem[location:location+int32(len(data))], data)
 }
 

--- a/runtime/wasmer.go
+++ b/runtime/wasmer.go
@@ -127,7 +127,9 @@ func (r *Runtime) StorageRoot() (common.Hash, error) {
 }
 
 func (r *Runtime) Store(data []byte, location int32) {
+	r.mutex.Lock()
 	mem := r.vm.Memory.Data()
+	r.mutex.Unlock()
 	copy(mem[location:location+int32(len(data))], data)
 }
 

--- a/runtime/wasmer_test.go
+++ b/runtime/wasmer_test.go
@@ -1055,8 +1055,10 @@ func TestExt_ed25519_public_keys(t *testing.T) {
 	testKps := []crypto.Keypair{}
 	expectedPubkeys := [][]byte{}
 	numKps := 12
+
+	var kp crypto.Keypair
 	for i := 0; i < numKps; i++ {
-		kp, err := crypto.GenerateEd25519Keypair()
+		kp, err = crypto.GenerateEd25519Keypair()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1068,7 +1070,7 @@ func TestExt_ed25519_public_keys(t *testing.T) {
 
 	// put some sr25519 keypairs in the keystore to make sure they don't get returned
 	for i := 0; i < numKps; i++ {
-		kp, err := crypto.GenerateSr25519Keypair()
+		kp, err = crypto.GenerateSr25519Keypair()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1123,8 +1125,10 @@ func TestExt_sr25519_public_keys(t *testing.T) {
 	testKps := []crypto.Keypair{}
 	expectedPubkeys := [][]byte{}
 	numKps := 12
+
+	var kp crypto.Keypair
 	for i := 0; i < numKps; i++ {
-		kp, err := crypto.GenerateSr25519Keypair()
+		kp, err = crypto.GenerateSr25519Keypair()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1136,7 +1140,7 @@ func TestExt_sr25519_public_keys(t *testing.T) {
 
 	// put some ed25519 keypairs in the keystore to make sure they don't get returned
 	for i := 0; i < numKps; i++ {
-		kp, err := crypto.GenerateEd25519Keypair()
+		kp, err = crypto.GenerateEd25519Keypair()
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Changes
- implement ext_ed25519_public_keys, ext_sr25519_public_keys, ext_ed25519_sign, ext_sr25519_sign
- implement functions to get public keys/keypairs from keystore
- add constants to crypto package for pubkey length, privkey length, seed length, signature length

## Tests:
```
go test ./crypto/ ./runtime/
```

### Issues:
closes #281 closes #279 