### PR TITLE
cmd, dot, node: use subdirectories for each node

### DIFF
--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -247,20 +247,17 @@ func generateKeypair(keytype, datadir string, password []byte) (string, error) {
 	return fp, nil
 }
 
-// keystoreDir returnns the absolute filepath of the keystore directory given gossamer's datadir
-// by default, it is ~/.gossamer/keystore/
-// otherwise, it is datadir/keystore/
+// keystoreDir returns the absolute filepath of the keystore directory
 func keystoreDir(datadir string) (keystorepath string, err error) {
-	// datadir specified, return datadir/keystore as absolute path
+	// datadir specified, set keystore filepath to absolute path of [datadir]/keystore
 	if datadir != "" {
 		keystorepath, err = filepath.Abs(datadir + "/keystore")
 		if err != nil {
 			return "", err
 		}
 	} else {
-		// datadir not specified, return ~/.gossamer/keystore as absolute path
+		// datadir not specified, use default datadir and set keystore filepath to absolute path of [datadir]/keystore
 		datadir = node.DefaultDataDir()
-
 		keystorepath, err = filepath.Abs(datadir + "/keystore")
 		if err != nil {
 			return "", fmt.Errorf("could not create keystore file path: %s", err)

--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -30,7 +30,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/secp256k1"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
-	"github.com/ChainSafe/gossamer/node"
+	"github.com/ChainSafe/gossamer/node/gssmr"
 
 	log "github.com/ChainSafe/log15"
 	"github.com/urfave/cli"
@@ -257,7 +257,7 @@ func keystoreDir(datadir string) (keystorepath string, err error) {
 		}
 	} else {
 		// datadir not specified, use default datadir and set keystore filepath to absolute path of [datadir]/keystore
-		datadir = node.DefaultDataDir()
+		datadir = gssmr.DefaultDataDir()
 		keystorepath, err = filepath.Abs(datadir + "/keystore")
 		if err != nil {
 			return "", fmt.Errorf("could not create keystore file path: %s", err)

--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -27,10 +27,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/runtime"
-	"github.com/ChainSafe/gossamer/node"
+	"github.com/ChainSafe/gossamer/node/gssmr"
 	"github.com/ChainSafe/gossamer/tests"
 
 	log "github.com/ChainSafe/log15"
@@ -67,8 +68,8 @@ func removeTestDataDir() {
 	}
 }
 
-func createTempConfigFile() (*os.File, *node.Config) {
-	testConfig := node.DefaultConfig()
+func createTempConfigFile() (*os.File, *dot.Config) {
+	testConfig := gssmr.DefaultConfig()
 	testConfig.Global.Authority = false
 	testConfig.Global.DataDir = TestDataDir
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "prefix-")
@@ -76,7 +77,7 @@ func createTempConfigFile() (*os.File, *node.Config) {
 		log.Crit("Cannot create temporary file", "err", err)
 		os.Exit(1)
 	}
-	f := node.ExportConfig(tmpFile.Name(), testConfig)
+	f := dot.ExportConfig(tmpFile.Name(), testConfig)
 	return f, testConfig
 }
 
@@ -146,9 +147,9 @@ func TestGetConfig(t *testing.T) {
 	tc := []struct {
 		name     string
 		value    string
-		expected *node.Config
+		expected *dot.Config
 	}{
-		{"", "", node.DefaultConfig()},
+		{"", "", gssmr.DefaultConfig()},
 		{"config", tempFile.Name(), cfgClone},
 	}
 
@@ -172,17 +173,17 @@ func TestSetGlobalConfig(t *testing.T) {
 		description string
 		flags       []string
 		values      []interface{}
-		expected    node.GlobalConfig
+		expected    dot.GlobalConfig
 	}{
 		{"datadir flag",
 			[]string{"datadir"},
 			[]interface{}{"test1"},
-			node.GlobalConfig{DataDir: tempPath},
+			dot.GlobalConfig{DataDir: tempPath},
 		},
 		{"roles flag",
 			[]string{"datadir", "roles"},
 			[]interface{}{"test1", "1"},
-			node.GlobalConfig{DataDir: tempPath, Roles: byte(1)},
+			dot.GlobalConfig{DataDir: tempPath, Roles: byte(1)},
 		},
 	}
 
@@ -192,7 +193,7 @@ func TestSetGlobalConfig(t *testing.T) {
 			context, err := createCliContext(c.description, c.flags, c.values)
 			require.Nil(t, err)
 
-			tCfg := &node.GlobalConfig{}
+			tCfg := &dot.GlobalConfig{}
 
 			setGlobalConfig(context, tCfg)
 
@@ -203,7 +204,7 @@ func TestSetGlobalConfig(t *testing.T) {
 
 func TestCreateNetworkService(t *testing.T) {
 	stateSrv := state.NewService(TestDataDir)
-	cfg := node.DefaultConfig()
+	cfg := gssmr.DefaultConfig()
 	cfg.Global.DataDir = TestDataDir
 	srv, _, _ := createNetworkService(cfg, &genesis.Data{}, stateSrv)
 	require.NotNil(t, srv, "failed to create network service")
@@ -217,7 +218,7 @@ func TestSetNetworkConfig(t *testing.T) {
 		description string
 		flags       []string
 		values      []interface{}
-		expected    node.NetworkConfig
+		expected    dot.NetworkConfig
 	}{
 		{
 			"config file",
@@ -229,10 +230,10 @@ func TestSetNetworkConfig(t *testing.T) {
 			"no bootstrap, no mdns",
 			[]string{"nobootstrap", "nomdns"},
 			[]interface{}{true, true},
-			node.NetworkConfig{
-				Bootnodes:   node.DefaultNetworkBootnodes,
-				ProtocolID:  node.DefaultNetworkProtocolID,
-				Port:        node.DefaultNetworkPort,
+			dot.NetworkConfig{
+				Bootnodes:   gssmr.DefaultNetworkBootnodes,
+				ProtocolID:  gssmr.DefaultNetworkProtocolID,
+				Port:        gssmr.DefaultNetworkPort,
 				NoBootstrap: true,
 				NoMdns:      true,
 			},
@@ -241,10 +242,10 @@ func TestSetNetworkConfig(t *testing.T) {
 			"bootstrap nodes",
 			[]string{"bootnodes"},
 			[]interface{}{strings.Join(TestBootnodes[:], ",")},
-			node.NetworkConfig{
+			dot.NetworkConfig{
 				Bootnodes:   TestBootnodes,
-				ProtocolID:  node.DefaultNetworkProtocolID,
-				Port:        node.DefaultNetworkPort,
+				ProtocolID:  gssmr.DefaultNetworkProtocolID,
+				Port:        gssmr.DefaultNetworkPort,
 				NoBootstrap: false,
 				NoMdns:      false,
 			},
@@ -253,9 +254,9 @@ func TestSetNetworkConfig(t *testing.T) {
 			"port",
 			[]string{"port"},
 			[]interface{}{uint(1337)},
-			node.NetworkConfig{
-				Bootnodes:   node.DefaultNetworkBootnodes,
-				ProtocolID:  node.DefaultNetworkProtocolID,
+			dot.NetworkConfig{
+				Bootnodes:   gssmr.DefaultNetworkBootnodes,
+				ProtocolID:  gssmr.DefaultNetworkProtocolID,
 				Port:        1337,
 				NoBootstrap: false,
 				NoMdns:      false,
@@ -265,9 +266,9 @@ func TestSetNetworkConfig(t *testing.T) {
 			"protocol id",
 			[]string{"protocol"},
 			[]interface{}{TestProtocolID},
-			node.NetworkConfig{
-				Bootnodes:   node.DefaultNetworkBootnodes,
-				Port:        node.DefaultNetworkPort,
+			dot.NetworkConfig{
+				Bootnodes:   gssmr.DefaultNetworkBootnodes,
+				Port:        gssmr.DefaultNetworkPort,
 				ProtocolID:  TestProtocolID,
 				NoBootstrap: false,
 				NoMdns:      false,
@@ -281,7 +282,7 @@ func TestSetNetworkConfig(t *testing.T) {
 			context, err := createCliContext(c.description, c.flags, c.values)
 			require.Nil(t, err)
 
-			input := node.DefaultConfig()
+			input := gssmr.DefaultConfig()
 			// Must call global setup to set data dir
 			setNetworkConfig(context, &input.Network)
 
@@ -299,7 +300,7 @@ func TestSetRPCConfig(t *testing.T) {
 		description string
 		flags       []string
 		values      []interface{}
-		expected    node.RPCConfig
+		expected    dot.RPCConfig
 	}{
 		{
 			"config file",
@@ -311,19 +312,19 @@ func TestSetRPCConfig(t *testing.T) {
 			"host and port",
 			[]string{"rpchost", "rpcport"},
 			[]interface{}{"someHost", uint(1337)},
-			node.RPCConfig{
+			dot.RPCConfig{
 				Port:    1337,
 				Host:    "someHost",
-				Modules: node.DefaultRPCModules,
+				Modules: gssmr.DefaultRPCModules,
 			},
 		},
 		{
 			"modules",
 			[]string{"rpcmods"},
 			[]interface{}{"system,state"},
-			node.RPCConfig{
-				Port:    node.DefaultRPCHTTPPort,
-				Host:    node.DefaultRPCHTTPHost,
+			dot.RPCConfig{
+				Port:    gssmr.DefaultRPCHTTPPort,
+				Host:    gssmr.DefaultRPCHTTPHost,
 				Modules: []string{"system", "state"},
 			},
 		},
@@ -335,7 +336,7 @@ func TestSetRPCConfig(t *testing.T) {
 			context, err := createCliContext(c.description, c.flags, c.values)
 			require.Nil(t, err)
 
-			input := node.DefaultConfig()
+			input := gssmr.DefaultConfig()
 			setRPCConfig(context, &input.RPC)
 
 			require.Equal(t, c.expected, input.RPC)
@@ -357,7 +358,7 @@ func TestMakeNode(t *testing.T) {
 		name     string
 		flags    []string
 		values   []interface{}
-		expected *node.Config
+		expected *dot.Config
 	}{
 		{"node from config (norpc)", []string{"config", "genesis"}, []interface{}{tempFile.Name(), genesisPath}, cfgClone},
 		{"default node (norpc)", []string{"genesis"}, []interface{}{genesisPath}, cfgClone},

--- a/cmd/gossamer/configcmd_test.go
+++ b/cmd/gossamer/configcmd_test.go
@@ -203,7 +203,9 @@ func TestSetGlobalConfig(t *testing.T) {
 
 func TestCreateNetworkService(t *testing.T) {
 	stateSrv := state.NewService(TestDataDir)
-	srv, _, _ := createNetworkService(node.DefaultConfig(), &genesis.Data{}, stateSrv)
+	cfg := node.DefaultConfig()
+	cfg.Global.DataDir = TestDataDir
+	srv, _, _ := createNetworkService(cfg, &genesis.Data{}, stateSrv)
 	require.NotNil(t, srv, "failed to create network service")
 }
 

--- a/cmd/gossamer/genesis.go
+++ b/cmd/gossamer/genesis.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/node"
+	"github.com/ChainSafe/gossamer/node/gssmr"
 
 	log "github.com/ChainSafe/log15"
 	"github.com/urfave/cli"
@@ -131,6 +131,6 @@ func getGenesisPath(ctx *cli.Context) string {
 	} else if file := ctx.GlobalString(GenesisFlag.Name); file != "" {
 		return file
 	} else {
-		return node.DefaultGenesisPath
+		return gssmr.DefaultGenesisPath
 	}
 }

--- a/cmd/gossamer/genesis_test.go
+++ b/cmd/gossamer/genesis_test.go
@@ -24,13 +24,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/node"
 
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
@@ -121,8 +121,8 @@ func TestGenesisStateLoading(t *testing.T) {
 	d, _, err := makeNode(context)
 	require.Nil(t, err)
 
-	if reflect.TypeOf(d) != reflect.TypeOf(&node.Node{}) {
-		t.Fatalf("failed to return correct type: got %v expected %v", reflect.TypeOf(d), reflect.TypeOf(&node.Node{}))
+	if reflect.TypeOf(d) != reflect.TypeOf(&dot.Node{}) {
+		t.Fatalf("failed to return correct type: got %v expected %v", reflect.TypeOf(d), reflect.TypeOf(&dot.Node{}))
 	}
 
 	expected := &trie.Trie{}

--- a/dot/config.go
+++ b/dot/config.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
-package node
+package dot
 
 import (
 	"encoding/json"

--- a/dot/dot.go
+++ b/dot/dot.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
-package node
+package dot
 
 import (
 	"os"

--- a/dot/dot_test.go
+++ b/dot/dot_test.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
-package node
+package dot
 
 import (
 	"math/big"

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -29,7 +29,7 @@ import (
 const DefaultKeyFile = "node.key"
 
 // DefaultDataDir for the gossamer database and related blockchain files
-const DefaultDataDir = "~/.gossamer"
+const DefaultDataDir = "~/.gossamer/gssmr"
 
 // DefaultPort is the default por const
 const DefaultPort = uint32(7000)
@@ -38,7 +38,7 @@ const DefaultPort = uint32(7000)
 const DefaultRandSeed = int64(0)
 
 // DefaultProtocolID ID
-const DefaultProtocolID = "/gossamer/dot/0"
+const DefaultProtocolID = "/gossamer/gssmr/0"
 
 // DefaultRoles full node
 const DefaultRoles = byte(1)

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -104,7 +104,7 @@ func loadKey(fp string) (crypto.PrivKey, error) {
 	return crypto.UnmarshalEd25519PrivateKey(dec)
 }
 
-// makeDir creates `.gossamer/[node]` if directory does not already exist
+// makeDir makes directory if directory does not already exist
 func makeDir(fp string) error {
 	_, e := os.Stat(fp)
 	if os.IsNotExist(e) {

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -104,7 +104,7 @@ func loadKey(fp string) (crypto.PrivKey, error) {
 	return crypto.UnmarshalEd25519PrivateKey(dec)
 }
 
-// makeDir creates `.gossamer` if directory does not already exist
+// makeDir creates `.gossamer/[node]` if directory does not already exist
 func makeDir(fp string) error {
 	_, e := os.Stat(fp)
 	if os.IsNotExist(e) {

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -79,8 +79,8 @@ func DefaultConfig() *Config {
 	}
 }
 
-// DefaultDataDir is the default data directory to use for the databases and other
-// persistence requirements.
+// DefaultDataDir is the default data directory for the databases and other
+// persistence requirements (uses "gssmr" subdirectory by default)
 func DefaultDataDir() string {
 	// Try to place the data folder in the user's home dir
 	home := HomeDir()
@@ -90,7 +90,7 @@ func DefaultDataDir() string {
 		} else if runtime.GOOS == "windows" {
 			return filepath.Join(home, "AppData", "Roaming", "Gossamer")
 		} else {
-			return filepath.Join(home, ".gossamer")
+			return filepath.Join(home, ".gossamer", "gssmr")
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later

--- a/node/gssmr/defaults.go
+++ b/node/gssmr/defaults.go
@@ -14,47 +14,54 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
-package node
+package gssmr
 
 import (
 	"os"
 	"os/user"
 	"path/filepath"
 	"runtime"
+
+	"github.com/ChainSafe/gossamer/dot"
 )
 
 const (
-	// DefaultRPCHTTPHost Default host interface for the HTTP RPC server
-	DefaultRPCHTTPHost = "localhost"
-	// DefaultRPCHTTPPort http port
-	DefaultRPCHTTPPort = 8545
+	// DefaultNode Default node implementation
+	DefaultNode = "gssmr"
+	// DefaultConfigPath Default toml configuration path
+	DefaultConfigPath = "./node/gssmr/config.toml"
+	// DefaultGenesisPath Default genesis configuration path
+	DefaultGenesisPath = "./node/gssmr/genesis.json"
 
 	// DefaultNetworkPort network port
 	DefaultNetworkPort = 7001
 	// DefaultNetworkProtocolID ID
 	DefaultNetworkProtocolID = "/gossamer/gssmr/0"
 
-	// DefaultGenesisPath Genesis path
-	DefaultGenesisPath = "./node/gssmr/genesis.json"
+	// DefaultRPCHTTPHost Default host interface for the HTTP RPC server
+	DefaultRPCHTTPHost = "localhost"
+	// DefaultRPCHTTPPort http port
+	DefaultRPCHTTPPort = 8545
 )
 
 var (
 	// DefaultNetworkBootnodes Must be non-nil to match toml parsing semantics
 	DefaultNetworkBootnodes = []string{}
+
 	// DefaultRPCModules holds defaults RPC modules
 	DefaultRPCModules = []string{"system", "author"}
 )
 
 var (
 	// DefaultGlobalConfig Global
-	DefaultGlobalConfig = GlobalConfig{
+	DefaultGlobalConfig = dot.GlobalConfig{
 		DataDir:   DefaultDataDir(),
 		Roles:     byte(1), // full node
 		Authority: true,    // BABE block producer
 	}
 
 	// DefaultNetworkConfig Network
-	DefaultNetworkConfig = NetworkConfig{
+	DefaultNetworkConfig = dot.NetworkConfig{
 		Bootnodes:   DefaultNetworkBootnodes,
 		ProtocolID:  DefaultNetworkProtocolID,
 		Port:        DefaultNetworkPort,
@@ -63,7 +70,7 @@ var (
 	}
 
 	// DefaultRPCConfig RPC
-	DefaultRPCConfig = RPCConfig{
+	DefaultRPCConfig = dot.RPCConfig{
 		Host:    DefaultRPCHTTPHost,
 		Port:    DefaultRPCHTTPPort,
 		Modules: DefaultRPCModules,
@@ -71,16 +78,15 @@ var (
 )
 
 // DefaultConfig is the default settings used when a config.toml file is not passed in during instantiation
-func DefaultConfig() *Config {
-	return &Config{
+func DefaultConfig() *dot.Config {
+	return &dot.Config{
 		Global:  DefaultGlobalConfig,
 		Network: DefaultNetworkConfig,
 		RPC:     DefaultRPCConfig,
 	}
 }
 
-// DefaultDataDir is the default data directory for the databases and other
-// persistence requirements (uses "gssmr" subdirectory by default)
+// DefaultDataDir is the default data directory for the default node
 func DefaultDataDir() string {
 	// Try to place the data folder in the user's home dir
 	home := HomeDir()
@@ -90,7 +96,7 @@ func DefaultDataDir() string {
 		} else if runtime.GOOS == "windows" {
 			return filepath.Join(home, "AppData", "Roaming", "Gossamer")
 		} else {
-			return filepath.Join(home, ".gossamer", "gssmr")
+			return filepath.Join(home, ".gossamer", DefaultNode)
 		}
 	}
 	// As we cannot guess a stable location, return empty and handle later

--- a/node/gssmr/genesis.json
+++ b/node/gssmr/genesis.json
@@ -1,10 +1,10 @@
 {
   "name": "Gossamer Testnet",
-  "id": "gssmr0",
+  "id": "gssmr",
   "bootNodes": [
     "/ip4/104.211.54.233/tcp/30363/p2p/16Uiu2HAmFWPUx45xYYeCpAryQbvU3dY8PWGdMwS2tLm1dB1CsmCj"
   ],
-  "protocolId": "gssmr0",
+  "protocolId": "gssmr",
   "genesis": {
     "raw": [
       {

--- a/node/ksmcc/config.toml
+++ b/node/ksmcc/config.toml
@@ -1,6 +1,6 @@
 [global]
-data-dir = "~/.gossamer/gssmr"
-authority = true
+data-dir = "~/.gossamer/ksmcc"
+authority = false
 
 [network]
 bootstrap-nodes = []
@@ -11,4 +11,4 @@ no-mdns = false
 [rpc]
 port = 8545
 host = "localhost"
-modules = ["system", "author"]
+modules = ["system"]

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -37,7 +37,7 @@ func createTestNode(t *testing.T, testDir string) *Node {
 	networkCfg := &network.Config{
 		BlockState:   &state.BlockState{},   // required
 		NetworkState: &state.NetworkState{}, // required
-		DataDir:      testDir,               // default "~/.gossamer"
+		DataDir:      testDir,               // default "~/.gossamer/gssmr"
 		Roles:        1,                     // required
 		RandSeed:     1,                     // default 0
 	}


### PR DESCRIPTION
## Changes

This pull request updates the default datadir to account for multiple node implementation.

## Tests

```
./bin/gossamer init --datadir ~/.gossamer/ksmcc
```

```
./bin/gossamer --datadir ~/.gossamer/ksmcc
```