### PR TITLE
cmd: update port flag and migrate utils

### DIFF
--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/ChainSafe/gossamer/cmd/utils"
 	cfg "github.com/ChainSafe/gossamer/config"
 	"github.com/ChainSafe/gossamer/crypto"
 	"github.com/ChainSafe/gossamer/crypto/ed25519"
@@ -35,7 +34,7 @@ func handleAccounts(ctx *cli.Context) error {
 
 	// key directory is datadir/keystore/
 	var datadir string
-	if dir := ctx.String(utils.DataDirFlag.Name); dir != "" {
+	if dir := ctx.String(DataDirFlag.Name); dir != "" {
 		datadir, err = filepath.Abs(dir)
 		if err != nil {
 			log.Error("invalid datadir", "error", err)
@@ -46,22 +45,22 @@ func handleAccounts(ctx *cli.Context) error {
 	// check if we want to generate a new keypair
 	// can specify key type using --ed25519, --sr25519, --secp256k1
 	// otherwise defaults to sr25519
-	if keygen := ctx.Bool(utils.GenerateFlag.Name); keygen {
+	if keygen := ctx.Bool(GenerateFlag.Name); keygen {
 		log.Info("generating keypair...")
 
 		// check if --ed25519, --sr25519, --secp256k1 is set
 		keytype := crypto.Sr25519Type
-		if flagtype := ctx.Bool(utils.Sr25519Flag.Name); flagtype {
+		if flagtype := ctx.Bool(Sr25519Flag.Name); flagtype {
 			keytype = crypto.Sr25519Type
-		} else if flagtype := ctx.Bool(utils.Ed25519Flag.Name); flagtype {
+		} else if flagtype := ctx.Bool(Ed25519Flag.Name); flagtype {
 			keytype = crypto.Ed25519Type
-		} else if flagtype := ctx.Bool(utils.Secp256k1Flag.Name); flagtype {
+		} else if flagtype := ctx.Bool(Secp256k1Flag.Name); flagtype {
 			keytype = crypto.Secp256k1Type
 		}
 
 		// check if --password is set
 		var password []byte = nil
-		if pwdflag := ctx.String(utils.PasswordFlag.Name); pwdflag != "" {
+		if pwdflag := ctx.String(PasswordFlag.Name); pwdflag != "" {
 			password = []byte(pwdflag)
 		}
 
@@ -73,7 +72,7 @@ func handleAccounts(ctx *cli.Context) error {
 	}
 
 	// import key
-	if keyimport := ctx.String(utils.ImportFlag.Name); keyimport != "" {
+	if keyimport := ctx.String(ImportFlag.Name); keyimport != "" {
 		log.Info("importing key...")
 		_, err = importKey(keyimport, datadir)
 		if err != nil {
@@ -83,7 +82,7 @@ func handleAccounts(ctx *cli.Context) error {
 	}
 
 	// list keys
-	if keylist := ctx.Bool(utils.ListFlag.Name); keylist {
+	if keylist := ctx.Bool(ListFlag.Name); keylist {
 		_, err = listKeys(datadir)
 		if err != nil {
 			log.Error("list error", "error", err)

--- a/cmd/gossamer/configcmd.go
+++ b/cmd/gossamer/configcmd.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/ChainSafe/gossamer/cmd/utils"
 	"github.com/ChainSafe/gossamer/common"
 	cfg "github.com/ChainSafe/gossamer/config"
 	"github.com/ChainSafe/gossamer/config/genesis"
@@ -69,7 +68,7 @@ func makeNode(ctx *cli.Context) (*dot.Dot, *cfg.Config, error) {
 	// load all static keys from keystore directory
 	ks := keystore.NewKeystore()
 	// unlock keys, if specified
-	if keyindices := ctx.String(utils.UnlockFlag.Name); keyindices != "" {
+	if keyindices := ctx.String(UnlockFlag.Name); keyindices != "" {
 		err = unlockKeys(ctx, dataDir, ks)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not unlock keys: %s", err)
@@ -139,8 +138,8 @@ func loadStateAndRuntime(ss *state.StorageState, ks *keystore.Keystore) (*runtim
 func getConfig(ctx *cli.Context) (*cfg.Config, error) {
 	currentConfig := cfg.DefaultConfig()
 	// Load config file.
-	if file := ctx.GlobalString(utils.ConfigFileFlag.Name); file != "" {
-		configFile := ctx.GlobalString(utils.ConfigFileFlag.Name)
+	if file := ctx.GlobalString(ConfigFileFlag.Name); file != "" {
+		configFile := ctx.GlobalString(ConfigFileFlag.Name)
 		err := loadConfig(configFile, currentConfig)
 		if err != nil {
 			log.Warn("err loading toml file", "err", err.Error())
@@ -180,13 +179,13 @@ func loadConfig(file string, config *cfg.Config) error {
 
 func setGlobalConfig(ctx *cli.Context, currentConfig *cfg.GlobalConfig) {
 	newDataDir := currentConfig.DataDir
-	if dir := ctx.GlobalString(utils.DataDirFlag.Name); dir != "" {
+	if dir := ctx.GlobalString(DataDirFlag.Name); dir != "" {
 		newDataDir = expandTildeOrDot(dir)
 	}
 	currentConfig.DataDir, _ = filepath.Abs(newDataDir)
 
 	newRoles := currentConfig.Roles
-	if roles := ctx.GlobalString(utils.RolesFlag.Name); roles != "" {
+	if roles := ctx.GlobalString(RolesFlag.Name); roles != "" {
 		b, err := strconv.Atoi(roles)
 		if err != nil {
 			log.Debug("Failed to convert to byte", "roles", roles)
@@ -199,25 +198,25 @@ func setGlobalConfig(ctx *cli.Context, currentConfig *cfg.GlobalConfig) {
 
 func setP2pConfig(ctx *cli.Context, fig *cfg.P2pCfg) {
 	// Bootnodes
-	if bnodes := ctx.GlobalString(utils.BootnodesFlag.Name); bnodes != "" {
-		fig.Bootnodes = strings.Split(ctx.GlobalString(utils.BootnodesFlag.Name), ",")
+	if bnodes := ctx.GlobalString(BootnodesFlag.Name); bnodes != "" {
+		fig.Bootnodes = strings.Split(ctx.GlobalString(BootnodesFlag.Name), ",")
 	}
 
-	if protocol := ctx.GlobalString(utils.ProtocolIDFlag.Name); protocol != "" {
+	if protocol := ctx.GlobalString(ProtocolIDFlag.Name); protocol != "" {
 		fig.ProtocolID = protocol
 	}
 
-	if port := ctx.GlobalUint(utils.P2pPortFlag.Name); port != 0 {
+	if port := ctx.GlobalUint(P2pPortFlag.Name); port != 0 {
 		fig.Port = uint32(port)
 	}
 
 	// NoBootstrap
-	if off := ctx.GlobalBool(utils.NoBootstrapFlag.Name); off {
+	if off := ctx.GlobalBool(NoBootstrapFlag.Name); off {
 		fig.NoBootstrap = true
 	}
 
 	// NoMdns
-	if off := ctx.GlobalBool(utils.NoMdnsFlag.Name); off {
+	if off := ctx.GlobalBool(NoMdnsFlag.Name); off {
 		fig.NoMdns = true
 	}
 }
@@ -276,24 +275,24 @@ func createCoreService(coreConfig *core.Config) *core.Service {
 
 func setRPCConfig(ctx *cli.Context, fig *cfg.RPCCfg) {
 	// Modules
-	if mods := ctx.GlobalString(utils.RPCModuleFlag.Name); mods != "" {
-		fig.Modules = strToMods(strings.Split(ctx.GlobalString(utils.RPCModuleFlag.Name), ","))
+	if mods := ctx.GlobalString(RPCModuleFlag.Name); mods != "" {
+		fig.Modules = strToMods(strings.Split(ctx.GlobalString(RPCModuleFlag.Name), ","))
 	}
 
 	// Host
-	if host := ctx.GlobalString(utils.RPCHostFlag.Name); host != "" {
+	if host := ctx.GlobalString(RPCHostFlag.Name); host != "" {
 		fig.Host = host
 	}
 
 	// Port
-	if port := ctx.GlobalUint(utils.RPCPortFlag.Name); port != 0 {
+	if port := ctx.GlobalUint(RPCPortFlag.Name); port != 0 {
 		fig.Port = uint32(port)
 	}
 
 }
 
 func startRPC(ctx *cli.Context, fig cfg.RPCCfg, apiSrvc *api.Service) *rpc.HTTPServer {
-	if ctx.GlobalBool(utils.RPCEnabledFlag.Name) {
+	if ctx.GlobalBool(RPCEnabledFlag.Name) {
 		return rpc.NewHTTPServer(apiSrvc.API, &json2.Codec{}, fig.Host, fig.Port, fig.Modules)
 	}
 	return nil

--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -249,7 +249,7 @@ func TestSetP2pConfig(t *testing.T) {
 		},
 		{
 			"port",
-			[]string{"p2pport"},
+			[]string{"port"},
 			[]interface{}{uint(1337)},
 			cfg.P2pCfg{
 				Bootnodes:   cfg.DefaultP2PBootnodes,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
-package utils
+package main
 
 import (
 	log "github.com/ChainSafe/log15"
@@ -64,7 +64,7 @@ var (
 	}
 	// P2pPortFlag Set P2P listening port
 	P2pPortFlag = cli.UintFlag{
-		Name:  "p2pport",
+		Name:  "port",
 		Usage: "Set P2P listening port",
 	}
 	// ProtocolIDFlag Set protocol id

--- a/cmd/gossamer/genesis.go
+++ b/cmd/gossamer/genesis.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"path/filepath"
 
-	"github.com/ChainSafe/gossamer/cmd/utils"
 	"github.com/ChainSafe/gossamer/common"
 	cfg "github.com/ChainSafe/gossamer/config"
 	"github.com/ChainSafe/gossamer/config/genesis"
@@ -25,8 +24,8 @@ func loadGenesis(ctx *cli.Context) error {
 	// read genesis file
 	genesisPath := getGenesisPath(ctx)
 	dataDir := expandTildeOrDot(currentConfig.Global.DataDir)
-	if ctx.String(utils.DataDirFlag.Name) != "" {
-		dataDir = expandTildeOrDot(ctx.String(utils.DataDirFlag.Name))
+	if ctx.String(DataDirFlag.Name) != "" {
+		dataDir = expandTildeOrDot(ctx.String(DataDirFlag.Name))
 	}
 
 	log.Debug("Loading genesis", "genesisPath", genesisPath, "dataDir", dataDir)
@@ -110,9 +109,9 @@ func initializeGenesisState(gen genesis.GenesisFields) (*trie.Trie, *types.Heade
 // getGenesisPath gets the path to the genesis file
 func getGenesisPath(ctx *cli.Context) string {
 	// Check local string genesis flags first
-	if file := ctx.String(utils.GenesisFlag.Name); file != "" {
+	if file := ctx.String(GenesisFlag.Name); file != "" {
 		return file
-	} else if file := ctx.GlobalString(utils.GenesisFlag.Name); file != "" {
+	} else if file := ctx.GlobalString(GenesisFlag.Name); file != "" {
 		return file
 	} else {
 		return cfg.DefaultGenesisPath

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/ChainSafe/gossamer/cmd/utils"
 	log "github.com/ChainSafe/log15"
 	"github.com/urfave/cli"
 )
@@ -29,45 +28,45 @@ import (
 var (
 	app       = cli.NewApp()
 	nodeFlags = []cli.Flag{
-		utils.DataDirFlag,
-		utils.RolesFlag,
-		utils.ConfigFileFlag,
-		utils.UnlockFlag,
-		utils.PasswordFlag,
+		DataDirFlag,
+		RolesFlag,
+		ConfigFileFlag,
+		UnlockFlag,
+		PasswordFlag,
 	}
 	p2pFlags = []cli.Flag{
-		utils.BootnodesFlag,
-		utils.P2pPortFlag,
-		utils.ProtocolIDFlag,
-		utils.NoBootstrapFlag,
-		utils.NoMdnsFlag,
+		BootnodesFlag,
+		P2pPortFlag,
+		ProtocolIDFlag,
+		NoBootstrapFlag,
+		NoMdnsFlag,
 	}
 	rpcFlags = []cli.Flag{
-		utils.RPCEnabledFlag,
-		utils.RPCHostFlag,
-		utils.RPCPortFlag,
-		utils.RPCModuleFlag,
+		RPCEnabledFlag,
+		RPCHostFlag,
+		RPCPortFlag,
+		RPCModuleFlag,
 	}
 	genesisFlags = []cli.Flag{
-		utils.GenesisFlag,
+		GenesisFlag,
 	}
 	cliFlags = []cli.Flag{
-		utils.VerbosityFlag,
+		VerbosityFlag,
 	}
 	accountFlags = []cli.Flag{
-		utils.GenerateFlag,
-		utils.Sr25519Flag,
-		utils.Ed25519Flag,
-		utils.Secp256k1Flag,
-		utils.ImportFlag,
-		utils.ListFlag,
-		utils.PasswordFlag,
+		GenerateFlag,
+		Sr25519Flag,
+		Ed25519Flag,
+		Secp256k1Flag,
+		ImportFlag,
+		ListFlag,
+		PasswordFlag,
 	}
 )
 
 var (
 	dumpConfigCommand = cli.Command{
-		Action:      utils.FixFlagOrder(dumpConfig),
+		Action:      FixFlagOrder(dumpConfig),
 		Name:        "dumpconfig",
 		Usage:       "Show configuration values",
 		ArgsUsage:   "",
@@ -76,24 +75,24 @@ var (
 		Description: `The dumpconfig command shows configuration values.`,
 	}
 	initCommand = cli.Command{
-		Action:    utils.FixFlagOrder(initNode),
+		Action:    FixFlagOrder(initNode),
 		Name:      "init",
 		Usage:     "Initialize node genesis state",
 		ArgsUsage: "",
 		Flags: []cli.Flag{
-			utils.DataDirFlag,
-			utils.GenesisFlag,
-			utils.VerbosityFlag,
-			utils.ConfigFileFlag,
+			DataDirFlag,
+			GenesisFlag,
+			VerbosityFlag,
+			ConfigFileFlag,
 		},
 		Category:    "INITIALIZATION",
 		Description: `The init command initializes the node with a genesis state. Usage: gossamer init --genesis genesis.json`,
 	}
 	accountCommand = cli.Command{
-		Action:   utils.FixFlagOrder(handleAccounts),
+		Action:   FixFlagOrder(handleAccounts),
 		Name:     "account",
 		Usage:    "manage gossamer keystore",
-		Flags:    append(append(accountFlags, utils.DataDirFlag), utils.VerbosityFlag),
+		Flags:    append(append(accountFlags, DataDirFlag), VerbosityFlag),
 		Category: "KEYSTORE",
 		Description: "The account command is used to manage the gossamer keystore.\n" +
 			"\tTo generate a new sr25519 account: gossamer account --generate\n" +
@@ -137,9 +136,9 @@ func startLogger(ctx *cli.Context) error {
 	handler := logger.GetHandler()
 	var lvl log.Lvl
 
-	if lvlToInt, err := strconv.Atoi(ctx.String(utils.VerbosityFlag.Name)); err == nil {
+	if lvlToInt, err := strconv.Atoi(ctx.String(VerbosityFlag.Name)); err == nil {
 		lvl = log.Lvl(lvlToInt)
-	} else if lvl, err = log.LvlFromString(ctx.String(utils.VerbosityFlag.Name)); err != nil {
+	} else if lvl, err = log.LvlFromString(ctx.String(VerbosityFlag.Name)); err != nil {
 		return err
 	}
 	log.Root().SetHandler(log.LvlFilterHandler(lvl, handler))

--- a/cmd/gossamer/unlock.go
+++ b/cmd/gossamer/unlock.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ChainSafe/gossamer/cmd/utils"
 	"github.com/ChainSafe/gossamer/common"
 	"github.com/ChainSafe/gossamer/keystore"
 	"github.com/urfave/cli"
@@ -38,7 +37,7 @@ func unlockKeys(ctx *cli.Context, datadir string, ks *keystore.Keystore) error {
 	}
 
 	// indices of keys to unlock
-	if keyindices := ctx.String(utils.UnlockFlag.Name); keyindices != "" {
+	if keyindices := ctx.String(UnlockFlag.Name); keyindices != "" {
 		indices, err = common.StringToInts(keyindices)
 		if err != nil {
 			return err
@@ -46,7 +45,7 @@ func unlockKeys(ctx *cli.Context, datadir string, ks *keystore.Keystore) error {
 	}
 
 	// passwords corresponding to the keys
-	if passwordsStr := ctx.String(utils.PasswordFlag.Name); passwordsStr != "" {
+	if passwordsStr := ctx.String(PasswordFlag.Name); passwordsStr != "" {
 		passwords = strings.Split(passwordsStr, ",")
 	} else {
 		// no passwords specified, prompt user


### PR DESCRIPTION
## Changes

This pull request update `p2pport` flag to `port` and migrates `cmd/utils/flags.go` to `cmd/flags.go`.

## Tests:
```
go test ./... -short
```

### Issues:

closes #531