### PR TITLE
api, p2p, rpc, state: network information

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -38,14 +38,14 @@ type Api struct {
 type Module string
 
 // NewApiService creates a new API instance.
-func NewApiService(p2p apiModule.P2pApi, rt apiModule.RuntimeApi) *Service {
+func NewApiService(p2pApi apiModule.P2pApi, runtimeApi apiModule.RuntimeApi) *Service {
 	return &Service{
 		&Api{
 			P2pModule: &apiModule.P2pModule{
-				P2p: p2p,
+				P2pApi: p2pApi,
 			},
 			RuntimeModule: &apiModule.RuntimeModule{
-				Rt: rt,
+				RuntimeApi: runtimeApi,
 			},
 		},
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -18,90 +18,107 @@ package api
 
 import (
 	"testing"
+
+	"github.com/ChainSafe/gossamer/common"
+	"github.com/ChainSafe/gossamer/p2p"
 )
 
-// -------------- Mock Apis ------------------
 var (
-	testPeerCount   = 1
-	testVersion     = "0.0.1"
-	name            = "Gossamer"
-	peerID          = "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh"
-	noBootstrapping = false
-	peers           = []string{"QmeQeqpf3fz3CG2ckQq3CUWwUnyT2cqxJepHpjji7ehVtX"}
+	testChain        = "Chain"
+	testName         = "Gossamer"
+	testProperties   = "Properties"
+	testVersion      = "0.0.1"
+	testHealth       = p2p.Health{Peers: 1, IsSyncing: false, ShouldHavePeers: false}
+	testNetworkState = p2p.NetworkState{PeerId: "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh"}
+	testPeers        = append([]p2p.PeerInfo{}, p2p.PeerInfo{
+		PeerId:          "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh",
+		Roles:           0,
+		ProtocolVersion: 0,
+		BestHash:        common.Hash{},
+		BestNumber:      0,
+	})
 )
 
-// Creating a mock peer
-type MockP2pApi struct{}
-
-func (a *MockP2pApi) PeerCount() int {
-	return testPeerCount
-}
-
-func (a *MockP2pApi) Peers() []string {
-	return peers
-}
-
-func (b *MockP2pApi) ID() string {
-	return peerID
-}
-
-func (b *MockP2pApi) NoBootstrapping() bool {
-	return noBootstrapping
-}
-
-// Creating a mock runtime API
+// Mock RuntimeApi
 type MockRuntimeApi struct{}
 
-func (a *MockRuntimeApi) Name() string {
-	//TODO: Replace with dynamic name
-	return name
+func (r *MockRuntimeApi) Chain() string {
+	return testChain
 }
 
-func (a *MockRuntimeApi) Version() string {
+func (r *MockRuntimeApi) Name() string {
+	return testName
+}
+
+func (r *MockRuntimeApi) Properties() string {
+	return testProperties
+}
+
+func (r *MockRuntimeApi) Version() string {
 	return testVersion
 }
 
-// func (a *MockRuntimeApi) Chain() string {
-// 	return Chain
-// }
+// Mock P2pApi
+type MockP2pApi struct{}
 
-// // System properties not implemented yet
-// func (b *MockRuntimeApi) properties() string {
-// 	return properties
-// }
+func (n *MockP2pApi) Health() p2p.Health {
+	return testHealth
+}
 
-// -------------------------------------------
+func (n *MockP2pApi) NetworkState() p2p.NetworkState {
+	return testNetworkState
+}
+
+func (n *MockP2pApi) Peers() []p2p.PeerInfo {
+	return testPeers
+}
 
 func TestSystemModule(t *testing.T) {
-	srvc := NewApiService(&MockP2pApi{}, &MockRuntimeApi{})
+	s := NewApiService(&MockP2pApi{}, &MockRuntimeApi{})
+
+	// Runtime Module
+
+	// System.Chain
+	chain := s.Api.RuntimeModule.Chain()
+	if chain != testChain {
+		t.Fatalf("System.Chain - expected %+v got: %+v\n", testChain, chain)
+	}
 
 	// System.Name
-	n := srvc.Api.RuntimeModule.Name()
-	if n != name {
-		t.Fatalf("System.Name - expected %+v got: %+v\n", name, n)
+	name := s.Api.RuntimeModule.Name()
+	if name != testName {
+		t.Fatalf("System.Name - expected %+v got: %+v\n", testName, name)
 	}
 
-	// System.networkState
-	s := srvc.Api.P2pModule.ID()
-	if s != peerID {
-		t.Fatalf("System.NetworkState - expected %+v got: %+v\n", peerID, s)
-	}
-
-	// System.peers
-	p := srvc.Api.P2pModule.Peers()
-	if s != peerID {
-		t.Fatalf("System.NetworkState - expected %+v got: %+v\n", peers, p)
-	}
-
-	// System.PeerCount
-	c := srvc.Api.P2pModule.PeerCount()
-	if c != testPeerCount {
-		t.Fatalf("System.PeerCount - expected: %d got: %d\n", testPeerCount, c)
+	// System.Properties
+	properties := s.Api.RuntimeModule.Properties()
+	if properties != testProperties {
+		t.Fatalf("System.Properties - expected: %s got: %s\n", testProperties, properties)
 	}
 
 	// System.Version
-	v := srvc.Api.RuntimeModule.Version()
-	if v != testVersion {
-		t.Fatalf("System.Version - expected: %s got: %s\n", testVersion, v)
+	version := s.Api.RuntimeModule.Version()
+	if version != testVersion {
+		t.Fatalf("System.Version - expected: %s got: %s\n", testVersion, version)
+	}
+
+	// Network Module
+
+	// System.Health
+	health := s.Api.P2pModule.Health()
+	if health != testHealth {
+		t.Fatalf("System.Health - expected %+v got: %+v\n", testHealth, health)
+	}
+
+	// System.NetworkState
+	networkState := s.Api.P2pModule.NetworkState()
+	if networkState != testNetworkState {
+		t.Fatalf("System.NetworkState - expected %+v got: %+v\n", testNetworkState, networkState)
+	}
+
+	// System.Peers
+	peers := s.Api.P2pModule.Peers()
+	if len(peers) != len(testPeers) {
+		t.Fatalf("System.Peers - expected %+v got: %+v\n", testPeers, peers)
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -19,7 +19,6 @@ package api
 import (
 	"testing"
 
-	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/p2p"
 )
 
@@ -28,15 +27,9 @@ var (
 	testName         = "Gossamer"
 	testProperties   = "Properties"
 	testVersion      = "0.0.1"
-	testHealth       = p2p.Health{Peers: 1, IsSyncing: false, ShouldHavePeers: false}
-	testNetworkState = p2p.NetworkState{PeerId: "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh"}
-	testPeers        = append([]p2p.PeerInfo{}, p2p.PeerInfo{
-		PeerId:          "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh",
-		Roles:           0,
-		ProtocolVersion: 0,
-		BestHash:        common.Hash{},
-		BestNumber:      0,
-	})
+	testHealth       = p2p.Health{}
+	testNetworkState = p2p.NetworkState{}
+	testPeers        = append([]p2p.PeerInfo{}, p2p.PeerInfo{})
 )
 
 // Mock RuntimeApi

--- a/internal/api/modules/p2p_module.go
+++ b/internal/api/modules/p2p_module.go
@@ -37,19 +37,19 @@ func NewP2pModule(p2pApi P2pApi) *P2pModule {
 	return &P2pModule{p2pApi}
 }
 
-// Health returns p2p service Health() (rpc specific)
+// Health returns p2p service Health()
 func (m *P2pModule) Health() p2p.Health {
 	log.Debug("[rpc] Executing System.Health", "params", nil)
 	return m.P2pApi.Health()
 }
 
-// NetworkState returns p2p service NetworkState() (rpc specific)
+// NetworkState returns p2p service NetworkState()
 func (m *P2pModule) NetworkState() p2p.NetworkState {
 	log.Debug("[rpc] Executing System.NetworkState", "params", nil)
 	return m.P2pApi.NetworkState()
 }
 
-// Peers returns p2p service Peers() (rpc specific)
+// Peers returns p2p service Peers()
 func (m *P2pModule) Peers() []p2p.PeerInfo {
 	log.Debug("[rpc] Executing System.Peers", "params", nil)
 	return m.P2pApi.Peers()

--- a/internal/api/modules/p2p_module.go
+++ b/internal/api/modules/p2p_module.go
@@ -17,51 +17,40 @@
 package module
 
 import (
+	"github.com/ChainSafe/gossamer/p2p"
 	log "github.com/ChainSafe/log15"
 )
 
 type P2pModule struct {
-	P2p P2pApi
+	P2pApi P2pApi
 }
 
-// P2pApi is the interface expected to implemented by `p2p` package
+// P2pApi is the interface for the p2p package
 type P2pApi interface {
-	PeerCount() int
-	Peers() []string
-	NoBootstrapping() bool
-	ID() string
+	Health() p2p.Health
+	NetworkState() p2p.NetworkState
+	Peers() []p2p.PeerInfo
 }
 
-// P2pModule implements all the P2pApis
-func NewP2PModule(p2papi P2pApi) *P2pModule {
-	return &P2pModule{p2papi}
+// P2pModule implements P2pApi
+func NewP2pModule(p2pApi P2pApi) *P2pModule {
+	return &P2pModule{p2pApi}
 }
 
-// PeerCount Returns the number of peers of a node
-func (p *P2pModule) PeerCount() int {
-	log.Debug("[rpc] Executing System.PeerCount", "params", nil)
-	return len(p.Peers())
+// Health returns p2p service Health() (rpc specific)
+func (m *P2pModule) Health() p2p.Health {
+	log.Debug("[rpc] Executing System.Health", "params", nil)
+	return m.P2pApi.Health()
 }
 
-// Peers of the node
-func (p *P2pModule) Peers() []string {
-	log.Debug("[rpc] Executing System.Peers", "params", nil)
-	return p.P2p.Peers()
-}
-
-// NoBootstrapping Returns true the node can bootstrap to other nodes
-func (p *P2pModule) NoBootstrapping() bool {
-	log.Debug("[rpc] Executing System.NoBootstrapping", "params", nil)
-	return p.P2p.NoBootstrapping()
-}
-
-// ID Returns the ID of the node
-func (p *P2pModule) ID() string {
+// NetworkState returns p2p service NetworkState() (rpc specific)
+func (m *P2pModule) NetworkState() p2p.NetworkState {
 	log.Debug("[rpc] Executing System.NetworkState", "params", nil)
-	return p.P2p.ID()
+	return m.P2pApi.NetworkState()
 }
 
-// IsSyncing is true if the node is Syncing
-func (p *P2pModule) IsSyncing() bool {
-	return false
+// Peers returns p2p service Peers() (rpc specific)
+func (m *P2pModule) Peers() []p2p.PeerInfo {
+	log.Debug("[rpc] Executing System.Peers", "params", nil)
+	return m.P2pApi.Peers()
 }

--- a/internal/api/modules/runtime_module.go
+++ b/internal/api/modules/runtime_module.go
@@ -21,30 +21,41 @@ import (
 )
 
 type RuntimeModule struct {
-	Rt RuntimeApi
+	RuntimeApi RuntimeApi
 }
 
-// RuntimeApi is the interface expected to implemented by `runtime` package
+// RuntimeApi is the interface for the runtime package
 type RuntimeApi interface {
-	// Chain() string  //Cannot implement yet
-	Name() string //Replace with dynamic name later
-	// properties() string //Cannot implement yet
+	Chain() string
+	Name() string
+	Properties() string
 	Version() string
 }
 
-func NewRuntimeModule(RTapi RuntimeApi) *RuntimeModule {
-	return &RuntimeModule{RTapi}
+func NewRuntimeModule(runtimeApi RuntimeApi) *RuntimeModule {
+	return &RuntimeModule{runtimeApi}
 }
 
-// Release version
-func (r *RuntimeModule) Version() string {
-	log.Debug("[rpc] Executing System.Version", "params", nil)
-	//TODO: Replace with dynamic version
-	return "0.0.1"
+func (r *RuntimeModule) Chain() string {
+	log.Debug("[rpc] Executing System.Chain", "params", nil)
+	// TODO: replace with dynamic chain
+	return "Chain"
 }
 
 func (r *RuntimeModule) Name() string {
 	log.Debug("[rpc] Executing System.Name", "params", nil)
-	//TODO: Replace with dynamic name
+	// TODO: replace with dynamic name
 	return "Gossamer"
+}
+
+func (r *RuntimeModule) Properties() string {
+	log.Debug("[rpc] Executing System.Properties", "params", nil)
+	// TODO: replace with dynamic properties
+	return "Properties"
+}
+
+func (r *RuntimeModule) Version() string {
+	log.Debug("[rpc] Executing System.Version", "params", nil)
+	// TODO: replace with dynamic version
+	return "0.0.1"
 }

--- a/internal/api/modules/runtime_module.go
+++ b/internal/api/modules/runtime_module.go
@@ -32,30 +32,31 @@ type RuntimeApi interface {
 	Version() string
 }
 
+// RuntimeModule implements RuntimeApi
 func NewRuntimeModule(runtimeApi RuntimeApi) *RuntimeModule {
 	return &RuntimeModule{runtimeApi}
 }
 
-func (r *RuntimeModule) Chain() string {
+// Chain returns runtime Chain()
+func (m *RuntimeModule) Chain() string {
 	log.Debug("[rpc] Executing System.Chain", "params", nil)
-	// TODO: replace with dynamic chain
-	return "Chain"
+	return m.RuntimeApi.Chain()
 }
 
-func (r *RuntimeModule) Name() string {
+// Name returns runtime Name()
+func (m *RuntimeModule) Name() string {
 	log.Debug("[rpc] Executing System.Name", "params", nil)
-	// TODO: replace with dynamic name
-	return "Gossamer"
+	return m.RuntimeApi.Name()
 }
 
-func (r *RuntimeModule) Properties() string {
+// Properties returns runtime Properties()
+func (m *RuntimeModule) Properties() string {
 	log.Debug("[rpc] Executing System.Properties", "params", nil)
-	// TODO: replace with dynamic properties
-	return "Properties"
+	return m.RuntimeApi.Properties()
 }
 
-func (r *RuntimeModule) Version() string {
+// Version returns runtime Version()
+func (m *RuntimeModule) Version() string {
 	log.Debug("[rpc] Executing System.Version", "params", nil)
-	// TODO: replace with dynamic version
-	return "0.0.1"
+	return m.RuntimeApi.Version()
 }

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -21,18 +21,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-func peerIdsToStrings(ids []peer.ID) []string {
-	strings := make([]string, len(ids))
-	for i, id := range ids {
-		strings[i] = id.String()
-	}
-	return strings
-}
-
-func stringToPeerId(string string) peer.ID {
-	return peer.ID(string)
-}
-
 func stringToAddrInfo(s string) (peer.AddrInfo, error) {
 	maddr, err := ma.NewMultiaddr(s)
 	if err != nil {

--- a/rpc/modules/system.go
+++ b/rpc/modules/system.go
@@ -31,7 +31,7 @@ type SystemModule struct {
 // EmptyRequest represents an RPC request with no fields
 type EmptyRequest struct{}
 
-type NotYetImplemented string
+type StringResponse string
 
 type SystemHealthResponse struct {
 	Health p2p.Health `json:"health"`
@@ -59,25 +59,25 @@ func NewSystemModule(api *api.Api) *SystemModule {
 }
 
 // Chain returns the runtime chain
-func (sm *SystemModule) Chain(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+func (sm *SystemModule) Chain(r *http.Request, req *EmptyRequest, res *StringResponse) error {
 	*res = "not yet implemented"
 	return nil
 }
 
 // Name returns the runtime name
-func (sm *SystemModule) Name(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+func (sm *SystemModule) Name(r *http.Request, req *EmptyRequest, res *StringResponse) error {
 	*res = "not yet implemented"
 	return nil
 }
 
 // Properties returns the runtime properties
-func (sm *SystemModule) Properties(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+func (sm *SystemModule) Properties(r *http.Request, req *EmptyRequest, res *StringResponse) error {
 	*res = "not yet implemented"
 	return nil
 }
 
 // Version returns the runtime version
-func (sm *SystemModule) Version(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+func (sm *SystemModule) Version(r *http.Request, req *EmptyRequest, res *StringResponse) error {
 	*res = "not yet implemented"
 	return nil
 }

--- a/rpc/modules/system.go
+++ b/rpc/modules/system.go
@@ -17,44 +17,32 @@
 package modules
 
 import (
-	"math/big"
 	"net/http"
 
-	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/internal/api"
+	"github.com/ChainSafe/gossamer/p2p"
 )
 
-// SystemModule is an RPC module providing access to core API points.
+// SystemModule is an RPC module providing access to core API points
 type SystemModule struct {
-	api *api.Api
+	api *api.Api // TODO: migrate to network state
 }
 
 // EmptyRequest represents an RPC request with no fields
 type EmptyRequest struct{}
 
-type StringResponse string
+type NotYetImplemented string
 
 type SystemHealthResponse struct {
-	Peers           int  `json:"peers"`
-	IsSyncing       bool `json:"isSyncing"`
-	ShouldHavePeers bool `json:"shouldHavePeers"`
+	Health p2p.Health `json:"health"`
 }
 
 type SystemNetworkStateResponse struct {
-	Id string `json:"Id"`
-}
-
-// TODO: This should probably live elsewhere
-type Peer struct {
-	PeerId          string      `json:"peerId"`
-	Roles           string      `json:"roles"`
-	ProtocolVersion int         `json:"protocolVersion"`
-	BestHash        common.Hash `json:"bestHash"`
-	BestNumber      *big.Int    `json:"bestNumber"`
+	NetworkState p2p.NetworkState `json:"networkState"`
 }
 
 type SystemPeersResponse struct {
-	Peers []string `json:"peers"`
+	Peers []p2p.PeerInfo `json:"peers"`
 }
 
 type SystemPropertiesResponse struct {
@@ -63,52 +51,54 @@ type SystemPropertiesResponse struct {
 	TokenSymbol   string `json:"tokenSymbol"`
 }
 
-// NewSystemModule creates a new net API instance.
+// NewSystemModule creates a new API instance
 func NewSystemModule(api *api.Api) *SystemModule {
 	return &SystemModule{
-		api: api,
+		api: api, // TODO: migrate to network state
 	}
 }
 
-// Not implemented yet
-func (sm *SystemModule) Chain(r *http.Request, req *EmptyRequest, res *StringResponse) error {
+// Chain returns the runtime chain
+func (sm *SystemModule) Chain(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
 	*res = "not yet implemented"
 	return nil
 }
 
-// Returns the Health status of the node
+// Name returns the runtime name
+func (sm *SystemModule) Name(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+	*res = "not yet implemented"
+	return nil
+}
+
+// Properties returns the runtime properties
+func (sm *SystemModule) Properties(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+	*res = "not yet implemented"
+	return nil
+}
+
+// Version returns the runtime version
+func (sm *SystemModule) Version(r *http.Request, req *EmptyRequest, res *NotYetImplemented) error {
+	*res = "not yet implemented"
+	return nil
+}
+
+// Health returns the information about the health of the network
 func (sm *SystemModule) Health(r *http.Request, req *EmptyRequest, res *SystemHealthResponse) error {
-	res.Peers = len(sm.api.P2pModule.Peers())
-	res.IsSyncing = sm.api.P2pModule.IsSyncing()
-	res.ShouldHavePeers = !sm.api.P2pModule.NoBootstrapping()
+	// TODO: migrate from api to network state
+	res.Health = sm.api.P2pModule.Health()
 	return nil
 }
 
-// Not implemented yet
-func (sm *SystemModule) Name(r *http.Request, req *EmptyRequest, res *StringResponse) error {
-	*res = "not yet implemented"
-	return nil
-}
-
-// Return the node's Network State
+// NetworkState returns the network state (basic information about the host)
 func (sm *SystemModule) NetworkState(r *http.Request, req *EmptyRequest, res *SystemNetworkStateResponse) error {
-	res.Id = sm.api.P2pModule.ID()
+	// TODO: migrate from api to network state
+	res.NetworkState = sm.api.P2pModule.NetworkState()
 	return nil
 }
 
-// Returns the node's peers
+// Peers returns peer information for each connected and confirmed peer
 func (sm *SystemModule) Peers(r *http.Request, req *EmptyRequest, res *SystemPeersResponse) error {
+	// TODO: migrate from api to network state
 	res.Peers = sm.api.P2pModule.Peers()
-	return nil
-}
-
-// Returns the node's properties
-func (sm *SystemModule) Properties(r *http.Request, req *EmptyRequest, res *SystemPropertiesResponse) error {
-	return nil
-}
-
-// Not implemented yet
-func (sm *SystemModule) Version(r *http.Request, req *EmptyRequest, res *StringResponse) error {
-	*res = "not yet implemented"
 	return nil
 }

--- a/rpc/modules/system_test.go
+++ b/rpc/modules/system_test.go
@@ -19,7 +19,6 @@ package modules
 import (
 	"testing"
 
-	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/internal/api"
 	module "github.com/ChainSafe/gossamer/internal/api/modules"
 	"github.com/ChainSafe/gossamer/p2p"
@@ -30,15 +29,9 @@ var (
 	testRuntimeName       = "Gossamer"
 	testRuntimeProperties = "Properties"
 	testRuntimeVersion    = "0.0.1"
-	testHealth            = p2p.Health{Peers: 1, IsSyncing: false, ShouldHavePeers: false}
-	testNetworkState      = p2p.NetworkState{PeerId: "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh"}
-	testPeers             = append([]p2p.PeerInfo{}, p2p.PeerInfo{
-		PeerId:          "Qmc85Ephxa3sR7xaTzTq2UpCJ4a4HWAfxxaV6TarXHWVVh",
-		Roles:           0,
-		ProtocolVersion: 0,
-		BestHash:        common.Hash{},
-		BestNumber:      0,
-	})
+	testHealth            = p2p.Health{}
+	testNetworkState      = p2p.NetworkState{}
+	testPeers             = append([]p2p.PeerInfo{}, p2p.PeerInfo{})
 )
 
 // Mock runtime API
@@ -89,11 +82,11 @@ func newMockApi() *api.Api {
 func TestSystemModule_Health(t *testing.T) {
 	sys := NewSystemModule(newMockApi())
 
-	netHealth := &SystemHealthResponse{}
-	sys.Health(nil, nil, netHealth)
+	res := &SystemHealthResponse{}
+	sys.Health(nil, nil, res)
 
-	if netHealth.Health != testHealth {
-		t.Errorf("System.Health.: expected: %+v got: %+v\n", testHealth, netHealth.Health)
+	if res.Health != testHealth {
+		t.Errorf("System.Health.: expected: %+v got: %+v\n", testHealth, res.Health)
 	}
 }
 
@@ -101,11 +94,11 @@ func TestSystemModule_Health(t *testing.T) {
 func TestSystemModule_NetworkState(t *testing.T) {
 	sys := NewSystemModule(newMockApi())
 
-	netState := &SystemNetworkStateResponse{}
-	sys.NetworkState(nil, nil, netState)
+	res := &SystemNetworkStateResponse{}
+	sys.NetworkState(nil, nil, res)
 
-	if netState.NetworkState != testNetworkState {
-		t.Errorf("System.NetworkState: expected: %+v got: %+v\n", testNetworkState, netState.NetworkState)
+	if res.NetworkState != testNetworkState {
+		t.Errorf("System.NetworkState: expected: %+v got: %+v\n", testNetworkState, res.NetworkState)
 	}
 }
 
@@ -113,21 +106,10 @@ func TestSystemModule_NetworkState(t *testing.T) {
 func TestSystemModule_Peers(t *testing.T) {
 	sys := NewSystemModule(newMockApi())
 
-	peersRes := &SystemPeersResponse{}
-	sys.Peers(nil, nil, peersRes)
+	res := &SystemPeersResponse{}
+	sys.Peers(nil, nil, res)
 
-	equalPeers := true
-	for i, originalPeer := range testPeers {
-		if originalPeer != peersRes.Peers[i] {
-			equalPeers = false
-		}
-	}
-
-	if len(testPeers) != len(peersRes.Peers) {
-		equalPeers = false
-	}
-
-	if equalPeers == false {
-		t.Errorf("System.Peers: expected: %+v got: %+v\n", testPeers, *peersRes)
+	if len(res.Peers) != len(testPeers) {
+		t.Errorf("System.Peers: expected: %+v got: %+v\n", testPeers, res.Peers)
 	}
 }

--- a/state/network.go
+++ b/state/network.go
@@ -3,29 +3,27 @@ package state
 import "github.com/ChainSafe/gossamer/p2p"
 
 type networkState struct {
-	peer *p2p.Service
+	p2p *p2p.Service
 }
 
 func NewNetworkState() *networkState {
 	return &networkState{
-		peer: &p2p.Service{},
+		// TODO: pass p2p service instance to network state
+		p2p: &p2p.Service{},
 	}
 }
 
-func (ns *networkState) Peers() []string {
-	return ns.peer.Peers()
+func (ns *networkState) Health() p2p.Health {
+	// TODO: return Health() of p2p service
+	return p2p.Health{}
 }
 
-func (ns *networkState) State() string {
-	// TODO: return the network's state
-	return ""
+func (ns *networkState) NetworkState() p2p.NetworkState {
+	// TODO: return NetworkState() of p2p service
+	return p2p.NetworkState{}
 }
 
-func (ns *networkState) PeerCount() int {
-	return ns.peer.PeerCount()
-}
-
-func (ns *networkState) Status() string {
-	// TODO: return the network'status
-	return ""
+func (ns *networkState) Peers() []p2p.PeerInfo {
+	// TODO: return Peers() of p2p service
+	return []p2p.PeerInfo{}
 }

--- a/state/network_test.go
+++ b/state/network_test.go
@@ -34,18 +34,18 @@ func TestNetworkState(t *testing.T) {
 	// test state.Network.Health()
 	health := state.Network.Health()
 	if health != testHealth {
-		t.Fatalf("System.Health - expected %+v got: %+v\n", testHealth, health)
+		t.Errorf("System.Health - expected %+v got: %+v\n", testHealth, health)
 	}
 
 	// test state.Network.NetworkState()
 	networkState := state.Network.NetworkState()
 	if networkState != testNetworkState {
-		t.Fatalf("System.NetworkState - expected %+v got: %+v\n", testNetworkState, networkState)
+		t.Errorf("System.NetworkState - expected %+v got: %+v\n", testNetworkState, networkState)
 	}
 
 	// test state.Network.Peers()
 	peers := state.Network.Peers()
 	if len(peers) != len(testPeers) {
-		t.Fatalf("System.Peers - expected %+v got: %+v\n", testPeers, peers)
+		t.Errorf("System.Peers - expected %+v got: %+v\n", testPeers, peers)
 	}
 }

--- a/state/network_test.go
+++ b/state/network_test.go
@@ -13,31 +13,39 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package state
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
+
+	"github.com/ChainSafe/gossamer/p2p"
 )
 
-// helper method to create and start test state service
-func newTestService(t *testing.T) (state *Service) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
-	if err != nil {
-		t.Fatal("failed to create temp dir: " + err.Error())
-	}
+var testHealth = p2p.Health{}
+var testNetworkState = p2p.NetworkState{}
+var testPeers = []p2p.PeerInfo{}
 
-	state = NewService(dir)
+// test state.Network
+func TestNetworkState(t *testing.T) {
 
-	return state
-}
-
-func TestService_Start(t *testing.T) {
 	state := newTestService(t)
 
-	err := state.Start()
-	if err != nil {
-		t.Fatal(err)
+	// test state.Network.Health()
+	health := state.Network.Health()
+	if health != testHealth {
+		t.Fatalf("System.Health - expected %+v got: %+v\n", testHealth, health)
+	}
+
+	// test state.Network.NetworkState()
+	networkState := state.Network.NetworkState()
+	if networkState != testNetworkState {
+		t.Fatalf("System.NetworkState - expected %+v got: %+v\n", testNetworkState, networkState)
+	}
+
+	// test state.Network.Peers()
+	peers := state.Network.Peers()
+	if len(peers) != len(testPeers) {
+		t.Fatalf("System.Peers - expected %+v got: %+v\n", testPeers, peers)
 	}
 }

--- a/state/service.go
+++ b/state/service.go
@@ -8,7 +8,7 @@ type Service struct {
 	dbPath  string
 	Storage *storageState
 	Block   *blockState
-	Net     *networkState
+	Network *networkState
 }
 
 func NewService(path string) *Service {
@@ -16,7 +16,7 @@ func NewService(path string) *Service {
 		dbPath:  path,
 		Storage: nil,
 		Block:   nil,
-		Net:     &networkState{},
+		Network: nil,
 	}
 }
 
@@ -40,7 +40,7 @@ func (s *Service) Start() error {
 
 	s.Storage = storageDb
 	s.Block = blockDb
-	s.Net = NewNetworkState()
+	s.Network = NewNetworkState()
 
 	return nil
 }


### PR DESCRIPTION
## Changes

This pull request updates the public p2p service methods to align with information needed for the rpc server. This pull request also updates the network state in preparation for migrating the rpc server from using the api service to using the state service (see #488).

The information needed for the rpc server is up-to-date host and peer information that can be made available though public p2p service methods (`Health()`, `NetworkState()` and `Peers()`). Following the implementation of the status module, we do not need to store a separate peer state (see #399).

## Tests:
```
go test ./...
```

### Issues:
closes #399 and opens #488