### PR TITLE
state: update state to use one db

### DIFF
--- a/cmd/gossamer/genesis.go
+++ b/cmd/gossamer/genesis.go
@@ -19,11 +19,11 @@ package main
 import (
 	"fmt"
 	"math/big"
-	"path/filepath"
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/database"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/node"
@@ -69,22 +69,22 @@ func loadGenesis(ctx *cli.Context) error {
 		return fmt.Errorf("cannot initialize state service: %s", err)
 	}
 
-	stateDataDir := filepath.Join(dataDir, "state")
-	stateDb, err := state.NewStorageState(stateDataDir, t)
+	// initialize database with genesis storage state
+	db, err := database.NewBadgerDB(dataDir)
 	if err != nil {
-		return fmt.Errorf("cannot create state db: %s", err)
+		return err
 	}
 
 	defer func() {
-		err = stateDb.DB.DB.Close()
+		err = db.Close()
 		if err != nil {
-			log.Error("Loading genesis: cannot close stateDB", "error", err)
+			log.Error("Loading genesis: cannot close db", "error", err)
 		}
 	}()
 
 	// set up trie database
 	t.SetDb(&trie.Database{
-		DB: stateDb.DB.DB,
+		DB: db,
 	})
 
 	// write initial genesis data to DB

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/optional"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	"github.com/ChainSafe/gossamer/lib/database"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/transaction"
@@ -215,17 +216,12 @@ func TestProcessBlockResponseMessage(t *testing.T) {
 	ks := keystore.NewKeystore()
 	ks.Insert(kp)
 
-	datadir, err := ioutil.TempDir("", "./test_data")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	header := &types.Header{
 		Number:    big.NewInt(0),
 		StateRoot: trie.EmptyHash,
 	}
 
-	blockState, err := state.NewBlockStateFromGenesis(datadir, header)
+	blockState, err := state.NewBlockStateFromGenesis(database.NewMemDatabase(), header)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -32,9 +32,23 @@ import (
 	"github.com/ChainSafe/gossamer/lib/database"
 )
 
+var blockPrefix = []byte("block")
+
 // BlockDB stores block's in an underlying Database
 type BlockDB struct {
-	Db database.Database
+	db database.Database
+}
+
+// Put appends `block` to the key and sets the key-value pair in the db
+func (db *BlockDB) Put(key, value []byte) error {
+	key = append(blockPrefix, key...)
+	return db.db.Put(key, value)
+}
+
+// Get appends `block` to the key and retrieves the value from the db
+func (db *BlockDB) Get(key []byte) ([]byte, error) {
+	key = append(blockPrefix, key...)
+	return db.db.Get(key)
 }
 
 // BlockState defines fields for manipulating the state of blocks, such as BlockTree, BlockDB and Header
@@ -46,27 +60,21 @@ type BlockState struct {
 }
 
 // NewBlockDB instantiates a badgerDB instance for storing relevant BlockData
-func NewBlockDB(dataDir string) (*BlockDB, error) {
-	db, err := database.NewBadgerDB(dataDir)
-	if err != nil {
-		return nil, err
-	}
-
+func NewBlockDB(db database.Database) *BlockDB {
 	return &BlockDB{
 		db,
-	}, nil
+	}
 }
 
 // NewBlockState will create a new BlockState backed by the database located at dataDir
-func NewBlockState(dataDir string, latestHash common.Hash) (*BlockState, error) {
-	blockDb, err := NewBlockDB(dataDir)
-	if err != nil {
-		return nil, err
+func NewBlockState(db database.Database, latestHash common.Hash) (*BlockState, error) {
+	if db == nil {
+		return nil, fmt.Errorf("cannot have nil database")
 	}
 
 	bs := &BlockState{
 		bt: &blocktree.BlockTree{},
-		db: blockDb,
+		db: NewBlockDB(db),
 	}
 
 	latestHeader, err := bs.GetHeader(latestHash)
@@ -79,18 +87,13 @@ func NewBlockState(dataDir string, latestHash common.Hash) (*BlockState, error) 
 }
 
 // NewBlockStateFromGenesis initializes a BlockState from a genesis header, saving it to the database located at dataDir
-func NewBlockStateFromGenesis(dataDir string, header *types.Header) (*BlockState, error) {
-	blockDb, err := NewBlockDB(dataDir)
-	if err != nil {
-		return nil, err
-	}
-
+func NewBlockStateFromGenesis(db database.Database, header *types.Header) (*BlockState, error) {
 	bs := &BlockState{
 		bt: &blocktree.BlockTree{},
-		db: blockDb,
+		db: NewBlockDB(db),
 	}
 
-	err = bs.SetHeader(header)
+	err := bs.SetHeader(header)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +136,7 @@ func blockDataKey(hash common.Hash) []byte {
 func (bs *BlockState) GetHeader(hash common.Hash) (*types.Header, error) {
 	result := new(types.Header)
 
-	data, err := bs.db.Db.Get(headerKey(hash))
+	data, err := bs.db.Get(headerKey(hash))
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +154,7 @@ func (bs *BlockState) GetHeader(hash common.Hash) (*types.Header, error) {
 func (bs *BlockState) GetBlockData(hash common.Hash) (*types.BlockData, error) {
 	result := new(types.BlockData)
 
-	data, err := bs.db.Db.Get(blockDataKey(hash))
+	data, err := bs.db.Get(blockDataKey(hash))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +214,7 @@ func (bs *BlockState) GetBlockByHash(hash common.Hash) (*types.Block, error) {
 // GetBlockByNumber returns a block for a given blockNumber
 func (bs *BlockState) GetBlockByNumber(blockNumber *big.Int) (*types.Block, error) {
 	// First retrieve the block hash in a byte array based on the block number from the database
-	byteHash, err := bs.db.Db.Get(headerHashKey(blockNumber.Uint64()))
+	byteHash, err := bs.db.Get(headerHashKey(blockNumber.Uint64()))
 	if err != nil {
 		return nil, err
 	}
@@ -239,13 +242,13 @@ func (bs *BlockState) SetHeader(header *types.Header) error {
 		return err
 	}
 
-	err = bs.db.Db.Put(headerKey(hash), bh)
+	err = bs.db.Put(headerKey(hash), bh)
 	if err != nil {
 		return err
 	}
 
 	// Add a mapping of [blocknumber : hash] for retrieving the block by number
-	err = bs.db.Db.Put(headerHashKey(header.Number.Uint64()), header.Hash().ToBytes())
+	err = bs.db.Put(headerHashKey(header.Number.Uint64()), header.Hash().ToBytes())
 	return err
 }
 
@@ -270,7 +273,7 @@ func (bs *BlockState) SetBlockData(blockData *types.BlockData) error {
 		return err
 	}
 
-	err = bs.db.Db.Put(blockDataKey(blockData.Hash), bh)
+	err = bs.db.Put(blockDataKey(blockData.Hash), bh)
 	return err
 }
 
@@ -313,7 +316,7 @@ func babeHeaderKey(epoch uint64, slot uint64) []byte {
 func (bs *BlockState) GetBabeHeader(epoch uint64, slot uint64) (*babetypes.BabeHeader, error) {
 	result := new(babetypes.BabeHeader)
 
-	data, err := bs.db.Db.Get(babeHeaderKey(epoch, slot))
+	data, err := bs.db.Get(babeHeaderKey(epoch, slot))
 	if err != nil {
 		return nil, err
 	}
@@ -331,6 +334,6 @@ func (bs *BlockState) SetBabeHeader(epoch uint64, slot uint64, bh *babetypes.Bab
 		return err
 	}
 
-	err = bs.db.Db.Put(babeHeaderKey(epoch, slot), enc)
+	err = bs.db.Put(babeHeaderKey(epoch, slot), enc)
 	return err
 }

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -40,15 +40,15 @@ type BlockDB struct {
 }
 
 // Put appends `block` to the key and sets the key-value pair in the db
-func (db *BlockDB) Put(key, value []byte) error {
+func (blockDB *BlockDB) Put(key, value []byte) error {
 	key = append(blockPrefix, key...)
-	return db.db.Put(key, value)
+	return blockDB.db.Put(key, value)
 }
 
 // Get appends `block` to the key and retrieves the value from the db
-func (db *BlockDB) Get(key []byte) ([]byte, error) {
+func (blockDB *BlockDB) Get(key []byte) ([]byte, error) {
 	key = append(blockPrefix, key...)
-	return db.db.Get(key)
+	return blockDB.db.Get(key)
 }
 
 // BlockState defines fields for manipulating the state of blocks, such as BlockTree, BlockDB and Header

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -24,17 +24,20 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
+	"github.com/ChainSafe/gossamer/lib/database"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestConcurrencySetHeader(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "./test_data")
+	datadir, err := ioutil.TempDir("", "./test_data")
 	require.Nil(t, err)
 
-	blockDB, err := NewBlockDB(dataDir)
+	db, err := database.NewBadgerDB(datadir)
 	require.Nil(t, err)
+
+	blockDB := NewBlockDB(db)
 
 	threads := runtime.NumCPU()
 	dbs := make([]*BlockDB, threads)

--- a/dot/state/network.go
+++ b/dot/state/network.go
@@ -36,15 +36,15 @@ type NetworkDB struct {
 }
 
 // Put appends `network` to the key and sets the key-value pair in the db
-func (db *NetworkDB) Put(key, value []byte) error {
+func (networkDB *NetworkDB) Put(key, value []byte) error {
 	key = append(networkPrefix, key...)
-	return db.db.Put(key, value)
+	return networkDB.db.Put(key, value)
 }
 
 // Get appends `network` to the key and retrieves the value from the db
-func (db *NetworkDB) Get(key []byte) ([]byte, error) {
+func (networkDB *NetworkDB) Get(key []byte) ([]byte, error) {
 	key = append(networkPrefix, key...)
-	return db.db.Get(key)
+	return networkDB.db.Get(key)
 }
 
 // NetworkState defines fields for manipulating the state of network

--- a/dot/state/network.go
+++ b/dot/state/network.go
@@ -18,10 +18,13 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/database"
 )
+
+var networkPrefix = []byte("network")
 
 var healthKey = []byte("health")
 var networkStateKey = []byte("networkstate")
@@ -29,7 +32,19 @@ var peersKey = []byte("peers")
 
 // NetworkDB stores network information in an underlying database
 type NetworkDB struct {
-	Db database.Database
+	db database.Database
+}
+
+// Put appends `network` to the key and sets the key-value pair in the db
+func (db *NetworkDB) Put(key, value []byte) error {
+	key = append(networkPrefix, key...)
+	return db.db.Put(key, value)
+}
+
+// Get appends `network` to the key and retrieves the value from the db
+func (db *NetworkDB) Get(key []byte) ([]byte, error) {
+	key = append(networkPrefix, key...)
+	return db.db.Get(key)
 }
 
 // NetworkState defines fields for manipulating the state of network
@@ -38,31 +53,27 @@ type NetworkState struct {
 }
 
 // NewNetworkDB instantiates a badgerDB instance for storing relevant BlockData
-func NewNetworkDB(dataDir string) (*NetworkDB, error) {
-	db, err := database.NewBadgerDB(dataDir)
-	if err != nil {
-		return nil, err
-	}
+func NewNetworkDB(db database.Database) *NetworkDB {
 	return &NetworkDB{
 		db,
-	}, nil
+	}
 }
 
 // NewNetworkState creates NetworkState with a network database in DataDir
-func NewNetworkState(dataDir string) (*NetworkState, error) {
-	networkDb, err := NewNetworkDB(dataDir)
-	if err != nil {
-		return nil, err
+func NewNetworkState(db database.Database) (*NetworkState, error) {
+	if db == nil {
+		return nil, fmt.Errorf("cannot have nil database")
 	}
+
 	return &NetworkState{
-		db: networkDb,
+		db: NewNetworkDB(db),
 	}, nil
 }
 
 // GetHealth retrieves network health from the database
 func (ns *NetworkState) GetHealth() (*common.Health, error) {
 	res := new(common.Health)
-	data, err := ns.db.Db.Get(healthKey)
+	data, err := ns.db.Get(healthKey)
 	if err != nil {
 		return res, err
 	}
@@ -76,14 +87,14 @@ func (ns *NetworkState) SetHealth(health *common.Health) error {
 	if err != nil {
 		return err
 	}
-	err = ns.db.Db.Put(healthKey, enc)
+	err = ns.db.Put(healthKey, enc)
 	return err
 }
 
 // GetNetworkState retrieves network state from the database
 func (ns *NetworkState) GetNetworkState() (*common.NetworkState, error) {
 	res := new(common.NetworkState)
-	data, err := ns.db.Db.Get(networkStateKey)
+	data, err := ns.db.Get(networkStateKey)
 	if err != nil {
 		return res, err
 	}
@@ -97,14 +108,14 @@ func (ns *NetworkState) SetNetworkState(networkState *common.NetworkState) error
 	if err != nil {
 		return err
 	}
-	err = ns.db.Db.Put(networkStateKey, enc)
+	err = ns.db.Put(networkStateKey, enc)
 	return err
 }
 
 // GetPeers retrieves network state from the database
 func (ns *NetworkState) GetPeers() (*[]common.PeerInfo, error) {
 	res := new([]common.PeerInfo)
-	data, err := ns.db.Db.Get(peersKey)
+	data, err := ns.db.Get(peersKey)
 	if err != nil {
 		return res, err
 	}
@@ -118,6 +129,6 @@ func (ns *NetworkState) SetPeers(peers *[]common.PeerInfo) error {
 	if err != nil {
 		return err
 	}
-	err = ns.db.Db.Put(peersKey, enc)
+	err = ns.db.Put(peersKey, enc)
 	return err
 }

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/database"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
 	log "github.com/ChainSafe/log15"
@@ -30,6 +31,7 @@ import (
 // Service is the struct that holds storage, block and network states
 type Service struct {
 	dbPath           string
+	db               database.Database
 	Storage          *StorageState
 	Block            *BlockState
 	Network          *NetworkState
@@ -40,6 +42,7 @@ type Service struct {
 func NewService(path string) *Service {
 	return &Service{
 		dbPath:  path,
+		db:      nil,
 		Storage: nil,
 		Block:   nil,
 		Network: nil,
@@ -50,11 +53,19 @@ func NewService(path string) *Service {
 // The trie does not need a backing DB, since the DB will be created during Service.Start().
 // This only needs to be called during genesis initialization of the node; it doesn't need to be called during normal startup.
 func (s *Service) Initialize(genesisHeader *types.Header, t *trie.Trie) error {
-	stateDataDir := filepath.Join(s.dbPath, "state")
-	blockDataDir := filepath.Join(s.dbPath, "block")
-	networkDataDir := filepath.Join(s.dbPath, "network")
+	datadir, err := filepath.Abs(s.dbPath)
+	if err != nil {
+		return err
+	}
 
-	storageState, err := NewStorageState(stateDataDir, t)
+	// initialize database
+	db, err := database.NewBadgerDB(datadir)
+	if err != nil {
+		return err
+	}
+
+	// load genesis storage state into db
+	storageState, err := NewStorageState(db, t)
 	if err != nil {
 		return err
 	}
@@ -64,33 +75,20 @@ func (s *Service) Initialize(genesisHeader *types.Header, t *trie.Trie) error {
 		return err
 	}
 
+	// load genesis hash into db
 	hash := genesisHeader.Hash()
-	err = storageState.DB.DB.Put(common.LatestHeaderHashKey, hash[:])
+	err = db.Put(common.LatestHeaderHashKey, hash[:])
 	if err != nil {
 		return err
 	}
 
-	blockState, err := NewBlockStateFromGenesis(blockDataDir, genesisHeader)
+	// load genesis block into db
+	_, err = NewBlockStateFromGenesis(db, genesisHeader)
 	if err != nil {
 		return err
 	}
 
-	networkState, err := NewNetworkState(networkDataDir)
-	if err != nil {
-		return err
-	}
-
-	err = blockState.db.Db.Close()
-	if err != nil {
-		return err
-	}
-
-	err = networkState.db.Db.Close()
-	if err != nil {
-		return err
-	}
-
-	return storageState.DB.DB.Close()
+	return db.Close()
 }
 
 // Start initializes the Storage database and the Block database.
@@ -99,40 +97,52 @@ func (s *Service) Start() error {
 		return nil
 	}
 
-	stateDataDir := filepath.Join(s.dbPath, "state")
-	blockDataDir := filepath.Join(s.dbPath, "block")
-	networkDataDir := filepath.Join(s.dbPath, "network")
-
-	storageState, err := NewStorageState(stateDataDir, trie.NewEmptyTrie(nil))
+	datadir, err := filepath.Abs(s.dbPath)
 	if err != nil {
-		return fmt.Errorf("cannot make storage state: %s", err)
+		return err
 	}
 
-	latestHeaderHash, err := storageState.DB.DB.Get(common.LatestHeaderHashKey)
+	// initialize database
+	db, err := database.NewBadgerDB(datadir)
+	if err != nil {
+		return err
+	}
+
+	s.db = db
+
+	// retrieve latest header
+	latestHeaderHash, err := s.db.Get(common.LatestHeaderHashKey)
 	if err != nil {
 		return fmt.Errorf("cannot get latest hash: %s", err)
 	}
 
 	log.Trace("state service", "latestHeaderHash", latestHeaderHash)
 
-	blockState, err := NewBlockState(blockDataDir, common.BytesToHash(latestHeaderHash))
+	// create storage state
+	s.Storage, err = NewStorageState(db, trie.NewEmptyTrie(nil))
+	if err != nil {
+		return fmt.Errorf("cannot make storage state: %s", err)
+	}
+
+	// create block state
+	s.Block, err = NewBlockState(db, common.BytesToHash(latestHeaderHash))
 	if err != nil {
 		return fmt.Errorf("cannot make block state: %s", err)
 	}
 
-	err = storageState.LoadFromDB(blockState.latestHeader.StateRoot)
+	// load current storage state
+	err = s.Storage.LoadFromDB(s.Block.latestHeader.StateRoot)
 	if err != nil {
 		return fmt.Errorf("cannot load state from DB: %s", err)
 	}
 
-	networkState, err := NewNetworkState(networkDataDir)
+	// create network state
+	s.Network, err = NewNetworkState(db)
 	if err != nil {
 		return fmt.Errorf("cannot make network state: %s", err)
 	}
 
-	s.Storage = storageState
-	s.Block = blockState
-	s.Network = networkState
+	// create transaction queue
 	s.TransactionQueue = NewTransactionQueue()
 
 	return nil
@@ -145,20 +155,5 @@ func (s *Service) Stop() error {
 		return err
 	}
 
-	err = s.Storage.DB.DB.Close()
-	if err != nil {
-		return err
-	}
-
-	err = s.Block.db.Db.Close()
-	if err != nil {
-		return err
-	}
-
-	err = s.Network.db.Db.Close()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.db.Close()
 }

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -26,47 +26,57 @@ import (
 	"github.com/ChainSafe/gossamer/lib/trie"
 )
 
-// DB stores trie structure in an underlying Database
-type DB struct {
-	DB database.Database
+var storagePrefix = []byte("storage")
+
+// StorageDB stores trie structure in an underlying database
+type StorageDB struct {
+	db database.Database
+}
+
+// Put appends `storage` to the key and sets the key-value pair in the db
+func (db *StorageDB) Put(key, value []byte) error {
+	key = append(storagePrefix, key...)
+	return db.db.Put(key, value)
+}
+
+// Get appends `storage` to the key and retrieves the value from the db
+func (db *StorageDB) Get(key []byte) ([]byte, error) {
+	key = append(storagePrefix, key...)
+	return db.db.Get(key)
 }
 
 // StorageState is the struct that holds the trie, db and lock
 type StorageState struct {
 	trie *trie.Trie
-	DB   *DB
+	db   *StorageDB
 	lock sync.RWMutex
 }
 
 // NewStateDB instantiates badgerDB instance for storing trie structure
-func NewStateDB(dataDir string) (*DB, error) {
-	db, err := database.NewBadgerDB(dataDir)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DB{
+func NewStateDB(db database.Database) *StorageDB {
+	return &StorageDB{
 		db,
-	}, nil
+	}
 }
 
 // NewStorageState creates a new StorageState backed by the given trie and database located at dataDir.
-func NewStorageState(dataDir string, t *trie.Trie) (*StorageState, error) {
-	stateDb, err := NewStateDB(dataDir)
-	if err != nil {
-		return nil, err
+func NewStorageState(db database.Database, t *trie.Trie) (*StorageState, error) {
+	if db == nil {
+		return nil, fmt.Errorf("cannot have nil database")
 	}
-	db := trie.NewDatabase(stateDb.DB)
-	t.SetDb(db)
+
+	triedb := trie.NewDatabase(db)
+	t.SetDb(triedb)
+
 	return &StorageState{
 		trie: t,
-		DB:   stateDb,
+		db:   NewStateDB(db),
 	}, nil
 }
 
 // SetLatestHeaderHash sets the LatestHeaderHashKey in the DB to the given hash
 func (s *StorageState) SetLatestHeaderHash(hash []byte) error {
-	err := s.DB.DB.Put(common.LatestHeaderHashKey, hash)
+	err := s.db.Put(common.LatestHeaderHashKey, hash)
 	if err != nil {
 		return fmt.Errorf("cannot get latest hash: %s", err)
 	}
@@ -76,7 +86,7 @@ func (s *StorageState) SetLatestHeaderHash(hash []byte) error {
 
 // GetLatestHeaderHash retrieves the value stored in the DB at LatestHeaderHashKey
 func (s *StorageState) GetLatestHeaderHash() ([]byte, error) {
-	latestHeaderHash, err := s.DB.DB.Get(common.LatestHeaderHashKey)
+	latestHeaderHash, err := s.db.Get(common.LatestHeaderHashKey)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get latest hash: %s", err)
 	}

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -34,15 +34,15 @@ type StorageDB struct {
 }
 
 // Put appends `storage` to the key and sets the key-value pair in the db
-func (db *StorageDB) Put(key, value []byte) error {
+func (storageDB *StorageDB) Put(key, value []byte) error {
 	key = append(storagePrefix, key...)
-	return db.db.Put(key, value)
+	return storageDB.db.Put(key, value)
 }
 
 // Get appends `storage` to the key and retrieves the value from the db
-func (db *StorageDB) Get(key []byte) ([]byte, error) {
+func (storageDB *StorageDB) Get(key []byte) ([]byte, error) {
 	key = append(storagePrefix, key...)
-	return db.db.Get(key)
+	return storageDB.db.Get(key)
 }
 
 // StorageState is the struct that holds the trie, db and lock

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -19,12 +19,7 @@
 set -e
 
 echo ">> Running tests..."
-go test -short -coverprofile c.out ./cmd/...
-go test -short -coverprofile c.out ./dot/core
-go test -short -coverprofile c.out ./dot/network
-go test -short -coverprofile c.out ./dot/rpc
-go test -short -coverprofile c.out ./dot/state
-go test -short -coverprofile c.out ./lib/...
+go test -short -coverprofile c.out ./...
 ./cc-test-reporter after-build --exit-code $?
 # echo ">> Running race condition test on runtime"
 # go test -short -race ./lib/runtime

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -20,7 +20,7 @@ set -e
 
 echo ">> Running tests..."
 go test -short -coverprofile c.out ./cmd/...
-# go test -short -coverprofile c.out ./dot/core
+go test -short -coverprofile c.out ./dot/core
 go test -short -coverprofile c.out ./dot/network
 go test -short -coverprofile c.out ./dot/rpc
 go test -short -coverprofile c.out ./dot/state


### PR DESCRIPTION
# Changes
- update state service to use one db for block, state, and network
- update core tests accordingly

mem performance before:
```
Showing nodes accounting for 11687.57MB, 99.76% of 11715.21MB total
Dropped 84 nodes (cum <= 58.58MB)
      flat  flat%   sum%        cum   cum%
         0     0%     0% 11705.17MB 99.91%  testing.tRunner
         0     0%     0% 11693.12MB 99.81%  github.com/ChainSafe/gossamer/lib/database.NewBadgerDB
    0.50MB 0.0043% 0.0043% 11692.62MB 99.81%  github.com/dgraph-io/badger/v2.Open
         0     0% 0.0043% 11233.88MB 95.89%  github.com/ChainSafe/gossamer/dot/core.newTestService
    6.99MB  0.06% 0.064%  9608.99MB 82.02%  github.com/dgraph-io/ristretto.NewCache
         0     0% 0.064%  9600.50MB 81.95%  github.com/dgraph-io/ristretto.newDefaultPolicy
         0     0% 0.064%  9600.50MB 81.95%  github.com/dgraph-io/ristretto.newPolicy
         0     0% 0.064%  9600.50MB 81.95%  github.com/dgraph-io/ristretto.newTinyLFU
         0     0% 0.064%  6400.50MB 54.63%  github.com/dgraph-io/ristretto.newCmSketch
    6400MB 54.63% 54.69%     6400MB 54.63%  github.com/dgraph-io/ristretto.newCmRow
```

mem performance after:
```
Showing nodes accounting for 2048.64MB, 54.62% of 3750.95MB total
Dropped 76 nodes (cum <= 18.75MB)
Showing top 10 nodes out of 20
      flat  flat%   sum%        cum   cum%
         0     0%     0%  3744.75MB 99.83%  testing.tRunner
         0     0%     0%  3743.23MB 99.79%  github.com/ChainSafe/gossamer/dot/core.newTestService
         0     0%     0%  3740.80MB 99.73%  github.com/ChainSafe/gossamer/lib/database.NewBadgerDB
         0     0%     0%  3740.80MB 99.73%  github.com/dgraph-io/badger/v2.Open
    0.64MB 0.017% 0.017%  3073.64MB 81.94%  github.com/dgraph-io/ristretto.NewCache
         0     0% 0.017%     3072MB 81.90%  github.com/dgraph-io/ristretto.newDefaultPolicy
         0     0% 0.017%     3072MB 81.90%  github.com/dgraph-io/ristretto.newPolicy
         0     0% 0.017%     3072MB 81.90%  github.com/dgraph-io/ristretto.newTinyLFU
    2048MB 54.60% 54.62%     2048MB 54.60%  github.com/dgraph-io/ristretto.newCmRow
         0     0% 54.62%     2048MB 54.60%  github.com/dgraph-io/ristretto.newCmSketch
```

it's approximately 1/3 of what it was before which makes sense

## Tests:
```
go test ./... -short
```

## Issues:
closes #638 closes #635 