### PR TITLE
cmd, dot: load genesis data for initialized node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 *.wasm
 
 test_data
+tmp

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -345,7 +345,7 @@ func updateDotConfigFromGenesisJSON(ctx *cli.Context, cfg *dot.Config) {
 	}
 
 	log.Debug(
-		"[cmd] Updated config from genesis json",
+		"[cmd] Configuration after genesis json",
 		"name", cfg.Global.Name,
 		"id", cfg.Global.ID,
 		"bootnodes", cfg.Network.Bootnodes,
@@ -354,7 +354,7 @@ func updateDotConfigFromGenesisJSON(ctx *cli.Context, cfg *dot.Config) {
 }
 
 // updateDotConfigFromGenesisData updates the configuration from genesis data of an initialized node
-func updateDotConfigFromGenesisData(cfg *dot.Config) error {
+func updateDotConfigFromGenesisData(ctx *cli.Context, cfg *dot.Config) error {
 
 	// initialize database using data directory
 	db, err := database.NewBadgerDB(cfg.Global.DataDir)
@@ -368,11 +368,25 @@ func updateDotConfigFromGenesisData(cfg *dot.Config) error {
 		return fmt.Errorf("failed to load genesis data: %s", err)
 	}
 
-	// update configuration values
-	cfg.Global.Name = gen.Name
-	cfg.Global.ID = gen.ID
-	cfg.Network.Bootnodes = common.BytesToStringArray(gen.Bootnodes)
-	cfg.Network.ProtocolID = gen.ProtocolID
+	// check genesis name and use genesis name if --name flag not set
+	if !ctx.GlobalIsSet(NameFlag.Name) {
+		cfg.Global.Name = gen.Name
+	}
+
+	// check genesis id and use genesis id if --node flag not set
+	if !ctx.GlobalIsSet(NodeFlag.Name) {
+		cfg.Global.ID = gen.ID
+	}
+
+	// check genesis bootnodes and use genesis --bootnodes if name flag not set
+	if !ctx.GlobalIsSet(BootnodesFlag.Name) {
+		cfg.Network.Bootnodes = common.BytesToStringArray(gen.Bootnodes)
+	}
+
+	// check genesis protocol and use genesis --protocol if name flag not set
+	if !ctx.GlobalIsSet(ProtocolFlag.Name) {
+		cfg.Network.ProtocolID = gen.ProtocolID
+	}
 
 	// close database
 	err = db.Close()
@@ -381,7 +395,7 @@ func updateDotConfigFromGenesisData(cfg *dot.Config) error {
 	}
 
 	log.Debug(
-		"[cmd] Updated config from genesis data",
+		"[cmd] Configuration after genesis data",
 		"name", cfg.Global.Name,
 		"id", cfg.Global.ID,
 		"bootnodes", cfg.Network.Bootnodes,

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -476,42 +476,73 @@ func TestRPCConfigFromFlags(t *testing.T) {
 
 // TestUpdateConfigFromGenesisJSON tests updateDotConfigFromGenesisJSON
 func TestUpdateConfigFromGenesisJSON(t *testing.T) {
-	cfg := dot.NewTestConfig(t)
-	require.NotNil(t, cfg)
-
-	cfg.Network.Bootnodes = []string{"test"}
-	cfg.Network.ProtocolID = "test"
-
-	genFile := dot.NewTestGenesisFile(t, cfg)
+	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 
 	defer utils.RemoveTestDir(t)
 
-	gen, err := genesis.NewGenesisFromJSON(genFile.Name())
+	ctx, err := newTestContext(
+		t.Name(),
+		[]string{"config", "name"},
+		[]interface{}{testCfgFile.Name(), "TESTNODE"},
+	)
 	require.Nil(t, err)
 
-	require.Equal(t, gen.Name, cfg.Global.Name)
-	require.Equal(t, gen.ID, cfg.Global.ID)
-	require.Equal(t, gen.Bootnodes, cfg.Network.Bootnodes)
-	require.Equal(t, gen.ProtocolID, cfg.Network.ProtocolID)
+	expected := &dot.Config{
+		Global: dot.GlobalConfig{
+			Name:    "TESTNODE",
+			ID:      testCfg.Global.ID,
+			DataDir: testCfg.Global.DataDir,
+		},
+		Account: testCfg.Account,
+		Core:    testCfg.Core,
+		Network: testCfg.Network,
+		RPC:     testCfg.RPC,
+	}
+
+	cfg, err := createDotConfig(ctx)
+	require.Nil(t, err)
+
+	updateDotConfigFromGenesisJSON(ctx, cfg)
+
+	require.Equal(t, expected, cfg)
 }
 
-// TestUpdateConfigFromGenesisData tests updateDotConfigFromGenesisData
 func TestUpdateConfigFromGenesisData(t *testing.T) {
-	cfg := dot.NewTestConfig(t)
-	require.NotNil(t, cfg)
-
-	cfg.Network.Bootnodes = []string{"test"}
-	cfg.Network.ProtocolID = "test"
-
-	genFile := dot.NewTestGenesisFile(t, cfg)
+	testCfg, testCfgFile := dot.NewTestConfigWithFile(t)
 
 	defer utils.RemoveTestDir(t)
 
-	gen, err := genesis.NewGenesisFromJSON(genFile.Name())
+	ctx, err := newTestContext(
+		t.Name(),
+		[]string{"config", "name"},
+		[]interface{}{testCfgFile.Name(), "TESTNODE"},
+	)
+	require.Nil(t, err)
+
+	expected := &dot.Config{
+		Global: dot.GlobalConfig{
+			Name:    "TESTNODE",
+			ID:      testCfg.Global.ID,
+			DataDir: testCfg.Global.DataDir,
+		},
+		Account: testCfg.Account,
+		Core:    testCfg.Core,
+		Network: testCfg.Network,
+		RPC:     testCfg.RPC,
+	}
+
+	cfg, err := createDotConfig(ctx)
 	require.Nil(t, err)
 
 	db, err := database.NewBadgerDB(cfg.Global.DataDir)
 	require.Nil(t, err)
+
+	genFile := dot.NewTestGenesisFile(t, testCfg)
+
+	gen, err := genesis.NewGenesisFromJSON(genFile.Name())
+	require.Nil(t, err)
+
+	gen.Name = "TESTNODE" // simulate initialized node with name
 
 	err = state.StoreGenesisData(db, gen.GenesisData())
 	require.Nil(t, err)
@@ -519,11 +550,8 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 	err = db.Close()
 	require.Nil(t, err)
 
-	err = updateDotConfigFromGenesisData(cfg)
+	err = updateDotConfigFromGenesisData(ctx, cfg) // name should not be updated if provided as flag value
 	require.Nil(t, err)
 
-	require.Equal(t, cfg.Global.Name, gen.Name)
-	require.Equal(t, cfg.Global.ID, gen.ID)
-	require.Equal(t, cfg.Network.Bootnodes, gen.Bootnodes)
-	require.Equal(t, cfg.Network.ProtocolID, gen.ProtocolID)
+	require.Equal(t, expected, cfg)
 }

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -119,12 +119,12 @@ func gossamerAction(ctx *cli.Context) error {
 		return err
 	}
 
-	// expand data directory and update node configuration (performed separate
+	// expand data directory and update node configuration (performed separately
 	// from createDotConfig because dot config should not include expanded path)
 	cfg.Global.DataDir = utils.ExpandDir(cfg.Global.DataDir)
 
-	// check if node has not been initialized
-	if !dot.NodeInitialized(cfg) {
+	// check if node has not been initialized (expected true - add warning log)
+	if !dot.NodeInitialized(cfg, true) {
 
 		// initialize node (initialize databases and load genesis data)
 		err = dot.InitNode(cfg)
@@ -134,7 +134,9 @@ func gossamerAction(ctx *cli.Context) error {
 		}
 	}
 
-	err = updateDotConfigFromGenesisData(cfg)
+	// ensure configuration matches genesis data stored during node initialization
+	// and overwrite with flag values if flag values are provided
+	err = updateDotConfigFromGenesisData(ctx, cfg)
 	if err != nil {
 		log.Error("[cmd] Failed to update config from genesis data", "error", err)
 		return err
@@ -181,12 +183,12 @@ func initAction(ctx *cli.Context) error {
 		return err
 	}
 
-	// expand data directory and update node configuration (performed separate
+	// expand data directory and update node configuration (performed separately
 	// from createDotConfig because dot config should not include expanded path)
 	cfg.Global.DataDir = utils.ExpandDir(cfg.Global.DataDir)
 
-	// check if node has been initialized
-	if dot.NodeInitialized(cfg) {
+	// check if node has been initialized (expected false - no warning log)
+	if dot.NodeInitialized(cfg, false) {
 
 		// TODO: prompt user to confirm when reinitializing a node #760
 		log.Warn("[cmd] Node has already been initialized, reinitializing node...")

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -125,11 +125,19 @@ func gossamerAction(ctx *cli.Context) error {
 
 	// check if node has not been initialized
 	if !dot.NodeInitialized(cfg) {
+
+		// initialize node (initialize databases and load genesis data)
 		err = dot.InitNode(cfg)
 		if err != nil {
 			log.Error("[cmd] Failed to initialize node", "error", err)
 			return err
 		}
+	}
+
+	err = updateDotConfigFromGenesisData(cfg)
+	if err != nil {
+		log.Error("[cmd] Failed to update config from genesis data", "error", err)
+		return err
 	}
 
 	ks, err := keystore.LoadKeystore(cfg.Account.Key)
@@ -182,7 +190,6 @@ func initAction(ctx *cli.Context) error {
 
 		// TODO: prompt user to confirm when reinitializing a node #760
 		log.Warn("[cmd] Node has already been initialized, reinitializing node...")
-
 	}
 
 	// initialize node (initialize databases and load genesis data)

--- a/dot/node.go
+++ b/dot/node.go
@@ -105,17 +105,19 @@ func InitNode(cfg *Config) error {
 
 // NodeInitialized returns true if, within the configured data directory for the
 // node, the state database has been created and the genesis data has been loaded
-func NodeInitialized(cfg *Config) bool {
+func NodeInitialized(cfg *Config, expected bool) bool {
 
 	// check if key registry exists
 	registry := path.Join(cfg.Global.DataDir, "KEYREGISTRY")
 	_, err := os.Stat(registry)
 	if os.IsNotExist(err) {
-		log.Warn(
-			"[dot] Node has not been initialized",
-			"datadir", cfg.Global.DataDir,
-			"error", "failed to locate KEYREGISTRY file in data directory",
-		)
+		if expected {
+			log.Warn(
+				"[dot] Node has not been initialized",
+				"datadir", cfg.Global.DataDir,
+				"error", "failed to locate KEYREGISTRY file in data directory",
+			)
+		}
 		return false
 	}
 
@@ -123,11 +125,13 @@ func NodeInitialized(cfg *Config) bool {
 	manifest := path.Join(cfg.Global.DataDir, "MANIFEST")
 	_, err = os.Stat(manifest)
 	if os.IsNotExist(err) {
-		log.Warn(
-			"[dot] Node has not been initialized",
-			"datadir", cfg.Global.DataDir,
-			"error", "failed to locate MANIFEST file in data directory",
-		)
+		if expected {
+			log.Warn(
+				"[dot] Node has not been initialized",
+				"datadir", cfg.Global.DataDir,
+				"error", "failed to locate MANIFEST file in data directory",
+			)
+		}
 		return false
 	}
 
@@ -148,7 +152,11 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 
 	log.Info(
 		"[dot] Creating node services...",
+		"name", cfg.Global.Name,
+		"id", cfg.Global.ID,
 		"datadir", cfg.Global.DataDir,
+		"bootnodes", cfg.Network.Bootnodes,
+		"protocol", cfg.Network.ProtocolID,
 	)
 
 	var nodeSrvcs []services.Service

--- a/dot/node.go
+++ b/dot/node.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
+	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/services"
@@ -74,8 +75,18 @@ func InitNode(cfg *Config) error {
 	// create new state service
 	stateSrvc := state.NewService(cfg.Global.DataDir)
 
+	// declare genesis data
+	data := gen.GenesisData()
+
+	// set genesis data using configuration values (assumes the genesis values
+	// have already been loaded into the configuration)
+	data.Name = cfg.Global.Name
+	data.ID = cfg.Global.ID
+	data.Bootnodes = common.StringArrayToBytes(cfg.Network.Bootnodes)
+	data.ProtocolID = cfg.Network.ProtocolID
+
 	// initialize state service with genesis data, block, and trie
-	err = stateSrvc.Initialize(gen.GenesisData(), header, t)
+	err = stateSrvc.Initialize(data, header, t)
 	if err != nil {
 		return fmt.Errorf("failed to initialize state service: %s", err)
 	}

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -55,7 +55,7 @@ func NewTestConfig(t *testing.T) *Config {
 		},
 		Network: NetworkConfig{
 			Port:        uint32(7001),
-			Bootnodes:   []string(nil),
+			Bootnodes:   []string{"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"},
 			ProtocolID:  string("/gossamer/test/0"),
 			NoBootstrap: false,
 			NoMDNS:      false,


### PR DESCRIPTION
## Changes
- load genesis data from database if node already initialized

## Tests:

run tests...
```
go test ./cmd/...
```

run gossamer command...
```
make gossamer

./bin/gossamer --key alice --datadir tmp/alice --name TESTNODE --verbosity trace init
./bin/gossamer --key alice --datadir tmp/alice --name TESTNODE --verbosity trace
```

...then update name in `gssmr/genesis.config` to `ANOTHERNODE` and rerun commands.

(1) you should see a warning that the name within the genesis file and the config file do not match and the config name value is being overwritten with the genesis name value

(2) you should see that we load and update using the genesis data for an initialized node and the config is overwritten a second time using the genesis data before being passed to `NewNode`

### Issues:
closes #713 