### PR TITLE
dot/core: first block in epoch and core refactor

### DIFF
--- a/dot/core/babe.go
+++ b/dot/core/babe.go
@@ -1,0 +1,132 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/ChainSafe/gossamer/dot/core/types"
+	"github.com/ChainSafe/gossamer/lib/babe"
+	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	log "github.com/ChainSafe/log15"
+)
+
+// finalizeBabeSession finalizes the BABE session by ensuring the first block
+// was set and first block and epoch number are reset for the next epoch
+func (s *Service) finalizeBabeSession() error {
+
+	// check if first block was set for current epoch
+	if s.firstBlock == nil {
+
+		// TODO: NextEpochDescriptor is included in first block of an epoch #662
+		// return fmt.Errorf("first block not set for current epoch")
+
+		log.Error("[core] first block not set for current epoch")
+	}
+
+	// verify best block is from current epoch
+	bestHash := s.blockState.BestBlockHash()
+	currentEpoch, err := s.blockFromCurrentEpoch(bestHash)
+	if err != nil {
+		return fmt.Errorf("failed to check block from current epoch: %s", err)
+	}
+
+	if !currentEpoch {
+		return fmt.Errorf("best block is not from current epoch: %s", err)
+	}
+
+	// get best epoch number from best header
+	bestEpoch, err := s.getBlockEpoch(bestHash)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch number for best block: %s", err)
+	}
+
+	// verify current epoch number matches best epoch number
+	if s.epochNumber != bestEpoch {
+		return fmt.Errorf("block epoch does not match current epoch")
+	}
+
+	// set next epoch number
+	s.epochNumber = bestEpoch + 1
+
+	// reset first block number
+	s.firstBlock = nil
+
+	return nil
+}
+
+// initializeBabeSession creates a new BABE session
+func (s *Service) initializeBabeSession() (*babe.Session, error) {
+	log.Debug(
+		"[core] initializing BABE session...",
+		"epoch", s.epochNumber,
+	)
+
+	// AuthorityData comes from NextEpochDescriptor within the ConsensusDigest
+	// of the block Digest, which is included in the first block of each epoch
+	authData := s.bs.AuthorityData()
+	if len(authData) == 0 {
+		return nil, fmt.Errorf("authority data not set")
+	}
+
+	newBlocks := make(chan types.Block)
+	s.blkRec = newBlocks
+
+	epochDone := make(chan struct{})
+	s.epochDone = epochDone
+
+	babeKill := make(chan struct{})
+	s.babeKill = babeKill
+
+	keys := s.keys.Sr25519Keypairs()
+
+	// get best slot to determine next start slot
+	bestHash := s.blockState.BestBlockHash()
+	bestSlot, err := s.blockState.GetSlotForBlock(bestHash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get slot for latest block: %s", err)
+	}
+
+	// BABE session configuration
+	bsConfig := &babe.SessionConfig{
+		Keypair:          keys[0].(*sr25519.Keypair),
+		Runtime:          s.rt,
+		NewBlocks:        newBlocks, // becomes block send channel in BABE session
+		BlockState:       s.blockState,
+		StorageState:     s.storageState,
+		TransactionQueue: s.transactionQueue,
+		AuthData:         authData,
+		Done:             epochDone,
+		Kill:             babeKill,
+		StartSlot:        bestSlot + 1,
+		SyncLock:         s.syncLock,
+	}
+
+	// create new BABE session
+	bs, err := babe.NewSession(bsConfig)
+	if err != nil {
+		log.Error("[core] failed to initialize BABE session", "error", err)
+		return nil, err
+	}
+
+	log.Debug(
+		"[core] BABE session initialized",
+		"epoch", s.epochNumber,
+	)
+
+	return bs, nil
+}

--- a/dot/core/babe.go
+++ b/dot/core/babe.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/lib/babe"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+
 	log "github.com/ChainSafe/log15"
 )
 
@@ -35,16 +36,17 @@ func (s *Service) finalizeBabeSession() error {
 		// TODO: NextEpochDescriptor is included in first block of an epoch #662
 		// return fmt.Errorf("first block not set for current epoch")
 
-		log.Error("[core] first block not set for current epoch")
+		log.Error("[core] first block not set for current epoch") // TODO: remove
 	}
 
-	// verify best block is from current epoch
+	// get epoch number for best block
 	bestHash := s.blockState.BestBlockHash()
 	currentEpoch, err := s.blockFromCurrentEpoch(bestHash)
 	if err != nil {
-		return fmt.Errorf("failed to check block from current epoch: %s", err)
+		return fmt.Errorf("failed to check best block from current epoch: %s", err)
 	}
 
+	// verify best block is from current epoch
 	if !currentEpoch {
 		return fmt.Errorf("best block is not from current epoch: %s", err)
 	}

--- a/dot/core/babe_test.go
+++ b/dot/core/babe_test.go
@@ -1,0 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+// TODO: test NextEpochDescriptor is included in first block of an epoch #662

--- a/dot/core/babe_test.go
+++ b/dot/core/babe_test.go
@@ -16,4 +16,60 @@
 
 package core
 
-// TODO: test NextEpochDescriptor is included in first block of an epoch #662
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test finalizeBabeSession
+func TestFinalizeBabeSession(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
+
+	number, err := s.blockState.BestBlockNumber()
+	require.Nil(t, err)
+
+	header, err := s.blockState.BestBlockHeader()
+	require.Nil(t, err)
+
+	err = s.handleBlockDigest(header)
+	require.Nil(t, err)
+
+	require.Equal(t, number, s.firstBlock)
+
+	err = s.finalizeBabeSession()
+	require.Nil(t, err)
+
+	require.Nil(t, s.firstBlock)
+}
+
+// test initializeBabeSession
+func TestInitializeBabeSession(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
+
+	number, err := s.blockState.BestBlockNumber()
+	require.Nil(t, err)
+
+	header, err := s.blockState.BestBlockHeader()
+	require.Nil(t, err)
+
+	err = s.handleBlockDigest(header)
+	require.Nil(t, err)
+
+	require.Equal(t, number, s.firstBlock)
+
+	epochNumber := s.epochNumber
+
+	err = s.finalizeBabeSession()
+	require.Nil(t, err)
+
+	require.Nil(t, s.firstBlock)
+
+	bs, err := s.initializeBabeSession()
+	require.Nil(t, err)
+
+	require.Equal(t, epochNumber+1, s.epochNumber)
+	require.Nil(t, s.firstBlock)
+
+	require.NotNil(t, bs)
+}

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/lib/babe"
+
 	log "github.com/ChainSafe/log15"
 )
 

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -81,13 +81,15 @@ func (s *Service) handleConsensusDigest(header *types.Header, digest *types.Cons
 	// check if first block has been set for current epoch
 	if s.firstBlock != nil {
 
-		// check if first block has lower block number than block header
-		if s.firstBlock.Cmp(header.Number) != -1 {
+		// check if block header has lower block number than current first block
+		if header.Number.Cmp(s.firstBlock) >= 0 {
+
+			// error if block header does not have lower block number
 			return fmt.Errorf("first block already set for current epoch")
 		}
 
-		// log error if BABE produced two first blocks or received false first block from connected peer
-		log.Error("[core] received first block header with lower block number than current first block")
+		// either BABE produced two first blocks or we received invalid first block from connected peer
+		log.Warn("[core] received first block header with lower block number than current first block")
 	}
 
 	err = s.setNextEpochDescriptor(digest.Data)

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -1,0 +1,118 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ChainSafe/gossamer/dot/core/types"
+	"github.com/ChainSafe/gossamer/lib/babe"
+	log "github.com/ChainSafe/log15"
+)
+
+// handleBlockDigest checks if the provided header is the block header for
+// the first block of the current epoch, finds and decodes the consensus digest
+// item from the block digest, and then sets the epoch data for the next epoch
+func (s *Service) handleBlockDigest(header *types.Header) (err error) {
+
+	// check if block header digest items exist
+	if header.Digest == nil || len(header.Digest) == 0 {
+		return fmt.Errorf("header digest is not set")
+	}
+
+	// declare digest item
+	var item types.DigestItem
+
+	// decode each digest item and check its type
+	for _, digest := range header.Digest {
+		item, err = types.DecodeDigestItem(digest)
+		if err != nil {
+			return err
+		}
+
+		// check if digest item is consensus digest type
+		if item.Type() == types.ConsensusDigestType {
+
+			// cast decoded consensus digest item to conensus digest type
+			consensusDigest, ok := item.(*types.ConsensusDigest)
+			if !ok {
+				return errors.New("failed to cast DigestItem to ConsensusDigest")
+			}
+
+			err = s.handleConsensusDigest(header, consensusDigest)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// handleConsensusDigest checks if the first block has been set for the current
+// epoch, if first block has not been set or the block header has a lower block
+// number, sets epoch data for the next epoch using data in the ConsensusDigest
+func (s *Service) handleConsensusDigest(header *types.Header, digest *types.ConsensusDigest) error {
+
+	// check if block header is from current epoch
+	currentEpoch, err := s.blockFromCurrentEpoch(header.Hash())
+	if err != nil {
+		return fmt.Errorf("failed to check if block header is from current epoch: %s", err)
+	} else if !currentEpoch {
+		return fmt.Errorf("block header is not from current epoch: %s", err)
+	}
+
+	// check if first block has been set for current epoch
+	if s.firstBlock != nil {
+
+		// check if first block has lower block number than block header
+		if s.firstBlock.Cmp(header.Number) != -1 {
+			return fmt.Errorf("first block already set for current epoch")
+		}
+
+		// log error if BABE produced two first blocks or received false first block from connected peer
+		log.Error("[core] received first block header with lower block number than current first block")
+	}
+
+	err = s.setNextEpochDescriptor(digest.Data)
+	if err != nil {
+		return fmt.Errorf("failed to set next epoch descriptor: %s", err)
+	}
+
+	// set first block in current epoch
+	s.firstBlock = header.Number
+
+	return nil
+}
+
+// setNextEpochDescriptor sets the epoch data for the next epoch from the data
+// included in the ConsensusDigest of the first block of each epoch
+func (s *Service) setNextEpochDescriptor(data []byte) error {
+
+	// initialize epoch data interface for next epoch
+	nextEpochData := new(babe.NextEpochDescriptor)
+
+	// decode consensus digest data for next epoch
+	err := nextEpochData.Decode(data)
+	if err != nil {
+		return err
+	}
+
+	// set epoch data for next epoch
+	return s.bs.SetEpochData(nextEpochData)
+}

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/dot/core/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test handleBlockDigest
+func TestHandleBlockDigest(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
+
+	number, err := s.blockState.BestBlockNumber()
+	require.Nil(t, err)
+
+	header, err := s.blockState.BestBlockHeader()
+	require.Nil(t, err)
+
+	err = s.handleBlockDigest(header)
+	require.Nil(t, err)
+
+	require.Equal(t, number, s.firstBlock)
+}
+
+// test handleConsensusDigest
+func TestHandleConsensusDigest(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
+
+	number, err := s.blockState.BestBlockNumber()
+	require.Nil(t, err)
+
+	header, err := s.blockState.BestBlockHeader()
+	require.Nil(t, err)
+
+	var item types.DigestItem
+
+	for _, digest := range header.Digest {
+		item, err = types.DecodeDigestItem(digest)
+		require.Nil(t, err)
+	}
+
+	// check if digest item is consensus digest type
+	if item.Type() == types.ConsensusDigestType {
+		digest := item.(*types.ConsensusDigest)
+
+		err = s.handleConsensusDigest(header, digest)
+		require.Nil(t, err)
+	}
+
+	require.Equal(t, number, s.firstBlock)
+}

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
@@ -38,6 +39,24 @@ func TestHandleBlockDigest(t *testing.T) {
 	require.Nil(t, err)
 
 	require.Equal(t, number, s.firstBlock)
+
+	// test two blocks claiming to be first block
+	s.firstBlock = big.NewInt(1)
+
+	err = s.handleBlockDigest(header)
+	require.NotNil(t, err) // expect error: "first block already set for current epoch"
+
+	// expect first block not to be updated
+	require.Equal(t, s.firstBlock, big.NewInt(1))
+
+	// test two blocks claiming to be first block
+	s.firstBlock = big.NewInt(99)
+
+	err = s.handleBlockDigest(header)
+	require.Nil(t, err)
+
+	// expect first block to be updated
+	require.Equal(t, s.firstBlock, number)
 }
 
 // test handleConsensusDigest

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -67,3 +67,26 @@ func TestHandleConsensusDigest(t *testing.T) {
 
 	require.Equal(t, number, s.firstBlock)
 }
+
+// test setNextEpochDescriptor
+func TestSetNextEpochDescriptor(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
+
+	header, err := s.blockState.BestBlockHeader()
+	require.Nil(t, err)
+
+	var item types.DigestItem
+
+	for _, digest := range header.Digest {
+		item, err = types.DecodeDigestItem(digest)
+		require.Nil(t, err)
+	}
+
+	// check if digest item is consensus digest type
+	if item.Type() == types.ConsensusDigestType {
+		digest := item.(*types.ConsensusDigest)
+
+		err = s.setNextEpochDescriptor(digest.Data)
+		require.Nil(t, err)
+	}
+}

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -54,7 +54,6 @@ func (s *Service) createBlockResponse(blockRequest *network.BlockRequestMessage)
 		}
 		block, err := s.blockState.GetBlockByNumber(big.NewInt(0).SetUint64(startBlock))
 		if err != nil {
-			log.Error("[core] failed to get starting block", "number", startBlock)
 			return nil, err
 		}
 
@@ -273,7 +272,12 @@ func (s *Service) ProcessTransactionMessage(msg *network.TransactionMessage) err
 
 		if s.isBabeAuthority {
 			// push to the transaction queue of BABE session
-			s.transactionQueue.Push(vtx)
+			hash, err := s.transactionQueue.Push(vtx)
+			if err != nil {
+				log.Trace("[core] Failed to push transaction to queue", "error", err)
+			} else {
+				log.Trace("[core] Added transaction to queue", "hash", hash)
+			}
 		}
 	}
 

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -1,0 +1,281 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+
+	"github.com/ChainSafe/gossamer/dot/core/types"
+	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/common/optional"
+	"github.com/ChainSafe/gossamer/lib/transaction"
+
+	log "github.com/ChainSafe/log15"
+)
+
+// BlockRequestMessage 1
+
+// ProcessBlockRequestMessage processes a block request message, returning a block response message
+func (s *Service) ProcessBlockRequestMessage(msg *network.BlockRequestMessage) error {
+	log.Debug("[core] received BlockRequestMessage")
+
+	res, err := s.createBlockResponse(msg)
+	if err != nil {
+		return err
+	}
+
+	return s.safeMsgSend(res)
+}
+
+// createBlockResponse create a block response message from a block request message
+func (s *Service) createBlockResponse(blockRequest *network.BlockRequestMessage) (*network.BlockResponseMessage, error) {
+	var startHash common.Hash
+	var endHash common.Hash
+
+	switch startBlock := blockRequest.StartingBlock.Value().(type) {
+	case uint64:
+		if startBlock == 0 {
+			startBlock = 1
+		}
+		block, err := s.blockState.GetBlockByNumber(big.NewInt(0).SetUint64(startBlock))
+		if err != nil {
+			log.Error("[core] failed to get starting block", "number", startBlock)
+			return nil, err
+		}
+
+		startHash = block.Header.Hash()
+	case common.Hash:
+		startHash = startBlock
+	}
+
+	if blockRequest.EndBlockHash.Exists() {
+		endHash = blockRequest.EndBlockHash.Value()
+	} else {
+		endHash = s.blockState.BestBlockHash()
+	}
+
+	log.Debug("[core] BlockRequestMessage", "startHash", startHash, "endHash", endHash)
+
+	// get sub-chain of block hashes
+	subchain, err := s.blockState.SubChain(startHash, endHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(subchain) > int(maxResponseSize) {
+		subchain = subchain[:maxResponseSize]
+	}
+
+	log.Trace("[core] subchain", "start", subchain[0], "end", subchain[len(subchain)-1])
+
+	responseData := []*types.BlockData{}
+
+	for _, hash := range subchain {
+
+		blockData := new(types.BlockData)
+		blockData.Hash = hash
+
+		// set defaults
+		blockData.Header = optional.NewHeader(false, nil)
+		blockData.Body = optional.NewBody(false, nil)
+		blockData.Receipt = optional.NewBytes(false, nil)
+		blockData.MessageQueue = optional.NewBytes(false, nil)
+		blockData.Justification = optional.NewBytes(false, nil)
+
+		// header
+		if (blockRequest.RequestedData & 1) == 1 {
+			retData, err := s.blockState.GetHeader(hash)
+			if err == nil && retData != nil {
+				blockData.Header = retData.AsOptional()
+			}
+		}
+		// body
+		if (blockRequest.RequestedData&2)>>1 == 1 {
+			retData, err := s.blockState.GetBlockBody(hash)
+			if err == nil && retData != nil {
+				blockData.Body = retData.AsOptional()
+			}
+		}
+		// receipt
+		if (blockRequest.RequestedData&4)>>2 == 1 {
+			retData, err := s.blockState.GetReceipt(hash)
+			if err == nil && retData != nil {
+				blockData.Receipt = optional.NewBytes(true, retData)
+			}
+		}
+		// message queue
+		if (blockRequest.RequestedData&8)>>3 == 1 {
+			retData, err := s.blockState.GetMessageQueue(hash)
+			if err == nil && retData != nil {
+				blockData.MessageQueue = optional.NewBytes(true, retData)
+			}
+		}
+		// justification
+		if (blockRequest.RequestedData&16)>>4 == 1 {
+			retData, err := s.blockState.GetJustification(hash)
+			if err == nil && retData != nil {
+				blockData.Justification = optional.NewBytes(true, retData)
+			}
+		}
+
+		responseData = append(responseData, blockData)
+	}
+
+	return &network.BlockResponseMessage{
+		ID:        blockRequest.ID,
+		BlockData: responseData,
+	}, nil
+}
+
+// BlockResponseMessage 2
+
+// ProcessBlockResponseMessage attempts to validate and add the block to the
+// chain by calling `core_execute_block`. Valid blocks are stored in the block
+// database to become part of the canonical chain.
+func (s *Service) ProcessBlockResponseMessage(msg *network.BlockResponseMessage) error {
+	log.Debug("[core] received BlockResponseMessage")
+
+	// loop through block data in block response message
+	for _, bd := range msg.BlockData {
+		if bd.Header.Exists() {
+
+			header, err := types.NewHeader(
+				bd.Header.Value().ParentHash,
+				bd.Header.Value().Number,
+				bd.Header.Value().StateRoot,
+				bd.Header.Value().ExtrinsicsRoot,
+				bd.Header.Value().Digest,
+			)
+			if err != nil {
+				return err
+			}
+
+			// if authority, check if first block and set epoch data for next epoch
+			if s.isBabeAuthority {
+				err = s.handleBlockDigest(header)
+				if err != nil {
+					log.Trace("[core] block is not first block in epoch", "error", err)
+				}
+			}
+		}
+	}
+
+	// send block response message to syncer
+	s.respOut <- msg
+
+	// TODO: should we wait for syncer to handle message before we check for runtime changes...?
+
+	// check if we need to update the runtime
+	err := s.checkForRuntimeChanges()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BlockAnnounceMessage 3
+
+// ProcessBlockAnnounceMessage creates a block request message from the block
+// announce messages (block announce messages include the header but the full
+// block is required to execute `core_execute_block`).
+func (s *Service) ProcessBlockAnnounceMessage(msg *network.BlockAnnounceMessage) error {
+	log.Debug("[core] received BlockAnnounceMessage")
+
+	// create header from message
+	header, err := types.NewHeader(
+		msg.ParentHash,
+		msg.Number,
+		msg.StateRoot,
+		msg.ExtrinsicsRoot,
+		msg.Digest,
+	)
+	if err != nil {
+		return err
+	}
+
+	// if authority, check if first block and set epoch data for next epoch
+	if s.isBabeAuthority {
+		err = s.handleBlockDigest(header)
+		if err != nil {
+			log.Trace("[core] block is not first block in epoch", "error", err)
+		}
+	}
+
+	// check if block header is stored in block state and save block header
+	_, err = s.blockState.GetHeader(header.Hash())
+	if err != nil && err.Error() == "Key not found" {
+		err = s.blockState.SetHeader(header)
+		if err != nil {
+			return err
+		}
+		log.Debug(
+			"[core] saved block header to block state",
+			"number", header.Number,
+			"hash", header.Hash(),
+		)
+	} else {
+		return err
+	}
+
+	// check if block body is stored in block state (if we should send to syncer)
+	_, err = s.blockState.GetBlockBody(header.Hash())
+	if err != nil && err.Error() == "Key not found" {
+		log.Debug(
+			"[core] sending block number to syncer",
+			"number", msg.Number,
+		)
+		s.blockNumOut <- msg.Number
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TransactionMessage 4
+
+// ProcessTransactionMessage validates each transaction in the message and
+// adds valid transactions to the transaction queue of the BABE session
+func (s *Service) ProcessTransactionMessage(msg *network.TransactionMessage) error {
+	log.Debug("[core] received TransactionMessage")
+
+	// get transactions from message extrinsics
+	txs := msg.Extrinsics
+
+	for _, tx := range txs {
+		tx := tx // pin
+
+		// validate each transaction
+		val, err := s.ValidateTransaction(tx)
+		if err != nil {
+			log.Error("[core] failed to validate transaction", "err", err)
+			return err // exit
+		}
+
+		// create new valid transaction
+		vtx := transaction.NewValidTransaction(tx, val)
+
+		if s.isBabeAuthority {
+			// push to the transaction queue of BABE session
+			s.transactionQueue.Push(vtx)
+		}
+	}
+
+	return nil
+}

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -1,0 +1,413 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ChainSafe/gossamer/dot/core/types"
+	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/common/optional"
+	"github.com/ChainSafe/gossamer/lib/common/variadic"
+	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
+	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/transaction"
+	"github.com/ChainSafe/gossamer/lib/trie"
+	"github.com/ChainSafe/gossamer/tests"
+
+	"github.com/stretchr/testify/require"
+)
+
+// BlockRequestMessage 1
+
+// tests the ProcessBlockRequestMessage method
+func TestService_ProcessBlockRequestMessage(t *testing.T) {
+	msgSend := make(chan network.Message, 10)
+
+	cfg := &Config{
+		MsgSend: msgSend,
+	}
+
+	s := newTestService(t, cfg)
+
+	addTestBlocksToState(t, 2, s.blockState)
+
+	bestHash := s.blockState.BestBlockHash()
+	bestBlock, err := s.blockState.GetBlockByNumber(big.NewInt(1))
+	require.Nil(t, err)
+
+	// set some nils and check no error is thrown
+	bds := &types.BlockData{
+		Hash:          bestHash,
+		Header:        nil,
+		Receipt:       nil,
+		MessageQueue:  nil,
+		Justification: nil,
+	}
+	err = s.blockState.CompareAndSetBlockData(bds)
+	require.Nil(t, err)
+
+	// set receipt message and justification
+	bds = &types.BlockData{
+		Hash:          bestHash,
+		Receipt:       optional.NewBytes(true, []byte("asdf")),
+		MessageQueue:  optional.NewBytes(true, []byte("ghjkl")),
+		Justification: optional.NewBytes(true, []byte("qwerty")),
+	}
+
+	endHash := s.blockState.BestBlockHash()
+	start, err := variadic.NewUint64OrHash(uint64(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.blockState.CompareAndSetBlockData(bds)
+
+	require.Nil(t, err)
+
+	testsCases := []struct {
+		description      string
+		value            *network.BlockRequestMessage
+		expectedMsgType  int
+		expectedMsgValue *network.BlockResponseMessage
+	}{
+		{
+			description: "test get Header and Body",
+			value: &network.BlockRequestMessage{
+				ID:            1,
+				RequestedData: 3,
+				StartingBlock: start,
+				EndBlockHash:  optional.NewHash(true, endHash),
+				Direction:     1,
+				Max:           optional.NewUint32(false, 0),
+			},
+			expectedMsgType: network.BlockResponseMsgType,
+			expectedMsgValue: &network.BlockResponseMessage{
+				ID: 1,
+				BlockData: []*types.BlockData{
+					{
+						Hash:   optional.NewHash(true, bestHash).Value(),
+						Header: bestBlock.Header.AsOptional(),
+						Body:   bestBlock.Body.AsOptional(),
+					},
+				},
+			},
+		},
+		{
+			description: "test get Header",
+			value: &network.BlockRequestMessage{
+				ID:            2,
+				RequestedData: 1,
+				StartingBlock: start,
+				EndBlockHash:  optional.NewHash(true, endHash),
+				Direction:     1,
+				Max:           optional.NewUint32(false, 0),
+			},
+			expectedMsgType: network.BlockResponseMsgType,
+			expectedMsgValue: &network.BlockResponseMessage{
+				ID: 2,
+				BlockData: []*types.BlockData{
+					{
+						Hash:   optional.NewHash(true, bestHash).Value(),
+						Header: bestBlock.Header.AsOptional(),
+						Body:   optional.NewBody(false, nil),
+					},
+				},
+			},
+		},
+		{
+			description: "test get Receipt",
+			value: &network.BlockRequestMessage{
+				ID:            2,
+				RequestedData: 4,
+				StartingBlock: start,
+				EndBlockHash:  optional.NewHash(true, endHash),
+				Direction:     1,
+				Max:           optional.NewUint32(false, 0),
+			},
+			expectedMsgType: network.BlockResponseMsgType,
+			expectedMsgValue: &network.BlockResponseMessage{
+				ID: 2,
+				BlockData: []*types.BlockData{
+					{
+						Hash:    optional.NewHash(true, bestHash).Value(),
+						Header:  optional.NewHeader(false, nil),
+						Body:    optional.NewBody(false, nil),
+						Receipt: bds.Receipt,
+					},
+				},
+			},
+		},
+		{
+			description: "test get MessageQueue",
+			value: &network.BlockRequestMessage{
+				ID:            2,
+				RequestedData: 8,
+				StartingBlock: start,
+				EndBlockHash:  optional.NewHash(true, endHash),
+				Direction:     1,
+				Max:           optional.NewUint32(false, 0),
+			},
+			expectedMsgType: network.BlockResponseMsgType,
+			expectedMsgValue: &network.BlockResponseMessage{
+				ID: 2,
+				BlockData: []*types.BlockData{
+					{
+						Hash:         optional.NewHash(true, bestHash).Value(),
+						Header:       optional.NewHeader(false, nil),
+						Body:         optional.NewBody(false, nil),
+						MessageQueue: bds.MessageQueue,
+					},
+				},
+			},
+		},
+		{
+			description: "test get Justification",
+			value: &network.BlockRequestMessage{
+				ID:            2,
+				RequestedData: 16,
+				StartingBlock: start,
+				EndBlockHash:  optional.NewHash(true, endHash),
+				Direction:     1,
+				Max:           optional.NewUint32(false, 0),
+			},
+			expectedMsgType: network.BlockResponseMsgType,
+			expectedMsgValue: &network.BlockResponseMessage{
+				ID: 2,
+				BlockData: []*types.BlockData{
+					{
+						Hash:          optional.NewHash(true, bestHash).Value(),
+						Header:        optional.NewHeader(false, nil),
+						Body:          optional.NewBody(false, nil),
+						Justification: bds.Justification,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testsCases {
+		t.Run(test.description, func(t *testing.T) {
+
+			err := s.ProcessBlockRequestMessage(test.value)
+			require.Nil(t, err)
+
+			select {
+			case resp := <-msgSend:
+				msgType := resp.GetType()
+
+				require.Equal(t, test.expectedMsgType, msgType)
+
+				require.Equal(t, test.expectedMsgValue.ID, resp.(*network.BlockResponseMessage).ID)
+
+				require.Len(t, resp.(*network.BlockResponseMessage).BlockData, 2)
+
+				require.Equal(t, test.expectedMsgValue.BlockData[0].Hash, bestHash)
+				require.Equal(t, test.expectedMsgValue.BlockData[0].Header, resp.(*network.BlockResponseMessage).BlockData[0].Header)
+				require.Equal(t, test.expectedMsgValue.BlockData[0].Body, resp.(*network.BlockResponseMessage).BlockData[0].Body)
+
+				if test.expectedMsgValue.BlockData[0].Receipt != nil {
+					require.Equal(t, test.expectedMsgValue.BlockData[0].Receipt, resp.(*network.BlockResponseMessage).BlockData[1].Receipt)
+				}
+
+				if test.expectedMsgValue.BlockData[0].MessageQueue != nil {
+					require.Equal(t, test.expectedMsgValue.BlockData[0].MessageQueue, resp.(*network.BlockResponseMessage).BlockData[1].MessageQueue)
+				}
+
+				if test.expectedMsgValue.BlockData[0].Justification != nil {
+					require.Equal(t, test.expectedMsgValue.BlockData[0].Justification, resp.(*network.BlockResponseMessage).BlockData[1].Justification)
+				}
+			case <-time.After(testMessageTimeout):
+				t.Error("timeout waiting for message")
+			}
+		})
+	}
+}
+
+// BlockResponseMessage 2
+
+// tests the ProcessBlockResponseMessage method
+func TestService_ProcessBlockResponseMessage(t *testing.T) {
+	tt := trie.NewEmptyTrie()
+	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
+
+	kp, err := sr25519.GenerateKeypair()
+	require.Nil(t, err)
+
+	pubkey := kp.Public().Encode()
+	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, pubkey...))
+	require.Nil(t, err)
+
+	ks := keystore.NewKeystore()
+	ks.Insert(kp)
+	msgSend := make(chan network.Message, 10)
+
+	cfg := &Config{
+		Runtime:         rt,
+		Keystore:        ks,
+		IsBabeAuthority: true,
+		MsgSend:         msgSend,
+	}
+
+	s := newTestService(t, cfg)
+
+	hash := common.NewHash([]byte{0})
+	body := optional.CoreBody{0xa, 0xb, 0xc, 0xd}
+
+	parentHash := testGenesisHeader.Hash()
+	stateRoot, err := common.HexToHash("0x2747ab7c0dc38b7f2afba82bd5e2d6acef8c31e09800f660b75ec84a7005099f")
+	require.Nil(t, err)
+
+	extrinsicsRoot, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
+	require.Nil(t, err)
+
+	preDigest, err := common.HexToBytes("0x014241424538e93dcef2efc275b72b4fa748332dc4c9f13be1125909cf90c8e9109c45da16b04bc5fdf9fe06a4f35e4ae4ed7e251ff9ee3d0d840c8237c9fb9057442dbf00f210d697a7b4959f792a81b948ff88937e30bf9709a8ab1314f71284da89a40000000000000000001100000000000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := &types.Header{
+		ParentHash:     parentHash,
+		Number:         big.NewInt(1),
+		StateRoot:      stateRoot,
+		ExtrinsicsRoot: extrinsicsRoot,
+		Digest:         [][]byte{preDigest},
+	}
+
+	bds := []*types.BlockData{{
+		Hash:          header.Hash(),
+		Header:        header.AsOptional(),
+		Body:          types.NewBody([]byte{}).AsOptional(),
+		Receipt:       optional.NewBytes(false, nil),
+		MessageQueue:  optional.NewBytes(false, nil),
+		Justification: optional.NewBytes(false, nil),
+	}, {
+		Hash:          hash,
+		Header:        optional.NewHeader(false, nil),
+		Body:          optional.NewBody(true, body),
+		Receipt:       optional.NewBytes(true, []byte("asdf")),
+		MessageQueue:  optional.NewBytes(true, []byte("ghjkl")),
+		Justification: optional.NewBytes(true, []byte("qwerty")),
+	}}
+
+	blockResponse := &network.BlockResponseMessage{
+		BlockData: bds,
+	}
+
+	err = s.blockState.SetHeader(header)
+	require.Nil(t, err)
+
+	err = s.ProcessBlockResponseMessage(blockResponse)
+	require.Nil(t, err)
+
+	select {
+	case resp := <-s.syncer.respIn:
+		msgType := resp.GetType()
+		require.Equal(t, network.BlockResponseMsgType, msgType)
+	case <-time.After(testMessageTimeout):
+		t.Error("timeout waiting for message")
+	}
+}
+
+// BlockAnnounceMessage 3
+
+// tests the ProcessBlockAnnounceMessage method
+func TestService_ProcessBlockAnnounceMessage(t *testing.T) {
+	msgSend := make(chan network.Message)
+	newBlocks := make(chan types.Block)
+
+	cfg := &Config{
+		MsgSend:         msgSend,
+		Keystore:        keystore.NewKeystore(),
+		NewBlocks:       newBlocks,
+		IsBabeAuthority: false,
+	}
+
+	s := newTestService(t, cfg)
+	err := s.Start()
+	require.Nil(t, err)
+
+	expected := &network.BlockAnnounceMessage{
+		Number:         big.NewInt(1),
+		ParentHash:     testGenesisHeader.Hash(),
+		StateRoot:      common.Hash{},
+		ExtrinsicsRoot: common.Hash{},
+		Digest:         nil,
+	}
+
+	// simulate block sent from BABE session
+	newBlocks <- types.Block{
+		Header: &types.Header{
+			Number:     big.NewInt(1),
+			ParentHash: testGenesisHeader.Hash(),
+		},
+		Body: types.NewBody([]byte{}),
+	}
+
+	select {
+	case msg := <-msgSend:
+		msgType := msg.GetType()
+		require.Equal(t, network.BlockAnnounceMsgType, msgType)
+		require.Equal(t, expected, msg)
+	case <-time.After(testMessageTimeout):
+		t.Error("timeout waiting for message")
+	}
+}
+
+// TransactionMessage 4
+
+// tests the ProcessTransactionMessage method
+func TestService_ProcessTransactionMessage(t *testing.T) {
+	tt := trie.NewEmptyTrie()
+	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
+
+	kp, err := sr25519.GenerateKeypair()
+	require.Nil(t, err)
+
+	pubkey := kp.Public().Encode()
+	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, pubkey...))
+	require.Nil(t, err)
+
+	ks := keystore.NewKeystore()
+	ks.Insert(kp)
+
+	cfg := &Config{
+		Runtime:          rt,
+		Keystore:         ks,
+		TransactionQueue: transaction.NewPriorityQueue(),
+		IsBabeAuthority:  true,
+	}
+
+	s := newTestService(t, cfg)
+
+	// https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
+	ext := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
+
+	msg := &network.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
+
+	err = s.ProcessTransactionMessage(msg)
+	require.Nil(t, err)
+
+	bsTx := s.transactionQueue.Peek()
+	bsTxExt := []byte(bsTx.Extrinsic)
+
+	require.Equal(t, ext, bsTxExt)
+}

--- a/dot/core/runtime_test.go
+++ b/dot/core/runtime_test.go
@@ -17,15 +17,20 @@
 package core
 
 import (
+	"io/ioutil"
 	"reflect"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/babe"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/tests"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRetrieveAuthorityData(t *testing.T) {
@@ -46,7 +51,7 @@ func TestRetrieveAuthorityData(t *testing.T) {
 		rt: rt,
 	}
 
-	auths, err := s.retrieveAuthorityData()
+	auths, err := s.grandpaAuthorities()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,4 +70,73 @@ func TestRetrieveAuthorityData(t *testing.T) {
 	if !reflect.DeepEqual(auths, expected) {
 		t.Fatalf("Fail: got %v expected %v", auths, expected)
 	}
+}
+
+func TestValidateBlock(t *testing.T) {
+	s := newTestService(t, nil)
+
+	// https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/test-runtime/src/system.rs#L371
+	data := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 179, 38, 109, 225, 55, 210, 10, 93, 15, 243, 166, 64, 30, 181, 113, 39, 82, 95, 217, 178, 105, 55, 1, 240, 191, 90, 138, 133, 63, 163, 235, 224, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
+
+	// `core_execute_block` will throw error, no expected result
+	err := s.executeBlock(data)
+	require.Nil(t, err)
+}
+
+func TestValidateTransaction(t *testing.T) {
+	s := newTestService(t, nil)
+
+	// https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
+	tx := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
+
+	validity, err := s.ValidateTransaction(tx)
+	require.Nil(t, err)
+
+	// https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L190
+	expected := &transaction.Validity{
+		Priority: 69,
+		Requires: [][]byte{},
+		// https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L173
+		Provides:  [][]byte{{146, 157, 61, 99, 63, 98, 30, 242, 128, 49, 150, 90, 140, 165, 187, 249}},
+		Longevity: 64,
+		Propagate: true,
+	}
+
+	require.Equal(t, expected, validity)
+}
+
+func TestCheckForRuntimeChanges(t *testing.T) {
+	tt := trie.NewEmptyTrie()
+	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
+
+	kp, err := sr25519.GenerateKeypair()
+	require.Nil(t, err)
+
+	pubkey := kp.Public().Encode()
+	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, pubkey...))
+	require.Nil(t, err)
+
+	ks := keystore.NewKeystore()
+	ks.Insert(kp)
+
+	cfg := &Config{
+		Runtime:          rt,
+		Keystore:         ks,
+		TransactionQueue: transaction.NewPriorityQueue(),
+		IsBabeAuthority:  false,
+	}
+
+	s := newTestService(t, cfg)
+
+	_, err = tests.GetRuntimeBlob(tests.TESTS_FP, tests.TEST_WASM_URL)
+	require.Nil(t, err)
+
+	testRuntime, err := ioutil.ReadFile(tests.TESTS_FP)
+	require.Nil(t, err)
+
+	err = s.storageState.SetStorage([]byte(":code"), testRuntime)
+	require.Nil(t, err)
+
+	err = s.checkForRuntimeChanges()
+	require.Nil(t, err)
 }

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -17,25 +17,22 @@
 package core
 
 import (
-	"io/ioutil"
 	"math/big"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
+	"github.com/ChainSafe/gossamer/lib/babe"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/common/optional"
-	"github.com/ChainSafe/gossamer/lib/common/variadic"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
-	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/tests"
+
+	"github.com/stretchr/testify/require"
 )
 
 // testMessageTimeout is the wait time for messages to be exchanged
@@ -100,6 +97,82 @@ func newTestService(t *testing.T, cfg *Config) *Service {
 	return s
 }
 
+// newTestServiceWithFirstBlock creates a new test service with a test block
+func newTestServiceWithFirstBlock(t *testing.T) *Service {
+	tt := trie.NewEmptyTrie()
+	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
+
+	kp, err := sr25519.GenerateKeypair()
+	require.Nil(t, err)
+
+	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, kp.Public().Encode()...))
+	require.Nil(t, err)
+
+	ks := keystore.NewKeystore()
+	ks.Insert(kp)
+
+	cfg := &Config{
+		Runtime:         rt,
+		Keystore:        ks,
+		IsBabeAuthority: true,
+	}
+
+	s := newTestService(t, cfg)
+
+	preDigest, err := common.HexToBytes("0x014241424538e93dcef2efc275b72b4fa748332dc4c9f13be1125909cf90c8e9109c45da16b04bc5fdf9fe06a4f35e4ae4ed7e251ff9ee3d0d840c8237c9fb9057442dbf00f210d697a7b4959f792a81b948ff88937e30bf9709a8ab1314f71284da89a40000000000000000001100000000000000")
+	require.Nil(t, err)
+
+	s.epochNumber = uint64(2) // test preDigest item is for block in slot 17 epoch 2
+
+	nextEpochData := &babe.NextEpochDescriptor{
+		Authorities: s.bs.AuthorityData(),
+	}
+
+	consensusDigest := &types.ConsensusDigest{
+		ConsensusEngineID: types.BabeEngineID,
+		Data:              nextEpochData.Encode(),
+	}
+
+	conDigest := consensusDigest.Encode()
+
+	header := &types.Header{
+		ParentHash: testGenesisHeader.Hash(),
+		Number:     big.NewInt(1),
+		Digest:     [][]byte{preDigest, conDigest},
+	}
+
+	firstBlock := &types.Block{
+		Header: header,
+		Body:   &types.Body{},
+	}
+
+	err = s.blockState.AddBlock(firstBlock)
+	require.Nil(t, err)
+
+	return s
+}
+
+func addTestBlocksToState(t *testing.T, depth int, blockState BlockState) {
+	previousHash := blockState.BestBlockHash()
+	previousNum, err := blockState.BestBlockNumber()
+	require.Nil(t, err)
+
+	for i := 1; i <= depth; i++ {
+		block := &types.Block{
+			Header: &types.Header{
+				ParentHash: previousHash,
+				Number:     big.NewInt(int64(i)).Add(previousNum, big.NewInt(int64(i))),
+			},
+			Body: &types.Body{},
+		}
+
+		previousHash = block.Header.Hash()
+
+		err := blockState.AddBlock(block)
+		require.Nil(t, err)
+	}
+}
+
 func TestStartService(t *testing.T) {
 	s := newTestService(t, nil)
 	require.NotNil(t, s) // TODO: improve dot core tests
@@ -110,37 +183,16 @@ func TestStartService(t *testing.T) {
 	s.Stop()
 }
 
-func TestValidateBlock(t *testing.T) {
-	s := newTestService(t, nil)
-
-	// https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/test-runtime/src/system.rs#L371
-	data := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 179, 38, 109, 225, 55, 210, 10, 93, 15, 243, 166, 64, 30, 181, 113, 39, 82, 95, 217, 178, 105, 55, 1, 240, 191, 90, 138, 133, 63, 163, 235, 224, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
-
-	// `core_execute_block` will throw error, no expected result
-	err := s.executeBlock(data)
-	require.Nil(t, err)
-}
-
-func TestValidateTransaction(t *testing.T) {
-	s := newTestService(t, nil)
-
-	// https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
-	tx := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
-
-	validity, err := s.ValidateTransaction(tx)
-	require.Nil(t, err)
-
-	// https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L190
-	expected := &transaction.Validity{
-		Priority: 69,
-		Requires: [][]byte{},
-		// https://github.com/paritytech/substrate/blob/ea2644a235f4b189c8029b9c9eac9d4df64ee91e/core/test-runtime/src/system.rs#L173
-		Provides:  [][]byte{{146, 157, 61, 99, 63, 98, 30, 242, 128, 49, 150, 90, 140, 165, 187, 249}},
-		Longevity: 64,
-		Propagate: true,
+func TestNotAuthority(t *testing.T) {
+	cfg := &Config{
+		Keystore:        keystore.NewKeystore(),
+		IsBabeAuthority: false,
 	}
 
-	require.Equal(t, expected, validity)
+	s := newTestService(t, cfg)
+	if s.bs != nil {
+		t.Fatal("Fail: should not have babe session")
+	}
 }
 
 func TestAnnounceBlock(t *testing.T) {
@@ -180,427 +232,26 @@ func TestAnnounceBlock(t *testing.T) {
 	}
 }
 
-func TestProcessBlockResponseMessage(t *testing.T) {
-	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
+// test getBlockEpoch
+func TestGetBlockEpoch(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
 
-	kp, err := sr25519.GenerateKeypair()
+	blockHash := s.blockState.BestBlockHash()
+
+	epoch, err := s.getBlockEpoch(blockHash)
 	require.Nil(t, err)
 
-	pubkey := kp.Public().Encode()
-	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, pubkey...))
-	require.Nil(t, err)
-
-	ks := keystore.NewKeystore()
-	ks.Insert(kp)
-	msgSend := make(chan network.Message, 10)
-
-	cfg := &Config{
-		Runtime:         rt,
-		Keystore:        ks,
-		IsBabeAuthority: false,
-		MsgSend:         msgSend,
-	}
-
-	s := newTestService(t, cfg)
-
-	hash := common.NewHash([]byte{0})
-	body := optional.CoreBody{0xa, 0xb, 0xc, 0xd}
-
-	parentHash := testGenesisHeader.Hash()
-	stateRoot, err := common.HexToHash("0x2747ab7c0dc38b7f2afba82bd5e2d6acef8c31e09800f660b75ec84a7005099f")
-	require.Nil(t, err)
-
-	extrinsicsRoot, err := common.HexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-	require.Nil(t, err)
-
-	header := &types.Header{
-		ParentHash:     parentHash,
-		Number:         big.NewInt(1),
-		StateRoot:      stateRoot,
-		ExtrinsicsRoot: extrinsicsRoot,
-		Digest:         [][]byte{},
-	}
-
-	bds := []*types.BlockData{{
-		Hash:          header.Hash(),
-		Header:        header.AsOptional(),
-		Body:          types.NewBody([]byte{}).AsOptional(),
-		Receipt:       optional.NewBytes(false, nil),
-		MessageQueue:  optional.NewBytes(false, nil),
-		Justification: optional.NewBytes(false, nil),
-	}, {
-		Hash:          hash,
-		Header:        optional.NewHeader(false, nil),
-		Body:          optional.NewBody(true, body),
-		Receipt:       optional.NewBytes(true, []byte("asdf")),
-		MessageQueue:  optional.NewBytes(true, []byte("ghjkl")),
-		Justification: optional.NewBytes(true, []byte("qwerty")),
-	}}
-
-	blockResponse := &network.BlockResponseMessage{
-		BlockData: bds,
-	}
-
-	err = s.ProcessBlockResponseMessage(blockResponse)
-	require.Nil(t, err)
-
-	select {
-	case resp := <-s.syncer.respIn:
-		msgType := resp.GetType()
-		require.Equal(t, network.BlockResponseMsgType, msgType)
-	case <-time.After(testMessageTimeout):
-		t.Error("timeout waiting for message")
-	}
+	require.Equal(t, s.epochNumber, epoch)
 }
 
-func TestProcessTransactionMessage(t *testing.T) {
-	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
+// test blockFromCurrentEpoch
+func TestVerifyCurrentEpoch(t *testing.T) {
+	s := newTestServiceWithFirstBlock(t)
 
-	kp, err := sr25519.GenerateKeypair()
+	blockHash := s.blockState.BestBlockHash()
+
+	currentEpoch, err := s.blockFromCurrentEpoch(blockHash)
 	require.Nil(t, err)
 
-	pubkey := kp.Public().Encode()
-	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, pubkey...))
-	require.Nil(t, err)
-
-	ks := keystore.NewKeystore()
-	ks.Insert(kp)
-
-	cfg := &Config{
-		Runtime:          rt,
-		Keystore:         ks,
-		TransactionQueue: transaction.NewPriorityQueue(),
-		IsBabeAuthority:  true,
-	}
-
-	s := newTestService(t, cfg)
-
-	// https://github.com/paritytech/substrate/blob/5420de3face1349a97eb954ae71c5b0b940c31de/core/transaction-pool/src/tests.rs#L95
-	ext := []byte{1, 212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133, 76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125, 142, 175, 4, 21, 22, 135, 115, 99, 38, 201, 254, 161, 126, 37, 252, 82, 135, 97, 54, 147, 201, 18, 144, 156, 178, 38, 170, 71, 148, 242, 106, 72, 69, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 216, 5, 113, 87, 87, 40, 221, 120, 247, 252, 137, 201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163, 149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245, 24, 225, 37, 154, 163, 142}
-
-	msg := &network.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
-
-	err = s.ProcessTransactionMessage(msg)
-	require.Nil(t, err)
-
-	bsTx := s.transactionQueue.Peek()
-	bsTxExt := []byte(bsTx.Extrinsic)
-
-	require.Equal(t, ext, bsTxExt)
-}
-
-func TestNotAuthority(t *testing.T) {
-	cfg := &Config{
-		Keystore:        keystore.NewKeystore(),
-		IsBabeAuthority: false,
-	}
-
-	s := newTestService(t, cfg)
-	if s.bs != nil {
-		t.Fatal("Fail: should not have babe session")
-	}
-}
-
-func TestCheckForRuntimeChanges(t *testing.T) {
-	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, tests.POLKADOT_RUNTIME, tt)
-
-	kp, err := sr25519.GenerateKeypair()
-	require.Nil(t, err)
-
-	pubkey := kp.Public().Encode()
-	err = tt.Put(tests.AuthorityDataKey, append([]byte{4}, pubkey...))
-	require.Nil(t, err)
-
-	ks := keystore.NewKeystore()
-	ks.Insert(kp)
-
-	cfg := &Config{
-		Runtime:          rt,
-		Keystore:         ks,
-		TransactionQueue: transaction.NewPriorityQueue(),
-		IsBabeAuthority:  false,
-	}
-
-	s := newTestService(t, cfg)
-
-	_, err = tests.GetRuntimeBlob(tests.TESTS_FP, tests.TEST_WASM_URL)
-	require.Nil(t, err)
-
-	testRuntime, err := ioutil.ReadFile(tests.TESTS_FP)
-	require.Nil(t, err)
-
-	err = s.storageState.SetStorage([]byte(":code"), testRuntime)
-	require.Nil(t, err)
-
-	err = s.checkForRuntimeChanges()
-	require.Nil(t, err)
-}
-
-func addTestBlocksToState(t *testing.T, depth int, blockState BlockState) {
-	previousHash := blockState.BestBlockHash()
-	previousNum, err := blockState.BestBlockNumber()
-	require.Nil(t, err)
-
-	for i := 1; i <= depth; i++ {
-		block := &types.Block{
-			Header: &types.Header{
-				ParentHash: previousHash,
-				Number:     big.NewInt(int64(i)).Add(previousNum, big.NewInt(int64(i))),
-			},
-			Body: &types.Body{},
-		}
-
-		previousHash = block.Header.Hash()
-
-		err := blockState.AddBlock(block)
-		require.Nil(t, err)
-	}
-}
-
-func TestService_ProcessBlockRequest(t *testing.T) {
-	msgSend := make(chan network.Message, 10)
-
-	cfg := &Config{
-		MsgSend: msgSend,
-	}
-
-	s := newTestService(t, cfg)
-
-	addTestBlocksToState(t, 2, s.blockState)
-
-	bestHash := s.blockState.BestBlockHash()
-	bestBlock, err := s.blockState.GetBlockByNumber(big.NewInt(1))
-	require.Nil(t, err)
-
-	//set some nils and check no error is thrown
-	bds := &types.BlockData{
-		Hash:          bestHash,
-		Header:        nil,
-		Receipt:       nil,
-		MessageQueue:  nil,
-		Justification: nil,
-	}
-	err = s.blockState.CompareAndSetBlockData(bds)
-	require.Nil(t, err)
-
-	// set receipt message and justification
-	bds = &types.BlockData{
-		Hash:          bestHash,
-		Receipt:       optional.NewBytes(true, []byte("asdf")),
-		MessageQueue:  optional.NewBytes(true, []byte("ghjkl")),
-		Justification: optional.NewBytes(true, []byte("qwerty")),
-	}
-
-	endHash := s.blockState.BestBlockHash()
-	start, err := variadic.NewUint64OrHash(uint64(1))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = s.blockState.CompareAndSetBlockData(bds)
-
-	require.Nil(t, err)
-
-	testsCases := []struct {
-		description      string
-		value            *network.BlockRequestMessage
-		expectedMsgType  int
-		expectedMsgValue *network.BlockResponseMessage
-	}{
-		{
-			description: "test get Header and Body",
-			value: &network.BlockRequestMessage{
-				ID:            1,
-				RequestedData: 3,
-				StartingBlock: start,
-				EndBlockHash:  optional.NewHash(true, endHash),
-				Direction:     1,
-				Max:           optional.NewUint32(false, 0),
-			},
-			expectedMsgType: network.BlockResponseMsgType,
-			expectedMsgValue: &network.BlockResponseMessage{
-				ID: 1,
-				BlockData: []*types.BlockData{
-					{
-						Hash:   optional.NewHash(true, bestHash).Value(),
-						Header: bestBlock.Header.AsOptional(),
-						Body:   bestBlock.Body.AsOptional(),
-					},
-				},
-			},
-		},
-		{
-			description: "test get Header",
-			value: &network.BlockRequestMessage{
-				ID:            2,
-				RequestedData: 1,
-				StartingBlock: start,
-				EndBlockHash:  optional.NewHash(true, endHash),
-				Direction:     1,
-				Max:           optional.NewUint32(false, 0),
-			},
-			expectedMsgType: network.BlockResponseMsgType,
-			expectedMsgValue: &network.BlockResponseMessage{
-				ID: 2,
-				BlockData: []*types.BlockData{
-					{
-						Hash:   optional.NewHash(true, bestHash).Value(),
-						Header: bestBlock.Header.AsOptional(),
-						Body:   optional.NewBody(false, nil),
-					},
-				},
-			},
-		},
-		{
-			description: "test get Receipt",
-			value: &network.BlockRequestMessage{
-				ID:            2,
-				RequestedData: 4,
-				StartingBlock: start,
-				EndBlockHash:  optional.NewHash(true, endHash),
-				Direction:     1,
-				Max:           optional.NewUint32(false, 0),
-			},
-			expectedMsgType: network.BlockResponseMsgType,
-			expectedMsgValue: &network.BlockResponseMessage{
-				ID: 2,
-				BlockData: []*types.BlockData{
-					{
-						Hash:    optional.NewHash(true, bestHash).Value(),
-						Header:  optional.NewHeader(false, nil),
-						Body:    optional.NewBody(false, nil),
-						Receipt: bds.Receipt,
-					},
-				},
-			},
-		},
-		{
-			description: "test get MessageQueue",
-			value: &network.BlockRequestMessage{
-				ID:            2,
-				RequestedData: 8,
-				StartingBlock: start,
-				EndBlockHash:  optional.NewHash(true, endHash),
-				Direction:     1,
-				Max:           optional.NewUint32(false, 0),
-			},
-			expectedMsgType: network.BlockResponseMsgType,
-			expectedMsgValue: &network.BlockResponseMessage{
-				ID: 2,
-				BlockData: []*types.BlockData{
-					{
-						Hash:         optional.NewHash(true, bestHash).Value(),
-						Header:       optional.NewHeader(false, nil),
-						Body:         optional.NewBody(false, nil),
-						MessageQueue: bds.MessageQueue,
-					},
-				},
-			},
-		},
-		{
-			description: "test get Justification",
-			value: &network.BlockRequestMessage{
-				ID:            2,
-				RequestedData: 16,
-				StartingBlock: start,
-				EndBlockHash:  optional.NewHash(true, endHash),
-				Direction:     1,
-				Max:           optional.NewUint32(false, 0),
-			},
-			expectedMsgType: network.BlockResponseMsgType,
-			expectedMsgValue: &network.BlockResponseMessage{
-				ID: 2,
-				BlockData: []*types.BlockData{
-					{
-						Hash:          optional.NewHash(true, bestHash).Value(),
-						Header:        optional.NewHeader(false, nil),
-						Body:          optional.NewBody(false, nil),
-						Justification: bds.Justification,
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range testsCases {
-		t.Run(test.description, func(t *testing.T) {
-
-			err := s.ProcessBlockRequestMessage(test.value)
-			require.Nil(t, err)
-
-			select {
-			case resp := <-msgSend:
-				msgType := resp.GetType()
-
-				require.Equal(t, test.expectedMsgType, msgType)
-
-				require.Equal(t, test.expectedMsgValue.ID, resp.(*network.BlockResponseMessage).ID)
-
-				require.Len(t, resp.(*network.BlockResponseMessage).BlockData, 2)
-
-				require.Equal(t, test.expectedMsgValue.BlockData[0].Hash, bestHash)
-				require.Equal(t, test.expectedMsgValue.BlockData[0].Header, resp.(*network.BlockResponseMessage).BlockData[0].Header)
-				require.Equal(t, test.expectedMsgValue.BlockData[0].Body, resp.(*network.BlockResponseMessage).BlockData[0].Body)
-
-				if test.expectedMsgValue.BlockData[0].Receipt != nil {
-					require.Equal(t, test.expectedMsgValue.BlockData[0].Receipt, resp.(*network.BlockResponseMessage).BlockData[1].Receipt)
-				}
-
-				if test.expectedMsgValue.BlockData[0].MessageQueue != nil {
-					require.Equal(t, test.expectedMsgValue.BlockData[0].MessageQueue, resp.(*network.BlockResponseMessage).BlockData[1].MessageQueue)
-				}
-
-				if test.expectedMsgValue.BlockData[0].Justification != nil {
-					require.Equal(t, test.expectedMsgValue.BlockData[0].Justification, resp.(*network.BlockResponseMessage).BlockData[1].Justification)
-				}
-			case <-time.After(testMessageTimeout):
-				t.Error("timeout waiting for message")
-			}
-		})
-	}
-}
-
-func TestProcessBlockAnnounce(t *testing.T) {
-	msgSend := make(chan network.Message)
-	newBlocks := make(chan types.Block)
-
-	cfg := &Config{
-		MsgSend:         msgSend,
-		Keystore:        keystore.NewKeystore(),
-		NewBlocks:       newBlocks,
-		IsBabeAuthority: false,
-	}
-
-	s := newTestService(t, cfg)
-	err := s.Start()
-	require.Nil(t, err)
-
-	expected := &network.BlockAnnounceMessage{
-		Number:         big.NewInt(1),
-		ParentHash:     testGenesisHeader.Hash(),
-		StateRoot:      common.Hash{},
-		ExtrinsicsRoot: common.Hash{},
-		Digest:         nil,
-	}
-
-	// simulate block sent from BABE session
-	newBlocks <- types.Block{
-		Header: &types.Header{
-			Number:     big.NewInt(1),
-			ParentHash: testGenesisHeader.Hash(),
-		},
-		Body: types.NewBody([]byte{}),
-	}
-
-	select {
-	case msg := <-msgSend:
-		msgType := msg.GetType()
-		require.Equal(t, network.BlockAnnounceMsgType, msgType)
-		require.Equal(t, expected, msg)
-	case <-time.After(testMessageTimeout):
-		t.Error("timeout waiting for message")
-	}
+	require.Equal(t, true, currentEpoch)
 }

--- a/dot/core/syncer.go
+++ b/dot/core/syncer.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/dot/core/syncer_test.go
+++ b/dot/core/syncer_test.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -31,7 +31,6 @@ import (
 // helper method to create and start test state service
 func newTestService(t *testing.T) (state *Service) {
 	testDir := utils.NewTestDir(t)
-	defer utils.RemoveTestDir(t)
 
 	state = NewService(testDir)
 
@@ -46,6 +45,7 @@ func newTestMemDBService() *Service {
 
 func TestService_Start(t *testing.T) {
 	state := newTestService(t)
+	defer utils.RemoveTestDir(t)
 
 	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), big.NewInt(0), trie.EmptyHash, trie.EmptyHash, [][]byte{})
 	if err != nil {


### PR DESCRIPTION
## Changes

- [x] determine if block is first in epoch using `handleConsensusDigest`
- [x] ensure the consensus digest is included in first block of each epoch
- [x] clean up core service methods and tests / add new files to core

## Notes

- determine what epoch a block was produced at with `(slot - GENESIS_SLOT) / epoch_len`

## Tests:

all tests should pass:

```
go test dot/core -v
```

running the gossamer node...

```
make gossamer

./bin/gossamer --key alice
```

should produce the following error related to #662:

```
EROR[03-27|10:32:22] [core] failed to verify first block error="failed to verify first block: first block never set"
```

### Issues:

closes #599