### PR TITLE
scale: move initialization of large byte arrays

### DIFF
--- a/codec/decode_ptr_test.go
+++ b/codec/decode_ptr_test.go
@@ -146,6 +146,12 @@ func TestLargeDecodePtrByteArrays(t *testing.T) {
 	if testing.Short() {
 		t.Skip("\033[33mSkipping memory intesive test for TestDecodePtrByteArrays in short mode\033[0m")
 	} else {
+		// Causes memory leaks with the CI's
+		var largeDecodeByteArrayTests = []decodeByteArrayTest{
+			{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823)},
+			{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824)},
+		}
+
 		for _, test := range largeDecodeByteArrayTests {
 			var result = make([]byte, len(test.output))
 			err := DecodePtr(test.val, result)

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -217,12 +217,6 @@ var decodeByteArrayTests = []decodeByteArrayTest{
 	{val: append([]byte{0x02, 0x00, 0x01, 0x00}, byteArray(16384)...), output: byteArray(16384)},
 }
 
-// Causes memory leaks with the CI's
-var largeDecodeByteArrayTests = []decodeByteArrayTest{
-	{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823)},
-	{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824)},
-}
-
 var decodeBoolTests = []decodeBoolTest{
 	{val: 0x01, output: true},
 	{val: 0x00, output: false},
@@ -446,6 +440,12 @@ func TestLargeDecodeByteArrays(t *testing.T) {
 	if testing.Short() {
 		t.Skip("\033[33mSkipping memory intesive test for TestDecodeByteArrays in short mode\033[0m")
 	} else {
+		// Causes memory leaks with the CI's
+		var largeDecodeByteArrayTests = []decodeByteArrayTest{
+			{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823)},
+			{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824)},
+		}
+
 		for _, test := range largeDecodeByteArrayTests {
 			output, err := Decode(test.val, []byte{})
 			if err != nil {


### PR DESCRIPTION
## Changes
- I was occassionally getting out of memory errors when running tests due to the large byte arrays being initialized, so I moved them inside the block that's executed when not -short

## Tests:
```
go test ./... -short
```
