### PR TITLE
utils, network, state: add / implement test utils

### DIFF
--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -17,20 +17,19 @@
 package network
 
 import (
-	"os"
-	"path"
 	"reflect"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/state"
+	"github.com/ChainSafe/gossamer/lib/utils"
 
 	"github.com/stretchr/testify/require"
 )
 
 // test buildIdentity method
 func TestBuildIdentity(t *testing.T) {
-	testDir := path.Join(os.TempDir(), "gossamer-test")
-	defer os.RemoveAll(testDir)
+	testDir := utils.NewTestDir(t)
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir: testDir,
@@ -79,8 +78,8 @@ func TestBuildIdentity(t *testing.T) {
 
 // test build configuration method
 func TestBuild(t *testing.T) {
-	testDataDir := path.Join(os.TempDir(), "gossamer-test")
-	defer os.RemoveAll(testDataDir)
+	testDataDir := utils.NewTestDataDir(t, "node")
+	defer utils.RemoveTestDir(t)
 
 	testBlockState := &state.BlockState{}
 	testNetworkState := &state.NetworkState{}

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -17,15 +17,18 @@
 package network
 
 import (
-	"os"
 	"testing"
 	"time"
+
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // test gossip messages to connected peers
 func TestGossip(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -40,8 +43,7 @@ func TestGossip(t *testing.T) {
 
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,
@@ -71,8 +73,7 @@ func TestGossip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dataDirC := newTestDataDir(t, "nodeC")
-	defer os.RemoveAll(dataDirC)
+	dataDirC := utils.NewTestDataDir(t, "nodeC")
 
 	configC := &Config{
 		DataDir:     dataDirC,

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -17,16 +17,19 @@
 package network
 
 import (
-	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // test host connect method
 func TestConnect(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -42,8 +45,7 @@ func TestConnect(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,
@@ -96,8 +98,10 @@ func TestConnect(t *testing.T) {
 
 // test host bootstrap method on start
 func TestBootstrap(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -115,8 +119,7 @@ func TestBootstrap(t *testing.T) {
 
 	addrA := nodeA.host.multiaddrs()[0]
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:   dataDirB,
@@ -162,8 +165,10 @@ func TestBootstrap(t *testing.T) {
 
 // test host ping method
 func TestPing(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -179,8 +184,7 @@ func TestPing(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,
@@ -229,8 +233,10 @@ func TestPing(t *testing.T) {
 
 // test host send method
 func TestSend(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -246,8 +252,7 @@ func TestSend(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,
@@ -299,8 +304,10 @@ func TestSend(t *testing.T) {
 
 // test host broadcast method
 func TestBroadcast(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -316,8 +323,7 @@ func TestBroadcast(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,
@@ -348,8 +354,7 @@ func TestBroadcast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dataDirC := newTestDataDir(t, "nodeC")
-	defer os.RemoveAll(dataDirC)
+	dataDirC := utils.NewTestDataDir(t, "")
 
 	configC := &Config{
 		DataDir:     dataDirC,
@@ -412,8 +417,10 @@ func TestBroadcast(t *testing.T) {
 
 // test host send method with existing stream
 func TestExistingStream(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -434,8 +441,7 @@ func TestExistingStream(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,

--- a/dot/network/mdns_test.go
+++ b/dot/network/mdns_test.go
@@ -17,9 +17,10 @@
 package network
 
 import (
-	"os"
 	"testing"
 	"time"
+
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // wait time to discover and connect using mdns discovery
@@ -27,8 +28,10 @@ var TestMDNSTimeout = time.Second
 
 // test mdns discovery service (discovers and connects)
 func TestMDNS(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -43,8 +46,7 @@ func TestMDNS(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -17,8 +17,6 @@
 package network
 
 import (
-	"os"
-	"path"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,6 +24,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/optional"
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 var TestProtocolID = "/gossamer/test/0"
@@ -46,11 +45,6 @@ var TestMessageTimeout = 3 * time.Second
 
 // time between connection retries (BackoffBase default 5 seconds)
 var TestBackoffTimeout = 5 * time.Second
-
-// newTestDataDir returns the path of a test directory
-func newTestDataDir(t *testing.T, name string) string {
-	return path.Join(os.TempDir(), "gossamer-test", t.Name(), name)
-}
 
 // failedToDial returns true if "failed to dial" error, otherwise false
 func failedToDial(err error) bool {
@@ -82,8 +76,10 @@ func createTestService(t *testing.T, cfg *Config) (node *Service, msgSend chan M
 
 // test network service starts
 func TestStartService(t *testing.T) {
-	dataDir := path.Join(os.TempDir(), "gossamer-test", "node")
-	defer os.RemoveAll(dataDir)
+	dataDir := utils.NewTestDataDir(t, "node")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	config := &Config{
 		DataDir:     dataDir,
@@ -98,8 +94,10 @@ func TestStartService(t *testing.T) {
 
 // test broacast messages from core service
 func TestBroadcastMessages(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -115,8 +113,7 @@ func TestBroadcastMessages(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,

--- a/dot/network/status_test.go
+++ b/dot/network/status_test.go
@@ -17,13 +17,13 @@
 package network
 
 import (
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // wait time for status messages to be exchanged and handled
@@ -31,8 +31,10 @@ var TestStatusTimeout = time.Second
 
 // test exchange status messages after peer connected
 func TestStatus(t *testing.T) {
-	dataDirA := newTestDataDir(t, "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -70,8 +72,7 @@ func TestStatus(t *testing.T) {
 	// simulate host status message sent from core service on startup
 	msgRecA <- testStatusMessage
 
-	dataDirB := newTestDataDir(t, "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,

--- a/dot/network/syncer_test.go
+++ b/dot/network/syncer_test.go
@@ -18,20 +18,22 @@ package network
 
 import (
 	"math/big"
-	"os"
-	"path"
 	"testing"
 	"time"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/optional"
+	"github.com/ChainSafe/gossamer/lib/utils"
+
 	"github.com/stretchr/testify/require"
 )
 
 // TestRequestedBlockIDs tests adding and removing block ids from requestedBlockIDs
 func TestRequestedBlockIDs(t *testing.T) {
-	dataDir := path.Join(os.TempDir(), "gossamer-test", t.Name())
-	defer os.RemoveAll(dataDir)
+	dataDir := utils.NewTestDataDir(t, "node")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	config := &Config{
 		DataDir:     dataDir,
@@ -60,8 +62,10 @@ func TestRequestedBlockIDs(t *testing.T) {
 // have a peer send a message status with a block ahead
 // test exchanged messages after peer connected are correct
 func TestHandleStatusMessage(t *testing.T) {
-	dataDirA := path.Join(os.TempDir(), "gossamer-test", "nodeA")
-	defer os.RemoveAll(dataDirA)
+	dataDirA := utils.NewTestDataDir(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
 		DataDir:     dataDirA,
@@ -100,8 +104,7 @@ func TestHandleStatusMessage(t *testing.T) {
 	// simulate host status message sent from core service on startup
 	msgRecA <- testStatusMessage
 
-	dataDirB := path.Join(os.TempDir(), "gossamer-test", "nodeB")
-	defer os.RemoveAll(dataDirB)
+	dataDirB := utils.NewTestDataDir(t, "nodeB")
 
 	configB := &Config{
 		DataDir:     dataDirB,

--- a/dot/network/utils_test.go
+++ b/dot/network/utils_test.go
@@ -17,10 +17,10 @@
 package network
 
 import (
-	"os"
-	"path"
 	"reflect"
 	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // list of IPFS peers, for testing only
@@ -62,9 +62,8 @@ func TestStringsToAddrInfos(t *testing.T) {
 }
 
 func TestGenerateKey(t *testing.T) {
-	testDir := path.Join(os.TempDir(), "gossamer-test")
-
-	defer os.RemoveAll(testDir)
+	testDir := utils.NewTestDir(t)
+	defer utils.RemoveTestDir(t)
 
 	keyA, err := generateKey(0, testDir)
 	if err != nil {

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -17,26 +17,23 @@
 package state
 
 import (
-	"io/ioutil"
 	"math/big"
 	"math/rand"
-	"os"
 	"reflect"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/trie"
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // helper method to create and start test state service
 func newTestService(t *testing.T) (state *Service) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
-	if err != nil {
-		t.Fatal("failed to create temp dir: " + err.Error())
-	}
+	testDir := utils.NewTestDir(t)
+	defer utils.RemoveTestDir(t)
 
-	state = NewService(dir)
+	state = NewService(testDir)
 
 	return state
 }
@@ -149,12 +146,12 @@ func addBlocksToState(blockState *BlockState, depth int) {
 }
 
 func TestService_BlockTree(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test_data")
-	if err != nil {
-		t.Fatal("failed to create temp dir: " + err.Error())
-	}
+	testDir := utils.NewTestDir(t)
 
-	state := NewService(dir)
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
+
+	state := NewService(testDir)
 
 	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), big.NewInt(0), trie.EmptyHash, trie.EmptyHash, [][]byte{})
 	if err != nil {
@@ -177,7 +174,7 @@ func TestService_BlockTree(t *testing.T) {
 
 	state.Stop()
 
-	state2 := NewService(dir)
+	state2 := NewService(testDir)
 
 	err = state2.Start()
 	if err != nil {

--- a/lib/keystore/keystore_test.go
+++ b/lib/keystore/keystore_test.go
@@ -164,7 +164,7 @@ func TestGetSecp256k1PublicKeys(t *testing.T) {
 
 func TestGenerateKey_Sr25519(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	keyfile, err := GenerateKeypair("sr25519", testdir, testPassword)
 	if err != nil {
@@ -187,7 +187,7 @@ func TestGenerateKey_Sr25519(t *testing.T) {
 
 func TestGenerateKey_Ed25519(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	keyfile, err := GenerateKeypair("ed25519", testdir, testPassword)
 	if err != nil {
@@ -225,7 +225,7 @@ func TestGenerateKey_Ed25519(t *testing.T) {
 
 func TestGenerateKey_Secp256k1(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	keyfile, err := GenerateKeypair("secp256k1", testdir, testPassword)
 	if err != nil {
@@ -263,7 +263,7 @@ func TestGenerateKey_Secp256k1(t *testing.T) {
 
 func TestGenerateKey_NoType(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	keyfile, err := GenerateKeypair("", testdir, testPassword)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestGenerateKey_NoType(t *testing.T) {
 
 func TestImportKey_ShouldFail(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	_, err := ImportKeypair("./notakey.key", testdir)
 	if err == nil {
@@ -297,10 +297,10 @@ func TestImportKey_ShouldFail(t *testing.T) {
 }
 
 func TestImportKey(t *testing.T) {
-	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	dataDir := utils.NewTestDataDir(t, "keystore")
+	defer utils.RemoveTestDir(t)
 
-	keypath := "../../"
+	keypath := dataDir + "keystore"
 
 	importkeyfile, err := GenerateKeypair("sr25519", keypath, testPassword)
 	if err != nil {
@@ -309,12 +309,12 @@ func TestImportKey(t *testing.T) {
 
 	defer os.RemoveAll(importkeyfile)
 
-	keyfile, err := ImportKeypair(importkeyfile, testdir)
+	keyfile, err := ImportKeypair(importkeyfile, dataDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	keys, err := utils.KeystoreFilepaths(testdir)
+	keys, err := utils.KeystoreFilepaths(dataDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestImportKey(t *testing.T) {
 
 func TestListKeys(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	expected := []string{}
 
@@ -375,7 +375,7 @@ func TestListKeys(t *testing.T) {
 
 func TestUnlockKeys(t *testing.T) {
 	testdir := utils.NewTestDir(t)
-	defer os.RemoveAll(testdir)
+	defer utils.RemoveTestDir(t)
 
 	keyfile, err := GenerateKeypair("sr25519", testdir, testPassword)
 	require.Nil(t, err)

--- a/lib/utils/test_utils.go
+++ b/lib/utils/test_utils.go
@@ -28,26 +28,49 @@ const TestDir = "./test_data"
 
 // NewTestDir create new test data directory
 func NewTestDir(t *testing.T) string {
-	dir := path.Join(TestDir, t.Name())
+	testDir := path.Join(TestDir, t.Name())
 
 	err := os.Mkdir(TestDir, os.ModePerm)
-	if err != nil && !Exists(TestDir) {
+	if err != nil && !PathExists(TestDir) {
 		fmt.Println(fmt.Errorf("failed to create test directory: %s", err))
 	}
 
-	err = os.Mkdir(dir, os.ModePerm)
-	if err != nil && !Exists(dir) {
+	err = os.Mkdir(testDir, os.ModePerm)
+	if err != nil && !PathExists(testDir) {
 		fmt.Println(fmt.Errorf("failed to create test directory: %s", err))
 	}
 
-	return dir
+	return testDir
+}
+
+// NewTestDataDir create new test data directory
+func NewTestDataDir(t *testing.T, name string) string {
+	testDir := path.Join(TestDir, t.Name())
+	dataDir := path.Join(testDir, name)
+
+	err := os.Mkdir(TestDir, os.ModePerm)
+	if err != nil && !PathExists(TestDir) {
+		fmt.Println(fmt.Errorf("failed to create test directory: %s", err))
+	}
+
+	err = os.Mkdir(testDir, os.ModePerm)
+	if err != nil && !PathExists(testDir) {
+		fmt.Println(fmt.Errorf("failed to create test directory: %s", err))
+	}
+
+	err = os.Mkdir(dataDir, os.ModePerm)
+	if err != nil && !PathExists(dataDir) {
+		fmt.Println(fmt.Errorf("failed to create test data directory: %s", err))
+	}
+
+	return dataDir
 }
 
 // RemoveTestDir removes the test data directory
 func RemoveTestDir(t *testing.T) {
-	dir := path.Join(TestDir, t.Name())
-	err := os.RemoveAll(dir)
-	if err != nil && !Exists(dir) {
+	testDir := path.Join(TestDir, t.Name())
+	err := os.RemoveAll(testDir)
+	if err != nil && !PathExists(testDir) {
 		fmt.Println(fmt.Errorf("failed to remove test directory: %s", err))
 	}
 }

--- a/lib/utils/test_utils_test.go
+++ b/lib/utils/test_utils_test.go
@@ -16,4 +16,44 @@
 
 package utils
 
-// TODO: add utils tests
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTestDir tests the NewTestDir method
+func TestNewTestDir(t *testing.T) {
+	testDir := NewTestDir(t)
+
+	expected := path.Join(TestDir, t.Name())
+
+	require.Equal(t, expected, testDir)
+	require.Equal(t, PathExists(testDir), true)
+}
+
+// TestNewTestDataDir tests the NewTestDataDir method
+func TestNewTestDataDir(t *testing.T) {
+	dataDir := "testnode"
+
+	testDir := NewTestDataDir(t, dataDir)
+
+	expected := path.Join(TestDir, t.Name(), dataDir)
+
+	require.Equal(t, expected, testDir)
+	require.Equal(t, PathExists(testDir), true)
+}
+
+// TestRemoveTestDir tests the RemoveTestDir method
+func TestRemoveTestDir(t *testing.T) {
+	testDir := NewTestDir(t)
+
+	expected := path.Join(TestDir, t.Name())
+
+	require.Equal(t, expected, testDir)
+	require.Equal(t, PathExists(testDir), true)
+
+	RemoveTestDir(t)
+	require.Equal(t, PathExists(testDir), false)
+}

--- a/lib/utils/test_utils_test.go
+++ b/lib/utils/test_utils_test.go
@@ -31,11 +31,13 @@ func TestNewTestDir(t *testing.T) {
 
 	require.Equal(t, expected, testDir)
 	require.Equal(t, PathExists(testDir), true)
+
+	RemoveTestDir(t)
 }
 
 // TestNewTestDataDir tests the NewTestDataDir method
 func TestNewTestDataDir(t *testing.T) {
-	dataDir := "testnode"
+	dataDir := "test"
 
 	testDir := NewTestDataDir(t, dataDir)
 
@@ -43,6 +45,8 @@ func TestNewTestDataDir(t *testing.T) {
 
 	require.Equal(t, expected, testDir)
 	require.Equal(t, PathExists(testDir), true)
+
+	RemoveTestDir(t)
 }
 
 // TestRemoveTestDir tests the RemoveTestDir method

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -27,6 +27,16 @@ import (
 	"strings"
 )
 
+// PathExists returns true if the named file or directory exists, otherwise false
+func PathExists(p string) bool {
+	if _, err := os.Stat(p); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
 // HomeDir returns the user's current HOME directory
 func HomeDir() string {
 	if home := os.Getenv("HOME"); home != "" {
@@ -36,16 +46,6 @@ func HomeDir() string {
 		return usr.HomeDir
 	}
 	return ""
-}
-
-// Exists returns true if the named file or directory exists, otherwise false
-func Exists(fp string) bool {
-	if _, err := os.Stat(fp); err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
-	}
-	return true
 }
 
 // ExpandDir expands a tilde prefix path to a full home path

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -45,6 +45,7 @@ func TestExpandDir(t *testing.T) {
 	require.Equal(t, strings.Contains(expandedDirA, homeDir), true)
 
 	testDirB := NewTestDataDir(t, "test")
+	defer RemoveTestDir(t)
 
 	expandedDirB := ExpandDir(testDirB)
 
@@ -55,6 +56,7 @@ func TestExpandDir(t *testing.T) {
 // TestDataDir tests the DataDir method
 func TestDataDir(t *testing.T) {
 	testDir := NewTestDataDir(t, "test")
+	defer RemoveTestDir(t)
 
 	homeDir := HomeDir()
 	dataDir := DataDir(testDir)
@@ -66,6 +68,7 @@ func TestDataDir(t *testing.T) {
 // TestKeystoreDir tests the KeystoreDir method
 func TestKeystoreDir(t *testing.T) {
 	testDir := NewTestDataDir(t, "test")
+	defer RemoveTestDir(t)
 
 	homeDir := HomeDir()
 	dataDir := DataDir(testDir)

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -16,4 +16,63 @@
 
 package utils
 
-// TODO: add utils tests
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPathExists tests the NewTestDir method
+func TestPathExists(t *testing.T) {
+	require.Equal(t, PathExists("../utils"), true)
+	require.Equal(t, PathExists("../utilzzz"), false)
+}
+
+// TestHomeDir tests the HomeDir method
+func TestHomeDir(t *testing.T) {
+	require.NotEqual(t, HomeDir(), "")
+}
+
+// TestExpandDir tests the ExpandDir method
+func TestExpandDir(t *testing.T) {
+	testDirA := "~/.gossamer-test"
+
+	homeDir := HomeDir()
+	expandedDirA := ExpandDir(testDirA)
+
+	require.NotEqual(t, testDirA, expandedDirA)
+	require.Equal(t, strings.Contains(expandedDirA, homeDir), true)
+
+	testDirB := NewTestDataDir(t, "test")
+
+	expandedDirB := ExpandDir(testDirB)
+
+	require.Equal(t, testDirB, expandedDirB)
+	require.Equal(t, strings.Contains(expandedDirB, homeDir), false)
+}
+
+// TestDataDir tests the DataDir method
+func TestDataDir(t *testing.T) {
+	testDir := NewTestDataDir(t, "test")
+
+	homeDir := HomeDir()
+	dataDir := DataDir(testDir)
+
+	require.NotEqual(t, testDir, dataDir)
+	require.Equal(t, strings.Contains(dataDir, homeDir), true)
+}
+
+// TestKeystoreDir tests the KeystoreDir method
+func TestKeystoreDir(t *testing.T) {
+	testDir := NewTestDataDir(t, "test")
+
+	homeDir := HomeDir()
+	dataDir := DataDir(testDir)
+
+	keystoreDir, err := KeystoreDir(testDir)
+	require.Nil(t, err)
+
+	require.NotEqual(t, testDir, dataDir)
+	require.Equal(t, strings.Contains(keystoreDir, homeDir), true)
+}

--- a/tests/wasmer_test_util.go
+++ b/tests/wasmer_test_util.go
@@ -63,7 +63,7 @@ func GetRuntimeVars(targetRuntime string) (string, string) {
 
 // GetRuntimeBlob checks if the test wasm @testRuntimeFilePath exists and if not, it fetches it from @testRuntimeURL
 func GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL string) (n int64, err error) {
-	if utils.Exists(testRuntimeFilePath) {
+	if utils.PathExists(testRuntimeFilePath) {
 		return 0, nil
 	}
 


### PR DESCRIPTION
## Changes

- implements the same test directory utility methods used by `dot` and `cmd`
- adds a test directory utility method that adds a directory within the test directory

## Tests:

```
go test lib/utils -v
```

### Issues:

closes #689 