### PR TITLE
cmd: Genesis Init Failure Fix

### DIFF
--- a/cmd/gossamer/genesis.go
+++ b/cmd/gossamer/genesis.go
@@ -22,7 +22,11 @@ func loadGenesis(ctx *cli.Context) error {
 
 	// read genesis file
 	fp := getGenesisPath(ctx)
-	log.Debug("Loading genesis", "genesisfile", fp, "datadir", fig.Global.DataDir)
+	dataDir := fig.Global.DataDir
+	if ctx.String(utils.DataDirFlag.Name) != "" {
+		dataDir = ctx.String(utils.DataDirFlag.Name)
+	}
+	log.Debug("Loading genesis", "genesisfile", fp, "datadir", dataDir)
 
 	gen, err := genesis.LoadGenesisData(fp)
 	if err != nil {
@@ -32,7 +36,7 @@ func loadGenesis(ctx *cli.Context) error {
 	log.Info("🕸\t Initializing node", "name", gen.Name, "id", gen.Id, "protocolID", gen.ProtocolId, "bootnodes", common.BytesToStringArray(gen.Bootnodes))
 
 	// Create service, initialize stateDB and blockDB
-	stateSrv := state.NewService(fig.Global.DataDir)
+	stateSrv := state.NewService(dataDir)
 
 	err = stateSrv.Start()
 	if err != nil {


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
- Checks for datadir flag in when loading the genesis file

<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:


<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues:
Closes #454  