### PR TITLE
dot/state, lib/blocktree: set block number->hash mapping for current chain only

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -336,15 +336,14 @@ func (bs *BlockState) AddBlockWithArrivalTime(block *types.Block, arrivalTime ui
 	hash := block.Header.Hash()
 
 	// set best block key if this is the highest block we've seen
-	if block.Header.Number.Cmp(bs.highestBlockHeader.Number) == 1 || hash == bs.BestBlockHash() {
+	if hash == bs.BestBlockHash() {
 		err = bs.setBestBlockHashKey(hash)
 		if err != nil {
 			return err
 		}
 	}
 
-	// TODO: only set number->hash mapping for our canonical chain, otherwise, this messes up BlockResponses
-	// store number to hash
+	// Tonly set number->hash mapping for our current chain
 	if ok, err := bs.isBlockOnCurrentChain(block.Header); ok && err == nil {
 		err = bs.db.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes())
 		if err != nil {

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -344,7 +344,8 @@ func (bs *BlockState) AddBlockWithArrivalTime(block *types.Block, arrivalTime ui
 	}
 
 	// only set number->hash mapping for our current chain
-	if ok, err := bs.isBlockOnCurrentChain(block.Header); ok && err == nil {
+	var ok bool
+	if ok, err = bs.isBlockOnCurrentChain(block.Header); ok && err == nil {
 		err = bs.db.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes())
 		if err != nil {
 			return err

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -344,9 +344,11 @@ func (bs *BlockState) AddBlockWithArrivalTime(block *types.Block, arrivalTime ui
 	}
 
 	// store number to hash
-	err = bs.db.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes())
-	if err != nil {
-		return err
+	if ok, err := bs.isBlockOnCurrentChain(block.Header); ok && err == nil {
+		err = bs.db.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes())
+		if err != nil {
+			return err
+		}
 	}
 
 	err = bs.SetBlockBody(block.Header.Hash(), types.NewBody(block.Body.AsOptional().Value))

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -344,8 +344,8 @@ func (bs *BlockState) AddBlockWithArrivalTime(block *types.Block, arrivalTime ui
 	}
 
 	// only set number->hash mapping for our current chain
-	var ok bool
-	if ok, err = bs.isBlockOnCurrentChain(block.Header); ok && err == nil {
+	var onChain bool
+	if onChain, err = bs.isBlockOnCurrentChain(block.Header); onChain && err == nil {
 		err = bs.db.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes())
 		if err != nil {
 			return err

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -343,7 +343,7 @@ func (bs *BlockState) AddBlockWithArrivalTime(block *types.Block, arrivalTime ui
 		}
 	}
 
-	// Tonly set number->hash mapping for our current chain
+	// only set number->hash mapping for our current chain
 	if ok, err := bs.isBlockOnCurrentChain(block.Header); ok && err == nil {
 		err = bs.db.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes())
 		if err != nil {

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -256,8 +256,9 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var resBlock *types.Block
 	for _, header := range currChain {
-		resBlock, err := bs.GetBlockByNumber(header.Number)
+		resBlock, err = bs.GetBlockByNumber(header.Number)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -268,7 +269,7 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 	}
 
 	for _, header := range branchChains {
-		resBlock, err := bs.GetBlockByNumber(header.Number)
+		resBlock, err = bs.GetBlockByNumber(header.Number)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -291,7 +292,7 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resBlock, err := bs.GetBlockByNumber(newBlock.Header.Number)
+	resBlock, err = bs.GetBlockByNumber(newBlock.Header.Number)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -211,6 +212,20 @@ func TestGetSlotForBlock(t *testing.T) {
 	}
 }
 
+func TestIsBlockOnCurrentChain(t *testing.T) {
+	genesisHeader := &types.Header{
+		Number:    big.NewInt(0),
+		StateRoot: trie.EmptyHash,
+	}
+
+	bs := newTestBlockState(genesisHeader)
+	branches := addBlocksToState(bs, 8)
+	
+	for _, branch := range branches {
+		fmt.Printf("branch hash=%s depth=%d\n", branch.hash, branch.depth)
+	}
+}
+
 func TestAddBlock_BlockNumberToHash(t *testing.T) {
 	genesisHeader := &types.Header{
 		Number:    big.NewInt(0),
@@ -218,7 +233,9 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 	}
 
 	bs := newTestBlockState(genesisHeader)
-	//branches := addBlocksToState(bs, 8)
+	branches := addBlocksToState(bs, 8)
+	t.Log(branches)
+
 	addBlocksToState(bs, 8)
 
 	bestHash := bs.BestBlockHash()

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -221,21 +221,21 @@ func TestIsBlockOnCurrentChain(t *testing.T) {
 	currChain, branchChains := addBlocksToState(bs, 8)
 
 	for _, header := range currChain {
-		ok, err := bs.isBlockOnCurrentChain(header)
+		onChain, err := bs.isBlockOnCurrentChain(header)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !ok {
+		if !onChain {
 			t.Fatalf("Fail: expected block %s to be on current chain", header.Hash())
 		}
 	}
 
 	for _, header := range branchChains {
-		ok, err := bs.isBlockOnCurrentChain(header)
+		onChain, err := bs.isBlockOnCurrentChain(header)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ok {
+		if onChain {
 			t.Fatalf("Fail: expected block %s not to be on current chain", header.Hash())
 		}
 	}

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -90,14 +90,14 @@ func TestMemDB_Start(t *testing.T) {
 	state.Stop()
 }
 
-func addBlocksToState(blockState *BlockState, depth int) {
-	previousHash := blockState.BestBlockHash()
+// branch tree randomly
+type testBranch struct {
+	hash  common.Hash
+	depth int
+}
 
-	// branch tree randomly
-	type testBranch struct {
-		hash  common.Hash
-		depth int
-	}
+func addBlocksToState(blockState *BlockState, depth int) []testBranch {
+	previousHash := blockState.BestBlockHash()
 
 	branches := []testBranch{}
 	r := *rand.New(rand.NewSource(rand.Int63()))
@@ -143,6 +143,8 @@ func addBlocksToState(blockState *BlockState, depth int) {
 			previousHash = hash
 		}
 	}
+
+	return branches
 }
 
 func TestService_BlockTree(t *testing.T) {

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -136,10 +136,12 @@ func addBlocksToState(blockState *BlockState, depth int) ([]*types.Header, []*ty
 
 	// create tree branches
 	for _, branch := range branches {
+		previousHash = branch.hash
+
 		for i := branch.depth; i < depth; i++ {
 			block := &types.Block{
 				Header: &types.Header{
-					ParentHash: branch.hash,
+					ParentHash: previousHash,
 					Number:     big.NewInt(int64(i) + 1),
 					StateRoot:  trie.EmptyHash,
 					Digest:     [][]byte{{byte(i)}},

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"fmt"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -113,6 +114,8 @@ func addBlocksToState(blockState *BlockState, depth int) []testBranch {
 			Body: &types.Body{},
 		}
 
+
+		fmt.Printf("hash=%s number=%d\n", block.Header.Hash(), block.Header.Number)
 		hash := block.Header.Hash()
 		blockState.AddBlock(block)
 		previousHash = hash

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -93,7 +93,6 @@ func (bt *BlockTree) AddBlock(block *types.Block, arrivalTime uint64) error {
 		arrivalTime: arrivalTime,
 	}
 	parent.addChild(n)
-
 	bt.leaves.replace(parent, n)
 
 	return nil

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -179,7 +179,8 @@ func (bt *BlockTree) deepestLeaf() *node {
 	return bt.leaves.deepestLeaf()
 }
 
-// DeepestBlockHash returns the hash of the leftmost deepest block in the blocktree
+// DeepestBlockHash returns the hash of the deepest block in the blocktree
+// If there is multiple deepest blocks, it returns the one with the earliest arrival time.
 func (bt *BlockTree) DeepestBlockHash() Hash {
 	return bt.leaves.deepestLeaf().hash
 }

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -177,14 +177,14 @@ func TestBlockTree_DeepestLeaf(t *testing.T) {
 		Number:     big.NewInt(0),
 	}
 
-	arrivalTime := uint64(1)
+	arrivalTime := uint64(256)
 	var expected Hash
 
 	bt, _ := createTestBlockTree(header, 8, nil)
 
 	for leaf, node := range bt.leaves {
 		node.arrivalTime = arrivalTime
-		arrivalTime++
+		arrivalTime--
 		expected = leaf
 		t.Logf("leaf=%s depth=%d arrivalTime=%d", leaf, node.depth, node.arrivalTime)
 	}
@@ -195,12 +195,12 @@ func TestBlockTree_DeepestLeaf(t *testing.T) {
 	}
 
 	r := *rand.New(rand.NewSource(rand.Int63()))
-	greatestTime := uint64(0)
+	earliestTime := uint64(1 << 63)
 
 	for leaf, node := range bt.leaves {
 		node.arrivalTime = uint64(r.Intn(256))
-		if node.arrivalTime > greatestTime {
-			greatestTime = node.arrivalTime
+		if node.arrivalTime < earliestTime {
+			earliestTime = node.arrivalTime
 			expected = node.hash
 		}
 		t.Logf("leaf=%s depth=%d arrivalTime=%d", leaf, node.depth, node.arrivalTime)

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -40,7 +40,7 @@ func (ls leafMap) deepestLeaf() *node {
 		if max.Cmp(n.depth) < 0 {
 			max = n.depth
 			dLeaf = n
-		} else if max.Cmp(n.depth) == 0 && n.arrivalTime > dLeaf.arrivalTime {
+		} else if max.Cmp(n.depth) == 0 && n.arrivalTime < dLeaf.arrivalTime {
 			dLeaf = n
 		}
 	}


### PR DESCRIPTION
## Changes
- addisBlockOnCurrentChain function to block state to check if block we are adding is on our current chain, if so, update number->hash mapping in db, otherwise don't 
- fix blocktree deepestLeaf function, wasn't correct before

## Tests:
```
go test ./... -short
```

### Issues:
closes #717 