### PR TITLE
dot/state: set number to hash mapping for genesis

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -104,6 +104,11 @@ func NewBlockStateFromGenesis(db database.Database, header *types.Header) (*Bloc
 		return nil, err
 	}
 
+	err = bs.db.Put(headerHashKey(header.Number.Uint64()), header.Hash().ToBytes())
+	if err != nil {
+		return nil, err
+	}
+
 	err = bs.SetBlockBody(header.Hash(), types.NewBody([]byte{}))
 
 	if err != nil {


### PR DESCRIPTION
## Changes

- set number to hash mapping for genesis block

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
./bin/gossamer --key alice --rpc
```
in another terminal:
```
curl -X POST --data '{"jsonrpc":"2.0","method":"chain_getBlockHash","params":["0"],"id":1}' -H "Content-Type: application/json" http://localhost:8545
```

