### PR TITLE
cmd/gossamer: confirm reinitializing a node

### DIFF
--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -135,7 +135,7 @@ func gossamerAction(ctx *cli.Context) error {
 	}
 
 	// ensure configuration matches genesis data stored during node initialization
-	// and overwrite with flag values if flag values are provided
+	// but do not overwrite configuration if the corresponding flag value is set
 	err = updateDotConfigFromGenesisData(ctx, cfg)
 	if err != nil {
 		log.Error("[cmd] Failed to update config from genesis data", "error", err)

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -193,7 +193,7 @@ func initAction(ctx *cli.Context) error {
 		// prompt user to confirm reinitialization
 		if confirm("Are you sure you want to reinitialize the node? [Y/n]") {
 
-			log.Info("[cmd] Reinitializing node...")
+			log.Info("[cmd] Reinitializing node...", "datadir", cfg.Global.DataDir)
 
 			// initialize node (initialize state database and load genesis data)
 			err = dot.InitNode(cfg)

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -191,7 +191,7 @@ func initAction(ctx *cli.Context) error {
 	if dot.NodeInitialized(cfg.Global.DataDir, false) {
 
 		// prompt user to confirm reinitialization
-		if confirm("Are you sure you want to reinitialize the node? [Y/n]") {
+		if confirmMessage("Are you sure you want to reinitialize the node? [Y/n]") {
 
 			log.Info("[cmd] Reinitializing node...", "datadir", cfg.Global.DataDir)
 

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -126,7 +126,7 @@ func gossamerAction(ctx *cli.Context) error {
 	// check if node has not been initialized (expected true - add warning log)
 	if !dot.NodeInitialized(cfg, true) {
 
-		// initialize node (initialize databases and load genesis data)
+		// initialize node (initialize state database and load genesis data)
 		err = dot.InitNode(cfg)
 		if err != nil {
 			log.Error("[cmd] Failed to initialize node", "error", err)
@@ -190,15 +190,18 @@ func initAction(ctx *cli.Context) error {
 	// check if node has been initialized (expected false - no warning log)
 	if dot.NodeInitialized(cfg, false) {
 
-		// TODO: prompt user to confirm when reinitializing a node #760
-		log.Warn("[cmd] Node has already been initialized, reinitializing node...")
-	}
+		// prompt user to confirm reinitialization
+		if confirm("Are you sure you want to reinitialize the node? [Y/n]") {
 
-	// initialize node (initialize databases and load genesis data)
-	err = dot.InitNode(cfg)
-	if err != nil {
-		log.Error("[cmd] Failed to initialize node", "error", err)
-		return err
+			log.Info("[cmd] Reinitializing node...")
+
+			// initialize node (initialize state database and load genesis data)
+			err = dot.InitNode(cfg)
+			if err != nil {
+				log.Error("[cmd] Failed to initialize node", "error", err)
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -17,8 +17,11 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"syscall"
 
 	log "github.com/ChainSafe/log15"
@@ -56,5 +59,20 @@ func getPassword(msg string) []byte {
 			fmt.Printf("\n")
 			return password
 		}
+	}
+}
+
+// prompt user to confirm message
+func confirm(msg string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println(msg)
+	fmt.Print("> ")
+	for {
+		text, _ := reader.ReadString('\n')
+		text = strings.Replace(text, "\n", "", -1)
+		if strings.Compare("Y", text) == 0 {
+			return true
+		}
+		return false
 	}
 }

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -47,7 +47,7 @@ func startLogger(ctx *cli.Context) error {
 	return nil
 }
 
-// prompt user to enter password for encrypted keystore
+// getPassword prompts user to enter password
 func getPassword(msg string) []byte {
 	for {
 		fmt.Println(msg)
@@ -62,8 +62,8 @@ func getPassword(msg string) []byte {
 	}
 }
 
-// prompt user to confirm message
-func confirm(msg string) bool {
+// confirmMessage prompts user to confirm message and returns true if "Y"
+func confirmMessage(msg string) bool {
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Println(msg)
 	fmt.Print("> ")

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -70,9 +70,6 @@ func confirm(msg string) bool {
 	for {
 		text, _ := reader.ReadString('\n')
 		text = strings.Replace(text, "\n", "", -1)
-		if strings.Compare("Y", text) == 0 {
-			return true
-		}
-		return false
+		return strings.Compare("Y", text) == 0
 	}
 }

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -19,7 +19,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 )
 
@@ -40,4 +43,44 @@ func newTestContext(description string, flags []string, values []interface{}) (*
 	}
 	ctx := cli.NewContext(nil, set, nil)
 	return ctx, nil
+}
+
+// TestStartLogger
+func TestStartLogger(t *testing.T) {
+	testApp := cli.NewApp()
+	testApp.Writer = ioutil.Discard
+
+	testcases := []struct {
+		description string
+		flags       []string
+		values      []interface{}
+	}{
+		{
+			"Test gossamer --verbosity info",
+			[]string{"verbosity"},
+			[]interface{}{"info"},
+		},
+		{
+			"Test gossamer --verbosity debug",
+			[]string{"verbosity"},
+			[]interface{}{"debug"},
+		},
+		{
+			"Test gossamer --verbosity trace",
+			[]string{"verbosity"},
+			[]interface{}{"trace"},
+		},
+	}
+
+	for _, c := range testcases {
+		c := c // bypass scopelint false positive
+		t.Run(c.description, func(t *testing.T) {
+			ctx, err := newTestContext(c.description, c.flags, c.values)
+			require.Nil(t, err)
+
+			err = startLogger(ctx)
+			require.Nil(t, err)
+		})
+	}
+
 }

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -54,21 +54,31 @@ func TestStartLogger(t *testing.T) {
 		description string
 		flags       []string
 		values      []interface{}
+		expected    error
 	}{
 		{
 			"Test gossamer --verbosity info",
 			[]string{"verbosity"},
 			[]interface{}{"info"},
+			nil,
 		},
 		{
 			"Test gossamer --verbosity debug",
 			[]string{"verbosity"},
 			[]interface{}{"debug"},
+			nil,
 		},
 		{
 			"Test gossamer --verbosity trace",
 			[]string{"verbosity"},
 			[]interface{}{"trace"},
+			nil,
+		},
+		{
+			"Test gossamer --verbosity blah",
+			[]string{"verbosity"},
+			[]interface{}{"blah"},
+			fmt.Errorf("Unknown level: blah"),
 		},
 	}
 
@@ -79,8 +89,7 @@ func TestStartLogger(t *testing.T) {
 			require.Nil(t, err)
 
 			err = startLogger(ctx)
-			require.Nil(t, err)
+			require.Equal(t, c.expected, err)
 		})
 	}
-
 }


### PR DESCRIPTION
## Changes
- prompt user to confirm with `Y` when attempting to initialize an already initialized node

## Tests:
```
make gossamer

./bin/gossamer --datadir tmp/alice --key alice init

./bin/gossamer --datadir tmp/alice --key alice init
```

### Issues:
closes #760 