### PR TITLE
core: process block announce message

### DIFF
--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -89,7 +89,7 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	srvcs = append(srvcs, p2pSrvc)
 
 	// Core
-	coreConfig := &core.ServiceConfig{
+	coreConfig := &core.Config{
 		Keystore: ks,
 		Runtime:  r,
 		MsgRec:   p2pMsgSend, // message channel from p2p service to core service
@@ -217,7 +217,7 @@ func createP2PService(fig *cfg.Config, gendata *genesis.GenesisData) (*p2p.Servi
 }
 
 // createCoreService creates the core service from the provided core configuration
-func createCoreService(coreConfig *core.ServiceConfig) *core.Service {
+func createCoreService(coreConfig *core.Config) *core.Service {
 
 	coreBlkRec := make(chan types.Block)
 

--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -248,8 +248,7 @@ func TestCreateP2PService(t *testing.T) {
 		ProtocolId: "gossamer",
 	}
 
-	srv, _ := createP2PService(cfg.DefaultConfig(), gendata)
-
+	srv, _, _ := createP2PService(cfg.DefaultConfig(), gendata)
 	if srv == nil {
 		t.Fatalf("failed to create p2p service")
 	}

--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -28,42 +28,36 @@ import (
 	tx "github.com/ChainSafe/gossamer/common/transaction"
 	"github.com/ChainSafe/gossamer/core/types"
 	"github.com/ChainSafe/gossamer/keystore"
-	"github.com/ChainSafe/gossamer/p2p"
 	"github.com/ChainSafe/gossamer/runtime"
 )
 
 // Session contains the VRF keys for the validator
 type Session struct {
-	keystore *keystore.Keystore
-	rt       *runtime.Runtime
-
-	config *BabeConfiguration
-
+	keystore       *keystore.Keystore
+	rt             *runtime.Runtime
+	config         *BabeConfiguration
 	authorityIndex uint64
 	authorityData  []AuthorityData
-
 	epochThreshold *big.Int // validator threshold for this epoch
 	txQueue        *tx.PriorityQueue
-	isProducer     map[uint64]bool // whether we are a block producer at a slot
-
-	// Block announce channel used every time a block is created
-	blockAnnounce chan<- p2p.Message
+	isProducer     map[uint64]bool    // whether we are a block producer at a slot
+	blockSend      chan<- types.Block // send blocks to core service
 }
 
 type SessionConfig struct {
-	Keystore             *keystore.Keystore
-	Runtime              *runtime.Runtime
-	BlockAnnounceChannel chan<- p2p.Message
+	Keystore  *keystore.Keystore
+	Runtime   *runtime.Runtime
+	BlockSend chan<- types.Block
 }
 
 // NewSession returns a new Babe session using the provided VRF keys and runtime
 func NewSession(cfg *SessionConfig) (*Session, error) {
 	babeSession := &Session{
-		keystore:      cfg.Keystore,
-		rt:            cfg.Runtime,
-		txQueue:       new(tx.PriorityQueue),
-		isProducer:    make(map[uint64]bool),
-		blockAnnounce: cfg.BlockAnnounceChannel,
+		keystore:   cfg.Keystore,
+		rt:         cfg.Runtime,
+		txQueue:    new(tx.PriorityQueue),
+		isProducer: make(map[uint64]bool),
+		blockSend:  cfg.BlockSend,
 	}
 
 	err := babeSession.configurationFromRuntime()
@@ -109,16 +103,7 @@ func (b *Session) invokeBlockAuthoring() {
 			if err != nil {
 				return
 			}
-
-			// Broadcast the block
-			blockAnnounceMsg := &p2p.BlockAnnounceMessage{
-				ParentHash:     block.Header.ParentHash,
-				Number:         block.Header.Number,
-				StateRoot:      block.Header.StateRoot,
-				ExtrinsicsRoot: block.Header.ExtrinsicsRoot,
-				Digest:         block.Header.Digest,
-			}
-			b.blockAnnounce <- blockAnnounceMsg
+			b.blockSend <- *block
 		}
 
 		time.Sleep(time.Millisecond * time.Duration(b.config.SlotDuration))

--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -41,13 +41,13 @@ type Session struct {
 	epochThreshold *big.Int // validator threshold for this epoch
 	txQueue        *tx.PriorityQueue
 	isProducer     map[uint64]bool    // whether we are a block producer at a slot
-	blockSend      chan<- types.Block // send blocks to core service
+	newBlocks      chan<- types.Block // send blocks to core service
 }
 
 type SessionConfig struct {
 	Keystore  *keystore.Keystore
 	Runtime   *runtime.Runtime
-	BlockSend chan<- types.Block
+	NewBlocks chan<- types.Block
 }
 
 // NewSession returns a new Babe session using the provided VRF keys and runtime
@@ -57,7 +57,7 @@ func NewSession(cfg *SessionConfig) (*Session, error) {
 		rt:         cfg.Runtime,
 		txQueue:    new(tx.PriorityQueue),
 		isProducer: make(map[uint64]bool),
-		blockSend:  cfg.BlockSend,
+		newBlocks:  cfg.NewBlocks,
 	}
 
 	err := babeSession.configurationFromRuntime()
@@ -103,7 +103,7 @@ func (b *Session) invokeBlockAuthoring() {
 			if err != nil {
 				return
 			}
-			b.blockSend <- *block
+			b.newBlocks <- *block
 		}
 
 		time.Sleep(time.Millisecond * time.Duration(b.config.SlotDuration))

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/core/blocktree"
 	"github.com/ChainSafe/gossamer/core/types"
-	"github.com/ChainSafe/gossamer/p2p"
 	db "github.com/ChainSafe/gossamer/polkadb"
 	"github.com/ChainSafe/gossamer/runtime"
 	"github.com/ChainSafe/gossamer/trie"
@@ -410,11 +409,12 @@ func TestStart(t *testing.T) {
 
 func TestBabeAnnounceMessage(t *testing.T) {
 	rt := newRuntime(t)
-	blockAnnounceChan := make(chan p2p.Message)
+
+	blockSend := make(chan types.Block)
 
 	cfg := &SessionConfig{
-		Runtime:              rt,
-		BlockAnnounceChannel: blockAnnounceChan,
+		Runtime:   rt,
+		BlockSend: blockSend,
 	}
 
 	babesession, err := NewSession(cfg)
@@ -434,14 +434,10 @@ func TestBabeAnnounceMessage(t *testing.T) {
 	time.Sleep(time.Duration(babesession.config.SlotDuration) * time.Duration(babesession.config.EpochLength) * time.Millisecond)
 
 	for i := 0; i < int(babesession.config.EpochLength); i++ {
-		blk := <-blockAnnounceChan
-
-		expectedBlockAnnounceMsg := &p2p.BlockAnnounceMessage{
-			Number: big.NewInt(int64(i)),
-		}
-
-		if !reflect.DeepEqual(blk, expectedBlockAnnounceMsg) {
-			t.Fatalf("Didn't receive the correct block: %+v\nExpected block: %+v", blk, expectedBlockAnnounceMsg)
+		block := <-blockSend
+		blockNumber := big.NewInt(int64(i))
+		if !reflect.DeepEqual(block.Header.Number, blockNumber) {
+			t.Fatalf("Didn't receive the correct block: %+v\nExpected block: %+v", block.Header.Number, blockNumber)
 		}
 	}
 

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -410,11 +410,11 @@ func TestStart(t *testing.T) {
 func TestBabeAnnounceMessage(t *testing.T) {
 	rt := newRuntime(t)
 
-	blockSend := make(chan types.Block)
+	newBlocks := make(chan types.Block)
 
 	cfg := &SessionConfig{
 		Runtime:   rt,
-		BlockSend: blockSend,
+		NewBlocks: newBlocks,
 	}
 
 	babesession, err := NewSession(cfg)
@@ -434,7 +434,7 @@ func TestBabeAnnounceMessage(t *testing.T) {
 	time.Sleep(time.Duration(babesession.config.SlotDuration) * time.Duration(babesession.config.EpochLength) * time.Millisecond)
 
 	for i := 0; i < int(babesession.config.EpochLength); i++ {
-		block := <-blockSend
+		block := <-newBlocks
 		blockNumber := big.NewInt(int64(i))
 		if !reflect.DeepEqual(block.Header.Number, blockNumber) {
 			t.Fatalf("Didn't receive the correct block: %+v\nExpected block: %+v", block.Header.Number, blockNumber)

--- a/core/service.go
+++ b/core/service.go
@@ -80,10 +80,10 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 func (s *Service) Start() error {
 
 	// start receiving blocks from BABE session
-	go s.startReceivingBlocks()
+	go s.receiveBlocks()
 
 	// start receiving messages from p2p service
-	go s.startReceivingMessages()
+	go s.receiveMessages()
 
 	return nil
 }
@@ -109,8 +109,8 @@ func (s *Service) StorageRoot() (common.Hash, error) {
 	return s.rt.StorageRoot()
 }
 
-// startReceivingBlocks starts receiving blocks from the BABE session
-func (s *Service) startReceivingBlocks() {
+// receiveBlocks starts receiving blocks from the BABE session
+func (s *Service) receiveBlocks() {
 	for {
 		block, ok := <-s.bsRec
 		if !ok {
@@ -124,8 +124,8 @@ func (s *Service) startReceivingBlocks() {
 	}
 }
 
-// startReceivingMessages starts receiving messages from the p2p service
-func (s *Service) startReceivingMessages() {
+// receiveMessages starts receiving messages from the p2p service
+func (s *Service) receiveMessages() {
 	for {
 		msg, ok := <-s.p2pRec
 		if !ok {

--- a/core/service.go
+++ b/core/service.go
@@ -44,7 +44,7 @@ type Service struct {
 	msgSend chan<- p2p.Message // send messages to p2p service
 }
 
-type ServiceConfig struct {
+type Config struct {
 	Keystore *keystore.Keystore
 	Runtime  *runtime.Runtime
 	MsgRec   <-chan p2p.Message
@@ -53,7 +53,7 @@ type ServiceConfig struct {
 
 // NewService returns a new core service that connects the runtime, BABE
 // session, and p2p service.
-func NewService(cfg *ServiceConfig, newBlocks chan types.Block) (*Service, error) {
+func NewService(cfg *Config, newBlocks chan types.Block) (*Service, error) {
 
 	// BABE session configuration
 	bsConfig := &babe.SessionConfig{

--- a/core/service.go
+++ b/core/service.go
@@ -47,9 +47,9 @@ type Service struct {
 type ServiceConfig struct {
 	Keystore *keystore.Keystore
 	Runtime  *runtime.Runtime
-	BsChan   chan types.Block   // send and receive blocks from BABE session
-	P2pRec   <-chan p2p.Message // receive messages from p2p service
-	P2pSend  chan<- p2p.Message // send messages to p2p service
+	BsChan   chan types.Block // send and receive blocks between core service and BABE session
+	P2pRec   <-chan p2p.Message
+	P2pSend  chan<- p2p.Message
 }
 
 // NewService returns a new core service that connects the runtime, BABE

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -17,8 +17,8 @@
 package core
 
 import (
-	"bytes"
 	"io"
+	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	tx "github.com/ChainSafe/gossamer/common/transaction"
+	"github.com/ChainSafe/gossamer/common/transaction"
 	"github.com/ChainSafe/gossamer/core/types"
 	"github.com/ChainSafe/gossamer/p2p"
 	"github.com/ChainSafe/gossamer/runtime"
@@ -36,7 +36,10 @@ import (
 const POLKADOT_RUNTIME_FP string = "../substrate_test_runtime.compact.wasm"
 const POLKADOT_RUNTIME_URL string = "https://github.com/noot/substrate/blob/add-blob/core/test-runtime/wasm/wasm32-unknown-unknown/release/wbuild/substrate-test-runtime/substrate_test_runtime.compact.wasm?raw=true"
 
-// getRuntimeBlob checks if the polkadot runtime wasm file exists and if not, it fetches it from github
+var TestMessageTimeout = 2 * time.Second
+
+// getRuntimeBlob checks if the polkadot runtime wasm file exists and then it
+// will fetch the file from github if the file does not exist.
 func getRuntimeBlob() (n int64, err error) {
 	if Exists(POLKADOT_RUNTIME_FP) {
 		return 0, nil
@@ -71,12 +74,12 @@ func Exists(name string) bool {
 func newRuntime(t *testing.T) *runtime.Runtime {
 	_, err := getRuntimeBlob()
 	if err != nil {
-		t.Fatalf("Fail: could not get polkadot runtime")
+		t.Fatal("Failed to get runtime blob")
 	}
 
 	fp, err := filepath.Abs(POLKADOT_RUNTIME_FP)
 	if err != nil {
-		t.Fatal("could not create filepath")
+		t.Fatal("Failed to create runtime filepath")
 	}
 
 	tt := &trie.Trie{}
@@ -85,27 +88,49 @@ func newRuntime(t *testing.T) *runtime.Runtime {
 	if err != nil {
 		t.Fatal(err)
 	} else if r == nil {
-		t.Fatal("did not create new VM")
+		t.Fatal("Failed to create new runtime from file")
 	}
 
 	return r
 }
 
-func TestNewService_Start(t *testing.T) {
+func TestStartService(t *testing.T) {
 	rt := newRuntime(t)
-	msgSend := make(chan p2p.Message)
 
 	cfg := &ServiceConfig{
 		Runtime: rt,
-		MsgSend: msgSend,
 	}
 
-	mgr, err := NewService(cfg)
+	s, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = mgr.Start()
+	err = s.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.Stop()
+}
+
+func TestValidateBlock(t *testing.T) {
+	rt := newRuntime(t)
+
+	cfg := &ServiceConfig{
+		Runtime: rt,
+	}
+
+	s, err := NewService(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/test-runtime/src/system.rs#L371
+	data := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 179, 38, 109, 225, 55, 210, 10, 93, 15, 243, 166, 64, 30, 181, 113, 39, 82, 95, 217, 178, 105, 55, 1, 240, 191, 90, 138, 133, 63, 163, 235, 224, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
+
+	err = s.validateBlock(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,171 +138,193 @@ func TestNewService_Start(t *testing.T) {
 
 func TestValidateTransaction(t *testing.T) {
 	rt := newRuntime(t)
-	msgSend := make(chan p2p.Message)
 
 	cfg := &ServiceConfig{
 		Runtime: rt,
-		MsgSend: msgSend,
 	}
 
-	mgr, err := NewService(cfg)
+	s, err := NewService(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
+	tx := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
+
+	validity, err := s.validateTransaction(tx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// from https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
-	// added:
-	// let utx = Transfer {
-	//  from: AccountKeyring::Alice.into(),
-	//  to: AccountKeyring::Bob.into(),
-	//  amount: 69,
-	//  nonce: 0,
-	// }.into_signed_tx();
-	// println!("extrinsic: {:?}", &utx.encode());
-	// at line 377
-
-	ext := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
-
-	validity, err := mgr.validateTransaction(ext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// see: https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L190
-	expected := &tx.Validity{
+	// https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L190
+	expected := &transaction.Validity{
 		Priority: 69,
 		Requires: [][]byte{{}},
-		// Provides is the twox128 hash of nonce and from: see https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L173
+		// https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L173
 		Provides:  [][]byte{{146, 157, 61, 99, 63, 98, 30, 242, 128, 49, 150, 90, 140, 165, 187, 249}},
 		Longevity: 64,
 		Propagate: true,
 	}
 
 	if !reflect.DeepEqual(expected, validity) {
-		t.Fatalf("Fail: got %v expected %v", validity, expected)
+		t.Error(
+			"received unexpected validity",
+			"\nexpected:", expected,
+			"\nreceived:", validity,
+		)
 	}
 }
 
-func TestProcessTransaction(t *testing.T) {
+func TestAnnounceBlock(t *testing.T) {
 	rt := newRuntime(t)
-	msgSend := make(chan p2p.Message)
+
+	bsChan := make(chan types.Block)
+	p2pSend := make(chan p2p.Message)
 
 	cfg := &ServiceConfig{
 		Runtime: rt,
-		MsgSend: msgSend,
+		BsChan:  bsChan,
+		P2pSend: p2pSend,
 	}
 
-	mgr, err := NewService(cfg)
+	s, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ext := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
-
-	msg := &p2p.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
-
-	err = mgr.ProcessTransactionMessage(msg)
+	err = s.Start()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Stop()
 
-	// check if in babe tx queue
-	tx := mgr.b.PeekFromTxQueue()
-	if !bytes.Equal([]byte(*tx.Extrinsic), ext) {
-		t.Fatalf("Fail: got %x expected %x", tx.Extrinsic, ext)
+	// simulate block sent from BABE session
+	bsChan <- types.Block{}
+
+	select {
+	case msg := <-p2pSend:
+		msgType := msg.GetType()
+		if !reflect.DeepEqual(msgType, p2p.BlockAnnounceMsgType) {
+			t.Error(
+				"received unexpected message type",
+				"\nexpected:", p2p.BlockAnnounceMsgType,
+				"\nreceived:", msgType,
+			)
+		}
+	case <-time.After(TestMessageTimeout):
+		t.Error("timeout waiting for message")
 	}
 }
 
-func TestValidateBlock(t *testing.T) {
+func TestProcessBlockAnnounceMessage(t *testing.T) {
 	rt := newRuntime(t)
-	msgSend := make(chan p2p.Message)
+
+	p2pRec := make(chan p2p.Message)
+	p2pSend := make(chan p2p.Message)
 
 	cfg := &ServiceConfig{
 		Runtime: rt,
-		MsgSend: msgSend,
+		P2pRec:  p2pRec,
+		P2pSend: p2pSend,
 	}
 
-	mgr, err := NewService(cfg)
+	s, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// from https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/test-runtime/src/system.rs#L371
+
+	err = s.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	blockAnnounce := &p2p.BlockAnnounceMessage{
+		Number: big.NewInt(1),
+	}
+
+	// simulate block sent from p2p service
+	p2pRec <- blockAnnounce
+
+	select {
+	case msg := <-p2pSend:
+		msgType := msg.GetType()
+		if msgType != p2p.BlockRequestMsgType {
+			t.Error(
+				"received unexpected message type",
+				"\nexpected:", p2p.BlockRequestMsgType,
+				"\nreceived:", msgType,
+			)
+		}
+	case <-time.After(TestMessageTimeout):
+		t.Error("timeout waiting for message")
+	}
+}
+
+func TestProcessBlockResponseMessage(t *testing.T) {
+	rt := newRuntime(t)
+
+	cfg := &ServiceConfig{
+		Runtime: rt,
+	}
+
+	s, err := NewService(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Stop()
+
+	// wait for service to start
+	time.Sleep(time.Second)
+
+	// https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/test-runtime/src/system.rs#L371
 	data := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 179, 38, 109, 225, 55, 210, 10, 93, 15, 243, 166, 64, 30, 181, 113, 39, 82, 95, 217, 178, 105, 55, 1, 240, 191, 90, 138, 133, 63, 163, 235, 224, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
 
-	err = mgr.validateBlock(data)
+	blockResponse := &p2p.BlockResponseMessage{Data: data}
+
+	err = s.ProcessBlockResponseMessage(blockResponse)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
-func TestHandleMsg_Transaction(t *testing.T) {
+func TestProcessTransactionMessage(t *testing.T) {
 	rt := newRuntime(t)
-	msgSend := make(chan p2p.Message)
 
 	cfg := &ServiceConfig{
 		Runtime: rt,
-		MsgRec:  msgSend,
 	}
 
-	mgr, err := NewService(cfg)
+	s, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer s.Stop()
 
-	err = mgr.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// wait for mgr to start
-	time.Sleep(time.Second)
-
+	// https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
 	ext := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
+
 	msg := &p2p.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
-	msgSend <- msg
 
-	// wait for message to be handled
-	time.Sleep(time.Second)
-
-	// check if in babe tx queue
-	tx := mgr.b.PeekFromTxQueue()
-	if tx == nil {
-		t.Fatalf("Fail: got nil expected %x", ext)
-	} else if !bytes.Equal([]byte(*tx.Extrinsic), ext) {
-		t.Fatalf("Fail: got %x expected %x", tx.Extrinsic, ext)
-	}
-}
-
-func TestHandleMsg_BlockResponse(t *testing.T) {
-	rt := newRuntime(t)
-	msgSend := make(chan p2p.Message)
-
-	cfg := &ServiceConfig{
-		Runtime: rt,
-		MsgRec:  msgSend,
-	}
-
-	mgr, err := NewService(cfg)
+	err = s.ProcessTransactionMessage(msg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	e := make(chan error)
-	go mgr.start(e)
-	if err := <-e; err != nil {
-		t.Fatal(err)
-	}
+	bsTx := s.bs.PeekFromTxQueue()
+	bsTxExt := []byte(*bsTx.Extrinsic)
 
-	// wait for mgr to start
-	time.Sleep(time.Second)
-
-	block := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 179, 38, 109, 225, 55, 210, 10, 93, 15, 243, 166, 64, 30, 181, 113, 39, 82, 95, 217, 178, 105, 55, 1, 240, 191, 90, 138, 133, 63, 163, 235, 224, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
-	msg := &p2p.BlockResponseMessage{Data: block}
-	msgSend <- msg
-
-	// wait for message to be handled
-	time.Sleep(time.Second)
-	if err := <-e; err != nil {
-		t.Fatal(err)
+	if !reflect.DeepEqual(ext, bsTxExt) {
+		t.Error(
+			"received unexpected transaction extrinsic",
+			"\nexpected:", ext,
+			"\nreceived:", bsTxExt,
+		)
 	}
 }

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -97,7 +97,7 @@ func newRuntime(t *testing.T) *runtime.Runtime {
 func TestStartService(t *testing.T) {
 	rt := newRuntime(t)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 	}
 
@@ -117,7 +117,7 @@ func TestStartService(t *testing.T) {
 func TestValidateBlock(t *testing.T) {
 	rt := newRuntime(t)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 	}
 
@@ -140,7 +140,7 @@ func TestValidateBlock(t *testing.T) {
 func TestValidateTransaction(t *testing.T) {
 	rt := newRuntime(t)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 	}
 
@@ -183,7 +183,7 @@ func TestAnnounceBlock(t *testing.T) {
 	blkRec := make(chan types.Block)
 	msgSend := make(chan p2p.Message)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 		MsgSend: msgSend, // message channel from core service to p2p service
 	}
@@ -223,7 +223,7 @@ func TestProcessBlockAnnounceMessage(t *testing.T) {
 	msgRec := make(chan p2p.Message)
 	msgSend := make(chan p2p.Message)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 		MsgRec:  msgRec,
 		MsgSend: msgSend,
@@ -265,7 +265,7 @@ func TestProcessBlockAnnounceMessage(t *testing.T) {
 func TestProcessBlockResponseMessage(t *testing.T) {
 	rt := newRuntime(t)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 	}
 
@@ -294,7 +294,7 @@ func TestProcessBlockResponseMessage(t *testing.T) {
 func TestProcessTransactionMessage(t *testing.T) {
 	rt := newRuntime(t)
 
-	cfg := &ServiceConfig{
+	cfg := &Config{
 		Runtime: rt,
 	}
 

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-var TestMessageTimeout = 10 * time.Second
+var TestMessageTimeout = 30 * time.Second
 
 func startNewService(t *testing.T, cfg *Config, msgSend chan Message, msgRec chan Message) *Service {
 	node, err := NewService(cfg, msgSend, msgRec)


### PR DESCRIPTION
### Changes

This pull request adds functionality to announce blocks from the BABE session and to process block announce messages from the p2p service.

We needed to create a new channel in order to send messages to the p2p service, which means we had to rename the channels.

## Tests:
```
go test ./core -v
```

### Issues:
closes #346