### PR TITLE
runtime: fix enumerated trie root

### DIFF
--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -514,7 +514,7 @@ func TestBuildBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	extrinsicsHash, err := common.HexToHash("0xad07a4b35c5e14f1e555ab965258cc2679eafcb48d142e378815edc7e6ecfc53")
+	extrinsicsHash, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -501,7 +501,6 @@ func TestBuildBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-
 	extrinsicsHash, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
 	if err != nil {
 		t.Fatal(err)

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -356,8 +356,6 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 
-	//runtimeCtx := instanceContext.Data().(*RuntimeCtx)
-	//s := runtimeCtx.storage
 	t := &trie.Trie{}
 	var i int32
 	var pos int32 = 0

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -62,6 +62,8 @@ import (
 	"math/big"
 	"unsafe"
 
+	"github.com/ChainSafe/gossamer/trie"
+
 	"github.com/ChainSafe/gossamer/codec"
 
 	"github.com/ChainSafe/gossamer/common"
@@ -354,8 +356,9 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 
-	runtimeCtx := instanceContext.Data().(*RuntimeCtx)
-	s := runtimeCtx.storage
+	//runtimeCtx := instanceContext.Data().(*RuntimeCtx)
+	//s := runtimeCtx.storage
+	t := &trie.Trie{}
 	var i int32
 	var pos int32 = 0
 	for i = 0; i < lensLen; i++ {
@@ -372,13 +375,13 @@ func ext_blake2_256_enumerated_trie_root(context unsafe.Pointer, valuesData, len
 			return
 		}
 		log.Trace("[ext_blake2_256_enumerated_trie_root]", "key", i, "key value", encodedOutput)
-		err = s.SetStorage(encodedOutput, value)
+		err = t.Put(encodedOutput, value)
 		if err != nil {
 			log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)
 			return
 		}
 	}
-	root, err := s.StorageRoot()
+	root, err := t.Hash()
 	log.Trace("[ext_blake2_256_enumerated_trie_root]", "root hash", fmt.Sprintf("0x%x", root))
 	if err != nil {
 		log.Error("[ext_blake2_256_enumerated_trie_root]", "error", err)


### PR DESCRIPTION
<!--
 Before submitting a PR please ensure all code is commented and all tests are passing. Make sure to review the changes and ensure that only required changes are included (eg. no unnecessary reformatting by your editor)
-->

<!-- Please begin the title of this PR with a list of the packages touched (eg. "cmd, rpc: Add Literal Bells and Whistles") -->


<!-- Brief but specific list of changes made, describe the change in functionality rather than the change in code -->
## Changes
This is a fix for an issue I introduced when I was doing storage refactoring.  In ext_blake2_256_enumerated_trie_root I inadvertently changed the reference for the trie to the storge trie.  But in this function we need to use a fresh trie to calculate root hash.  This fix corrects this so that a fresh trie is used.


<!-- Details on how to run only the tests for the changes in the PR -->
## Tests:
```
cd runtime/
go test -v -run TestExt_blake2_256_enumerated_trie_root
```

<!-- Issues that this PR will close -->
<!-- 
    NOTE: you must say 'closes #xx' or 'fixes #xx' for EACH issue this closes. 
    eg: 'closes #1 and closes #2'
    See: https://help.github.com/en/articles/closing-issues-using-keywords
-->
### Issues: