### PR TITLE
dot/core, lib/blocktree, lib/database: create error definitions

### DIFF
--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -5,21 +5,35 @@ import (
 	"fmt"
 )
 
+// ErrNilBlockState is returned when BlockState is nik
 var ErrNilBlockState = errors.New("cannot have nil BlockState")
+
+// ErrNilStorageState is returned when StorageState is nik
 var ErrNilStorageState = errors.New("cannot have nil StorageState")
+
+// ErrNilKeystore is returned when keystore is nil
 var ErrNilKeystore = errors.New("cannot have nil keystore")
+
+// ErrNoKeysProvided is returned when no keys are given for an authority node
 var ErrNoKeysProvided = errors.New("no keys provided for authority node")
+
+// ErrServiceStopped is returned when the service has been stopped
 var ErrServiceStopped = errors.New("service has been stopped")
+
+// ErrCannotValidateTx is returned if the call to runtime function TaggedTransactionQueueValidateTransaction fails
 var ErrCannotValidateTx = errors.New("could not validate transaction")
 
+// ErrNilChannel is returned if a channel is nil
 func ErrNilChannel(s string) error {
 	return fmt.Errorf("cannot have nil channel %s", s)
 }
 
+// ErrMessageCast is returned if unable to cast a network.Message to a type
 func ErrMessageCast(s string) error {
 	return fmt.Errorf("could not cast network.Message to %s", s)
 }
 
+// ErrUnsupportedMsgType is returned if we receive an unknown message type
 func ErrUnsupportedMsgType(d int) error {
 	return fmt.Errorf("received unsupported message type %d", d)
 }

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -6,8 +6,20 @@ import (
 )
 
 var ErrNilBlockState = errors.New("cannot have nil BlockState")
+var ErrNilStorageState = errors.New("cannot have nil StorageState")
+var ErrNilKeystore = errors.New("cannot have nil keystore")
+var ErrNoKeysProvided = errors.New("no keys provided for authority node")
 var ErrServiceStopped = errors.New("service has been stopped")
+var ErrCannotValidateTx = errors.New("could not validate transaction")
 
 func ErrNilChannel(s string) error {
 	return fmt.Errorf("cannot have nil channel %s", s)
+}
+
+func ErrMessageCast(s string) error {
+	return fmt.Errorf("could not cast network.Message to %s", s)
+}
+
+func ErrUnsupportedMsgType(d int) error {
+	return fmt.Errorf("received unsupported message type %d", d)
 }

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -1,0 +1,13 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrNilBlockState = errors.New("cannot have nil BlockState")
+var ErrServiceStopped = errors.New("service has been stopped")
+
+func ErrNilChannel(s string) error {
+	return fmt.Errorf("cannot have nil channel %s", s)
+}

--- a/dot/core/runtime.go
+++ b/dot/core/runtime.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
@@ -37,7 +36,7 @@ func (s *Service) ValidateTransaction(e types.Extrinsic) (*transaction.Validity,
 	}
 
 	if ret[0] != 0 {
-		return nil, errors.New("could not validate transaction")
+		return nil, ErrCannotValidateTx
 	}
 
 	v := transaction.NewValidity(0, [][]byte{{}}, [][]byte{{}}, 0, false)

--- a/dot/core/sync.go
+++ b/dot/core/sync.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"math/big"
 	mrand "math/rand"
-	"strings"
 	"sync"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/core/types"
 	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/optional"
 	"github.com/ChainSafe/gossamer/lib/common/variadic"
@@ -48,15 +48,15 @@ type SyncerConfig struct {
 // NewSyncer returns a new Syncer
 func NewSyncer(cfg *SyncerConfig) (*Syncer, error) {
 	if cfg.BlockState == nil {
-		return nil, errors.New("cannot have nil BlockState")
+		return nil, ErrNilBlockState
 	}
 
 	if cfg.BlockNumIn == nil {
-		return nil, errors.New("cannot have nil BlockNumIn channel")
+		return nil, ErrNilChannel("BlockNumIn")
 	}
 
 	if cfg.MsgOut == nil {
-		return nil, errors.New("cannot have nil MsgOut channel")
+		return nil, ErrNilChannel("MsgOut")
 	}
 
 	return &Syncer{
@@ -132,7 +132,7 @@ func (s *Syncer) watchForResponses() {
 
 			// if we cannot find the parent block in our blocktree, we are missing some blocks, and need to request
 			// blocks from farther back in the chain
-			if err.Error() == "cannot find parent block in blocktree" {
+			if err == blocktree.ErrParentNotFound {
 				// set request start
 				s.requestStart = s.requestStart - maxResponseSize
 				if s.requestStart <= 0 {
@@ -176,7 +176,7 @@ func (s *Syncer) safeMsgSend(msg network.Message) error {
 	s.chanLock.Lock()
 	defer s.chanLock.Unlock()
 	if s.stopped {
-		return errors.New("service has been stopped")
+		return ErrServiceStopped
 	}
 	s.msgOut <- msg
 	return nil
@@ -262,9 +262,9 @@ func (s *Syncer) handleBlockResponse(msg *network.BlockResponseMessage) (int64, 
 
 			err = s.blockState.AddBlock(block)
 			if err != nil {
-				if err.Error() == "cannot find parent block in blocktree" && header.Number.Cmp(big.NewInt(0)) != 0 {
+				if err == blocktree.ErrParentNotFound && header.Number.Cmp(big.NewInt(0)) != 0 {
 					return 0, err
-				} else if strings.Contains(err.Error(), "cannot add block to blocktree that already exists") {
+				} else if err == blocktree.ErrBlockExists {
 					// this is fine
 					continue
 				} else if header.Number.Cmp(big.NewInt(0)) == 0 {

--- a/dot/core/sync.go
+++ b/dot/core/sync.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"errors"
 	"math/big"
 	mrand "math/rand"
 	"sync"

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -73,13 +73,13 @@ func (bt *BlockTree) GenesisHash() Hash {
 func (bt *BlockTree) AddBlock(block *types.Block, arrivalTime uint64) error {
 	parent := bt.getNode(block.Header.ParentHash)
 	if parent == nil {
-		return fmt.Errorf("cannot find parent block in blocktree")
+		return ErrParentNotFound
 	}
 
 	// Check if it already exists
 	n := bt.getNode(block.Header.Hash())
 	if n != nil {
-		return fmt.Errorf("cannot add block to blocktree that already exists: hash=%s", n.hash)
+		return ErrBlockExists
 	}
 
 	depth := big.NewInt(0)
@@ -151,11 +151,11 @@ func (bt *BlockTree) longestPath() []*node {
 func (bt *BlockTree) subChain(start Hash, end Hash) ([]*node, error) {
 	sn := bt.getNode(start)
 	if sn == nil {
-		return nil, fmt.Errorf("start node does not exist")
+		return nil, ErrStartNodeNotFound
 	}
 	en := bt.getNode(end)
 	if en == nil {
-		return nil, fmt.Errorf("end node does not exist")
+		return nil, ErrEndNodeNotFound
 	}
 	return sn.subChain(en)
 }

--- a/lib/blocktree/database.go
+++ b/lib/blocktree/database.go
@@ -3,7 +3,6 @@ package blocktree
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"io"
 	"math/big"
 
@@ -13,7 +12,7 @@ import (
 // Store stores the blocktree in the underlying db
 func (bt *BlockTree) Store() error {
 	if bt.db == nil {
-		return errors.New("blocktree db is nil")
+		return ErrNilDatabase
 	}
 
 	enc, err := bt.Encode()
@@ -27,7 +26,7 @@ func (bt *BlockTree) Store() error {
 // Load loads the blocktree from the underlying db
 func (bt *BlockTree) Load() error {
 	if bt.db == nil {
-		return errors.New("blocktree db is nil")
+		return ErrNilDatabase
 	}
 
 	enc, err := bt.db.Get(common.BlockTreeKey)

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -1,0 +1,13 @@
+package blocktree
+
+import (
+	"errors"
+)
+
+var ErrParentNotFound = errors.New("cannot find parent block in blocktree")
+var ErrBlockExists = errors.New("cannot add block to blocktree that already exists")
+var ErrStartNodeNotFound = errors.New("start node does not exist")
+var ErrEndNodeNotFound = errors.New("end node does not exist")
+var ErrNilDatabase = errors.New("blocktree database is nil")
+var ErrNilDescendant = errors.New("descendant node is nil")
+var ErrDescendantNotFound = errors.New("could not find descendant node")

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -4,10 +4,23 @@ import (
 	"errors"
 )
 
+// ErrParentNotFound is returned if the parent hash does not exist in the blocktree
 var ErrParentNotFound = errors.New("cannot find parent block in blocktree")
+
+// ErrBlockExists is returned if attempting to re-add a block
 var ErrBlockExists = errors.New("cannot add block to blocktree that already exists")
+
+// ErrStartNodeNotFound is returned if the start of a subchain does not exist
 var ErrStartNodeNotFound = errors.New("start node does not exist")
+
+// ErrEndNodeNotFound is returned if the end of a subchain does not exist
 var ErrEndNodeNotFound = errors.New("end node does not exist")
+
+// ErrNilDatabase is returned in the database is nil
 var ErrNilDatabase = errors.New("blocktree database is nil")
+
+// ErrNilDescendant is returned if calling subchain with a nil node
 var ErrNilDescendant = errors.New("descendant node is nil")
+
+// ErrDescendantNotFound is returned if a descendant in a subchain cannot be found
 var ErrDescendantNotFound = errors.New("could not find descendant node")

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -71,7 +71,7 @@ func (n *node) getNode(h common.Hash) *node {
 // subChain recursively searches for a chain with head n and end descendant
 func (n *node) subChain(descendant *node) ([]*node, error) {
 	if descendant == nil {
-		return nil, fmt.Errorf("descendant node is nil")
+		return nil, ErrNilDescendant
 	}
 
 	var path []*node
@@ -88,7 +88,7 @@ func (n *node) subChain(descendant *node) ([]*node, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("could not find descendant node")
+	return nil, ErrDescendantNotFound
 }
 
 // TODO: This would improved by using parent in node struct and searching child -> parent

--- a/lib/database/errors.go
+++ b/lib/database/errors.go
@@ -4,4 +4,5 @@ import (
 	"github.com/dgraph-io/badger/v2"
 )
 
+// ErrKeyNotFound is returned if there is a database get for a key that does not exist
 var ErrKeyNotFound = badger.ErrKeyNotFound

--- a/lib/database/errors.go
+++ b/lib/database/errors.go
@@ -1,0 +1,7 @@
+package database
+
+import (
+	"github.com/dgraph-io/badger/v2"
+)
+
+var ErrKeyNotFound = badger.ErrKeyNotFound

--- a/lib/database/memoryDB.go
+++ b/lib/database/memoryDB.go
@@ -17,7 +17,6 @@
 package database
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 )
@@ -61,7 +60,7 @@ func (db *MemDatabase) Get(k []byte) ([]byte, error) {
 	if v, ok := db.db[string(k)]; ok {
 		return v, nil
 	}
-	return nil, errors.New("Key not found")
+	return nil, ErrKeyNotFound
 }
 
 // Keys returns [][]byte of mapping keys


### PR DESCRIPTION
## Changes
- use defined errors in core, blocktree, database (I just did these ones for now since these are the ones that were doing error comparisons)

## Tests:
```
go test ./... -short
```

### Issues:
partially closes #305 