### PR TITLE
lib/crypto: fix PubkeyToAddress to conform to ss58

### DIFF
--- a/lib/crypto/keypair.go
+++ b/lib/crypto/keypair.go
@@ -66,7 +66,7 @@ var ss58Prefix = []byte("SS58PRE")
 // see: https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58)
 // also see: https://github.com/paritytech/substrate/blob/master/primitives/core/src/crypto.rs#L275
 func PublicKeyToAddress(pub PublicKey) common.Address {
-	enc := append([]byte{42}, pub.Encode()...) //should add 42 type
+	enc := append([]byte{42}, pub.Encode()...)
 	hasher, err := blake2b.New(64, nil)
 	if err != nil {
 		return ""

--- a/lib/crypto/keypair.go
+++ b/lib/crypto/keypair.go
@@ -66,7 +66,7 @@ var ss58Prefix = []byte("SS58PRE")
 // see: https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58)
 // also see: https://github.com/paritytech/substrate/blob/master/primitives/core/src/crypto.rs#L275
 func PublicKeyToAddress(pub PublicKey) common.Address {
-	enc := pub.Encode()
+	enc := append([]byte{42}, pub.Encode()...) //should add 42 type
 	hasher, err := blake2b.New(64, nil)
 	if err != nil {
 		return ""

--- a/lib/crypto/keypair_test.go
+++ b/lib/crypto/keypair_test.go
@@ -1,0 +1,21 @@
+package crypto_test
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPubkeyToAddress(t *testing.T) {
+	// randomly generated from subkey
+	pub, _ := common.HexToBytes("0x6ec2950d29adda8d965d06fc78b7e05f8923b8de3e312c7b5957cdcfd8d4820c")
+	addr := "5EZvvkH5RUjigUNT7pabMzMnHtmrYamsSe7yW6vVACBzTHFe"
+
+	pk, err := sr25519.NewPublicKey(pub)
+	require.NoError(t, err)
+	a := pk.Address()
+	require.Equal(t, addr, string(a))
+}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix PubkeyToAddress to conform to ss58
- add test case
- https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58) 42 is substrate wildcard

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/crypto
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #845 
