### PR TITLE
cmd, core, consensus/babe: add configs for core.Service, babe.Session, add keystore

### DIFF
--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -91,7 +91,14 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	srvcs = append(srvcs, p2pSrvc)
 
 	// core.Service
-	coreSrvc, err := core.NewService(r, msgSend, msgRec)
+	coreCfg := &core.ServiceConfig{
+		Keystore: ks,
+		Runtime:  r,
+		MsgRec:   msgRec,
+		MsgSend:  msgSend,
+	}
+
+	coreSrvc, err := core.NewService(coreCfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -40,9 +40,7 @@ type Session struct {
 	config *BabeConfiguration
 
 	authorityIndex uint64
-
-	// authorities []VrfPublicKey
-	authorityWeights []uint64
+	authorityData  []AuthorityData
 
 	epochThreshold *big.Int // validator threshold for this epoch
 	txQueue        *tx.PriorityQueue
@@ -156,12 +154,20 @@ func (b *Session) setEpochThreshold() error {
 		return errors.New("cannot set threshold: no babe config")
 	}
 
-	b.epochThreshold, err = calculateThreshold(b.config.C1, b.config.C2, b.authorityIndex, b.authorityWeights)
+	b.epochThreshold, err = calculateThreshold(b.config.C1, b.config.C2, b.authorityIndex, b.authorityWeights())
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (b *Session) authorityWeights() []uint64 {
+	weights := make([]uint64, len(b.authorityData))
+	for i, auth := range b.authorityData {
+		weights[i] = auth.weight
+	}
+	return weights
 }
 
 // calculates the slot lottery threshold for the authority at authorityIndex.

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -164,10 +164,16 @@ func TestCalculateThreshold_AuthorityWeights(t *testing.T) {
 
 func TestRunLottery(t *testing.T) {
 	rt := newRuntime(t)
-	babesession, err := NewSession([32]byte{}, [64]byte{}, rt, nil)
+
+	cfg := &SessionConfig{
+		Runtime: rt,
+	}
+
+	babesession, err := NewSession(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	babesession.authorityIndex = 0
 	babesession.authorityWeights = []uint64{1, 1, 1}
 	conf := &BabeConfiguration{
@@ -201,10 +207,15 @@ func TestCalculateThreshold_Failing(t *testing.T) {
 
 func TestConfigurationFromRuntime(t *testing.T) {
 	rt := newRuntime(t)
-	babesession, err := NewSession([32]byte{}, [64]byte{}, rt, nil)
+	cfg := &SessionConfig{
+		Runtime: rt,
+	}
+
+	babesession, err := NewSession(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	err = babesession.configurationFromRuntime()
 	if err != nil {
 		t.Fatal(err)
@@ -337,10 +348,15 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 func TestSlotTime(t *testing.T) {
 	rt := newRuntime(t)
 	bt := createFlatBlockTree(t, 100)
-	babesession, err := NewSession([32]byte{}, [64]byte{}, rt, nil)
+	cfg := &SessionConfig{
+		Runtime: rt,
+	}
+
+	babesession, err := NewSession(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	err = babesession.configurationFromRuntime()
 	if err != nil {
 		t.Fatal(err)
@@ -361,10 +377,15 @@ func TestSlotTime(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	rt := newRuntime(t)
-	babesession, err := NewSession([32]byte{}, [64]byte{}, rt, nil)
+	cfg := &SessionConfig{
+		Runtime: rt,
+	}
+
+	babesession, err := NewSession(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	babesession.authorityIndex = 0
 	babesession.authorityWeights = []uint64{1}
 	conf := &BabeConfiguration{
@@ -387,13 +408,18 @@ func TestStart(t *testing.T) {
 
 func TestBabeAnnounceMessage(t *testing.T) {
 	rt := newRuntime(t)
-
-	// Block Announce Channel called when Build-Block Creates a block
 	blockAnnounceChan := make(chan p2p.Message)
-	babesession, err := NewSession([32]byte{}, [64]byte{}, rt, blockAnnounceChan)
+
+	cfg := &SessionConfig{
+		Runtime:              rt,
+		BlockAnnounceChannel: blockAnnounceChan,
+	}
+
+	babesession, err := NewSession(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	babesession.authorityIndex = 0
 	babesession.authorityWeights = []uint64{1, 1, 1}
 

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -175,13 +175,15 @@ func TestRunLottery(t *testing.T) {
 	}
 
 	babesession.authorityIndex = 0
-	babesession.authorityWeights = []uint64{1, 1, 1}
+	babesession.authorityData = []AuthorityData{
+		{nil, 1}, {nil, 1}, {nil, 1},
+	}
 	conf := &BabeConfiguration{
 		SlotDuration:       1000,
 		EpochLength:        6,
 		C1:                 3,
 		C2:                 10,
-		GenesisAuthorities: []AuthorityData{},
+		GenesisAuthorities: []AuthorityDataRaw{},
 		Randomness:         0,
 		SecondarySlots:     false,
 	}
@@ -227,7 +229,7 @@ func TestConfigurationFromRuntime(t *testing.T) {
 		EpochLength:        6,
 		C1:                 3,
 		C2:                 10,
-		GenesisAuthorities: []AuthorityData{},
+		GenesisAuthorities: []AuthorityDataRaw{},
 		Randomness:         0,
 		SecondarySlots:     false,
 	}
@@ -387,13 +389,13 @@ func TestStart(t *testing.T) {
 	}
 
 	babesession.authorityIndex = 0
-	babesession.authorityWeights = []uint64{1}
+	babesession.authorityData = []AuthorityData{{nil, 1}}
 	conf := &BabeConfiguration{
 		SlotDuration:       1,
 		EpochLength:        6,
 		C1:                 1,
 		C2:                 10,
-		GenesisAuthorities: []AuthorityData{},
+		GenesisAuthorities: []AuthorityDataRaw{},
 		Randomness:         0,
 		SecondarySlots:     false,
 	}
@@ -421,7 +423,9 @@ func TestBabeAnnounceMessage(t *testing.T) {
 	}
 
 	babesession.authorityIndex = 0
-	babesession.authorityWeights = []uint64{1, 1, 1}
+	babesession.authorityData = []AuthorityData{
+		{nil, 1}, {nil, 1}, {nil, 1},
+	}
 
 	err = babesession.Start()
 	if err != nil {

--- a/consensus/babe/runtime.go
+++ b/consensus/babe/runtime.go
@@ -29,7 +29,6 @@ func (b *Session) configurationFromRuntime() error {
 	}
 
 	bc := new(BabeConfiguration)
-	//bc.GenesisAuthorities = []AuthorityData{}
 	_, err = scale.Decode(ret, bc)
 	if err != nil {
 		return err

--- a/consensus/babe/runtime.go
+++ b/consensus/babe/runtime.go
@@ -29,9 +29,8 @@ func (b *Session) configurationFromRuntime() error {
 	}
 
 	bc := new(BabeConfiguration)
-	bc.GenesisAuthorities = []AuthorityData{}
+	//bc.GenesisAuthorities = []AuthorityData{}
 	_, err = scale.Decode(ret, bc)
-
 	if err != nil {
 		return err
 	}

--- a/consensus/babe/types.go
+++ b/consensus/babe/types.go
@@ -16,6 +16,10 @@
 
 package babe
 
+import (
+	"github.com/ChainSafe/gossamer/crypto"
+)
+
 // TODO: change to Schnorrkel keys
 type VrfPublicKey [32]byte
 type VrfPrivateKey [64]byte
@@ -27,13 +31,17 @@ type BabeConfiguration struct {
 	EpochLength        uint64 // duration of epoch in slots
 	C1                 uint64 // (1-(c1/c2)) is the probability of a slot being empty
 	C2                 uint64
-	GenesisAuthorities []AuthorityData
+	GenesisAuthorities []AuthorityDataRaw
 	Randomness         byte
 	SecondarySlots     bool
 }
 
+type AuthorityDataRaw struct {
+	id     [32]byte
+	weight uint64
+}
+
 type AuthorityData struct {
-	// TODO: change to Schnorrkel public key
-	AuthorityId     [32]byte
-	AuthorityWeight uint64
+	id     *crypto.Sr25519PublicKey
+	weight uint64
 }

--- a/consensus/babe/types.go
+++ b/consensus/babe/types.go
@@ -37,10 +37,11 @@ type BabeConfiguration struct {
 }
 
 type AuthorityDataRaw struct {
-	id     [32]byte
-	weight uint64
+	Id     [32]byte
+	Weight uint64
 }
 
+//nolint:structcheck
 type AuthorityData struct {
 	id     *crypto.Sr25519PublicKey
 	weight uint64

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -93,10 +93,14 @@ func newRuntime(t *testing.T) *runtime.Runtime {
 
 func TestNewService_Start(t *testing.T) {
 	rt := newRuntime(t)
-
 	msgSend := make(chan p2p.Message)
 
-	mgr, err := NewService(rt, msgSend, nil)
+	cfg := &ServiceConfig{
+		Runtime: rt,
+		MsgSend: msgSend,
+	}
+
+	mgr, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,10 +113,14 @@ func TestNewService_Start(t *testing.T) {
 
 func TestValidateTransaction(t *testing.T) {
 	rt := newRuntime(t)
-
 	msgSend := make(chan p2p.Message)
 
-	mgr, err := NewService(rt, msgSend, nil)
+	cfg := &ServiceConfig{
+		Runtime: rt,
+		MsgSend: msgSend,
+	}
+
+	mgr, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,10 +160,14 @@ func TestValidateTransaction(t *testing.T) {
 
 func TestProcessTransaction(t *testing.T) {
 	rt := newRuntime(t)
-
 	msgSend := make(chan p2p.Message)
 
-	mgr, err := NewService(rt, msgSend, nil)
+	cfg := &ServiceConfig{
+		Runtime: rt,
+		MsgSend: msgSend,
+	}
+
+	mgr, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,10 +190,14 @@ func TestProcessTransaction(t *testing.T) {
 
 func TestValidateBlock(t *testing.T) {
 	rt := newRuntime(t)
-
 	msgSend := make(chan p2p.Message)
 
-	mgr, err := NewService(rt, msgSend, nil)
+	cfg := &ServiceConfig{
+		Runtime: rt,
+		MsgSend: msgSend,
+	}
+
+	mgr, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,10 +212,14 @@ func TestValidateBlock(t *testing.T) {
 
 func TestHandleMsg_Transaction(t *testing.T) {
 	rt := newRuntime(t)
-
 	msgSend := make(chan p2p.Message)
 
-	mgr, err := NewService(rt, msgSend, nil)
+	cfg := &ServiceConfig{
+		Runtime: rt,
+		MsgRec:  msgSend,
+	}
+
+	mgr, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,9 +233,7 @@ func TestHandleMsg_Transaction(t *testing.T) {
 	time.Sleep(time.Second)
 
 	ext := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
-
 	msg := &p2p.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
-
 	msgSend <- msg
 
 	// wait for message to be handled
@@ -232,18 +250,20 @@ func TestHandleMsg_Transaction(t *testing.T) {
 
 func TestHandleMsg_BlockResponse(t *testing.T) {
 	rt := newRuntime(t)
-
 	msgSend := make(chan p2p.Message)
 
-	mgr, err := NewService(rt, msgSend, nil)
+	cfg := &ServiceConfig{
+		Runtime: rt,
+		MsgRec:  msgSend,
+	}
+
+	mgr, err := NewService(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	e := make(chan error)
-
-	go mgr.start(e)
-	if err := <-e; err != nil {
+	err = mgr.Start()
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -251,14 +271,12 @@ func TestHandleMsg_BlockResponse(t *testing.T) {
 	time.Sleep(time.Second)
 
 	block := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 179, 38, 109, 225, 55, 210, 10, 93, 15, 243, 166, 64, 30, 181, 113, 39, 82, 95, 217, 178, 105, 55, 1, 240, 191, 90, 138, 133, 63, 163, 235, 224, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
-
 	msg := &p2p.BlockResponseMessage{Data: block}
-
 	msgSend <- msg
 
-	// wait for message to be handled
-	time.Sleep(time.Second)
-	if err := <-e; err != nil {
-		t.Fatal(err)
-	}
+	//wait for message to be handled
+	// time.Sleep(time.Second)
+	// if err := <-e; err != nil {
+	// 	t.Fatal(err)
+	// }
 }

--- a/core/service_test.go
+++ b/core/service_test.go
@@ -262,8 +262,9 @@ func TestHandleMsg_BlockResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = mgr.Start()
-	if err != nil {
+	e := make(chan error)
+	go mgr.start(e)
+	if err := <-e; err != nil {
 		t.Fatal(err)
 	}
 
@@ -274,9 +275,9 @@ func TestHandleMsg_BlockResponse(t *testing.T) {
 	msg := &p2p.BlockResponseMessage{Data: block}
 	msgSend <- msg
 
-	//wait for message to be handled
-	// time.Sleep(time.Second)
-	// if err := <-e; err != nil {
-	// 	t.Fatal(err)
-	// }
+	// wait for message to be handled
+	time.Sleep(time.Second)
+	if err := <-e; err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Changes
- cleanup core and babe a bit, have their constructors take a config struct instead of a bunch of params. will make it easier to update config options in the future, rather than having to update function args everywhere
- add keystore to core/babe
- replace babe key stubs with key types

## Tests:
```
go test ./...
```