### PR TITLE
export gossamer build to bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@
 *.sublime*
 
 test_data/
-/build/bin
+/bin
 chaindata/
 *.wasm
 node.key

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -33,10 +33,10 @@ RUN go mod download
 COPY . $GOPATH/src/github.com/ChainSafe/gossamer
 
 # Build
-RUN GOBIN=$GOPATH/src/github.com/ChainSafe/gossamer/build/bin go run scripts/ci.go install
+RUN GOBIN=$GOPATH/src/github.com/ChainSafe/gossamer/bin go run scripts/ci.go install
 
 # Create symlink
-RUN ln -s $GOPATH/src/github.com/ChainSafe/gossamer/build/bin/gossamer /usr/local/gossamer
+RUN ln -s $GOPATH/src/github.com/ChainSafe/gossamer/bin/gossamer /usr/local/gossamer
 
 # Give permissions
 RUN chmod +x $GOPATH/src/github.com/ChainSafe/gossamer/scripts/docker-entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(GOLANGCI):
 ## lint: Lints project files, go gets golangci-lint if missing. Runs `golangci-lint` on project files.
 .PHONY: lint
 lint: $(GOLANGCI)
-	GOBIN=$(PWD)/build/bin go run scripts/ci.go lint
+	GOBIN=$(PWD)/bin go run scripts/ci.go lint
 
 clean:
 	rm -fr ./build
@@ -33,7 +33,7 @@ format:
 ## test: Runs `go test` on project test files.
 test:
 	@echo "  >  \033[32mRunning tests...\033[0m "
-	GOBIN=$(PWD)/build/bin go run scripts/ci.go test
+	GOBIN=$(PWD)/bin go run scripts/ci.go test
 
 ## test: Runs `go test -race` on project test files.
 test-state-race:
@@ -48,16 +48,16 @@ install:
 ## build: Builds application binary and stores it in `./bin/gossamer`
 build:
 	@echo "  >  \033[32mBuilding binary...\033[0m "
-	GOBIN=$(PWD)/build/bin go run scripts/ci.go install
+	GOBIN=$(PWD)/bin go run scripts/ci.go install
 
 # init: Init the gossamer folder using  gssmr0.json genesis file and default config file
 init:
-	./build/bin/gossamer init --genesis config/gssmr0.json --verbosity debug --config ./config.toml
+	./bin/gossamer init --genesis config/gssmr0.json --verbosity debug --config ./config.toml
 
 ## start: Starts application from binary executable in `./bin/gossamer`
 start:
 	@echo "  >  \033[32mStarting server...\033[0m "
-	./build/bin/gossamer
+	./bin/gossamer
 
 $(ADDLICENSE):
 	go get -u github.com/google/addlicense
@@ -81,4 +81,4 @@ docker-build:
 	docker build -t $(FULLDOCKERNAME) -f Dockerfile.dev .
 
 gossamer: clean
-	GOBIN=$(PWD)/build/bin go run scripts/ci.go install
+	GOBIN=$(PWD)/bin go run scripts/ci.go install

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ go get -u github.com/ChainSafe/gossamer
 
 ```
 make gossamer
-build/bin/gossamer init
-build/bin/gossamer
+bin/gossamer init
+bin/gossamer
 ```
 
 ## Docker


### PR DESCRIPTION
## Changes

This pull requests moves the `gossamer` build to the `bin` directory.

## Tests:
```
go test ./... -short
```