### PR TITLE
core/blocktree, core/rawdb, core/types, state: change types.BlockHeader to unexport hash field and add getter/setter

### DIFF
--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -202,7 +202,7 @@ func (b *Session) vrfSign(input []byte) ([]byte, error) {
 }
 
 // Block Build
-func (b *Session) buildBlock(parent *types.BlockHeaderWithHash, slot Slot) (*types.Block, error) {
+func (b *Session) buildBlock(parent *types.BlockHeader, slot Slot) (*types.Block, error) {
 	log.Debug("build-block", "parent", parent, "slot", slot)
 
 	// Initialize block

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -304,11 +304,6 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 		},
 		Body: &types.BlockBody{},
 	}
-
-	_, err := genesisBlock.Header.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
 	genesisBlock.SetBlockArrivalTime(uint64(1000))
 
 	d := &db.BlockDB{
@@ -316,7 +311,7 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 	}
 
 	bt := blocktree.NewBlockTreeFromGenesis(genesisBlock, d)
-	previousHash := genesisBlock.Header.MustHash()
+	previousHash := genesisBlock.Header.Hash()
 	previousAT := genesisBlock.GetBlockArrivalTime()
 
 	for i := 1; i <= depth; i++ {
@@ -328,10 +323,7 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 			Body: &types.BlockBody{},
 		}
 
-		hash, err := block.Header.Hash()
-		if err != nil {
-			t.Fatal(err)
-		}
+		hash := block.Header.Hash()
 		block.SetBlockArrivalTime(previousAT + uint64(1000))
 
 		bt.AddBlock(block)

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -305,7 +305,7 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 		Body: &types.BlockBody{},
 	}
 
-	hash, err := genesisBlock.Header.Hash()
+	_, err := genesisBlock.Header.Hash()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +328,7 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 			Body: &types.BlockBody{},
 		}
 
-		hash, err = block.Header.Hash()
+		hash, err := block.Header.Hash()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -17,7 +17,6 @@
 package babe
 
 import (
-	"fmt"
 	"io"
 	"math"
 	"math/big"
@@ -306,7 +305,10 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 		Body: &types.BlockBody{},
 	}
 
-	genesisBlock.Header.SetHash(common.Hash{0x00})
+	hash, err := genesisBlock.Header.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
 	genesisBlock.SetBlockArrivalTime(uint64(1000))
 
 	d := &db.BlockDB{
@@ -318,14 +320,6 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 	previousAT := genesisBlock.GetBlockArrivalTime()
 
 	for i := 1; i <= depth; i++ {
-		hex := fmt.Sprintf("%06x", i)
-
-		hash, err := common.HexToHash("0x" + hex)
-
-		if err != nil {
-			t.Error(err)
-		}
-
 		block := types.Block{
 			Header: &types.BlockHeader{
 				ParentHash: previousHash,
@@ -334,7 +328,10 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 			Body: &types.BlockBody{},
 		}
 
-		block.Header.SetHash(hash)
+		hash, err = block.Header.Hash()
+		if err != nil {
+			t.Fatal(err)
+		}
 		block.SetBlockArrivalTime(previousAT + uint64(1000))
 
 		bt.AddBlock(block)
@@ -343,7 +340,6 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 	}
 
 	return bt
-
 }
 
 func TestSlotTime(t *testing.T) {

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -299,15 +299,16 @@ func TestSlotOffset(t *testing.T) {
 
 func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 
-	genesisBlock := types.BlockWithHash{
-		Header: &types.BlockHeaderWithHash{
+	genesisBlock := types.Block{
+		Header: &types.BlockHeader{
 			ParentHash: zeroHash,
 			Number:     big.NewInt(0),
-			Hash:       common.Hash{0x00},
+			//Hash:       ,
 		},
 		Body: &types.BlockBody{},
 	}
 
+	genesisBlock.Header.SetHash(common.Hash{0x00})
 	genesisBlock.SetBlockArrivalTime(uint64(1000))
 
 	d := &db.BlockDB{
@@ -315,7 +316,7 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 	}
 
 	bt := blocktree.NewBlockTreeFromGenesis(genesisBlock, d)
-	previousHash := genesisBlock.Header.Hash
+	previousHash := genesisBlock.Header.GetHash()
 	previousAT := genesisBlock.GetBlockArrivalTime()
 
 	for i := 1; i <= depth; i++ {
@@ -327,15 +328,15 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 			t.Error(err)
 		}
 
-		block := types.BlockWithHash{
-			Header: &types.BlockHeaderWithHash{
+		block := types.Block{
+			Header: &types.BlockHeader{
 				ParentHash: previousHash,
-				Hash:       hash,
 				Number:     big.NewInt(int64(i)),
 			},
 			Body: &types.BlockBody{},
 		}
 
+		block.Header.SetHash(hash)
 		block.SetBlockArrivalTime(previousAT + uint64(1000))
 
 		bt.AddBlock(block)
@@ -492,7 +493,7 @@ func TestBuildBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	parentHeader := &types.BlockHeaderWithHash{
+	parentHeader := &types.BlockHeader{
 		ParentHash: zeroHash,
 		Number:     big.NewInt(0),
 	}

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -316,7 +316,7 @@ func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
 	}
 
 	bt := blocktree.NewBlockTreeFromGenesis(genesisBlock, d)
-	previousHash := genesisBlock.Header.GetHash()
+	previousHash := genesisBlock.Header.MustHash()
 	previousAT := genesisBlock.GetBlockArrivalTime()
 
 	for i := 1; i <= depth; i++ {

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -298,12 +298,10 @@ func TestSlotOffset(t *testing.T) {
 }
 
 func createFlatBlockTree(t *testing.T, depth int) *blocktree.BlockTree {
-
 	genesisBlock := types.Block{
 		Header: &types.BlockHeader{
 			ParentHash: zeroHash,
 			Number:     big.NewInt(0),
-			//Hash:       ,
 		},
 		Body: &types.BlockBody{},
 	}

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -41,9 +41,9 @@ type BlockTree struct {
 
 // NewBlockTreeFromGenesis initializes a blocktree with a genesis block.
 // Currently passes in arrival time as a parameter instead of setting it as time of instanciation
-func NewBlockTreeFromGenesis(genesis types.BlockWithHash, db *polkadb.BlockDB) *BlockTree {
+func NewBlockTreeFromGenesis(genesis types.Block, db *polkadb.BlockDB) *BlockTree {
 	head := &node{
-		hash:        genesis.Header.Hash,
+		hash:        genesis.Header.GetHash(),
 		number:      genesis.Header.Number,
 		parent:      nil,
 		children:    []*node{},
@@ -60,14 +60,14 @@ func NewBlockTreeFromGenesis(genesis types.BlockWithHash, db *polkadb.BlockDB) *
 
 // AddBlock inserts the block as child of its parent node
 // Note: Assumes block has no children
-func (bt *BlockTree) AddBlock(block types.BlockWithHash) {
+func (bt *BlockTree) AddBlock(block types.Block) {
 	parent := bt.GetNode(block.Header.ParentHash)
 	// Check if it already exists
 	// TODO: Can shortcut this by checking DB
 	// TODO: Write blockData to db
 	// TODO: Create getter functions to check if blockNum is greater than best block stored
 
-	n := bt.GetNode(block.Header.Hash)
+	n := bt.GetNode(block.Header.GetHash())
 	if n != nil {
 		log.Debug("Attempted to add block to tree that already exists", "Hash", n.hash)
 		return
@@ -77,7 +77,7 @@ func (bt *BlockTree) AddBlock(block types.BlockWithHash) {
 	depth.Add(parent.depth, big.NewInt(1))
 
 	n = &node{
-		hash:        block.Header.Hash,
+		hash:        block.Header.GetHash(),
 		number:      block.Header.Number,
 		parent:      parent,
 		children:    []*node{},
@@ -106,7 +106,7 @@ func (bt *BlockTree) GetNode(h Hash) *node {
 
 // GetBlockFromBlockNumber finds and returns a block from its number
 // TODO: Grab block details from Db, this currently constructs and returns a block from node info
-func (bt *BlockTree) GetBlockFromBlockNumber(b *big.Int) *types.BlockWithHash {
+func (bt *BlockTree) GetBlockFromBlockNumber(b *big.Int) *types.Block {
 	return bt.getNodeFromBlockNumber(b).getBlockFromNode()
 
 }
@@ -167,11 +167,11 @@ func (bt *BlockTree) SubChain(start Hash, end Hash) []*node {
 }
 
 // SubChain returns the path from the node with Hash start to the node with Hash end
-func (bt *BlockTree) SubBlockchain(start *big.Int, end *big.Int) []*types.BlockWithHash {
+func (bt *BlockTree) SubBlockchain(start *big.Int, end *big.Int) []*types.Block {
 	s := bt.getNodeFromBlockNumber(start)
 	e := bt.getNodeFromBlockNumber(end)
 	sc := bt.SubChain(s.hash, e.hash)
-	var bc []*types.BlockWithHash
+	var bc []*types.Block
 	for _, node := range sc {
 		bc = append(bc, node.getBlockFromNode())
 	}
@@ -185,14 +185,14 @@ func (bt *BlockTree) DeepestLeaf() *node {
 }
 
 // DeepestLeaf returns leftmost deepest block in BlockTree BT
-func (bt *BlockTree) DeepestBlock() *types.BlockWithHash {
+func (bt *BlockTree) DeepestBlock() *types.Block {
 	b := bt.leaves.DeepestLeaf().getBlockFromNode()
 	return b
 }
 
 // computes the slot for a block from genesis
 // helper for now, there's a better way to do this
-func (bt *BlockTree) ComputeSlotForBlock(b *types.BlockWithHash, sd uint64) uint64 {
+func (bt *BlockTree) ComputeSlotForBlock(b *types.Block, sd uint64) uint64 {
 	gt := bt.head.arrivalTime
 	nt := b.GetBlockArrivalTime()
 

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -43,7 +43,7 @@ type BlockTree struct {
 // Currently passes in arrival time as a parameter instead of setting it as time of instanciation
 func NewBlockTreeFromGenesis(genesis types.Block, db *polkadb.BlockDB) *BlockTree {
 	head := &node{
-		hash:        genesis.Header.MustHash(),
+		hash:        genesis.Header.Hash(),
 		number:      genesis.Header.Number,
 		parent:      nil,
 		children:    []*node{},
@@ -67,7 +67,7 @@ func (bt *BlockTree) AddBlock(block types.Block) {
 	// TODO: Write blockData to db
 	// TODO: Create getter functions to check if blockNum is greater than best block stored
 
-	n := bt.GetNode(block.Header.MustHash())
+	n := bt.GetNode(block.Header.Hash())
 	if n != nil {
 		log.Debug("Attempted to add block to tree that already exists", "Hash", n.hash)
 		return
@@ -77,7 +77,7 @@ func (bt *BlockTree) AddBlock(block types.Block) {
 	depth.Add(parent.depth, big.NewInt(1))
 
 	n = &node{
-		hash:        block.Header.MustHash(),
+		hash:        block.Header.Hash(),
 		number:      block.Header.Number,
 		parent:      parent,
 		children:    []*node{},

--- a/core/blocktree/blocktree.go
+++ b/core/blocktree/blocktree.go
@@ -43,7 +43,7 @@ type BlockTree struct {
 // Currently passes in arrival time as a parameter instead of setting it as time of instanciation
 func NewBlockTreeFromGenesis(genesis types.Block, db *polkadb.BlockDB) *BlockTree {
 	head := &node{
-		hash:        genesis.Header.GetHash(),
+		hash:        genesis.Header.MustHash(),
 		number:      genesis.Header.Number,
 		parent:      nil,
 		children:    []*node{},
@@ -67,7 +67,7 @@ func (bt *BlockTree) AddBlock(block types.Block) {
 	// TODO: Write blockData to db
 	// TODO: Create getter functions to check if blockNum is greater than best block stored
 
-	n := bt.GetNode(block.Header.GetHash())
+	n := bt.GetNode(block.Header.MustHash())
 	if n != nil {
 		log.Debug("Attempted to add block to tree that already exists", "Hash", n.hash)
 		return
@@ -77,7 +77,7 @@ func (bt *BlockTree) AddBlock(block types.Block) {
 	depth.Add(parent.depth, big.NewInt(1))
 
 	n = &node{
-		hash:        block.Header.GetHash(),
+		hash:        block.Header.MustHash(),
 		number:      block.Header.Number,
 		parent:      parent,
 		children:    []*node{},

--- a/core/blocktree/blocktree_test.go
+++ b/core/blocktree/blocktree_test.go
@@ -167,7 +167,6 @@ func TestBlockTree_LongestPath(t *testing.T) {
 		Header: &types.BlockHeader{
 			ParentHash: zeroHash,
 			Number:     big.NewInt(1),
-			//Hash:       common.Hash{0xAB},
 		},
 		Body: &types.BlockBody{},
 	}

--- a/core/blocktree/blocktree_test.go
+++ b/core/blocktree/blocktree_test.go
@@ -18,7 +18,6 @@ package blocktree
 
 import (
 	"math/big"
-	"strconv"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/core/types"
@@ -42,18 +41,6 @@ func createGenesisBlock() types.Block {
 	return b
 }
 
-func intToHashable(in int) string {
-	if in < 0 {
-		return ""
-	}
-
-	out := strconv.Itoa(in)
-	if len(out)%2 != 0 {
-		out = "0" + out
-	}
-	return "0x" + out
-}
-
 func createFlatTree(t *testing.T, depth int) (*BlockTree, []common.Hash) {
 	d := &db.BlockDB{
 		Db: db.NewMemDatabase(),
@@ -69,8 +56,7 @@ func createFlatTree(t *testing.T, depth int) (*BlockTree, []common.Hash) {
 		block := types.Block{
 			Header: &types.BlockHeader{
 				ParentHash: previousHash,
-				//Hash:       hash,
-				Number: big.NewInt(int64(i)),
+				Number:     big.NewInt(int64(i)),
 			},
 			Body: &types.BlockBody{},
 		}

--- a/core/blocktree/blocktree_test.go
+++ b/core/blocktree/blocktree_test.go
@@ -75,7 +75,6 @@ func createFlatTree(t *testing.T, depth int) (*BlockTree, []common.Hash) {
 			Body: &types.BlockBody{},
 		}
 
-		//block.Header.SetHash(hash)
 		hash, err := block.Header.Hash()
 		if err != nil {
 			t.Fatal(err)

--- a/core/blocktree/blocktree_test.go
+++ b/core/blocktree/blocktree_test.go
@@ -30,15 +30,15 @@ import (
 
 var zeroHash, _ = common.HexToHash("0x00")
 
-func createGenesisBlock() types.BlockWithHash {
-	b := types.BlockWithHash{
-		Header: &types.BlockHeaderWithHash{
+func createGenesisBlock() types.Block {
+	b := types.Block{
+		Header: &types.BlockHeader{
 			ParentHash: zeroHash,
 			Number:     big.NewInt(0),
-			Hash:       common.Hash{0x00},
 		},
 		Body: &types.BlockBody{},
 	}
+	b.Header.SetHash(common.Hash{0x00})
 	b.SetBlockArrivalTime(uint64(0))
 	return b
 }
@@ -72,15 +72,16 @@ func createFlatTree(t *testing.T, depth int) *BlockTree {
 			t.Error(err)
 		}
 
-		block := types.BlockWithHash{
-			Header: &types.BlockHeaderWithHash{
+		block := types.Block{
+			Header: &types.BlockHeader{
 				ParentHash: previousHash,
-				Hash:       hash,
-				Number:     big.NewInt(int64(i)),
+				//Hash:       hash,
+				Number: big.NewInt(int64(i)),
 			},
 			Body: &types.BlockBody{},
 		}
 
+		block.Header.SetHash(hash)
 		block.SetBlockArrivalTime(previousAT + uint64(1000))
 
 		bt.AddBlock(block)
@@ -111,15 +112,15 @@ func TestBlockTree_GetBlock(t *testing.T) {
 func TestBlockTree_AddBlock(t *testing.T) {
 	bt := createFlatTree(t, 1)
 
-	block := types.BlockWithHash{
-		Header: &types.BlockHeaderWithHash{
+	block := types.Block{
+		Header: &types.BlockHeader{
 			ParentHash: common.Hash{0x01},
 			Number:     nil,
-			Hash:       common.Hash{0x02},
 		},
 		Body: &types.BlockBody{},
 	}
 
+	block.Header.SetHash(common.Hash{0x02})
 	bt.AddBlock(block)
 
 	n := bt.GetNode(common.Hash{0x02})
@@ -162,15 +163,16 @@ func TestBlockTree_LongestPath(t *testing.T) {
 	bt := createFlatTree(t, 3)
 
 	// Insert a block to create a competing path
-	extraBlock := types.BlockWithHash{
-		Header: &types.BlockHeaderWithHash{
+	extraBlock := types.Block{
+		Header: &types.BlockHeader{
 			ParentHash: zeroHash,
 			Number:     big.NewInt(1),
-			Hash:       common.Hash{0xAB},
+			//Hash:       common.Hash{0xAB},
 		},
 		Body: &types.BlockBody{},
 	}
 
+	extraBlock.Header.SetHash(common.Hash{0xAB})
 	bt.AddBlock(extraBlock)
 
 	expectedPath := []*node{
@@ -193,15 +195,15 @@ func TestBlockTree_Subchain(t *testing.T) {
 	bt := createFlatTree(t, 4)
 
 	// Insert a block to create a competing path
-	extraBlock := types.BlockWithHash{
-		Header: &types.BlockHeaderWithHash{
+	extraBlock := types.Block{
+		Header: &types.BlockHeader{
 			ParentHash: zeroHash,
 			Number:     big.NewInt(1),
-			Hash:       common.Hash{0xAB},
 		},
 		Body: &types.BlockBody{},
 	}
 
+	extraBlock.Header.SetHash(common.Hash{0xAB})
 	bt.AddBlock(extraBlock)
 
 	expectedPath := []*node{

--- a/core/blocktree/blocktree_test.go
+++ b/core/blocktree/blocktree_test.go
@@ -36,7 +36,7 @@ func createGenesisBlock() types.Block {
 		},
 		Body: &types.BlockBody{},
 	}
-	_, _ = b.Header.Hash()
+	b.Header.Hash()
 	b.SetBlockArrivalTime(uint64(0))
 	return b
 }
@@ -61,10 +61,7 @@ func createFlatTree(t *testing.T, depth int) (*BlockTree, []common.Hash) {
 			Body: &types.BlockBody{},
 		}
 
-		hash, err := block.Header.Hash()
-		if err != nil {
-			t.Fatal(err)
-		}
+		hash := block.Header.Hash()
 		hashes = append(hashes, hash)
 		block.SetBlockArrivalTime(previousAT + uint64(1000))
 
@@ -102,10 +99,7 @@ func TestBlockTree_AddBlock(t *testing.T) {
 		Body: &types.BlockBody{},
 	}
 
-	hash, err := block.Header.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
+	hash := block.Header.Hash()
 	bt.AddBlock(block)
 
 	n := bt.GetNode(hash)
@@ -150,10 +144,7 @@ func TestBlockTree_LongestPath(t *testing.T) {
 		Body: &types.BlockBody{},
 	}
 
-	_, err := extraBlock.Header.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
+	extraBlock.Header.Hash()
 	bt.AddBlock(extraBlock)
 
 	longestPath := bt.LongestPath()
@@ -178,10 +169,7 @@ func TestBlockTree_Subchain(t *testing.T) {
 		Body: &types.BlockBody{},
 	}
 
-	_, err := extraBlock.Header.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
+	extraBlock.Header.Hash()
 	bt.AddBlock(extraBlock)
 
 	subChain := bt.SubChain(hashes[1], hashes[3])

--- a/core/blocktree/node.go
+++ b/core/blocktree/node.go
@@ -92,7 +92,10 @@ func (n *node) getBlockFromNode() *types.Block {
 		Number:     n.number,
 	}
 
-	bh.SetHash(n.hash)
+	_, err := bh.Hash()
+	if err != nil {
+		return nil
+	}
 
 	b := &types.Block{
 		Header: &bh,

--- a/core/blocktree/node.go
+++ b/core/blocktree/node.go
@@ -90,7 +90,6 @@ func (n *node) getBlockFromNode() *types.Block {
 	bh := types.BlockHeader{
 		ParentHash: n.parent.hash,
 		Number:     n.number,
-		//Hash:       n.hash,
 	}
 
 	bh.SetHash(n.hash)

--- a/core/blocktree/node.go
+++ b/core/blocktree/node.go
@@ -91,11 +91,7 @@ func (n *node) getBlockFromNode() *types.Block {
 		ParentHash: n.parent.hash,
 		Number:     n.number,
 	}
-
-	_, err := bh.Hash()
-	if err != nil {
-		return nil
-	}
+	bh.Hash()
 
 	b := &types.Block{
 		Header: &bh,

--- a/core/blocktree/node.go
+++ b/core/blocktree/node.go
@@ -86,14 +86,16 @@ func (n *node) getNodeFromBlockNumber(b *big.Int) *node {
 	return nil
 }
 
-func (n *node) getBlockFromNode() *types.BlockWithHash {
-	bh := types.BlockHeaderWithHash{
+func (n *node) getBlockFromNode() *types.Block {
+	bh := types.BlockHeader{
 		ParentHash: n.parent.hash,
 		Number:     n.number,
-		Hash:       n.hash,
+		//Hash:       n.hash,
 	}
 
-	b := &types.BlockWithHash{
+	bh.SetHash(n.hash)
+
+	b := &types.Block{
 		Header: &bh,
 		Body:   &types.BlockBody{},
 	}

--- a/core/rawdb/rawdb.go
+++ b/core/rawdb/rawdb.go
@@ -16,8 +16,9 @@ func check(e error) {
 }
 
 // SetHeader stores a block header into the KV-store; key is headerPrefix + hash
-func SetHeader(db polkadb.Writer, header *types.BlockHeaderWithHash) {
-	hash := header.Hash
+func SetHeader(db polkadb.Writer, header *types.BlockHeader) {
+	hash, err := header.Hash()
+	check(err)
 
 	// Write the encoded header
 	bh, err := json.Marshal(header)
@@ -28,8 +29,8 @@ func SetHeader(db polkadb.Writer, header *types.BlockHeaderWithHash) {
 }
 
 // GetHeader retrieves block header from KV-store using headerKey
-func GetHeader(db polkadb.Reader, hash common.Hash) types.BlockHeaderWithHash {
-	var result types.BlockHeaderWithHash
+func GetHeader(db polkadb.Reader, hash common.Hash) types.BlockHeader {
+	var result types.BlockHeader
 	get(db, headerKey(hash), &result)
 	return result
 }

--- a/core/rawdb/rawdb.go
+++ b/core/rawdb/rawdb.go
@@ -17,8 +17,7 @@ func check(e error) {
 
 // SetHeader stores a block header into the KV-store; key is headerPrefix + hash
 func SetHeader(db polkadb.Writer, header *types.BlockHeader) {
-	hash, err := header.Hash()
-	check(err)
+	hash := header.Hash()
 
 	// Write the encoded header
 	bh, err := json.Marshal(header)

--- a/core/rawdb/rawdb_test.go
+++ b/core/rawdb/rawdb_test.go
@@ -18,10 +18,7 @@ func setup(t *testing.T) (polkadb.Database, *types.BlockHeader) {
 		ExtrinsicsRoot: common.BytesToHash([]byte("extrinsics_test")),
 		Digest:         []byte("digest_test"),
 	}
-	_, err := h.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
+	h.Hash()
 	return polkadb.NewMemDatabase(), h
 }
 
@@ -29,15 +26,12 @@ func TestSetHeader(t *testing.T) {
 	memDB, h := setup(t)
 
 	SetHeader(memDB, h)
-	entry := GetHeader(memDB, h.MustHash())
+	entry := GetHeader(memDB, h.Hash())
 	if reflect.DeepEqual(entry, h) {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, h)
 	}
-	entryHash, err := entry.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if h.MustHash() != entryHash {
+	entryHash := entry.Hash()
+	if h.Hash() != entryHash {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, h)
 	}
 }
@@ -46,11 +40,7 @@ func TestSetBlockData(t *testing.T) {
 	var body *types.BlockBody
 	memDB, h := setup(t)
 
-	hash, err := h.Hash()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	hash := h.Hash()
 	bd := &types.BlockData{
 		Hash:   hash,
 		Header: h,
@@ -58,7 +48,7 @@ func TestSetBlockData(t *testing.T) {
 	}
 
 	SetBlockData(memDB, bd)
-	entry := GetBlockData(memDB, bd.Header.MustHash())
+	entry := GetBlockData(memDB, bd.Header.Hash())
 	if reflect.DeepEqual(entry, bd) {
 		t.Fatalf("Retrieved blockData mismatch: have %v, want %v", entry, bd)
 	}

--- a/core/rawdb/rawdb_test.go
+++ b/core/rawdb/rawdb_test.go
@@ -29,7 +29,7 @@ func TestSetHeader(t *testing.T) {
 	memDB, h := setup(t)
 
 	SetHeader(memDB, h)
-	entry := GetHeader(memDB, h.GetHash())
+	entry := GetHeader(memDB, h.MustHash())
 	if reflect.DeepEqual(entry, h) {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, h)
 	}
@@ -37,7 +37,7 @@ func TestSetHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if h.GetHash() != entryHash {
+	if h.MustHash() != entryHash {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, h)
 	}
 }
@@ -58,7 +58,7 @@ func TestSetBlockData(t *testing.T) {
 	}
 
 	SetBlockData(memDB, bd)
-	entry := GetBlockData(memDB, bd.Header.GetHash())
+	entry := GetBlockData(memDB, bd.Header.MustHash())
 	if reflect.DeepEqual(entry, bd) {
 		t.Fatalf("Retrieved blockData mismatch: have %v, want %v", entry, bd)
 	}

--- a/core/rawdb/rawdb_test.go
+++ b/core/rawdb/rawdb_test.go
@@ -10,43 +10,55 @@ import (
 	"github.com/ChainSafe/gossamer/polkadb"
 )
 
-func setup() (polkadb.Database, *types.BlockHeaderWithHash) {
-	h := &types.BlockHeaderWithHash{
+func setup(t *testing.T) (polkadb.Database, *types.BlockHeader) {
+	h := &types.BlockHeader{
 		ParentHash:     common.BytesToHash([]byte("parent_test")),
 		Number:         big.NewInt(2),
 		StateRoot:      common.BytesToHash([]byte("state_root_test")),
 		ExtrinsicsRoot: common.BytesToHash([]byte("extrinsics_test")),
 		Digest:         []byte("digest_test"),
-		Hash:           common.BytesToHash([]byte("hash_test")),
+	}
+	_, err := h.Hash()
+	if err != nil {
+		t.Fatal(err)
 	}
 	return polkadb.NewMemDatabase(), h
 }
 
 func TestSetHeader(t *testing.T) {
-	memDB, h := setup()
+	memDB, h := setup(t)
 
 	SetHeader(memDB, h)
-	entry := GetHeader(memDB, h.Hash)
+	entry := GetHeader(memDB, h.GetHash())
 	if reflect.DeepEqual(entry, h) {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, h)
 	}
-	if h.Hash != entry.Hash {
+	entryHash, err := entry.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.GetHash() != entryHash {
 		t.Fatalf("Retrieved header mismatch: have %v, want %v", entry, h)
 	}
 }
 
 func TestSetBlockData(t *testing.T) {
 	var body *types.BlockBody
-	memDB, h := setup()
+	memDB, h := setup(t)
+
+	hash, err := h.Hash()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	bd := &types.BlockData{
-		Hash:   common.BytesToHash([]byte("bd_hash")),
+		Hash:   hash,
 		Header: h,
 		Body:   body,
 	}
 
 	SetBlockData(memDB, bd)
-	entry := GetBlockData(memDB, bd.Hash)
+	entry := GetBlockData(memDB, bd.Header.GetHash())
 	if reflect.DeepEqual(entry, bd) {
 		t.Fatalf("Retrieved blockData mismatch: have %v, want %v", entry, bd)
 	}

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -53,32 +53,39 @@ type BlockHeader struct {
 	hash           common.Hash
 }
 
-// SetHash sets a block header's hash. Note, you would probably want to use Hash() instead,
-// unless you know the hash has already been set
-func (bh *BlockHeader) SetHash(h common.Hash) {
-	bh.hash = h
+func NewBlockHeader(parentHash common.Hash, number *big.Int, stateRoot common.Hash, extrinsicsRoot common.Hash, digest []byte) *BlockHeader {
+	return &BlockHeader{
+		ParentHash:     parentHash,
+		Number:         number,
+		StateRoot:      stateRoot,
+		ExtrinsicsRoot: extrinsicsRoot,
+		Digest:         digest,
+	}
 }
 
 // GetHash retrieves the header's hash. Since it may be empty if not set, you probably want
-// to use Hash() instead.
+// to use Hash() instead, unless you know Hash() has already been called.
 func (bh *BlockHeader) GetHash() common.Hash {
 	return bh.hash
 }
 
 // Hash hashes the block header, sets the header's internal hash field, and returns it
 func (bh *BlockHeader) Hash() (common.Hash, error) {
-	enc, err := scale.Encode(bh)
-	if err != nil {
-		return [32]byte{}, err
+	if bh.hash == [32]byte{} {
+		enc, err := scale.Encode(bh)
+		if err != nil {
+			return [32]byte{}, err
+		}
+
+		hash, err := common.Blake2bHash(enc)
+		if err != nil {
+			return [32]byte{}, err
+		}
+
+		bh.hash = hash
 	}
 
-	hash, err := common.Blake2bHash(enc)
-	if err != nil {
-		return [32]byte{}, err
-	}
-
-	bh.hash = hash
-	return hash, err
+	return bh.hash, nil
 }
 
 // BlockBody is the extrinsics inside a state block

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -33,13 +33,6 @@ type Block struct {
 	arrivalTime uint64 // arrival time of this block
 }
 
-// // Block defines a state block
-// type BlockWithHash struct {
-// 	Header      *BlockHeaderWithHash
-// 	Body        *BlockBody
-// 	arrivalTime uint64 // arrival time of this block
-// }
-
 // GetBlockArrivalTime returns the arrival time for a block
 func (b *Block) GetBlockArrivalTime() uint64 {
 	return b.arrivalTime

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -28,24 +28,25 @@ type Extrinsic []byte
 
 // Block defines a state block
 type Block struct {
-	Header *BlockHeader
-	Body   *BlockBody
-}
-
-// Block defines a state block
-type BlockWithHash struct {
-	Header      *BlockHeaderWithHash
+	Header      *BlockHeader
 	Body        *BlockBody
 	arrivalTime uint64 // arrival time of this block
 }
 
+// // Block defines a state block
+// type BlockWithHash struct {
+// 	Header      *BlockHeaderWithHash
+// 	Body        *BlockBody
+// 	arrivalTime uint64 // arrival time of this block
+// }
+
 // GetBlockArrivalTime returns the arrival time for a block
-func (b *BlockWithHash) GetBlockArrivalTime() uint64 {
+func (b *Block) GetBlockArrivalTime() uint64 {
 	return b.arrivalTime
 }
 
 // SetBlockArrivalTime sets the arrival time for a block
-func (b *BlockWithHash) SetBlockArrivalTime(t uint64) {
+func (b *Block) SetBlockArrivalTime(t uint64) {
 	b.arrivalTime = t
 }
 
@@ -56,6 +57,15 @@ type BlockHeader struct {
 	StateRoot      common.Hash `json:"stateRoot"`
 	ExtrinsicsRoot common.Hash `json:"extrinsicsRoot"`
 	Digest         []byte      `json:"digest"` // any additional block info eg. logs, seal
+	hash           common.Hash
+}
+
+func (bh *BlockHeader) SetHash(h common.Hash) {
+	bh.hash = h
+}
+
+func (bh *BlockHeader) GetHash() common.Hash {
+	return bh.hash
 }
 
 func (bh *BlockHeader) Hash() (common.Hash, error) {
@@ -64,49 +74,13 @@ func (bh *BlockHeader) Hash() (common.Hash, error) {
 		return [32]byte{}, err
 	}
 
-	return common.Blake2bHash(enc)
-}
-
-func (bh *BlockHeader) WithHash() (*BlockHeaderWithHash, error) {
-	enc, err := scale.Encode(bh)
-	if err != nil {
-		return nil, err
-	}
-
 	hash, err := common.Blake2bHash(enc)
 	if err != nil {
-		return nil, err
+		return [32]byte{}, err
 	}
 
-	return &BlockHeaderWithHash{
-		ParentHash:     bh.ParentHash,
-		Number:         bh.Number,
-		StateRoot:      bh.StateRoot,
-		ExtrinsicsRoot: bh.ExtrinsicsRoot,
-		Digest:         bh.Digest,
-		Hash:           hash,
-	}, nil
-}
-
-func (bh *BlockHeaderWithHash) WithoutHash() *BlockHeader {
-	return &BlockHeader{
-		ParentHash:     bh.ParentHash,
-		Number:         bh.Number,
-		StateRoot:      bh.StateRoot,
-		ExtrinsicsRoot: bh.ExtrinsicsRoot,
-		Digest:         bh.Digest,
-	}
-}
-
-// BlockHeaderWithHash is a state block header
-type BlockHeaderWithHash struct {
-	ParentHash     common.Hash `json:"parentHash"`
-	Number         *big.Int    `json:"number"`
-	StateRoot      common.Hash `json:"stateRoot"`
-	ExtrinsicsRoot common.Hash `json:"extrinsicsRoot"`
-	Digest         []byte      `json:"digest"` // any additional block info eg. logs, seal
-	// TODO: Not part of spec, can potentially remove
-	Hash common.Hash `json:"hash"`
+	bh.hash = hash
+	return hash, err
 }
 
 // BlockBody is the extrinsics inside a state block
@@ -115,7 +89,7 @@ type BlockBody []byte
 /// BlockData is stored within the BlockDB
 type BlockData struct {
 	Hash   common.Hash
-	Header *BlockHeaderWithHash
+	Header *BlockHeader
 	Body   *BlockBody
 	// Receipt
 	// MessageQueue

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -53,14 +53,19 @@ type BlockHeader struct {
 	hash           common.Hash
 }
 
+// SetHash sets a block header's hash. Note, you would probably want to use Hash() instead,
+// unless you know the hash has already been set
 func (bh *BlockHeader) SetHash(h common.Hash) {
 	bh.hash = h
 }
 
+// GetHash retrieves the header's hash. Since it may be empty if not set, you probably want
+// to use Hash() instead.
 func (bh *BlockHeader) GetHash() common.Hash {
 	return bh.hash
 }
 
+// Hash hashes the block header, sets the header's internal hash field, and returns it
 func (bh *BlockHeader) Hash() (common.Hash, error) {
 	enc, err := scale.Encode(bh)
 	if err != nil {

--- a/state/block.go
+++ b/state/block.go
@@ -118,10 +118,7 @@ func (bs *blockState) GetBlockByNumber(n *big.Int) types.Block {
 }
 
 func (bs *blockState) SetHeader(header types.BlockHeader) error {
-	hash, err := header.Hash()
-	if err != nil {
-		return err
-	}
+	hash := header.Hash()
 
 	// Write the encoded header
 	bh, err := json.Marshal(header)

--- a/state/interface.go
+++ b/state/interface.go
@@ -27,17 +27,17 @@ type StorageApi interface {
 
 // Read only
 type ROBlockApi interface {
-	GetHeader(hash common.Hash) (types.BlockHeaderWithHash, error)
+	GetHeader(hash common.Hash) (types.BlockHeader, error)
 	GetBlockData(hash common.Hash) (types.BlockData, error)
-	GetLatestBlock() types.BlockHeaderWithHash
+	GetLatestBlock() types.BlockHeader
 	GetBlockByHash(hash common.Hash) (types.Block, error)
 	GetBlockByNumber(n *big.Int) types.Block
 }
 
 type BlockApi interface {
 	ROBlockApi
-	SetHeader(header types.BlockHeaderWithHash) error
-	SetBlockData(hash common.Hash, header types.BlockHeaderWithHash) error
+	SetHeader(header types.BlockHeader) error
+	SetBlockData(hash common.Hash, header types.BlockHeader) error
 }
 
 type MessageApi interface {


### PR DESCRIPTION
# Changes
- remove types.BlockHeaderWithHash and types.BlockWithHash finally >:|
- add internal hash field that has a getter/setter. note we probably only want to use `Hash()` (and `GetHash()` once Hash() has been called) in most circumstances, however we need `Set()` for the blocktree.
- update other packages accordingly

## Tests:
```
go test ./...
```

### Issues:
closes #506 