### PR TITLE
cmd/gossamer: fix and update FixFlagOrder method

### DIFF
--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -238,15 +238,19 @@ var (
 	}, GlobalFlags...)
 )
 
-// FixFlagOrder allow us to use various flag order formats, eg: (gossamer init --config config.toml and  gossamer --config config.toml init)
+// FixFlagOrder allow us to use various flag order formats (ie, `gossamer init
+// --config config.toml` and `gossamer --config config.toml init`). FixFlagOrder
+// does not apply to non-global flags, which must come after the subcommand (ie,
+// `gossamer --force --config config.toml init` will not recognize `--force` but
+// `gossamer init --force --config config.toml` will work as expected).
 func FixFlagOrder(f func(ctx *cli.Context) error) func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
 		for _, flagName := range ctx.FlagNames() {
 			if ctx.IsSet(flagName) {
-				if err := ctx.Set(flagName, ctx.String(flagName)); err != nil {
-					if err := ctx.GlobalSet(flagName, ctx.String(flagName)); err != nil {
-						log.Trace("[cmd] Failed to fix flag order", "flag", flagName)
-					}
+				if err := ctx.GlobalSet(flagName, ctx.String(flagName)); err != nil {
+					log.Trace("[cmd] failed to set global flag", "flag", flagName)
+				} else if err := ctx.Set(flagName, ctx.String(flagName)); err != nil {
+					log.Trace("[cmd] failed to set flag", "flag", flagName)
 				}
 			}
 		}

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -247,10 +247,20 @@ func FixFlagOrder(f func(ctx *cli.Context) error) func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
 		for _, flagName := range ctx.FlagNames() {
 			if ctx.IsSet(flagName) {
-				if err := ctx.GlobalSet(flagName, ctx.String(flagName)); err != nil {
+				// attempt to set flag as global flag
+				err := ctx.GlobalSet(flagName, ctx.String(flagName))
+				if err != nil {
 					log.Trace("[cmd] failed to set global flag", "flag", flagName)
-				} else if err := ctx.Set(flagName, ctx.String(flagName)); err != nil {
-					log.Trace("[cmd] failed to set flag", "flag", flagName)
+				} else {
+					log.Trace("[cmd] global flag set", "flag", flagName)
+				}
+
+				// attempt to set flag as local flag
+				err = ctx.Set(flagName, ctx.String(flagName))
+				if err != nil {
+					log.Trace("[cmd] failed to set local flag", "flag", flagName)
+				} else {
+					log.Trace("[cmd] local flag set", "flag", flagName)
 				}
 			}
 		}

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -55,13 +55,13 @@ func TestFixFlagOrder(t *testing.T) {
 			[]interface{}{true, testConfig, "trace"},
 			true,
 		},
-    {
-      "Test gossamer [subcommand] --force --config --verbosity",
-      []string{"force", "config", "verbosity", "badflag"},
-      []interface{}{true, testConfig, "trace", "badflag"},
-      false,
-    },
-  }
+		{
+			"Test gossamer [subcommand] --force --config --verbosity",
+			[]string{"force", "config", "verbosity", "badflag"},
+			[]interface{}{true, testConfig, "trace", "badflag"},
+			false,
+		},
+	}
 
 	for _, c := range testcases {
 		c := c // bypass scopelint false positive


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix `FixFlagOrder` to allow the formats listed below and update comment to explain use of non-global flag after the subcommand (before or after global flags or mixed between is ok)

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer

mkdir tmp

./bin/gossamer export --config tmp/config.toml

./bin/gossamer --config tmp/config.toml export

./bin/gossamer export --config tmp/config.toml --force

./bin/gossamer export --force --config tmp/config.toml
```

The following does not work because `force` is not a global flag and, therefore, must be placed after the `export` subcommand. The help menu is appropriately displayed with global options.

```
./bin/gossamer --force --config tmp/config.toml export

./bin/gossamer --config tmp/config.toml --force export
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [ ] All integration tests and required coverage checks are passing ***- needs approval***

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #782
