### PR TITLE
network: send block request based on confirmed peer status

### DIFF
--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -232,7 +232,27 @@ func (s *Service) handleMessage(peer peer.ID, msg Message) {
 
 			// handle status message from peer with status submodule
 			s.status.handleMessage(peer, msg.(*StatusMessage))
+
 		}
+
+		// check if peer status confirmed
+		if s.status.confirmed(peer) {
+
+			// get latest block header from block state
+			latestBlock := s.cfg.BlockState.LatestHeader()
+
+			// check if peer block number is greater than host block number
+			if msg.BestBlockNumber > latestBlock.Number {
+
+				// TODO: set block request message
+				brm := &BlockRequestMessage{}
+
+				// send block request message
+				s.host.send(peer, brm)
+
+			}
+		}
+
 	}
 }
 

--- a/dot/network/status.go
+++ b/dot/network/status.go
@@ -102,10 +102,6 @@ func (status *status) handleMessage(peer peer.ID, msg *StatusMessage) {
 		// update peer status message
 		status.peerMessage[peer] = msg
 
-		// check if message arrived is a block bigger then our latest one
-		// if so, fallback
-		// BlockRequestMessage
-
 		// wait then send next host status message
 		go status.sendNextMessage(ctx, peer)
 

--- a/dot/network/status_test.go
+++ b/dot/network/status_test.go
@@ -108,6 +108,3 @@ func TestStatus(t *testing.T) {
 		t.Error("node B did not confirm status of node A")
 	}
 }
-
-//have a peer send a message status with a block ahead
-// check that the message returned is the expected


### PR DESCRIPTION
## Changes

This pull request sends a block request message if needed based on the best block number for the latest status message from each confirmed peer.

## Tests:
```
go test ./network -v
```

### Issues:
closes #637