### PR TITLE
trie: fix failing trie tests

### DIFF
--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -147,7 +147,8 @@ func generateRandomTest(kv map[string][]byte) trieTest {
 	test := trieTest{}
 
 	for {
-		size := r.Intn(510) + 2
+		n := 2 // arbitrary positive number
+		size := r.Intn(510) + n
 		buf := make([]byte, size)
 		r.Read(buf)
 
@@ -156,7 +157,7 @@ func generateRandomTest(kv map[string][]byte) trieTest {
 		if kv[string(buf)] == nil || key < 256 {
 			test.key = buf
 
-			buf = make([]byte, r.Intn(128)+2)
+			buf = make([]byte, r.Intn(128)+n)
 			r.Read(buf)
 			test.value = buf
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -156,7 +156,7 @@ func generateRandomTest(kv map[string][]byte) trieTest {
 		if kv[string(buf)] == nil || key < 256 {
 			test.key = buf
 
-			buf = make([]byte, r.Intn(128))
+			buf = make([]byte, r.Intn(128)+2)
 			r.Read(buf)
 			test.value = buf
 
@@ -560,7 +560,7 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 func TestDelete(t *testing.T) {
 	trie := newEmpty()
 
-	rt := generateRandomTests(10000)
+	rt := generateRandomTests(100)
 	for _, test := range rt {
 		err := trie.Put(test.key, test.value)
 		if err != nil {


### PR DESCRIPTION
## Changes

The random number generator was producing an empty value and when that test was being  written to the failing trie tests, the empty value would cause all tests to be offset and therefore we would received a very large number of errors caused by a single generated test with an empty value.

This pull request also reduces the number of delete tests generated to `100`.

## Tests:
```
go test ./trie -v
```

### Issues:
closes #201, related to #547