### PR TITLE
gossamer: use consistent flag and variable names

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -299,17 +299,17 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 		cfg.Enabled = false
 	}
 
-	// check --rpcport flag and update node configuration
+	// check --rpc-port flag and update node configuration
 	if port := ctx.GlobalUint(RPCPortFlag.Name); port != 0 {
 		cfg.Port = uint32(port)
 	}
 
-	// check --rpchost flag and update node configuration
+	// check --rpc-host flag and update node configuration
 	if host := ctx.GlobalString(RPCHostFlag.Name); host != "" {
 		cfg.Host = host
 	}
 
-	// check --rpcmods flag and update node configuration
+	// check --rpc-mods flag and update node configuration
 	if modules := ctx.GlobalString(RPCModulesFlag.Name); modules != "" {
 		cfg.Modules = strings.Split(ctx.GlobalString(RPCModulesFlag.Name), ",")
 	}

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -430,8 +430,8 @@ func TestRPCConfigFromFlags(t *testing.T) {
 			},
 		},
 		{
-			"Test gossamer --rpchost",
-			[]string{"config", "rpchost"},
+			"Test gossamer --rpc-host",
+			[]string{"config", "rpc-host"},
 			[]interface{}{testCfgFile.Name(), "testhost"}, // rpc must be enabled
 			dot.RPCConfig{
 				Enabled: testCfg.RPC.Enabled,
@@ -442,8 +442,8 @@ func TestRPCConfigFromFlags(t *testing.T) {
 			},
 		},
 		{
-			"Test gossamer --rpcport",
-			[]string{"config", "rpcport"},
+			"Test gossamer --rpc-port",
+			[]string{"config", "rpc-port"},
 			[]interface{}{testCfgFile.Name(), "5678"}, // rpc must be enabled
 			dot.RPCConfig{
 				Enabled: testCfg.RPC.Enabled,
@@ -455,7 +455,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		},
 		{
 			"Test gossamer --rpcsmods",
-			[]string{"config", "rpcmods"},
+			[]string{"config", "rpc-mods"},
 			[]interface{}{testCfgFile.Name(), "mod1,mod2"}, // rpc must be enabled
 			dot.RPCConfig{
 				Enabled: testCfg.RPC.Enabled,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -115,33 +115,70 @@ var (
 
 // RPC service configuration flags
 var (
-	// RPCEnabledFlag Enable the HTTP-RPC
+	// RPCCoresFlag to enable CORS via HTTP-RPC // TODO: not yet implemented
+	RPCCoresFlag = cli.StringFlag{
+		Name:  "rpc-cores",
+		Usage: "Enable CORS via HTTP-RPC",
+	}
+	// RPCEnabledFlag Enable the HTTP-RPC // TODO: not included in polkadot
 	RPCEnabledFlag = cli.BoolFlag{
 		Name:  "rpc",
 		Usage: "Enable the HTTP-RPC server",
 	}
-	// RPCHostFlag HTTP-RPC server listening hostname
+	// RPCExternalFlag
+	RPCExternalFlag = cli.BoolFlag{ // TODO: not yet implemented
+		Name: "rpc-external",
+		Usage: "Listen to all RPC interfaces (local by default)",
+	}
+	// RPCExternalUnsafeFlag
+	RPCExternalUnsafeFlag = cli.BoolFlag{ // TODO: not yet implemented
+		Name: "unsafe-rpc-external",
+		Usage: "Listen to all RPC interfaces (no warning)",
+	}
+	// RPCHostFlag HTTP-RPC server listening hostname // TODO: not included in polkadot
 	RPCHostFlag = cli.StringFlag{
-		Name:  "rpchost",
+		Name:  "rpc-host",
 		Usage: "HTTP-RPC server listening hostname",
 	}
 	// RPCPortFlag HTTP-RPC server listening port
 	RPCPortFlag = cli.IntFlag{
-		Name:  "rpcport",
+		Name:  "rpc-port",
 		Usage: "HTTP-RPC server listening port",
 	}
-	// RPCModulesFlag API modules to enable via HTTP-RPC
+	// RPCModulesFlag API modules to enable via HTTP-RPC // TODO: not included in polkadot
 	RPCModulesFlag = cli.StringFlag{
-		Name:  "rpcmods",
+		Name:  "rpc-mods",
 		Usage: "API modules to enable via HTTP-RPC, comma separated list",
 	}
-	WSPortFlag = cli.IntFlag{
-		Name:  "wsport",
-		Usage: "Websockets server listening port",
+	// RPCMethodsFlag API methods to enable via HTTP-RPC // TODO: not yet implemented
+	RPCMethodsFlag = cli.StringFlag{
+		Name:  "rpc-methods",
+		Usage: "API methods to enable via HTTP-RPC (Auto, Safe, Unsafe)",
 	}
-	WSEnabledFlag = cli.BoolFlag{
+	// WSEnabledFlag
+	WSEnabledFlag = cli.BoolFlag{ // TODO: not included in polkadot
 		Name:  "ws",
-		Usage: "Enable the websockets server",
+		Usage: "Enable the Websockets server",
+	}
+	// WSExternalFlag
+	WSExternalFlag = cli.BoolFlag{ // TODO: not yet implemented
+		Name: "ws-external",
+		Usage: "Listen to all Websocket interfaces (local by default)",
+	}
+	// WSExternalUnsafeFlag
+	WSExternalUnsafeFlag = cli.BoolFlag{ // TODO: not yet implemented
+		Name: "unsafe-ws-external",
+		Usage: "Listen to all Websocket interfaces (no warning)",
+	}
+	// WSMaxConnectionsFlag
+	WSMaxConnectionsFlag = cli.IntFlag{ // TODO: not yet implemented
+		Name:  "ws-max-connections",
+		Usage: "Maximum number of websocket connections",
+	}
+	// WSPortFlag
+	WSPortFlag = cli.IntFlag{
+		Name:  "ws-port",
+		Usage: "Websockets server listening port",
 	}
 )
 

--- a/scripts/integration-test-all.sh
+++ b/scripts/integration-test-all.sh
@@ -57,7 +57,7 @@ arr=()
 start_func() {
   echo "starting gossamer node $i in background ..."
   "$PWD"/bin/gossamer --port=$(($PORT + $i)) --key=$KEY --basepath="$BASE_PATH$i" \
-    --rpc --rpchost=$HOSTNAME --rpcport=$(($RPC_PORT + $i)) --rpcmods=system,author,chain >"$BASE_PATH"/node"$i".log 2>&1 & disown
+    --rpc --rpc-host=$HOSTNAME --rpc-port=$(($RPC_PORT + $i)) --rpc-mods=system,author,chain >"$BASE_PATH"/node"$i".log 2>&1 & disown
 
   GOSSAMER_PID=$!
   echo "started gossamer node, pid=$GOSSAMER_PID"

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -84,9 +84,9 @@ func RunGossamer(t *testing.T, idx int, basePath string) (*Node, error) {
 		//nolint
 		cmd = exec.Command(gossamerCMD, "--port", strconv.Itoa(basePort+idx),
 			"--basepath", basePath+strconv.Itoa(idx),
-			"--rpchost", HOSTNAME,
-			"--rpcport", rpcPort,
-			"--rpcmods", "system,author,chain,state",
+			"--rpc-host", HOSTNAME,
+			"--rpc-port", rpcPort,
+			"--rpc-mods", "system,author,chain,state",
 			"--roles", "1", // no key provided, non-authority node
 			"--rpc",
 		)
@@ -96,9 +96,9 @@ func RunGossamer(t *testing.T, idx int, basePath string) (*Node, error) {
 		cmd = exec.Command(gossamerCMD, "--port", strconv.Itoa(basePort+idx),
 			"--key", key,
 			"--basepath", basePath+strconv.Itoa(idx),
-			"--rpchost", HOSTNAME,
-			"--rpcport", rpcPort,
-			"--rpcmods", "system,author,chain,state",
+			"--rpc-host", HOSTNAME,
+			"--rpc-port", rpcPort,
+			"--rpc-mods", "system,author,chain,state",
 			"--roles", "4", // authority node
 			"--rpc",
 		)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

The following related changes were made in smaller pull requests:

- [x] rename node flag and directory #889
- [x] rename datadir to basepath #890
- [x] rename verbosity to log #891

The following changes still need to be completed:

- [ ] add required flags from the list below
- [ ] ensure all flags are properly formatted (add `-` where needed)
- [ ] ensure issues are opened for any placeholder flags added

## Required Flags

for [polkadot-deployer](https://github.com/w3f/polkadot-charts/blob/master/charts/polkadot/templates/statefulset.yaml#L86-L126)...

- [x] `--log` - ok
- [x] `--chain` - ok
- [x] `--name` - ok
- [x] `--base-path` - ok
- [ ] `-d` - ? - short for base-path
- [ ] `-l` - ? - short for log
- [x] `--unsafe-rpc-external` - not yet implement but added
- [x] `--unsafe-ws-external` - not yet implement but added
- [x] `--rpc-methods` - not yet implement but added
- [x] `--rpc-external` - not yet implement but added
- [x] `--ws-external` - not yet implement but added
- [x] `--rpc-cors` - not yet implement but added
- [x] `--port` - ok
- [ ] `--node-key` - ?
- [ ] `--validator` - ?
- [ ] `--in-peers` - ?
- [ ] `--telemetry-url` - ?
- [ ] `--prometheus-external` - ?
- [x] `--bootnodes` - ok

for [polkadot-validotor](https://github.com/w3f/polkadot-secure-validator/blob/master/ansible/roles/polkadot-validator/templates/polkadot.service.j2)...

- [x] `--log` - ok
- [x] `--chain` - ok
- [x] `--name` - ok
- [x] `--base-path` - ok
- [ ] `-d` - ? - short for base-path
- [ ] `-l` - ? - short for log
- [ ] `--listen-addr` - ?
- [ ] `--reserved-only` - ?
- [x] `--rpc-methods` - not yet implement but added
- [ ] `--reserved-nodes`
- [ ] `--telemetry-url` - ?
- [ ] `--no-telemetry` - ?

for [polkadot-public](https://github.com/w3f/polkadot-secure-validator/blob/master/ansible/roles/polkadot-public/templates/polkadot.service.j2)...

- [x] `--log` - ok
- [x] `--chain` - ok
- [x] `--name` - ok
- [x] `--base-path` - ok
- [ ] `-d` - ? - short for base-path
- [ ] `-l` - ? - short for log
- [ ] `--sentry` - ?
- [ ] `--telemetry-url` - ?
- [ ] `--no-telemetry` - ?

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [ ] I have provided as much information as possible and necessary
- [ ] I have reviewed my own pull request before requesting a review
- [ ] I have linked any relevant issues in my pull request comments
- [ ] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #772
