### PR TITLE
lib/keystore: add Ed25519Keyring; rename existing to Sr25519Keyring

### DIFF
--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -298,7 +298,7 @@ func TestInitNode_LoadBalances(t *testing.T) {
 		t.Fatal("core service is nil")
 	}
 
-	kr, _ := keystore.NewKeyring()
+	kr, _ := keystore.NewSr25519Keyring()
 	alice := kr.Alice.Public().Encode()
 	ab := [32]byte{}
 	copy(ab[:], alice)

--- a/dot/types/babe_test.go
+++ b/dot/types/babe_test.go
@@ -22,7 +22,7 @@ func TestAuthorityDataRaw(t *testing.T) {
 }
 
 func TestAuthorityData(t *testing.T) {
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestAuthorityData(t *testing.T) {
 }
 
 func TestAuthorityData_ToRaw(t *testing.T) {
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -51,9 +51,6 @@ type PrivateKey ed25519.PrivateKey
 // PublicKey is the ed25519 Public Key
 type PublicKey ed25519.PublicKey
 
-// PublicKeyBytes is an encoded ed25519 public key
-type PublicKeyBytes [32]byte
-
 // NewKeypair returns an Ed25519 keypair given a ed25519 private key
 func NewKeypair(priv ed25519.PrivateKey) *Keypair {
 	pubkey := PublicKey(priv.Public().(ed25519.PublicKey))
@@ -222,11 +219,4 @@ func (k *PublicKey) Hex() string {
 	enc := k.Encode()
 	h := hex.EncodeToString(enc)
 	return "0x" + h
-}
-
-// AsBytes returns the public key as PublicKeyBytes
-func (k *PublicKey) AsBytes() PublicKeyBytes {
-	b := [PublicKeyLength]byte{}
-	copy(b[:], k.Encode())
-	return b
 }

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -51,6 +51,9 @@ type PrivateKey ed25519.PrivateKey
 // PublicKey is the ed25519 Public Key
 type PublicKey ed25519.PublicKey
 
+// PublicKeyBytes is an encoded ed25519 public key
+type PublicKeyBytes [32]byte
+
 // NewKeypair returns an Ed25519 keypair given a ed25519 private key
 func NewKeypair(priv ed25519.PrivateKey) *Keypair {
 	pubkey := PublicKey(priv.Public().(ed25519.PublicKey))
@@ -80,6 +83,16 @@ func NewKeypairFromSeed(seed []byte) (*Keypair, error) {
 	}
 	edpriv := ed25519.NewKeyFromSeed(seed)
 	return NewKeypair(edpriv), nil
+}
+
+// NewKeypairFromPrivateKeyString returns a Keypair given a 0x prefixed private key string
+func NewKeypairFromPrivateKeyString(in string) (*Keypair, error) {
+	privBytes, err := common.HexToBytes(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewKeypairFromSeed(privBytes)
 }
 
 // GenerateKeypair returns a new ed25519 keypair
@@ -209,4 +222,11 @@ func (k *PublicKey) Hex() string {
 	enc := k.Encode()
 	h := hex.EncodeToString(enc)
 	return "0x" + h
+}
+
+// AsBytes returns the public key as PublicKeyBytes
+func (k *PublicKey) AsBytes() PublicKeyBytes {
+	b := [PublicKeyLength]byte{}
+	copy(b[:], k.Encode())
+	return b
 }

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -126,7 +126,7 @@ func LoadKeystore(key string) (*Keystore, error) {
 
 	if key != "" {
 
-		kr, err := NewKeyring()
+		kr, err := NewSr25519Keyring()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create keyring")
 		}

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -128,7 +128,7 @@ func LoadKeystore(key string) (*Keystore, error) {
 
 		kr, err := NewSr25519Keyring()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create keyring")
+			return nil, fmt.Errorf("failed to create keyring: %s", err)
 		}
 
 		switch strings.ToLower(key) {
@@ -148,6 +148,8 @@ func LoadKeystore(key string) (*Keystore, error) {
 			ks.Insert(kr.George)
 		case "heather":
 			ks.Insert(kr.Heather)
+		case "ian":
+			ks.Insert(kr.Ian)
 		default:
 			return nil, fmt.Errorf("invalid test key provided")
 		}

--- a/lib/keystore/keyring.go
+++ b/lib/keystore/keyring.go
@@ -32,6 +32,7 @@ var privateKeys = []string{
 	"0xacb6c03db1f04d23da738ff16d69153c3104e8e2d8a3572a894ee1df3b06520c",
 	"0x85e1562da2878744a30d62b5a44e694a3ad587ccde20b5f8c5796cf90f5df309",
 	"0x1655133c8a0339b2456ea1ee7f2adca6015b5c56109b854ccf88ca4150d8bd0f",
+	"0x2a8ec704e37867efd9f7d1f33560f208b1544527611fe2cc3014d17eb649ca0b",
 }
 
 // Sr25519Keyring represents a test keyring
@@ -44,6 +45,7 @@ type Sr25519Keyring struct {
 	Fred    *sr25519.Keypair
 	George  *sr25519.Keypair
 	Heather *sr25519.Keypair
+	Ian     *sr25519.Keypair
 }
 
 // NewSr25519Keyring returns an initialized sr25519 Keyring
@@ -74,6 +76,7 @@ type Ed25519Keyring struct {
 	Fred    *ed25519.Keypair
 	George  *ed25519.Keypair
 	Heather *ed25519.Keypair
+	Ian     *sr25519.Keypair
 
 	Keys []*ed25519.Keypair
 }

--- a/lib/keystore/keyring.go
+++ b/lib/keystore/keyring.go
@@ -76,7 +76,7 @@ type Ed25519Keyring struct {
 	Fred    *ed25519.Keypair
 	George  *ed25519.Keypair
 	Heather *ed25519.Keypair
-	Ian     *sr25519.Keypair
+	Ian     *ed25519.Keypair
 
 	Keys []*ed25519.Keypair
 }

--- a/lib/keystore/keyring.go
+++ b/lib/keystore/keyring.go
@@ -19,6 +19,7 @@ package keystore
 import (
 	"reflect"
 
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 )
 
@@ -33,8 +34,8 @@ var privateKeys = []string{
 	"0x1655133c8a0339b2456ea1ee7f2adca6015b5c56109b854ccf88ca4150d8bd0f",
 }
 
-// Keyring represents a test keyring
-type Keyring struct {
+// Sr25519Keyring represents a test keyring
+type Sr25519Keyring struct {
 	Alice   *sr25519.Keypair
 	Bob     *sr25519.Keypair
 	Charlie *sr25519.Keypair
@@ -45,9 +46,9 @@ type Keyring struct {
 	Heather *sr25519.Keypair
 }
 
-// NewKeyring returns an initialized Keyring
-func NewKeyring() (*Keyring, error) {
-	kr := new(Keyring)
+// NewSr25519Keyring returns an initialized sr25519 Keyring
+func NewSr25519Keyring() (*Sr25519Keyring, error) {
+	kr := new(Sr25519Keyring)
 
 	v := reflect.ValueOf(kr).Elem()
 
@@ -58,6 +59,41 @@ func NewKeyring() (*Keyring, error) {
 			return nil, err
 		}
 		who.Set(reflect.ValueOf(kp))
+	}
+
+	return kr, nil
+}
+
+// Ed25519Keyring represents a test ed25519 keyring
+type Ed25519Keyring struct {
+	Alice   *ed25519.Keypair
+	Bob     *ed25519.Keypair
+	Charlie *ed25519.Keypair
+	Dave    *ed25519.Keypair
+	Eve     *ed25519.Keypair
+	Fred    *ed25519.Keypair
+	George  *ed25519.Keypair
+	Heather *ed25519.Keypair
+
+	Keys []*ed25519.Keypair
+}
+
+// NewEd25519Keyring returns an initialized ed25519 Keyring
+func NewEd25519Keyring() (*Ed25519Keyring, error) {
+	kr := new(Ed25519Keyring)
+	kr.Keys = []*ed25519.Keypair{}
+
+	v := reflect.ValueOf(kr).Elem()
+
+	for i := 0; i < v.NumField()-1; i++ {
+		who := v.Field(i)
+		kp, err := ed25519.NewKeypairFromPrivateKeyString(privateKeys[i])
+		if err != nil {
+			return nil, err
+		}
+		who.Set(reflect.ValueOf(kp))
+
+		kr.Keys = append(kr.Keys, kp)
 	}
 
 	return kr, nil

--- a/lib/keystore/keyring_test.go
+++ b/lib/keystore/keyring_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestNewKeyring(t *testing.T) {
-	kr, err := NewKeyring()
+	kr, err := NewSr25519Keyring()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/keystore/keyring_test.go
+++ b/lib/keystore/keyring_test.go
@@ -20,10 +20,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 )
 
-func TestNewKeyring(t *testing.T) {
+func TestNewSr25519Keyring(t *testing.T) {
 	kr, err := NewSr25519Keyring()
 	if err != nil {
 		t.Fatal(err)
@@ -34,6 +35,22 @@ func TestNewKeyring(t *testing.T) {
 		key := v.Field(i).Interface().(*sr25519.Keypair).Private().Hex()
 		if key != privateKeys[i] {
 			t.Fatalf("Fail: got %s expected %s", key, privateKeys[i])
+		}
+	}
+}
+
+func TestNewEd25519Keyring(t *testing.T) {
+	kr, err := NewEd25519Keyring()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v := reflect.ValueOf(kr).Elem()
+	for i := 0; i < v.NumField()-1; i++ {
+		key := v.Field(i).Interface().(*ed25519.Keypair).Private().Hex()
+		// ed25519 private keys are stored in uncompressed format
+		if key[:66] != privateKeys[i] {
+			t.Fatalf("Fail: got %s expected %s", key[:66], privateKeys[i])
 		}
 	}
 }

--- a/lib/runtime/extrinsic/extrinsic_test.go
+++ b/lib/runtime/extrinsic/extrinsic_test.go
@@ -43,7 +43,7 @@ var alice, _ = common.HexToHash("0xd43593c715fdd31c61141abd04a99fd6822c8558854cc
 var bob, _ = common.HexToHash("0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22")
 
 func TestTransfer_AsSignedExtrinsic(t *testing.T) {
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 
 	transfer := NewTransfer(alice, bob, 1000, 1)

--- a/lib/runtime/helpers_test.go
+++ b/lib/runtime/helpers_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var kr, _ = keystore.NewKeyring()
+var kr, _ = keystore.NewSr25519Keyring()
 
 func TestExportRuntime(t *testing.T) {
 	fp := "runtime.out"


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add Ed25519Keyring since GRANDPA uses ed25519 keys
- rename existing keyring to Sr25519Keyring
- add 9th key to keyring

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #873 