### PR TITLE
cmd: add account secp256k1 flag option

### DIFF
--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -44,12 +44,12 @@ func handleAccounts(ctx *cli.Context) error {
 	}
 
 	// check if we want to generate a new keypair
-	// can specify key type using --ed25519 or --sr25519
+	// can specify key type using --ed25519, --sr25519, --secp256k1
 	// otherwise defaults to sr25519
 	if keygen := ctx.Bool(utils.GenerateFlag.Name); keygen {
 		log.Info("generating keypair...")
 
-		// check if --ed25519 or --sr25519 is set
+		// check if --ed25519, --sr25519, --secp256k1 is set
 		keytype := crypto.Sr25519Type
 		if flagtype := ctx.Bool(utils.Sr25519Flag.Name); flagtype {
 			keytype = crypto.Sr25519Type

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -55,7 +55,7 @@ var (
 		utils.GenerateFlag,
 		utils.Sr25519Flag,
 		utils.Ed25519Flag,
-		//utils.Secp256k1Flag,
+		utils.Secp256k1Flag,
 		utils.ImportFlag,
 		utils.ListFlag,
 		utils.PasswordFlag,
@@ -95,6 +95,7 @@ var (
 		Description: "The account command is used to manage the gossamer keystore.\n" +
 			"\tTo generate a new sr25519 account: gossamer account --generate\n" +
 			"\tTo generate a new ed25519 account: gossamer account --generate --ed25519\n" +
+			"\tTo generate a new secp256k1 account: gossamer account --generate --secp256k1\n" +
 			"\tTo import a keystore file: gossamer account --import=path/to/file\n" +
 			"\tTo list keys: gossamer account --list",
 	}


### PR DESCRIPTION
##  Changes

This pull request adds the missing `secp256k1` account option to `gossamer`.

## Tests:
```
./build/bin/gossamer account --generate --secp256k1
```