### PR TITLE
cmd, dot: overwrite config with genesis

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 
 	"github.com/ChainSafe/gossamer/dot"
+	"github.com/ChainSafe/gossamer/lib/genesis"
 
 	log "github.com/ChainSafe/log15"
 	"github.com/urfave/cli"
 )
 
-// loadConfigFile loads a default config file if --node is specified, a specific config if --config is specified,
-// or the default gossamer config otherwise.
+// loadConfigFile loads a default config file if --node is specified, a specific
+// config if --config is specified, or the default gossamer config otherwise.
 func loadConfigFile(ctx *cli.Context) (cfg *dot.Config, err error) {
 	// check --node flag and load node configuration from defaults.go
 	if name := ctx.GlobalString(NodeFlag.Name); name != "" {
@@ -71,6 +72,26 @@ func loadConfigFile(ctx *cli.Context) (cfg *dot.Config, err error) {
 	return cfg, nil
 }
 
+// createInitConfig creates the configuration required to initialize a dot node
+func createInitConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
+	cfg, err = loadConfigFile(ctx)
+	if err != nil {
+		log.Error("[cmd] Failed to load toml configuration", "error", err)
+		return nil, err
+	}
+
+	// set global configuration values
+	setDotGlobalConfig(ctx, &cfg.Global)
+
+	// set init configuration values
+	setDotInitConfig(ctx, &cfg.Init)
+
+	// ensure configuration values match genesis and overwrite with genesis
+	updateDotConfigFromGenesis(ctx, cfg)
+
+	return cfg, nil
+}
+
 // createDotConfig creates a new dot configuration from the provided flag values
 func createDotConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
 	cfg, err = loadConfigFile(ctx)
@@ -79,39 +100,33 @@ func createDotConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
 		return nil, err
 	}
 
-	// set dot configuration values
+	// set global configuration values
 	setDotGlobalConfig(ctx, &cfg.Global)
+
+	// ensure configuration values match genesis and overwrite with genesis
+	updateDotConfigFromGenesis(ctx, cfg)
+
+	// set cli configuration values
 	setDotAccountConfig(ctx, &cfg.Account)
-	setDotNetworkConfig(ctx, &cfg.Network)
 	setDotCoreConfig(ctx, &cfg.Core)
+	setDotNetworkConfig(ctx, &cfg.Network)
 	setDotRPCConfig(ctx, &cfg.RPC)
 
-	// return dot configuration ready for node initialization
 	return cfg, nil
-}
-
-func createInitConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
-	cfg, err = loadConfigFile(ctx)
-	if err != nil {
-		log.Error("[cmd] Failed to load toml configuration", "error", err)
-		return nil, err
-	}
-
-	setDotInitConfig(ctx, &cfg.Init)
-	setDotGlobalConfig(ctx, &cfg.Global)
-
-	return cfg, nil
-}
-
-func setDotInitConfig(ctx *cli.Context, cfg *dot.InitConfig) {
-	// check --genesis flag and update node configuration
-	if genesis := ctx.String(GenesisFlag.Name); genesis != "" {
-		cfg.Genesis = genesis
-	}
 }
 
 // setDotGlobalConfig sets dot.GlobalConfig using flag values from the cli context
 func setDotGlobalConfig(ctx *cli.Context, cfg *dot.GlobalConfig) {
+	// check --name flag and update node configuration
+	if name := ctx.GlobalString(NameFlag.Name); name != "" {
+		cfg.Name = name
+	}
+
+	// check --node flag and update node configuration
+	if id := ctx.GlobalString(NodeFlag.Name); id != "" {
+		cfg.ID = id
+	}
+
 	// check --datadir flag and update node configuration
 	if datadir := ctx.GlobalString(DataDirFlag.Name); datadir != "" {
 		cfg.DataDir = datadir
@@ -122,6 +137,18 @@ func setDotGlobalConfig(ctx *cli.Context, cfg *dot.GlobalConfig) {
 		"name", cfg.Name,
 		"id", cfg.ID,
 		"datadir", cfg.DataDir,
+	)
+}
+
+func setDotInitConfig(ctx *cli.Context, cfg *dot.InitConfig) {
+	// check --genesis flag and update init configuration
+	if genesis := ctx.String(GenesisFlag.Name); genesis != "" {
+		cfg.Genesis = genesis
+	}
+
+	log.Debug(
+		"[cmd] Init configuration",
+		"genesis", cfg.Genesis,
 	)
 }
 
@@ -265,4 +292,51 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 		"host", cfg.Host,
 		"modules", cfg.Modules,
 	)
+}
+
+// updateDotConfigFromGenesis updates the configuration based on the genesis file values
+func updateDotConfigFromGenesis(ctx *cli.Context, cfg *dot.Config) {
+
+	// load Genesis from genesis configuration file
+	gen, err := genesis.LoadGenesisFromJSON(cfg.Init.Genesis)
+	if err != nil {
+		log.Error("[cmd] failed to load genesis from file", "error", err)
+		return // exit
+	}
+
+	// check genesis name and use genesis name if configuration does not match
+	if gen.Name != cfg.Global.Name && !ctx.IsSet(NameFlag.Name) {
+		log.Warn("[cmd] genesis mismatch, overwriting name", "name", gen.Name)
+		cfg.Global.Name = gen.Name
+	}
+
+	// check genesis id and use genesis id if configuration does not match
+	if gen.ID != cfg.Global.ID && !ctx.IsSet(NodeFlag.Name) {
+		log.Warn("[cmd] genesis mismatch, overwriting id", "id", gen.ID)
+		cfg.Global.ID = gen.ID
+	}
+
+	// ensure matching bootnodes
+	matchingBootnodes := true
+	if len(gen.Bootnodes) != len(cfg.Network.Bootnodes) {
+		matchingBootnodes = false
+	} else {
+		for i, gb := range gen.Bootnodes {
+			if gb != cfg.Network.Bootnodes[i] {
+				matchingBootnodes = false
+			}
+		}
+	}
+
+	// check genesis bootnodes and use genesis bootnodes if configuration does not match
+	if !matchingBootnodes && !ctx.IsSet(BootnodesFlag.Name) {
+		log.Warn("[cmd] genesis mismatch, overwriting bootnodes", "bootnodes", gen.Bootnodes)
+		cfg.Network.Bootnodes = gen.Bootnodes
+	}
+
+	// check genesis protocol and use genesis protocol if configuration does not match
+	if gen.ProtocolID != cfg.Network.ProtocolID && !ctx.IsSet(ProtocolFlag.Name) {
+		log.Warn("[cmd] genesis mismatch, overwriting protocol", "protocol", gen.ProtocolID)
+		cfg.Network.ProtocolID = gen.ProtocolID
+	}
 }

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -72,26 +72,6 @@ func loadConfigFile(ctx *cli.Context) (cfg *dot.Config, err error) {
 	return cfg, nil
 }
 
-// createInitConfig creates the configuration required to initialize a dot node
-func createInitConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
-	cfg, err = loadConfigFile(ctx)
-	if err != nil {
-		log.Error("[cmd] Failed to load toml configuration", "error", err)
-		return nil, err
-	}
-
-	// set global configuration values
-	setDotGlobalConfig(ctx, &cfg.Global)
-
-	// set init configuration values
-	setDotInitConfig(ctx, &cfg.Init)
-
-	// ensure configuration values match genesis and overwrite with genesis
-	updateDotConfigFromGenesis(ctx, cfg)
-
-	return cfg, nil
-}
-
 // createDotConfig creates a new dot configuration from the provided flag values
 func createDotConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
 	cfg, err = loadConfigFile(ctx)
@@ -113,6 +93,39 @@ func createDotConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
 	setDotRPCConfig(ctx, &cfg.RPC)
 
 	return cfg, nil
+}
+
+// createInitConfig creates the configuration required to initialize a dot node
+func createInitConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
+	cfg, err = loadConfigFile(ctx)
+	if err != nil {
+		log.Error("[cmd] Failed to load toml configuration", "error", err)
+		return nil, err
+	}
+
+	// set global configuration values
+	setDotGlobalConfig(ctx, &cfg.Global)
+
+	// set init configuration values
+	setDotInitConfig(ctx, &cfg.Init)
+
+	// ensure configuration values match genesis and overwrite with genesis
+	updateDotConfigFromGenesis(ctx, cfg)
+
+	return cfg, nil
+}
+
+// setDotInitConfig sets dot.InitConfig using flag values from the cli context
+func setDotInitConfig(ctx *cli.Context, cfg *dot.InitConfig) {
+	// check --genesis flag and update init configuration
+	if genesis := ctx.String(GenesisFlag.Name); genesis != "" {
+		cfg.Genesis = genesis
+	}
+
+	log.Debug(
+		"[cmd] Init configuration",
+		"genesis", cfg.Genesis,
+	)
 }
 
 // setDotGlobalConfig sets dot.GlobalConfig using flag values from the cli context
@@ -137,18 +150,6 @@ func setDotGlobalConfig(ctx *cli.Context, cfg *dot.GlobalConfig) {
 		"name", cfg.Name,
 		"id", cfg.ID,
 		"datadir", cfg.DataDir,
-	)
-}
-
-func setDotInitConfig(ctx *cli.Context, cfg *dot.InitConfig) {
-	// check --genesis flag and update init configuration
-	if genesis := ctx.String(GenesisFlag.Name); genesis != "" {
-		cfg.Genesis = genesis
-	}
-
-	log.Debug(
-		"[cmd] Init configuration",
-		"genesis", cfg.Genesis,
 	)
 }
 

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -80,13 +80,8 @@ func createDotConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
 		return nil, err
 	}
 
-	// set global configuration values
-	setDotGlobalConfig(ctx, &cfg.Global)
-
-	// ensure configuration values match genesis and overwrite with genesis
-	updateDotConfigFromGenesis(ctx, cfg)
-
 	// set cli configuration values
+	setDotGlobalConfig(ctx, &cfg.Global)
 	setDotAccountConfig(ctx, &cfg.Account)
 	setDotCoreConfig(ctx, &cfg.Core)
 	setDotNetworkConfig(ctx, &cfg.Network)

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -75,7 +75,47 @@ func TestConfigFromNodeFlag(t *testing.T) {
 	}
 }
 
-// TestGlobalConfigFromFlags tests createDotConfig using relevant global flags
+// TestInitConfigFromFlags tests createDotInitConfig using relevant init flags
+func TestInitConfigFromFlags(t *testing.T) {
+	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
+	require.NotNil(t, testCfg)
+	require.NotNil(t, testCfgFile)
+
+	defer utils.RemoveTestDir(t)
+
+	testApp := cli.NewApp()
+	testApp.Writer = ioutil.Discard
+
+	testcases := []struct {
+		description string
+		flags       []string
+		values      []interface{}
+		expected    dot.InitConfig
+	}{
+		{
+			"Test gossamer --genesis",
+			[]string{"config", "genesis"},
+			[]interface{}{testCfgFile.Name(), "test_genesis"},
+			dot.InitConfig{
+				Genesis: "test_genesis",
+			},
+		},
+	}
+
+	for _, c := range testcases {
+		c := c // bypass scopelint false positive
+		t.Run(c.description, func(t *testing.T) {
+			ctx, err := newTestContext(c.description, c.flags, c.values)
+			require.Nil(t, err)
+			cfg, err := createInitConfig(ctx)
+			require.Nil(t, err)
+
+			require.Equal(t, c.expected, cfg.Init)
+		})
+	}
+}
+
+// TestGlobalConfigFromFlags tests createDotGlobalConfig using relevant global flags
 func TestGlobalConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 	require.NotNil(t, testCfg)
@@ -103,11 +143,21 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			},
 		},
 		{
-			"Test gossamer --genesis",
-			[]string{"config", "genesis"},
-			[]interface{}{testCfgFile.Name(), "test_genesis"},
+			"Test gossamer --node",
+			[]string{"config", "node"},
+			[]interface{}{testCfgFile.Name(), "ksmcc"},
 			dot.GlobalConfig{
 				Name:    testCfg.Global.Name,
+				ID:      "ksmcc",
+				DataDir: testCfg.Global.DataDir,
+			},
+		},
+		{
+			"Test gossamer --node",
+			[]string{"config", "name"},
+			[]interface{}{testCfgFile.Name(), "test_name"},
+			dot.GlobalConfig{
+				Name:    "test_name",
 				ID:      testCfg.Global.ID,
 				DataDir: testCfg.Global.DataDir,
 			},
@@ -147,7 +197,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 	}
 }
 
-// TestAccountConfigFromFlags tests createDotConfig using relevant account flags
+// TestAccountConfigFromFlags tests createDotAccountConfig using relevant account flags
 func TestAccountConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 	require.NotNil(t, testCfg)
@@ -196,7 +246,7 @@ func TestAccountConfigFromFlags(t *testing.T) {
 	}
 }
 
-// TestCoreConfigFromFlags tests createDotConfig using relevant core flags
+// TestCoreConfigFromFlags tests createDotCoreConfig using relevant core flags
 func TestCoreConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 	require.NotNil(t, testCfg)
@@ -245,7 +295,7 @@ func TestCoreConfigFromFlags(t *testing.T) {
 	}
 }
 
-// TestNetworkConfigFromFlags tests createDotConfig using relevant network flags
+// TestNetworkConfigFromFlags tests createDotNetworkConfig using relevant network flags
 func TestNetworkConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 	require.NotNil(t, testCfg)
@@ -336,7 +386,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 	}
 }
 
-// TestRPCConfigFromFlags tests createDotConfig using relevant rpc flags
+// TestRPCConfigFromFlags tests createDotRPCConfig using relevant rpc flags
 func TestRPCConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 	require.NotNil(t, testCfg)
@@ -422,7 +472,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 	}
 }
 
-// TestUpdateConfigFromGenesis tests UpdateConfigFromGenesis
+// TestUpdateConfigFromGenesis tests updateDotConfigFromGenesis
 func TestUpdateConfigFromGenesis(t *testing.T) {
 	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 	require.NotNil(t, testCfg)

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -48,10 +48,15 @@ var (
 		Usage: "Supports levels crit (silent) to trce (trace)",
 		Value: log.LvlInfo.String(),
 	}
-	// NodeFlag node implementation name
+	// NameFlag node implementation name
+	NameFlag = cli.StringFlag{
+		Name:  "name",
+		Usage: "Node implementation name",
+	}
+	// NodeFlag node implementation id used to load default node configuration
 	NodeFlag = cli.StringFlag{
 		Name:  "node",
-		Usage: "Node implementation name",
+		Usage: "Node implementation id used to load default node configuration",
 	}
 	// ConfigFlag TOML configuration file
 	ConfigFlag = cli.StringFlag{
@@ -170,10 +175,12 @@ var (
 	// GlobalFlags are flags that are valid for use with all commands
 	GlobalFlags = []cli.Flag{
 		VerbosityFlag,
+		NameFlag,
 		NodeFlag,
 		ConfigFlag,
 		DataDirFlag,
 	}
+
 	// InitFlags are flags that are valid for use with the init subcommand
 	InitFlags = append(GlobalFlags, GenesisFlag)
 

--- a/dot/config.go
+++ b/dot/config.go
@@ -34,11 +34,11 @@ import (
 // Config is a collection of configurations throughout the system
 type Config struct {
 	Global  GlobalConfig  `toml:"global"`
+	Init    InitConfig    `toml:"init"`
 	Account AccountConfig `toml:"account"`
 	Core    CoreConfig    `toml:"core"`
 	Network NetworkConfig `toml:"network"`
 	RPC     RPCConfig     `toml:"rpc"`
-	Init    InitConfig    `toml:"init"`
 }
 
 // GlobalConfig is to marshal/unmarshal toml global config vars

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -20,8 +20,15 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/utils"
+
 	"github.com/stretchr/testify/require"
 )
+
+const GssmrConfigPath = "../node/gssmr/config.toml"
+const GssmrGenesisPath = "../node/gssmr/genesis.json"
+
+const KsmccConfigPath = "../node/ksmcc/config.toml"
+const KsmccGenesisPath = "../node/ksmcc/genesis.json"
 
 // TestLoadConfig tests loading a toml configuration file
 func TestLoadConfig(t *testing.T) {
@@ -74,14 +81,14 @@ func TestLoadConfigGssmr(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	cfg.Global.DataDir = utils.NewTestDir(t)
-	cfg.Init.Genesis = "../node/gssmr/genesis.json"
+	cfg.Init.Genesis = GssmrGenesisPath
 
 	defer utils.RemoveTestDir(t)
 
 	err := InitNode(cfg)
 	require.Nil(t, err)
 
-	err = LoadConfig(cfg, "../node/gssmr/config.toml")
+	err = LoadConfig(cfg, GssmrConfigPath)
 	require.Nil(t, err)
 
 	// TODO: improve dot config tests
@@ -96,7 +103,7 @@ func TestExportConfigGssmr(t *testing.T) {
 	gssmrGenesis := cfg.Init.Genesis
 	gssmrDataDir := cfg.Global.DataDir
 	cfg.Global.DataDir = utils.NewTestDir(t)
-	cfg.Init.Genesis = "../node/gssmr/genesis.json"
+	cfg.Init.Genesis = GssmrGenesisPath
 
 	defer utils.RemoveTestDir(t)
 
@@ -106,7 +113,7 @@ func TestExportConfigGssmr(t *testing.T) {
 	cfg.Init.Genesis = gssmrGenesis
 	cfg.Global.DataDir = gssmrDataDir
 
-	file := ExportConfig(cfg, "../node/gssmr/config.toml")
+	file := ExportConfig(cfg, GssmrConfigPath)
 
 	// TODO: improve dot config tests
 	require.NotNil(t, file)
@@ -120,14 +127,14 @@ func TestLoadConfigKsmcc(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	cfg.Global.DataDir = utils.NewTestDir(t)
-	cfg.Init.Genesis = "../node/ksmcc/genesis.json"
+	cfg.Init.Genesis = KsmccGenesisPath
 
 	defer utils.RemoveTestDir(t)
 
 	err := InitNode(cfg)
 	require.Nil(t, err)
 
-	err = LoadConfig(cfg, "../node/ksmcc/config.toml")
+	err = LoadConfig(cfg, KsmccConfigPath)
 
 	// TODO: improve dot config tests
 	require.Nil(t, err)
@@ -141,7 +148,7 @@ func TestExportConfigKsmcc(t *testing.T) {
 	ksmccGenesis := cfg.Init.Genesis
 	ksmccDataDir := cfg.Global.DataDir
 	cfg.Global.DataDir = utils.NewTestDir(t)
-	cfg.Init.Genesis = "../node/ksmcc/genesis.json"
+	cfg.Init.Genesis = KsmccGenesisPath
 
 	defer utils.RemoveTestDir(t)
 
@@ -151,7 +158,7 @@ func TestExportConfigKsmcc(t *testing.T) {
 	cfg.Init.Genesis = ksmccGenesis
 	cfg.Global.DataDir = ksmccDataDir
 
-	file := ExportConfig(cfg, "../node/ksmcc/config.toml")
+	file := ExportConfig(cfg, KsmccConfigPath)
 
 	// TODO: improve dot config tests
 	require.NotNil(t, file)

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
@@ -82,10 +83,13 @@ func NewTestConfigWithFile(t *testing.T) (*Config, *os.File) {
 
 // NewTestGenesis returns a test genesis instance using "gssmr" raw data
 func NewTestGenesis(t *testing.T) *genesis.Genesis {
-	gssmrGen, err := genesis.LoadGenesisFromJSON("../node/gssmr/genesis.json")
+	fp := getGssmrGenesisPath(t)
+
+	gssmrGen, err := genesis.LoadGenesisFromJSON(fp)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return &genesis.Genesis{
 		Name:       "test",
 		ID:         "test",
@@ -100,15 +104,12 @@ func NewTestGenesisFile(t *testing.T, cfg *Config) *os.File {
 	dir := utils.NewTestDir(t)
 
 	file, err := ioutil.TempFile(dir, "genesis-")
-	if err != nil {
-		fmt.Println(fmt.Errorf("failed to create temporary file: %s", err))
-		require.Nil(t, err)
-	}
+	require.Nil(t, err)
 
-	gssmrGen, err := genesis.LoadGenesisFromJSON("../node/gssmr/genesis.json")
-	if err != nil {
-		t.Fatal(err)
-	}
+	fp := getGssmrGenesisPath(t)
+
+	gssmrGen, err := genesis.LoadGenesisFromJSON(fp)
+	require.Nil(t, err)
 
 	gen := &genesis.Genesis{
 		Name:       cfg.Global.Name,
@@ -125,4 +126,26 @@ func NewTestGenesisFile(t *testing.T, cfg *Config) *os.File {
 	require.Nil(t, err)
 
 	return file
+}
+
+// getGssmrGenesisPath gets the gossamer genesis path
+func getGssmrGenesisPath(t *testing.T) string {
+	path1 := "../node/gssmr/genesis.json"
+	path2 := "../../node/gssmr/genesis.json"
+
+	var fp string
+	var err error
+
+	if utils.PathExists(path1) {
+
+		fp, err = filepath.Abs(path1)
+		require.Nil(t, err)
+
+	} else if utils.PathExists(path2) {
+
+		fp, err = filepath.Abs(path2)
+		require.Nil(t, err)
+	}
+
+	return fp
 }

--- a/node/gssmr/config.toml
+++ b/node/gssmr/config.toml
@@ -3,6 +3,9 @@ name = "gssmr"
 id = "gssmr"
 datadir = "~/.gossamer/gssmr"
 
+[init]
+genesis = "./node/gssmr/genesis.json"
+
 [account]
 key = ""
 unlock = ""
@@ -23,6 +26,3 @@ enabled = false
 port = 8545
 host = "localhost"
 modules = ["system", "author", "chain"]
-
-[init]
-genesis = "./node/gssmr/genesis.json"

--- a/node/gssmr/defaults.go
+++ b/node/gssmr/defaults.go
@@ -25,12 +25,13 @@ var (
 	DefaultID = string("gssmr")
 	// DefaultConfig Default toml configuration path
 	DefaultConfig = string("./node/gssmr/config.toml")
-	// DefaultGenesis Default genesis configuration path
-	DefaultGenesis = string("./node/gssmr/genesis.json")
 	// DefaultDataDir Default node data directory
 	DefaultDataDir = string("~/.gossamer/gssmr")
-	// DefaultRoles Default node roles
-	DefaultRoles = byte(4) // authority node (see Table D.2)
+
+	// InitConfig
+
+	// DefaultGenesis Default genesis configuration path
+	DefaultGenesis = string("./node/gssmr/genesis.json")
 
 	// AccountConfig
 
@@ -43,6 +44,8 @@ var (
 
 	// DefaultAuthority true if BABE block producer
 	DefaultAuthority = true
+	// DefaultRoles Default node roles
+	DefaultRoles = byte(4) // authority node (see Table D.2)
 
 	// NetworkConfig
 

--- a/node/ksmcc/config.toml
+++ b/node/ksmcc/config.toml
@@ -3,6 +3,9 @@ name = "ksmcc"
 id = "ksmcc"
 datadir = "~/.gossamer/ksmcc"
 
+[init]
+genesis = "./node/ksmcc/genesis.json"
+
 [account]
 key = ""
 unlock = ""
@@ -23,6 +26,3 @@ enabled = false
 port = 8545
 host = "localhost"
 modules = ["system"]
-
-[init]
-genesis = "./node/ksmcc/genesis.json"

--- a/node/ksmcc/defaults.go
+++ b/node/ksmcc/defaults.go
@@ -25,12 +25,13 @@ var (
 	DefaultID = string("ksmcc")
 	// DefaultConfig Default toml configuration path
 	DefaultConfig = string("./node/ksmcc/config.toml")
-	// DefaultGenesis Default genesis configuration path
-	DefaultGenesis = string("./node/ksmcc/genesis.json")
 	// DefaultDataDir Default node data directory
 	DefaultDataDir = string("~/.gossamer/ksmcc")
-	// DefaultRoles Default node roles
-	DefaultRoles = byte(1) // full node (see Table D.2)
+
+	// InitConfig
+
+	// DefaultGenesis Default genesis configuration path
+	DefaultGenesis = string("./node/ksmcc/genesis.json")
 
 	// AccountConfig
 
@@ -43,6 +44,8 @@ var (
 
 	// DefaultAuthority true if BABE block producer
 	DefaultAuthority = false
+	// DefaultRoles Default node roles
+	DefaultRoles = byte(1) // full node (see Table D.2)
 
 	// NetworkConfig
 


### PR DESCRIPTION
## Changes

- load genesis configuration values (`Name`, `ID`, `Bootnodes`, `ProtocolID`) from genesis file while setting the node configuration and overwrite configuration if configuration values do not match.

- add `name` flag for telemetry

## Tests:
```
go test ./cmd/gossamer
go test ./dot
```

### Issues:
related to #713, no longer closes - ***updated***