### PR TITLE
consensus/babe, core: initialize new babe session for each epoch

### DIFF
--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	scale "github.com/ChainSafe/gossamer/codec"
+	"github.com/ChainSafe/gossamer/common"
 	tx "github.com/ChainSafe/gossamer/common/transaction"
 	babetypes "github.com/ChainSafe/gossamer/consensus/babe/types"
 	"github.com/ChainSafe/gossamer/core/types"
@@ -46,6 +47,7 @@ type Session struct {
 	txQueue        *tx.PriorityQueue
 	slotToProof    map[uint64]*VrfOutputAndProof // for slots where we are a producer, store the vrf output (bytes 0-32) + proof (bytes 32-96)
 	newBlocks      chan<- types.Block            // send blocks to core service
+	done           chan<- struct{}               // lets core know when the epoch is done
 }
 
 type SessionConfig struct {
@@ -56,6 +58,7 @@ type SessionConfig struct {
 	AuthorityIndex uint64
 	AuthData       []*AuthorityData
 	EpochThreshold *big.Int // should only be used for testing
+	Done           chan<- struct{}
 }
 
 // NewSession returns a new Babe session using the provided VRF keys and runtime
@@ -74,6 +77,7 @@ func NewSession(cfg *SessionConfig) (*Session, error) {
 		authorityIndex: cfg.AuthorityIndex,
 		authorityData:  cfg.AuthData,
 		epochThreshold: cfg.EpochThreshold,
+		done:           cfg.Done,
 	}
 
 	err := babeSession.configurationFromRuntime()
@@ -148,6 +152,7 @@ func (b *Session) invokeBlockAuthoring() {
 			} else {
 				hash := block.Header.Hash()
 				log.Info("BABE", "built block", hash.String(), "number", block.Header.Number)
+				log.Debug("BABE built block", "header", block.Header, "body", block.Body)
 				b.newBlocks <- *block
 				err = b.blockState.AddBlock(*block)
 				if err != nil {
@@ -157,6 +162,14 @@ func (b *Session) invokeBlockAuthoring() {
 		}
 
 		time.Sleep(time.Millisecond * time.Duration(b.config.SlotDuration))
+	}
+
+	if b.newBlocks != nil {
+		close(b.newBlocks)
+	}
+
+	if b.done != nil {
+		close(b.done)
 	}
 }
 
@@ -271,8 +284,14 @@ func (b *Session) buildBlock(parent *types.Header, slot Slot) (*types.Block, err
 		return nil, err
 	}
 
-	// initialize block
-	encodedHeader, err := scale.Encode(parent)
+	// create new block header
+	header, err := types.NewHeader(parent.Hash(), big.NewInt(0).Add(parent.Number, big.NewInt(1)), common.Hash{}, common.Hash{}, [][]byte{})
+	if err != nil {
+		return nil, err
+	}
+
+	// initialize block header
+	encodedHeader, err := scale.Encode(header)
 	if err != nil {
 		return nil, err
 	}
@@ -301,6 +320,7 @@ func (b *Session) buildBlock(parent *types.Header, slot Slot) (*types.Block, err
 		return nil, err
 	}
 
+	block.Header.ParentHash = parent.Hash()
 	block.Header.Number.Add(parent.Number, big.NewInt(1))
 
 	// add BABE header to digest

--- a/consensus/babe/babe.go
+++ b/consensus/babe/babe.go
@@ -285,7 +285,8 @@ func (b *Session) buildBlock(parent *types.Header, slot Slot) (*types.Block, err
 	}
 
 	// create new block header
-	header, err := types.NewHeader(parent.Hash(), big.NewInt(0).Add(parent.Number, big.NewInt(1)), common.Hash{}, common.Hash{}, [][]byte{})
+	number := big.NewInt(0).Add(parent.Number, big.NewInt(1))
+	header, err := types.NewHeader(parent.Hash(), number, common.Hash{}, common.Hash{}, [][]byte{})
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/babe/babe_test.go
+++ b/consensus/babe/babe_test.go
@@ -544,7 +544,7 @@ func TestBuildBlock_ok(t *testing.T) {
 	block, slot := createTestBlock(babesession, t)
 
 	// hash of parent header
-	parentHash, err := common.HexToHash("0x03106e6f6f740140676f7373616d65725f69735f636f6f6c6c00000000000000")
+	parentHash, err := common.HexToHash("0xdcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/service.go
+++ b/core/service.go
@@ -135,7 +135,7 @@ func (s *Service) Start() error {
 
 	err := s.bs.Start()
 	if err != nil {
-		log.Error("CORE could not start BABE", "error", err)
+		log.Error("core could not start BABE", "error", err)
 	}
 
 	return err
@@ -165,7 +165,7 @@ func (s *Service) StorageRoot() (common.Hash, error) {
 func (s *Service) handleBabeSession() {
 	for {
 		<-s.epochDone
-		log.Trace("CORE: BABE epoch complete, initializing new session")
+		log.Trace("core: BABE epoch complete, initializing new session")
 
 		newBlocks := make(chan types.Block)
 		s.blkRec = newBlocks
@@ -188,17 +188,17 @@ func (s *Service) handleBabeSession() {
 		// create a new BABE session
 		bs, err := babe.NewSession(bsConfig)
 		if err != nil {
-			log.Error("CORE could not initialize BABE", "error", err)
+			log.Error("core could not initialize BABE", "error", err)
 			return
 		}
 
 		err = bs.Start()
 		if err != nil {
-			log.Error("CORE could not start BABE", "error", err)
+			log.Error("core could not start BABE", "error", err)
 		}
 
 		s.bs = bs
-		log.Trace("CORE: BABE session initialized and started")
+		log.Trace("core: BABE session initialized and started")
 	}
 }
 
@@ -209,7 +209,7 @@ func (s *Service) receiveBlocks() {
 		block, ok := <-s.blkRec
 		if !ok {
 			// epoch complete
-			log.Debug("CORE: BABE session complete")
+			log.Debug("core: BABE session complete")
 		} else {
 			err := s.handleReceivedBlock(block)
 			if err != nil {

--- a/core/service.go
+++ b/core/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ChainSafe/gossamer/common/transaction"
 	"github.com/ChainSafe/gossamer/consensus/babe"
 	"github.com/ChainSafe/gossamer/core/types"
+	"github.com/ChainSafe/gossamer/crypto"
 	"github.com/ChainSafe/gossamer/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/internal/services"
 	"github.com/ChainSafe/gossamer/keystore"
@@ -43,8 +44,10 @@ type Service struct {
 	storageState StorageState
 	rt           *runtime.Runtime
 	bs           *babe.Session
+	keys         []crypto.Keypair
 	blkRec       <-chan types.Block // receive blocks from BABE session
 	msgRec       <-chan p2p.Message // receive messages from p2p service
+	epochDone    <-chan struct{}    // receive from this channel when BABE epoch changes
 	msgSend      chan<- p2p.Message // send messages to p2p service
 }
 
@@ -81,6 +84,8 @@ func NewService(cfg *Config) (*Service, error) {
 		cfg.NewBlocks = make(chan types.Block)
 	}
 
+	epochDone := make(chan struct{})
+
 	// BABE session configuration
 	bsConfig := &babe.SessionConfig{
 		Keypair:        keys[0].(*sr25519.Keypair),
@@ -90,6 +95,7 @@ func NewService(cfg *Config) (*Service, error) {
 		AuthorityIndex: 0, // TODO: where do we get the BABE authority data?
 		AuthData:       []*babe.AuthorityData{babe.NewAuthorityData(keys[0].Public().(*sr25519.PublicKey), 1)},
 		EpochThreshold: big.NewInt(0),
+		Done:           epochDone,
 	}
 
 	// create a new BABE session
@@ -102,11 +108,13 @@ func NewService(cfg *Config) (*Service, error) {
 	return &Service{
 		rt:           cfg.Runtime,
 		bs:           bs,
+		keys:         keys,
 		blkRec:       cfg.NewBlocks, // becomes block receive channel in core service
 		msgRec:       cfg.MsgRec,
 		msgSend:      cfg.MsgSend,
 		blockState:   cfg.BlockState,
 		storageState: cfg.StorageState,
+		epochDone:    epochDone,
 	}, nil
 }
 
@@ -121,6 +129,9 @@ func (s *Service) Start() error {
 
 	// start receiving messages from p2p service
 	go s.receiveMessages()
+
+	// monitor babe session for epoch changes
+	go s.handleBabeSession()
 
 	err := s.bs.Start()
 	if err != nil {
@@ -151,18 +162,59 @@ func (s *Service) StorageRoot() (common.Hash, error) {
 	return s.storageState.StorageRoot()
 }
 
+func (s *Service) handleBabeSession() {
+	for {
+		<-s.epochDone
+		log.Trace("CORE: BABE epoch complete, initializing new session")
+
+		newBlocks := make(chan types.Block)
+		s.blkRec = newBlocks
+
+		epochDone := make(chan struct{})
+		s.epochDone = epochDone
+
+		// BABE session configuration
+		bsConfig := &babe.SessionConfig{
+			Keypair:        s.keys[0].(*sr25519.Keypair),
+			Runtime:        s.rt,
+			NewBlocks:      newBlocks, // becomes block send channel in BABE session
+			BlockState:     s.blockState,
+			AuthorityIndex: 0, // TODO: where do we get the BABE authority data?
+			AuthData:       []*babe.AuthorityData{babe.NewAuthorityData(s.keys[0].Public().(*sr25519.PublicKey), 1)},
+			EpochThreshold: big.NewInt(0),
+			Done:           epochDone,
+		}
+
+		// create a new BABE session
+		bs, err := babe.NewSession(bsConfig)
+		if err != nil {
+			log.Error("CORE could not initialize BABE", "error", err)
+			return
+		}
+
+		err = bs.Start()
+		if err != nil {
+			log.Error("CORE could not start BABE", "error", err)
+		}
+
+		s.bs = bs
+		log.Trace("CORE: BABE session initialized and started")
+	}
+}
+
 // receiveBlocks starts receiving blocks from the BABE session
 func (s *Service) receiveBlocks() {
 	for {
 		// receive block from BABE session
 		block, ok := <-s.blkRec
 		if !ok {
-			log.Error("Failed to receive block from BABE session")
-			return // exit
-		}
-		err := s.handleReceivedBlock(block)
-		if err != nil {
-			log.Error("Failed to handle block from BABE session", "err", err)
+			// epoch complete
+			log.Debug("CORE: BABE session complete")
+		} else {
+			err := s.handleReceivedBlock(block)
+			if err != nil {
+				log.Error("Failed to handle block from BABE session", "err", err)
+			}
 		}
 	}
 }

--- a/runtime/imports.go
+++ b/runtime/imports.go
@@ -267,7 +267,7 @@ func ext_get_allocated_storage(context unsafe.Pointer, keyData, keyLen, writtenO
 	s := runtimeCtx.storage
 
 	key := memory[keyData : keyData+keyLen]
-	log.Debug("[ext_get_allocated_storage]", "key", key)
+	log.Trace("[ext_get_allocated_storage]", "key", key)
 
 	val, err := s.GetStorage(key)
 	if err != nil {
@@ -283,7 +283,7 @@ func ext_get_allocated_storage(context unsafe.Pointer, keyData, keyLen, writtenO
 	}
 
 	if val == nil {
-		log.Debug("[ext_get_allocated_storage]", "value", "nil")
+		log.Trace("[ext_get_allocated_storage]", "value", "nil")
 		copy(memory[writtenOut:writtenOut+4], []byte{0xff, 0xff, 0xff, 0xff})
 		return 0
 	}
@@ -492,10 +492,10 @@ func ext_sr25519_generate(context unsafe.Pointer, idData, seed, seedLen, out int
 
 	kp, err := sr25519.NewKeypairFromSeed(seedBytes)
 	if err != nil {
-		log.Debug("ext_sr25519_generate cannot generate key", "error", err)
+		log.Trace("ext_sr25519_generate cannot generate key", "error", err)
 	}
 
-	log.Debug("ext_sr25519_generate", "address", kp.Public().Address())
+	log.Trace("ext_sr25519_generate", "address", kp.Public().Address())
 
 	runtimeCtx.keystore.Insert(kp)
 
@@ -556,7 +556,7 @@ func ext_sr25519_public_keys(context unsafe.Pointer, idData, resultLen int32) in
 
 //export ext_ed25519_sign
 func ext_ed25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLen, out int32) int32 {
-	log.Debug("[ext_ed25519_sign] executing...")
+	log.Trace("[ext_ed25519_sign] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 
@@ -590,7 +590,7 @@ func ext_ed25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLe
 
 //export ext_sr25519_sign
 func ext_sr25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLen, out int32) int32 {
-	log.Debug("[ext_sr25519_sign] executing...")
+	log.Trace("[ext_sr25519_sign] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 
@@ -625,7 +625,7 @@ func ext_sr25519_sign(context unsafe.Pointer, idData, pubkeyData, msgData, msgLe
 
 //export ext_sr25519_verify
 func ext_sr25519_verify(context unsafe.Pointer, msgData, msgLen, sigData, pubkeyData int32) int32 {
-	log.Debug("[ext_sr25519_verify] executing...")
+	log.Trace("[ext_sr25519_verify] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 
@@ -646,7 +646,7 @@ func ext_sr25519_verify(context unsafe.Pointer, msgData, msgLen, sigData, pubkey
 
 //export ext_ed25519_generate
 func ext_ed25519_generate(context unsafe.Pointer, idData, seed, seedLen, out int32) {
-	log.Debug("[ext_ed25519_generate] executing...")
+	log.Trace("[ext_ed25519_generate] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 
@@ -659,10 +659,10 @@ func ext_ed25519_generate(context unsafe.Pointer, idData, seed, seedLen, out int
 
 	kp, err := ed25519.NewKeypairFromSeed(seedBytes)
 	if err != nil {
-		log.Debug("ext_ed25519_generate cannot generate key", "error", err)
+		log.Trace("ext_ed25519_generate cannot generate key", "error", err)
 	}
 
-	log.Debug("ext_ed25519_generate", "address", kp.Public().Address())
+	log.Trace("ext_ed25519_generate", "address", kp.Public().Address())
 
 	runtimeCtx.keystore.Insert(kp)
 


### PR DESCRIPTION
# Changes
- add done channel between babe and core, when epoch complete, done is signalled and core creates the next epoch's babe session
- slightly modify build block logic to conform to spec (we are supposed to pass in a new header to initialize_block, not the parent header)

## Tests:
```
go test ./consensus/...
```

running a 1-node block producer:
```
make gossamer
./build/bin/gossamer init
./build/bin/gossamer --verbosity debug
```

### Issues:
closes #565 