### PR TITLE
crypto/sr25519: fix NewKeypairFromSeed

### DIFF
--- a/crypto/sr25519/sr25519.go
+++ b/crypto/sr25519/sr25519.go
@@ -62,6 +62,7 @@ func NewKeypairFromPrivate(priv *PrivateKey) (*Keypair, error) {
 // NewKeypairFromSeed returns a new sr25519 Keypair given a seed
 func NewKeypairFromSeed(seed []byte) (*Keypair, error) {
 	buf := [SeedLength]byte{}
+	copy(buf[:], seed)
 	msc, err := sr25519.NewMiniSecretKeyFromRaw(buf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Changes
- NewKeypairFromSeed previously wasn't using seed, now it is

## Tests:
```
go test ./crypto/...
```
