### PR TITLE
runtime: scale encode key values in enumerated_trie_root

### DIFF
--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -60,8 +60,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
 	"sync"
 	"unsafe"
+
+	"github.com/ChainSafe/gossamer/codec"
 
 	common "github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/crypto"
@@ -377,10 +380,16 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 		valueLenBytes := memory[lensData+i*4 : lensData+(i+1)*4]
 		valueLen := int32(binary.LittleEndian.Uint32(valueLenBytes))
 		value := memory[valuesData+pos : valuesData+pos+valueLen]
-		log.Trace("[ext_blake2_256_enumerated_trie_root]", "key", i, "value", fmt.Sprintf("%x", value), "valueLen", valueLen)
+		log.Trace("[ext_blake2_256_enumerated_trie_root]", "key", i, "value", fmt.Sprintf("%d", value), "valueLen", valueLen)
 		pos += valueLen
 
-		err := t.Put([]byte{byte(i)}, value)
+		// encode the key
+		buffer := bytes.Buffer{}
+		scaleEncoder := codec.Encoder{&buffer}
+		scaleEncoder.Encode(big.NewInt(int64(i)))
+		encodedOutput := buffer.Bytes()
+		log.Trace("[ext_blake2_256_enumerated_trie_root]", "key", i, "key value", encodedOutput)
+		err := t.Put(encodedOutput, value)
 		if err != nil {
 			log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)
 			return
@@ -388,11 +397,11 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 	}
 
 	root, err := t.Hash()
+	log.Trace("[ext_blake2_256_enumerated_trie_root]", "root hash", fmt.Sprintf("0x%x", root))
 	if err != nil {
 		log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)
 		return
 	}
-
 	copy(memory[result:result+32], root[:])
 }
 

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -385,11 +385,15 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 
 		// encode the key
 		buffer := bytes.Buffer{}
-		scaleEncoder := codec.Encoder{&buffer}
-		scaleEncoder.Encode(big.NewInt(int64(i)))
+		scaleEncoder := codec.Encoder{Writer: &buffer}
+		_, err := scaleEncoder.Encode(big.NewInt(int64(i)))
+		if err != nil {
+			log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)
+			return
+		}
 		encodedOutput := buffer.Bytes()
 		log.Trace("[ext_blake2_256_enumerated_trie_root]", "key", i, "key value", encodedOutput)
-		err := t.Put(encodedOutput, value)
+		err = t.Put(encodedOutput, value)
 		if err != nil {
 			log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)
 			return

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -384,14 +384,11 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 		pos += valueLen
 
 		// encode the key
-		buffer := bytes.Buffer{}
-		scaleEncoder := codec.Encoder{Writer: &buffer}
-		_, err := scaleEncoder.Encode(big.NewInt(int64(i)))
+		encodedOutput, err := codec.Encode(big.NewInt(int64(i)))
 		if err != nil {
 			log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)
 			return
 		}
-		encodedOutput := buffer.Bytes()
 		log.Trace("[ext_blake2_256_enumerated_trie_root]", "key", i, "key value", encodedOutput)
 		err = t.Put(encodedOutput, value)
 		if err != nil {

--- a/runtime/wasmer_test.go
+++ b/runtime/wasmer_test.go
@@ -664,15 +664,11 @@ func TestExt_blake2_256_enumerated_trie_root(t *testing.T) {
 	lensArray := []byte{}
 
 	for _, test := range tests {
-		buffer := bytes.Buffer{}
-		scaleEncoder := codec.Encoder{Writer: &buffer}
-		keyBigInt := new(big.Int)
-		keyBigInt.SetBytes(test.key)
-		_, err = scaleEncoder.Encode(keyBigInt)
+		keyBigInt := new(big.Int).SetBytes(test.key)
+		encodedKey, err := codec.Encode(keyBigInt)
 		if err != nil {
 			t.Fatal(err)
 		}
-		encodedKey := buffer.Bytes()
 		e := expectedTrie.Put(encodedKey, test.value)
 		if e != nil {
 			t.Fatal(e)

--- a/runtime/wasmer_test.go
+++ b/runtime/wasmer_test.go
@@ -666,9 +666,9 @@ func TestExt_blake2_256_enumerated_trie_root(t *testing.T) {
 
 	for _, test := range tests {
 		keyBigInt := new(big.Int).SetBytes(test.key)
-		encodedKey, err := codec.Encode(keyBigInt)
-		if err != nil {
-			t.Fatal(err)
+		encodedKey, err2 := codec.Encode(keyBigInt)
+		if err2 != nil {
+			t.Fatal(err2)
 		}
 		e := expectedTrie.Put(encodedKey, test.value)
 		if e != nil {

--- a/runtime/wasmer_test.go
+++ b/runtime/wasmer_test.go
@@ -665,7 +665,7 @@ func TestExt_blake2_256_enumerated_trie_root(t *testing.T) {
 
 	for _, test := range tests {
 		buffer := bytes.Buffer{}
-		scaleEncoder := codec.Encoder{&buffer}
+		scaleEncoder := codec.Encoder{Writer: &buffer}
 		keyBigInt := new(big.Int)
 		keyBigInt.SetBytes(test.key)
 		_, err = scaleEncoder.Encode(keyBigInt)


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Added scale encoding to key values (index values) in
ext_blake2_256_enumerated_trie_root so that root hash matches expected
values. (test values from rust code
https://github.com/paritytech/substrate/blob/6e242a5a9fcc5d5ea34386864ec064a01677efff/client/executor/src/integration_tests/mod.rs#L419)

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
cd runtime/
go test -v -run TestExt_blake2_256_enumerated_trie_root
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues:
closes #379 