### PR TITLE
scripts, tests, rpc: add test for system_networkState

### DIFF
--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -47,7 +47,7 @@ func TestNewHTTPServer(t *testing.T) {
 	req, err := http.NewRequest("POST", "http://localhost:8545/", buf)
 	require.Nil(t, err)
 
-	req.Header.Set("Content-Type", "application/json;")
+	req.Header.Set("Content-Type", "application/json")
 
 	res, err := client.Do(req)
 	require.Nil(t, err)

--- a/tests/rpc/common.go
+++ b/tests/rpc/common.go
@@ -22,6 +22,7 @@ import (
 	"time"
 )
 
+//nolint
 var (
 	GOSSAMER_INTEGRATION_TEST_MODE = os.Getenv("GOSSAMER_INTEGRATION_TEST_MODE")
 

--- a/tests/rpc/common.go
+++ b/tests/rpc/common.go
@@ -33,7 +33,6 @@ var (
 	httpClientTimeout = 120 * time.Second
 )
 
-//TODO: json2.serverResponse should be exported and re-used instead
 type serverResponse struct {
 	// JSON-RPC Version
 	Version string `json:"jsonrpc"`

--- a/tests/rpc/common.go
+++ b/tests/rpc/common.go
@@ -1,0 +1,59 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+)
+
+var (
+	GOSSAMER_INTEGRATION_TEST_MODE = os.Getenv("GOSSAMER_INTEGRATION_TEST_MODE")
+
+	GOSSAMER_NODE_HOST = os.Getenv("GOSSAMER_NODE_HOST")
+
+	ContentTypeJSON   = "application/json"
+	dialTimeout       = 60 * time.Second
+	httpClientTimeout = 120 * time.Second
+)
+
+//TODO: json2.serverResponse should be exported and re-used instead
+type serverResponse struct {
+	// JSON-RPC Version
+	Version string `json:"jsonrpc"`
+	// Resulting values
+	Result json.RawMessage `json:"result"`
+	// Any generated errors
+	Error *Error `json:"error"`
+	// Request id
+	ID *json.RawMessage `json:"id"`
+}
+
+// ErrCode is a int type used for the rpc error codes
+type ErrCode int
+
+// Error is a struct that holds the error message and the error code for a error
+type Error struct {
+	Message   string
+	ErrorCode ErrCode
+}
+
+// Error returns the error Message string
+func (e *Error) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

- add test for system_networkState
- rename integration_test.go to system_integration_test.go
- refactor common test logic to common.go
- add option on integration-test-all.sh -z (Quantity of nodes to run tests against eg: 3) in order to 
- have local tests less strict asserting one node instead of 3 (default)
- update rpcmods node init param to start chain (for future tests)

## Tests:


```
./scripts/integration-test-all.sh -q 3 -z 1 -s 5
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [ ] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [ ] I have provided as much information as possible and necessary
- [ ] I have reviewed my own pull request before requesting a review
- [ ] I have linked any relevant issues in my pull request comments
- [ ] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
