### PR TITLE
cmd/gossamer, dot: add --ws, --wsport flags; add tests

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -294,7 +294,6 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 	// check --rpcport flag and update node configuration
 	if port := ctx.GlobalUint(RPCPortFlag.Name); port != 0 {
 		cfg.Port = uint32(port)
-		cfg.WSPort = uint32(port) + 1000
 	}
 
 	// check --rpchost flag and update node configuration
@@ -305,6 +304,16 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 	// check --rpcmods flag and update node configuration
 	if modules := ctx.GlobalString(RPCModulesFlag.Name); modules != "" {
 		cfg.Modules = strings.Split(ctx.GlobalString(RPCModulesFlag.Name), ",")
+	}
+
+	if wsport := ctx.GlobalUint(WSPortFlag.Name); wsport != 0 {
+		cfg.WSPort = uint32(wsport)
+	}
+
+	if wsenabled := ctx.GlobalBool(WSEnabledFlag.Name); wsenabled {
+		cfg.WSEnabled = true
+	} else {
+		cfg.WSEnabled = false
 	}
 
 	// format rpc modules
@@ -318,6 +327,8 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 		"port", cfg.Port,
 		"host", cfg.Host,
 		"modules", cfg.Modules,
+		"ws", cfg.WSEnabled,
+		"wsport", cfg.WSPort,
 	)
 }
 

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -468,7 +468,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --wsport",
 			[]string{"config", "wsport"},
-			[]interface{}{testCfgFile.Name(), "7070"}, // rpc must be enabled
+			[]interface{}{testCfgFile.Name(), "7070"}, 
 			dot.RPCConfig{
 				Enabled:   testCfg.RPC.Enabled,
 				Port:      testCfg.RPC.Port,
@@ -481,7 +481,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --ws",
 			[]string{"config", "ws"},
-			[]interface{}{testCfgFile.Name(), false}, // rpc must be enabled
+			[]interface{}{testCfgFile.Name(), false},
 			dot.RPCConfig{
 				Enabled:   testCfg.RPC.Enabled,
 				Port:      testCfg.RPC.Port,
@@ -494,7 +494,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --ws",
 			[]string{"config", "ws"},
-			[]interface{}{testCfgFile.Name(), true}, // rpc must be enabled
+			[]interface{}{testCfgFile.Name(), true},
 			dot.RPCConfig{
 				Enabled:   testCfg.RPC.Enabled,
 				Port:      testCfg.RPC.Port,

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -468,7 +468,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --wsport",
 			[]string{"config", "wsport"},
-			[]interface{}{testCfgFile.Name(), "7070"}, 
+			[]interface{}{testCfgFile.Name(), "7070"},
 			dot.RPCConfig{
 				Enabled:   testCfg.RPC.Enabled,
 				Port:      testCfg.RPC.Port,

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -450,7 +450,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				Port:    5678,
 				Host:    testCfg.RPC.Host,
 				Modules: testCfg.RPC.Modules,
-				WSPort:  6678,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		{
@@ -463,6 +463,45 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				Host:    testCfg.RPC.Host,
 				Modules: []string{"mod1", "mod2"},
 				WSPort:  testCfg.RPC.WSPort,
+			},
+		},
+		{
+			"Test gossamer --wsport",
+			[]string{"config", "wsport"},
+			[]interface{}{testCfgFile.Name(), "7070"}, // rpc must be enabled
+			dot.RPCConfig{
+				Enabled:   testCfg.RPC.Enabled,
+				Port:      testCfg.RPC.Port,
+				Host:      testCfg.RPC.Host,
+				Modules:   testCfg.RPC.Modules,
+				WSPort:    7070,
+				WSEnabled: false,
+			},
+		},
+		{
+			"Test gossamer --ws",
+			[]string{"config", "ws"},
+			[]interface{}{testCfgFile.Name(), false}, // rpc must be enabled
+			dot.RPCConfig{
+				Enabled:   testCfg.RPC.Enabled,
+				Port:      testCfg.RPC.Port,
+				Host:      testCfg.RPC.Host,
+				Modules:   testCfg.RPC.Modules,
+				WSPort:    testCfg.RPC.WSPort,
+				WSEnabled: false,
+			},
+		},
+		{
+			"Test gossamer --ws",
+			[]string{"config", "ws"},
+			[]interface{}{testCfgFile.Name(), true}, // rpc must be enabled
+			dot.RPCConfig{
+				Enabled:   testCfg.RPC.Enabled,
+				Port:      testCfg.RPC.Port,
+				Host:      testCfg.RPC.Host,
+				Modules:   testCfg.RPC.Modules,
+				WSPort:    testCfg.RPC.WSPort,
+				WSEnabled: true,
 			},
 		},
 	}

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -135,6 +135,14 @@ var (
 		Name:  "rpcmods",
 		Usage: "API modules to enable via HTTP-RPC, comma separated list",
 	}
+	WSPortFlag = cli.IntFlag{
+		Name:  "wsport",
+		Usage: "Websockets server listening port",
+	}
+	WSEnabledFlag = cli.BoolFlag{
+		Name:  "ws",
+		Usage: "Enable the websockets server",
+	}
 )
 
 // Account management flags
@@ -206,6 +214,8 @@ var (
 		RPCHostFlag,
 		RPCPortFlag,
 		RPCModulesFlag,
+		WSEnabledFlag,
+		WSPortFlag,
 	}
 )
 

--- a/dot/config.go
+++ b/dot/config.go
@@ -76,11 +76,12 @@ type CoreConfig struct {
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars
 type RPCConfig struct {
-	Enabled bool     `toml:"enabled"`
-	Port    uint32   `toml:"port"`
-	Host    string   `toml:"host"`
-	Modules []string `toml:"modules"`
-	WSPort  uint32   `toml:"ws-port"`
+	Enabled   bool     `toml:"enabled"`
+	Port      uint32   `toml:"port"`
+	Host      string   `toml:"host"`
+	Modules   []string `toml:"modules"`
+	WSPort    uint32   `toml:"ws-port"`
+	WSEnabled bool     `toml:"ws-enabled"`
 }
 
 // String will return the json representation for a Config

--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -150,7 +150,7 @@ func (h *HTTPServer) Start() error {
 
 // Stop stops the server
 func (h *HTTPServer) Stop() error {
-	if !h.serverConfig.WSEnabled {
+	if h.serverConfig.WSEnabled {
 		close(h.serverConfig.BlockAddedReceiverDone) // notify sender we're done receiving so it can close
 	}
 	return nil

--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -46,6 +46,7 @@ type HTTPServerConfig struct {
 	RPCAPI                 modules.RPCAPI
 	Host                   string
 	RPCPort                uint32
+	WSEnabled              bool
 	WSPort                 uint32
 	Modules                []string
 	WSSubscriptions        map[uint32]*WebSocketSubscription
@@ -122,6 +123,10 @@ func (h *HTTPServer) Start() error {
 		}
 	}()
 
+	if !h.serverConfig.WSEnabled {
+		return nil
+	}
+
 	log.Info("[rpc] Starting WebSocket Server...", "host", h.serverConfig.Host, "port", h.serverConfig.WSPort)
 	ws := mux.NewRouter()
 	ws.Handle("/", h)
@@ -145,6 +150,8 @@ func (h *HTTPServer) Start() error {
 
 // Stop stops the server
 func (h *HTTPServer) Stop() error {
-	close(h.serverConfig.BlockAddedReceiverDone) // notify sender we're done receiving so it can close
+	if !h.serverConfig.WSEnabled {
+		close(h.serverConfig.BlockAddedReceiverDone) // notify sender we're done receiving so it can close
+	}
 	return nil
 }

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -26,14 +26,14 @@ var testCalls = []struct {
 func TestNewWebSocketServer(t *testing.T) {
 	coreAPI := core.NewTestService(t, nil)
 	cfg := &HTTPServerConfig{
-		Modules: []string{"system", "chain"},
-		RPCPort: 8545,
-		WSPort:  8546,
+		Modules:   []string{"system", "chain"},
+		RPCPort:   8545,
+		WSPort:    8546,
 		WSEnabled: true,
-		RPCAPI:  NewService(),
-		CoreAPI: coreAPI,
+		RPCAPI:    NewService(),
+		CoreAPI:   coreAPI,
 	}
-	
+
 	s := NewHTTPServer(cfg)
 	err := s.Start()
 	require.Nil(t, err)

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -29,9 +29,11 @@ func TestNewWebSocketServer(t *testing.T) {
 		Modules: []string{"system", "chain"},
 		RPCPort: 8545,
 		WSPort:  8546,
+		WSEnabled: true,
 		RPCAPI:  NewService(),
 		CoreAPI: coreAPI,
 	}
+	
 	s := NewHTTPServer(cfg)
 	err := s.Start()
 	require.Nil(t, err)

--- a/dot/services.go
+++ b/dot/services.go
@@ -164,6 +164,7 @@ func createRPCService(cfg *Config, stateSrvc *state.Service, coreSrvc *core.Serv
 		RPCAPI:              rpcService,
 		Host:                cfg.RPC.Host,
 		RPCPort:             cfg.RPC.Port,
+		WSEnabled:           cfg.RPC.WSEnabled,
 		WSPort:              cfg.RPC.WSPort,
 		Modules:             cfg.RPC.Modules,
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `--wsport` flag for specifying websockets port
- add `--ws flag` for enabling/disabling ws, ws is now off by default, can be turned on with `--ws`. let me know what you guys think, if you prefer to keep it on by default as long as `--rpc` is provided

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
./bin/gossamer --key alice --rpc --ws
./bin/gossamer --key alice --rpc --wsport=7777 --ws
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #850 
