### PR TITLE
p2p: send messages with existing stream

### DIFF
--- a/p2p/gossip.go
+++ b/p2p/gossip.go
@@ -18,7 +18,6 @@ package p2p
 
 import (
 	log "github.com/ChainSafe/log15"
-	"github.com/libp2p/go-libp2p-core/network"
 )
 
 // gossip submodule
@@ -36,7 +35,7 @@ func newGossip(host *host) *gossip {
 }
 
 // handleMessage broadcasts messages that have not been seen
-func (g *gossip) handleMessage(stream network.Stream, msg Message) {
+func (g *gossip) handleMessage(msg Message) {
 
 	// check if message has not been seen
 	if !g.hasSeen[msg.Id()] {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -160,8 +160,7 @@ func (h *host) ping(peer peer.ID) error {
 }
 
 // send writes the given message to the outbound message stream for the given
-// peer (gets the already opened stream or opens a new stream). Each host uses
-// the same outbound message stream until otherwise closed or reset.
+// peer (gets the already opened outbound message stream or opens a new one).
 func (h *host) send(p peer.ID, msg Message) (err error) {
 
 	// get outbound stream for given peer
@@ -219,10 +218,9 @@ func (h *host) broadcast(msg Message) {
 	}
 }
 
-// getStream returns the outbound message stream for the given peer. Each p2p
-// service messsage is being written to the outbound message stream that uses
-// the same protocol id and that each host opens for each peer. Each host uses
-// the same outbound message stream until otherwise closed or reset.
+// getStream returns the outbound message stream for the given peer or returns
+// nil if no outbound message stream exists. For each peer, each host opens an
+// outbound message stream and writes to the same stream until closed or reset.
 func (h *host) getStream(p peer.ID) (stream network.Stream) {
 	conns := h.h.Network().ConnsToPeer(p)
 

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -188,11 +188,6 @@ func (h *host) send(p peer.ID, msg Message) (err error) {
 		return err
 	}
 
-	// _, err = s.Write(common.Uint16ToBytes(uint16(len(encMsg)))[0:1])
-	// if err != nil {
-	// 	return err
-	// }
-
 	_, err = s.Write(encMsg)
 	if err != nil {
 		return err
@@ -231,7 +226,7 @@ func (h *host) getStream(p peer.ID) (stream network.Stream) {
 		// loop through connection streams (unassigned streams and ipfs dht streams included)
 		for _, stream := range streams {
 
-			// only use streams with matching host protocol id and stream direction is outbound
+			// return stream with matching host protocol id and stream direction outbound
 			if stream.Protocol() == h.protocolId && stream.Stat().Direction == network.DirOutbound {
 				return stream
 			}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -235,12 +235,6 @@ func (h *host) getStream(p peer.ID) (stream network.Stream) {
 
 			// only use streams with matching host protocol id and stream direction is outbound
 			if stream.Protocol() == h.protocolId && stream.Stat().Direction == network.DirOutbound {
-				log.Trace(
-					"Existing stream",
-					"host", h.id(),
-					"peer", p,
-					"protocol", stream.Protocol(),
-				)
 				return stream
 			}
 		}

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ChainSafe/gossamer/common"
 	log "github.com/ChainSafe/log15"
 	ds "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/sync"
@@ -160,31 +159,40 @@ func (h *host) ping(peer peer.ID) error {
 	return h.dht.Ping(h.ctx, peer)
 }
 
-// send sends a non-status message to a specific peer
+// send writes the given message to the outbound message stream for the given
+// peer (gets the already opened stream or opens a new stream). Each host uses
+// the same outbound message stream until otherwise closed or reset.
 func (h *host) send(p peer.ID, msg Message) (err error) {
 
-	// create new stream with host protocol id
-	s, err := h.h.NewStream(h.ctx, p, h.protocolId)
-	if err != nil {
-		return err
-	}
+	// get outbound stream for given peer
+	s := h.getStream(p)
 
-	log.Trace(
-		"Opened stream",
-		"host", h.id(),
-		"peer", p,
-		"protocol", s.Protocol(),
-	)
+	// check if stream needs to be opened
+	if s == nil {
+
+		// open outbound stream with host protocol id
+		s, err = h.h.NewStream(h.ctx, p, h.protocolId)
+		if err != nil {
+			return err
+		}
+
+		log.Trace(
+			"Opened stream",
+			"host", h.id(),
+			"peer", p,
+			"protocol", s.Protocol(),
+		)
+	}
 
 	encMsg, err := msg.Encode()
 	if err != nil {
 		return err
 	}
 
-	_, err = s.Write(common.Uint16ToBytes(uint16(len(encMsg)))[0:1])
-	if err != nil {
-		return err
-	}
+	// _, err = s.Write(common.Uint16ToBytes(uint16(len(encMsg)))[0:1])
+	// if err != nil {
+	// 	return err
+	// }
 
 	_, err = s.Write(encMsg)
 	if err != nil {
@@ -209,6 +217,35 @@ func (h *host) broadcast(msg Message) {
 			log.Error("Failed to send message during broadcast", "peer", p, "err", err)
 		}
 	}
+}
+
+// getStream returns the outbound message stream for the given peer. Each p2p
+// service messsage is being written to the outbound message stream that uses
+// the same protocol id and that each host opens for each peer. Each host uses
+// the same outbound message stream until otherwise closed or reset.
+func (h *host) getStream(p peer.ID) (stream network.Stream) {
+	conns := h.h.Network().ConnsToPeer(p)
+
+	// loop through connections (only one for now)
+	for _, conn := range conns {
+		streams := conn.GetStreams()
+
+		// loop through connection streams (unassigned streams and ipfs dht streams included)
+		for _, stream := range streams {
+
+			// only use streams with matching host protocol id and stream direction is outbound
+			if stream.Protocol() == h.protocolId && stream.Stat().Direction == network.DirOutbound {
+				log.Trace(
+					"Existing stream",
+					"host", h.id(),
+					"peer", p,
+					"protocol", stream.Protocol(),
+				)
+				return stream
+			}
+		}
+	}
+	return nil
 }
 
 // closePeer closes the peer connection

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -170,7 +170,7 @@ func (s *Service) handleConn(conn network.Conn) {
 
 // handleStream starts reading from the inbound message stream (substream with
 // a matching protocol id that was opened by the connected peer) and continues
-// reading until the inbound message stream is closed or reset.
+// reading until the inbound message stream is either closed or reset.
 func (s *Service) handleStream(stream network.Stream) {
 	ctx := context.Background()
 
@@ -181,7 +181,7 @@ func (s *Service) handleStream(stream network.Stream) {
 }
 
 // readStream reads messages written to the inbound message stream until the
-// inbound message stream is otherwise closed or reset.
+// inbound message stream is either closed or reset.
 func (s *Service) readStream(ctx context.Context, stream network.Stream) {
 	peer := stream.Conn().RemotePeer()
 
@@ -209,7 +209,7 @@ func (s *Service) readStream(ctx context.Context, stream network.Stream) {
 	}
 }
 
-// handleMessage handles the message based on type and status
+// handleMessage handles the message based on peer status and message type
 func (s *Service) handleMessage(peer peer.ID, msg Message) {
 	log.Trace(
 		"Received message from peer",

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -182,7 +182,7 @@ func (s *Service) handleStream(stream network.Stream) {
 		msg, err := decodeMessage(r)
 		if err != nil {
 
-			// exit loop if nothing to read
+			// exit loop if last received byte was nil (stream closed or reset)
 			ub := r.UnreadByte()
 			if ub == nil {
 				return // exit

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -172,15 +172,6 @@ func (s *Service) handleConn(conn network.Conn) {
 // a matching protocol id that was opened by the connected peer) and continues
 // reading until the inbound message stream is closed or reset.
 func (s *Service) handleStream(stream network.Stream) {
-
-	// read from the inbound message stream
-	s.readStream(stream)
-
-	// the stream stays open until closed or reset
-}
-
-// readStream reads messages written to the inbound message stream.
-func (s *Service) readStream(stream network.Stream) {
 	peer := stream.Conn().RemotePeer()
 
 	// create buffer stream for non-blocking read
@@ -204,6 +195,8 @@ func (s *Service) readStream(stream network.Stream) {
 		// handle message based on peer status and message type
 		s.handleMessage(peer, msg)
 	}
+
+	// the stream stays open until closed or reset
 }
 
 // handleMessage handles the message based on peer status and message type

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -170,19 +170,17 @@ func (s *Service) handleConn(conn network.Conn) {
 
 // handleStream starts reading from the inbound message stream (substream with
 // a matching protocol id that was opened by the connected peer) and continues
-// reading until the inbound message stream is either closed or reset.
+// reading until the inbound message stream is closed or reset.
 func (s *Service) handleStream(stream network.Stream) {
-	ctx := context.Background()
 
-	// read from inbound stream
-	go s.readStream(ctx, stream)
+	// read from the inbound message stream
+	s.readStream(stream)
 
 	// the stream stays open until closed or reset
 }
 
-// readStream reads messages written to the inbound message stream until the
-// inbound message stream is either closed or reset.
-func (s *Service) readStream(ctx context.Context, stream network.Stream) {
+// readStream reads messages written to the inbound message stream.
+func (s *Service) readStream(stream network.Stream) {
 	peer := stream.Conn().RemotePeer()
 
 	// create buffer stream for non-blocking read
@@ -200,8 +198,7 @@ func (s *Service) readStream(ctx context.Context, stream network.Stream) {
 			}
 
 			log.Error("Failed to decode message from peer", "peer", peer, "err", err)
-			ctx.Done() // cancel running processes
-			return     // exit
+			return // exit
 		}
 
 		// handle message based on peer status and message type

--- a/p2p/service.go
+++ b/p2p/service.go
@@ -17,11 +17,13 @@
 package p2p
 
 import (
+	"bufio"
 	"context"
 
 	"github.com/ChainSafe/gossamer/internal/services"
 	log "github.com/ChainSafe/log15"
 	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 var _ services.Service = &Service{}
@@ -57,21 +59,12 @@ func NewService(cfg *Config, msgSend chan<- Message, msgRec <-chan Message) (*Se
 		return nil, err
 	}
 
-	// create a new mdns instance
-	mdns := newMdns(host)
-
-	// create a new status instance
-	status := newStatus(host)
-
-	// create a new gossip instance
-	gossip := newGossip(host)
-
 	p2p := &Service{
 		ctx:         ctx,
 		host:        host,
-		mdns:        mdns,
-		status:      status,
-		gossip:      gossip,
+		mdns:        newMdns(host),
+		status:      newStatus(host),
+		gossip:      newGossip(host),
 		msgRec:      msgRec,
 		msgSend:     msgSend,
 		noBootstrap: cfg.NoBootstrap,
@@ -144,7 +137,7 @@ func (s *Service) receiveCoreMessages() {
 		if msg.GetType() != StatusMsgType {
 
 			log.Trace(
-				"Broadcasting message to connected peers from core service",
+				"Broadcasting message from core service",
 				"host", s.host.id(),
 				"type", msg.GetType(),
 			)
@@ -175,18 +168,49 @@ func (s *Service) handleConn(conn network.Conn) {
 	}
 }
 
-// handleStream parses the message written to the data stream and calls the
-// associated message handler (non-status or status) based on message type
+// handleStream starts reading from the inbound message stream (substream with
+// a matching protocol id that was opened by the connected peer) and continues
+// reading until the inbound message stream is closed or reset.
 func (s *Service) handleStream(stream network.Stream) {
+	ctx := context.Background()
+
+	// read from inbound stream
+	go s.readStream(ctx, stream)
+
+	// the stream stays open until closed or reset
+}
+
+// readStream reads messages written to the inbound message stream until the
+// inbound message stream is otherwise closed or reset.
+func (s *Service) readStream(ctx context.Context, stream network.Stream) {
 	peer := stream.Conn().RemotePeer()
 
-	// parse message and exit on error
-	msg, err := parseMessage(stream)
-	if err != nil {
-		log.Error("Failed to parse message from peer", "err", err)
-		return // exit
-	}
+	// create buffer stream for non-blocking read
+	r := bufio.NewReader(stream)
 
+	for {
+		// decode message based on message type
+		msg, err := decodeMessage(r)
+		if err != nil {
+
+			// exit loop if nothing to read
+			ub := r.UnreadByte()
+			if ub == nil {
+				return // exit
+			}
+
+			log.Error("Failed to decode message from peer", "peer", peer, "err", err)
+			ctx.Done() // cancel running processes
+			return     // exit
+		}
+
+		// handle message based on peer status and message type
+		s.handleMessage(peer, msg)
+	}
+}
+
+// handleMessage handles the message based on type and status
+func (s *Service) handleMessage(peer peer.ID, msg Message) {
 	log.Trace(
 		"Received message from peer",
 		"host", s.host.id(),
@@ -207,7 +231,7 @@ func (s *Service) handleStream(stream network.Stream) {
 		if !s.noGossip {
 
 			// handle non-status message from peer with gossip submodule
-			s.gossip.handleMessage(stream, msg)
+			s.gossip.handleMessage(msg)
 		}
 
 	} else {
@@ -216,9 +240,8 @@ func (s *Service) handleStream(stream network.Stream) {
 		if !s.noStatus {
 
 			// handle status message from peer with status submodule
-			s.status.handleMessage(stream, msg.(*StatusMessage))
+			s.status.handleMessage(peer, msg.(*StatusMessage))
 		}
-
 	}
 }
 

--- a/p2p/service_test.go
+++ b/p2p/service_test.go
@@ -37,7 +37,7 @@ var TestMessage = &BlockRequestMessage{
 }
 
 // maximum wait time for non-status message to be handled
-var TestMessageTimeout = 10 * time.Second
+var TestMessageTimeout = 3 * time.Second
 
 // helper method to create and start a new p2p service
 func createTestService(t *testing.T, cfg *Config) (node *Service, msgSend chan Message, msgRec chan Message) {

--- a/p2p/status.go
+++ b/p2p/status.go
@@ -90,9 +90,8 @@ func (status *status) handleConn(conn network.Conn) {
 
 // handleMessage checks if the peer status message is compatibale with the host
 // status message, then either manages peer status or closes peer connection
-func (status *status) handleMessage(stream network.Stream, msg *StatusMessage) {
+func (status *status) handleMessage(peer peer.ID, msg *StatusMessage) {
 	ctx := context.Background()
-	peer := stream.Conn().RemotePeer()
 
 	// check if valid status message
 	if status.validMessage(msg) {

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -18,7 +18,9 @@ package p2p
 
 import (
 	crand "crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"io"
 	"io/ioutil"
 	mrand "math/rand"
@@ -26,14 +28,16 @@ import (
 	"path"
 	"path/filepath"
 
+	// leb128 "github.com/filecoin-project/go-leb128"
+	"github.com/ChainSafe/gossamer/common"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
-	ma "github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multiaddr"
 )
 
 // stringToAddrInfos converts a single string peer id to AddrInfo
 func stringToAddrInfo(s string) (peer.AddrInfo, error) {
-	maddr, err := ma.NewMultiaddr(s)
+	maddr, err := multiaddr.NewMultiaddr(s)
 	if err != nil {
 		return peer.AddrInfo{}, err
 	}
@@ -129,4 +133,89 @@ func saveKey(priv crypto.PrivKey, fp string) (err error) {
 		return err
 	}
 	return f.Close()
+}
+
+// TODO: implement LEB128 variable-length encoding
+
+// Decodes a byte array to uint64 using LEB128 variable-length encoding
+// func leb128ToUint64(in []byte) uint64 {
+// 	return leb128.ToUInt64(in)
+// }
+
+// decodeMessage decodes the message based on message type
+func decodeMessage(r io.Reader) (m Message, err error) {
+
+	// _, err := readByte(r)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	msgType, err := readByte(r)
+	if err != nil {
+		return nil, err
+	}
+
+	switch msgType {
+	case StatusMsgType:
+		m = new(StatusMessage)
+		err = m.Decode(r)
+	case BlockRequestMsgType:
+		m = new(BlockRequestMessage)
+		err = m.Decode(r)
+	case BlockResponseMsgType:
+		m = new(BlockResponseMessage)
+		err = m.Decode(r)
+	case BlockAnnounceMsgType:
+		m = new(BlockAnnounceMessage)
+		err = m.Decode(r)
+	case TransactionMsgType:
+		m = new(TransactionMessage)
+		err = m.Decode(r)
+	default:
+		return nil, errors.New("unsupported message type")
+	}
+
+	return m, err
+}
+
+// readByte
+func readByte(r io.Reader) (byte, error) {
+	buf := make([]byte, 1)
+	_, err := r.Read(buf)
+	if err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+// readHash
+func readHash(r io.Reader) (common.Hash, error) {
+	buf := make([]byte, 32)
+	_, err := r.Read(buf)
+	if err != nil {
+		return common.Hash{}, err
+	}
+	h := [32]byte{}
+	copy(h[:], buf)
+	return common.Hash(h), nil
+}
+
+// readUint32
+func readUint32(r io.Reader) (uint32, error) {
+	buf := make([]byte, 4)
+	_, err := r.Read(buf)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(buf), nil
+}
+
+// readUint64
+func readUint64(r io.Reader) (uint64, error) {
+	buf := make([]byte, 8)
+	_, err := r.Read(buf)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint64(buf), nil
 }

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -144,12 +144,6 @@ func saveKey(priv crypto.PrivKey, fp string) (err error) {
 
 // decodeMessage decodes the message based on message type
 func decodeMessage(r io.Reader) (m Message, err error) {
-
-	// _, err := readByte(r)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	msgType, err := readByte(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Changes

Use an existing stream to send messages if an existing stream is available.

See specifcation 4.4.2

> For the purposes of communicating Polkadot messages, the dailer of the connection opens a unique substream. Optionally, the node can keep a unique substream alive for this purpose.

## Tests:
```
go test ./p2p --run TestExistingStream -v
```

### Issues:
closes #437