### PR TITLE
dot/rpc Implement RPC call state_getMetadata 

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -17,7 +17,6 @@ package core
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"sync"
 
@@ -529,7 +528,6 @@ func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 }
 
 //GetMetadata calls runtime Metadata_metadata function
-func (s *Service) GetMetadata() {
-	ret, err := s.rt.Exec(runtime.Metadata_metadata, []byte{})
-	fmt.Printf("%v %v\n", ret, err)
+func (s *Service) GetMetadata() ([]byte, error) {
+	return s.rt.Exec(runtime.Metadata_metadata, []byte{})
 }

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -17,6 +17,7 @@ package core
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -525,4 +526,10 @@ func (s *Service) IsBabeAuthority() bool {
 func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 	msg := &network.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
 	return s.safeMsgSend(msg)
+}
+
+//GetMetadata calls runtime Metadata_metadata function
+func (s *Service) GetMetadata() {
+	ret, err := s.rt.Exec(runtime.Metadata_metadata, []byte{})
+	fmt.Printf("%v %v\n", ret, err)
 }

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -45,6 +45,7 @@ type CoreAPI interface {
 	GetRuntimeVersion() (*runtime.VersionAPI, error)
 	IsBabeAuthority() bool
 	HandleSubmittedExtrinsic(types.Extrinsic) error
+	GetMetadata() ([]byte, error)
 }
 
 // RPCAPI is the interface for methods related to RPC service

--- a/dot/rpc/modules/state.go
+++ b/dot/rpc/modules/state.go
@@ -188,8 +188,7 @@ func (sm *StateModule) GetKeys(r *http.Request, req *StateStorageKeyRequest, res
 func (sm *StateModule) GetMetadata(r *http.Request, req *StateRuntimeMetadataQuery, res *string) error {
 	// TODO implement change storage trie so that block hash parameter works (See issue #834)
 	metadata, err := sm.coreAPI.GetMetadata()
-	// TODO use common.BytesToHex once PR #848 is merged
-	*res = "0x" + hex.EncodeToString(metadata)
+	*res = common.BytesToHex(metadata)
 	return err
 }
 

--- a/dot/rpc/modules/state.go
+++ b/dot/rpc/modules/state.go
@@ -184,9 +184,13 @@ func (sm *StateModule) GetKeys(r *http.Request, req *StateStorageKeyRequest, res
 	// TODO implement change storage trie so that block hash parameter works (See issue #834)
 }
 
-// GetMetadata isn't implemented properly yet.
-func (sm *StateModule) GetMetadata(r *http.Request, req *StateRuntimeMetadataQuery, res *StateMetadataResponse) {
+// GetMetadata calls runtime Metadata_metadata function
+func (sm *StateModule) GetMetadata(r *http.Request, req *StateRuntimeMetadataQuery, res *string) error {
 	// TODO implement change storage trie so that block hash parameter works (See issue #834)
+	metadata, err := sm.coreAPI.GetMetadata()
+	// TODO use common.BytesToHex once PR #848 is merged
+	*res = "0x" + hex.EncodeToString(metadata)
+	return err
 }
 
 // GetRuntimeVersion Get the runtime version at a given block.

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -153,6 +153,18 @@ func TestStateModule_GetStorageSize_NotFound(t *testing.T) {
 	require.Equal(t, nil, res)
 }
 
+func TestStateModule_GetMetadata(t *testing.T) {
+	sm := setupStateModule(t)
+	var res string
+	err := sm.GetMetadata(nil, nil, &res)
+
+	// currently this is generating an error because runtime has not implemented Metadata_metadata yet
+	//  expect this to change when runtime changes
+	require.Equal(t, "0x", res)
+	require.EqualError(t, err, "Failed to call the `Metadata_metadata` exported function.")
+
+}
+
 func setupStateModule(t *testing.T) *StateModule {
 	// setup service
 	net := newNetworkService(t)

--- a/lib/runtime/runtime_test.go
+++ b/lib/runtime/runtime_test.go
@@ -67,12 +67,14 @@ func TestConcurrentRuntimeCalls(t *testing.T) {
 }
 
 func TestRuntime_Exec_Metadata(t *testing.T) {
-	// expected results based on results from previous runs
-	expected := []byte{16, 116, 101, 115, 116, 44, 112, 97, 114, 105, 116, 121, 45, 116, 101, 115, 116, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 36, 223, 106, 203, 104, 153, 7, 96, 155, 2, 0, 0, 0, 55, 227, 151, 252, 124, 145, 245, 228, 1, 0, 0, 0, 210, 188, 152, 151, 238, 208, 143, 21, 1, 0, 0, 0, 64, 254, 58, 212, 1, 248, 149, 154, 3, 0, 0, 0, 198, 233, 167, 99, 9, 243, 155, 9, 1, 0, 0, 0, 221, 113, 141, 92, 197, 50, 98, 212, 1, 0, 0, 0, 203, 202, 37, 227, 159, 20, 35, 135, 1, 0, 0, 0, 247, 139, 39, 139, 229, 63, 69, 76, 1, 0, 0, 0, 171, 60, 5, 114, 41, 31, 235, 139, 1, 0, 0, 0}
+	var expected []byte
 	runtime := NewTestRuntime(t, POLKADOT_RUNTIME_c768a7e4c70e)
 
-	ret, err := runtime.Exec(CoreVersion, []byte{})
-	require.NoError(t, err)
+	ret, err := runtime.Exec(Metadata_metadata, []byte{})
 
+	// currently this is returning an error because runtime has not implemented Metadata_metadata yet
+	//  expect this to change when runtime changes
+	require.EqualError(t, err, "Failed to call the `Metadata_metadata` exported function.")
 	require.Equal(t, expected, ret)
+
 }

--- a/lib/runtime/runtime_test.go
+++ b/lib/runtime/runtime_test.go
@@ -65,3 +65,14 @@ func TestConcurrentRuntimeCalls(t *testing.T) {
 		_, _ = runtime.Exec(CoreVersion, []byte{})
 	}()
 }
+
+func TestRuntime_Exec_Metadata(t *testing.T) {
+	// expected results based on results from previous runs
+	expected := []byte{16, 116, 101, 115, 116, 44, 112, 97, 114, 105, 116, 121, 45, 116, 101, 115, 116, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 36, 223, 106, 203, 104, 153, 7, 96, 155, 2, 0, 0, 0, 55, 227, 151, 252, 124, 145, 245, 228, 1, 0, 0, 0, 210, 188, 152, 151, 238, 208, 143, 21, 1, 0, 0, 0, 64, 254, 58, 212, 1, 248, 149, 154, 3, 0, 0, 0, 198, 233, 167, 99, 9, 243, 155, 9, 1, 0, 0, 0, 221, 113, 141, 92, 197, 50, 98, 212, 1, 0, 0, 0, 203, 202, 37, 227, 159, 20, 35, 135, 1, 0, 0, 0, 247, 139, 39, 139, 229, 63, 69, 76, 1, 0, 0, 0, 171, 60, 5, 114, 41, 31, 235, 139, 1, 0, 0, 0}
+	runtime := NewTestRuntime(t, POLKADOT_RUNTIME_c768a7e4c70e)
+
+	ret, err := runtime.Exec(CoreVersion, []byte{})
+	require.NoError(t, err)
+
+	require.Equal(t, expected, ret)
+}

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -84,6 +84,8 @@ var (
 	CoreInitializeBlock = "Core_initialize_block"
 	// CoreExecuteBlock is the runtime API call Core_execute_block
 	CoreExecuteBlock = "Core_execute_block"
+	// Metadata_metadata is the runtime API call Metadata_metadata
+	Metadata_metadata = "Metadata_metadata"
 	// TaggedTransactionQueueValidateTransaction is the runtime API call TaggedTransactionQueue_validate_transaction
 	TaggedTransactionQueueValidateTransaction = "TaggedTransactionQueue_validate_transaction"
 	// AuraAPIAuthorities is the runtime API call AuraApi_authorities


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implement RPC call state_getMetadata which returns the runtime metadata
- The current runtime has not implemented Metadata_metadata yet, so this will handle the error that is returned.
-

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/rpc/...
go test ./lib/runtime/...
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
