### PR TITLE
lib/blocktree: update leafmap to sync.Map

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -37,6 +37,7 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
+
 var _ services.Service = &Service{}
 
 var maxResponseSize int64 = 8 // maximum number of block datas to reply with in a BlockResponse message.

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -37,7 +37,6 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
-
 var _ services.Service = &Service{}
 
 var maxResponseSize int64 = 8 // maximum number of block datas to reply with in a BlockResponse message.

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -33,7 +33,7 @@ type Hash = common.Hash
 // BlockTree represents the current state with all possible blocks
 type BlockTree struct {
 	head   *node // genesis node
-	leaves leafMap
+	leaves *leafMap
 	db     database.Database
 }
 
@@ -41,7 +41,7 @@ type BlockTree struct {
 func NewEmptyBlockTree(db database.Database) *BlockTree {
 	return &BlockTree{
 		head:   nil,
-		leaves: make(leafMap),
+		leaves: NewEmptyLeafMap(),
 		db:     db,
 	}
 }
@@ -56,9 +56,12 @@ func NewBlockTreeFromGenesis(genesis *types.Header, db database.Database) *Block
 		depth:       big.NewInt(0),
 		arrivalTime: uint64(time.Now().Unix()), // TODO: genesis block doesn't need an arrival time, it isn't used in median algo
 	}
+
+	lm := NewLeafMap(head)
+
 	return &BlockTree{
 		head:   head,
-		leaves: leafMap{head.hash: head},
+		leaves: lm,
 		db:     db,
 	}
 }
@@ -126,9 +129,10 @@ func (bt *BlockTree) String() string {
 
 	// Format leaves
 	var leaves string
-	for k := range bt.leaves {
-		leaves = leaves + fmt.Sprintf("0x%s ", k)
-	}
+	bt.leaves.smap.Range(func(hash, node interface{}) bool {
+		leaves = leaves + fmt.Sprintf("%s\n", hash.(Hash))
+		return true
+	})
 
 	metadata := fmt.Sprintf("Leaves: %s", leaves)
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -41,7 +41,7 @@ type BlockTree struct {
 func NewEmptyBlockTree(db database.Database) *BlockTree {
 	return &BlockTree{
 		head:   nil,
-		leaves: NewEmptyLeafMap(),
+		leaves: newEmptyLeafMap(),
 		db:     db,
 	}
 }
@@ -57,11 +57,9 @@ func NewBlockTreeFromGenesis(genesis *types.Header, db database.Database) *Block
 		arrivalTime: uint64(time.Now().Unix()), // TODO: genesis block doesn't need an arrival time, it isn't used in median algo
 	}
 
-	lm := NewLeafMap(head)
-
 	return &BlockTree{
 		head:   head,
-		leaves: lm,
+		leaves: newLeafMap(head),
 		db:     db,
 	}
 }

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -89,9 +89,9 @@ func TestBlockTree_AddBlock(t *testing.T) {
 	hash := block.Header.Hash()
 	bt.AddBlock(block, 0)
 
-	n := bt.getNode(hash)
+	node := bt.getNode(hash)
 
-	if n, err := bt.leaves.load(n.hash); n == nil || err != nil {
+	if n, err := bt.leaves.load(node.hash); n == nil || err != nil {
 		t.Errorf("expected %x to be a leaf", n.hash)
 	}
 

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -91,13 +91,13 @@ func TestBlockTree_AddBlock(t *testing.T) {
 
 	n := bt.getNode(hash)
 
-	if bt.leaves[n.hash] == nil {
+	if n, err := bt.leaves.load(n.hash); n == nil || err != nil {
 		t.Errorf("expected %x to be a leaf", n.hash)
 	}
 
 	oldHash := common.Hash{0x01}
 
-	if bt.leaves[oldHash] != nil {
+	if n, err := bt.leaves.load(oldHash); n != nil || err == nil {
 		t.Errorf("expected %x to no longer be a leaf", oldHash)
 	}
 }
@@ -182,12 +182,15 @@ func TestBlockTree_DeepestLeaf(t *testing.T) {
 
 	bt, _ := createTestBlockTree(header, 8, nil)
 
-	for leaf, node := range bt.leaves {
+	bt.leaves.smap.Range(func(h, n interface{}) bool {
+		leaf := h.(Hash)
+		node := n.(*node)
 		node.arrivalTime = arrivalTime
 		arrivalTime++
 		expected = leaf
 		t.Logf("leaf=%s depth=%d arrivalTime=%d", leaf, node.depth, node.arrivalTime)
-	}
+		return true
+	})
 
 	deepestLeaf := bt.deepestLeaf()
 	if deepestLeaf.hash != expected {
@@ -197,14 +200,17 @@ func TestBlockTree_DeepestLeaf(t *testing.T) {
 	r := *rand.New(rand.NewSource(rand.Int63()))
 	greatestTime := uint64(0)
 
-	for leaf, node := range bt.leaves {
+	bt.leaves.smap.Range(func(h, n interface{}) bool {
+		leaf := h.(Hash)
+		node := n.(*node)
 		node.arrivalTime = uint64(r.Intn(256))
 		if node.arrivalTime > greatestTime {
 			greatestTime = node.arrivalTime
 			expected = node.hash
 		}
 		t.Logf("leaf=%s depth=%d arrivalTime=%d", leaf, node.depth, node.arrivalTime)
-	}
+		return true
+	})
 
 	deepestLeaf = bt.deepestLeaf()
 	if deepestLeaf.hash != expected {

--- a/lib/blocktree/database.go
+++ b/lib/blocktree/database.go
@@ -99,7 +99,7 @@ func (bt *BlockTree) Decode(in []byte) error {
 		arrivalTime: arrivalTime,
 	}
 
-	bt.leaves = leafMap{bt.head.hash: bt.head}
+	bt.leaves = NewLeafMap(bt.head)
 
 	return bt.decodeRecursive(r, bt.head)
 }

--- a/lib/blocktree/database.go
+++ b/lib/blocktree/database.go
@@ -99,7 +99,7 @@ func (bt *BlockTree) Decode(in []byte) error {
 		arrivalTime: arrivalTime,
 	}
 
-	bt.leaves = NewLeafMap(bt.head)
+	bt.leaves = newLeafMap(bt.head)
 
 	return bt.decodeRecursive(r, bt.head)
 }

--- a/lib/blocktree/database_test.go
+++ b/lib/blocktree/database_test.go
@@ -98,7 +98,13 @@ func TestStoreBlockTree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(bt, resBt) {
+	if !reflect.DeepEqual(bt.head, resBt.head) {
 		t.Fatalf("Fail: got %v expected %v", resBt, bt)
+	}
+
+	btLeafMap := bt.leaves.toMap()
+	resLeafMap := bt.leaves.toMap()
+	if !reflect.DeepEqual(btLeafMap, resLeafMap) {
+		t.Fatalf("Fail: got %v expected %v", btLeafMap, resLeafMap)
 	}
 }

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -17,32 +17,81 @@
 package blocktree
 
 import (
+	"errors"
 	"math/big"
+	"sync"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
 // leafMap provides quick lookup for existing leaves
-type leafMap map[common.Hash]*node
+type leafMap struct {
+	smap *sync.Map // map[common.Hash]*node
+}
+
+func NewEmptyLeafMap() *leafMap {
+	return &leafMap{
+		smap: &sync.Map{},
+	}
+}
+
+func NewLeafMap(n *node) *leafMap {
+	smap := &sync.Map{}
+	smap.Store(n.hash, n)
+	return &leafMap{
+		smap: smap,
+	}
+}
+
+func (ls *leafMap) store(key Hash, value *node) {
+	ls.smap.Store(key, value)
+}
+
+func (ls *leafMap) load(key Hash) (*node, error) {
+	v, ok := ls.smap.Load(key)
+	if !ok {
+		return nil, errors.New("Key not found")
+	}
+
+	return v.(*node), nil
+}
 
 // Replace deletes the old node from the map and inserts the new one
-func (ls leafMap) replace(old, new *node) {
-	delete(ls, old.hash)
-	ls[new.hash] = new
+func (ls *leafMap) replace(old, new *node) {
+	ls.smap.Delete(old.hash)
+	ls.store(new.hash, new)
 }
 
 // DeepestLeaf searches the stored leaves to the find the one with the greatest depth.
 // If there are two leaves with the same depth, choose the one with the earliest arrival time.
-func (ls leafMap) deepestLeaf() *node {
+func (ls *leafMap) deepestLeaf() *node {
 	max := big.NewInt(-1)
+
 	var dLeaf *node
-	for _, n := range ls {
-		if max.Cmp(n.depth) < 0 {
-			max = n.depth
-			dLeaf = n
-		} else if max.Cmp(n.depth) == 0 && n.arrivalTime > dLeaf.arrivalTime {
-			dLeaf = n
+	ls.smap.Range(func(h, n interface{}) bool {
+		node := n.(*node)
+		if max.Cmp(node.depth) < 0 {
+			max = node.depth
+			dLeaf = node
+		} else if max.Cmp(node.depth) == 0 && node.arrivalTime > dLeaf.arrivalTime {
+			dLeaf = node
 		}
-	}
+
+		return true
+	})
+
 	return dLeaf
+}
+
+func (ls *leafMap) toMap() map[common.Hash]*node {
+	mmap := make(map[common.Hash]*node)
+
+	ls.smap.Range(func(h, n interface{}) bool {
+		hash := h.(Hash)
+		node := n.(*node)
+		mmap[hash] = node
+		return true
+	})
+
+	return mmap
 }

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -29,13 +29,13 @@ type leafMap struct {
 	smap *sync.Map // map[common.Hash]*node
 }
 
-func NewEmptyLeafMap() *leafMap {
+func newEmptyLeafMap() *leafMap {
 	return &leafMap{
 		smap: &sync.Map{},
 	}
 }
 
-func NewLeafMap(n *node) *leafMap {
+func newLeafMap(n *node) *leafMap {
 	smap := &sync.Map{}
 	smap.Store(n.hash, n)
 	return &leafMap{


### PR DESCRIPTION
# Changes
- update blocktree leafMap to sync.Map to prevent concurrent writes panic

## Tests:
```
go test ./lib/blocktree
```

### Issues:
closes #730 