### PR TITLE
refactor(runtime): Update wasmer & remove Registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/urfave/cli v1.20.0
-	github.com/wasmerio/go-ext-wasm v0.0.0-20190716093451-605a12aad995
+	github.com/wasmerio/go-ext-wasm v0.0.0-20191206132826-225d01fcd22c
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20190916140828-c8589233b77d // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,7 @@ github.com/libp2p/go-yamux v1.2.2/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZ
 github.com/libp2p/go-yamux v1.2.3 h1:xX8A36vpXb59frIzWFdEgptLMsOANMFq2K7fPRlunYI=
 github.com/libp2p/go-yamux v1.2.3/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -338,6 +339,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/smola/gocompat v0.2.0 h1:6b1oIMlUXIpz//VKEDzPVBK8KG7beVwmHIUEBIs/Pns=
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
 github.com/spacemonkeygo/openssl v0.0.0-20181017203307-c2dcc5cca94a/go.mod h1:7AyxJNCJ7SBZ1MfVQCWD6Uqo2oubI2Eq2y2eqf+A5r0=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
@@ -361,8 +363,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190716093451-605a12aad995 h1:hH06i5qSlTVs6oVdC3oBUFa5PsNnZM1VkDAz0xvuZxo=
-github.com/wasmerio/go-ext-wasm v0.0.0-20190716093451-605a12aad995/go.mod h1:B0C/D0a2vNos7Y3IxQhMpGOY9PCuCKfLvfry33a1cKA=
+github.com/wasmerio/go-ext-wasm v0.0.0-20191206132826-225d01fcd22c h1:iJG6MdQ3UPiZTMlGI6+dVw3XJXKecjacOZTRajrTEXA=
+github.com/wasmerio/go-ext-wasm v0.0.0-20191206132826-225d01fcd22c/go.mod h1:B0C/D0a2vNos7Y3IxQhMpGOY9PCuCKfLvfry33a1cKA=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc h1:BCPnHtcboadS0DvysUuJXZ4lWVv5Bh5i7+tbIyi+ck4=
 github.com/whyrusleeping/base32 v0.0.0-20170828182744-c30ac30633cc/go.mod h1:r45hJU7yEoA81k6MWNhpMj/kms0n14dkzkxYHoB96UM=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
@@ -439,6 +441,7 @@ golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181130052023-1c3d964395ce/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=

--- a/runtime/allocator/allocator_test.go
+++ b/runtime/allocator/allocator_test.go
@@ -311,7 +311,7 @@ func NewWasmMemory() (*wasm.Memory, error) {
 		return nil, err
 	}
 
-	return &instance.Memory, nil
+	return instance.Memory, nil
 }
 
 // iterates allTests and runs tests on them based on data contained in


### PR DESCRIPTION
The latest version of github.com/wasmerio/go-ext-wasm now includes the
InstanceContext.Data registry that was initially built into the runtime.

This commit removes the runtime's registry which simplifies the code.

## Changes
- Update `github.com/wasmerio/go-ext-wasm` to latest in `go.mod`, run `go mod tidy`
- Remove all references to the `registry` and `mutex`.
- Update usage of `InstanceContext.Data()` to use a type assertion on the returned interface.

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
The tests are failing but with the same errors as can be observed on the current development branch. These fails appear to just be related to some unimplemented host functions.
```
$ go test ./runtime/...
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000f280 allocator:0xc000162000 keystore:0xc00000f2a0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=16
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=32
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=8
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=8
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=16
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=40
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=24
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=24
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=24
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=64
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=40
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=40
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=40
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=112
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=64
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=64
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=72
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=208
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=104
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=104
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=136
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=400
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=176
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=176
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=264
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc000164b20 allocator:0xc000162080 keystore:0xc000164b40}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_get_storage_into] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_get_storage_into] executing..."
t=2019-12-06T12:42:09-0900 lvl=eror msg=[ext_get_storage_into] err="value is nil"
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc000164d00 allocator:0xc0000f0000 keystore:0xc000164d20}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_set_storage] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_set_storage] key="[58 110 111 111 116]" val="[1 3 3 7]"
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e420 allocator:0xc0000f0080 keystore:0xc00000e4a0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_storage_root] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e5c0 allocator:0xc0000f0180 keystore:0xc00000e5e0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_get_allocated_storage] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_get_allocated_storage] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e400 allocator:0xc0000f0200 keystore:0xc00000e4c0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_clear_storage] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e900 allocator:0xc0000f0000 keystore:0xc00000f140}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_clear_prefix] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e580 allocator:0xc0000f0080 keystore:0xc00000e5a0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_blake2_128] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000f2a0 allocator:0xc0000f0180 keystore:0xc00000f2c0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_blake2_256] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e2a0 allocator:0xc0000f0200 keystore:0xc00000e2c0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_ed25519_verify] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_ed25519_verify] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e5c0 allocator:0xc0000f0000 keystore:0xc00000e5e0}"
t=2019-12-06T12:42:09-0900 lvl=dbug msg="[ext_sr25519_verify] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg="[ext_sr25519_verify] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e4c0 allocator:0xc0000f0080 keystore:0xc00000e4e0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_blake2_256_enumerated_trie_root] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_blake2_256_enumerated_trie_root] key=0 value=70656e valueLen=3
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_blake2_256_enumerated_trie_root] key=1 value=70656e6775696e valueLen=7
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_blake2_256_enumerated_trie_root] key=2 value=66656174686572 valueLen=7
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_blake2_256_enumerated_trie_root] key=3 value=6e6f6f74 valueLen=4
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000f4e0 allocator:0xc0000f0180 keystore:0xc00000f500}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_twox_64] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_twox_64] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e3e0 allocator:0xc0000f0200 keystore:0xc00000e400}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_twox_128] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_twox_128] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000f140 allocator:0xc0000f0000 keystore:0xc00000f180}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_keccak_256] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e2c0 allocator:0xc0000f0080 keystore:0xc00000e2e0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=16
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e620 allocator:0xc0000f0180 keystore:0xc00000e8e0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_malloc] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=16
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_free] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[ext_free] addr=8
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] ptr=8
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Deallocate] heap total_size after Deallocate=0
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc000164260 allocator:0xc0000f0200 keystore:0xc000164280}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_secp256k1_ecdsa_recover] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc0001643a0 allocator:0xc0000f0000 keystore:0xc0001643c0}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_sr25519_generate] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=ext_sr25519_generate address=63KH1bkorFNdyVktuFAoVdCHWz7HChPB7BrzfJFQvsFLfGM
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc000164160 allocator:0xc0000f0080 keystore:0xc000164180}"
t=2019-12-06T12:42:09-0900 lvl=dbug msg="[ext_ed25519_generate] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=ext_ed25519_generate address=hSoW5169fzXkzMZjA69Y58v3KhJLhA2UVpFVtiYyuj15zX
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc0001643e0 allocator:0xc0000f0180 keystore:0xc000164400}"
--- FAIL: TestExt_ed25519_public_keys (0.00s)
    wasmer_test.go:1088: could not find exported function
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc000164560 allocator:0xc0000f0280 keystore:0xc000164580}"
t=2019-12-06T12:42:09-0900 lvl=trce msg="[ext_sr25519_public_keys] executing..."
t=2019-12-06T12:42:09-0900 lvl=trce msg=[Allocate] heap_size after allocation=520
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc000164be0 allocator:0xc0000f0000 keystore:0xc000164c00}"
--- FAIL: TestExt_ed25519_sign (0.00s)
    wasmer_test.go:1223: could not find exported function
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc0001641c0 allocator:0xc000162000 keystore:0xc000164300}"
t=2019-12-06T12:42:09-0900 lvl=dbug msg="[ext_sr25519_sign] executing..."
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e2e0 allocator:0xc000162100 keystore:0xc00000e3e0}"
--- FAIL: TestExt_get_child_storage_into (0.00s)
    wasmer_test.go:1326: could not find exported function
t=2019-12-06T12:42:09-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e420 allocator:0xc000162180 keystore:0xc00000e4a0}"
--- FAIL: TestExt_set_child_storage (0.00s)
    wasmer_test.go:1372: could not find exported function
t=2019-12-06T12:42:10-0900 lvl=dbug msg=[NewRuntime] runtimeCtx="{trie:0xc00000e5c0 allocator:0xc0000f0080 keystore:0xc00000e5e0}"
FAIL
FAIL	github.com/ChainSafe/gossamer/runtime	0.806s
ok  	github.com/ChainSafe/gossamer/runtime/allocator	(cached)
FAIL
```