### PR TITLE
dot/rpc: Implement RPC method author_hasKey

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -17,7 +17,6 @@ package core
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"sync"
 
@@ -502,26 +501,7 @@ func (s *Service) InsertKey(kp crypto.Keypair) {
 // HasKey returns true if given hex encoded public key string is found in keystore, false otherwise, error if there
 //  are issues decoding string
 func (s *Service) HasKey(pubKeyStr string, keyType string) (bool, error) {
-	keyBytes, err := common.HexToBytes(pubKeyStr)
-	if err != nil {
-		return false, err
-	}
-	cKeyType := keystore.DetermineKeyType(keyType)
-	var err2 error
-	var pubKey crypto.PublicKey
-	// TODO: consider handling for different key types, see issue #768
-	switch cKeyType {
-	case crypto.Sr25519Type:
-		pubKey, err2 = sr25519.NewPublicKey(keyBytes)
-	default:
-		err2 = fmt.Errorf("unknown key type: %s", keyType)
-	}
-
-	if err2 != nil {
-		return false, err2
-	}
-	key := s.keys.Get(pubKey.Address())
-	return key != nil, nil
+	return keystore.HasKey(pubKeyStr, keyType, s.keys)
 }
 
 // GetRuntimeVersion gets the current RuntimeVersion

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -496,6 +496,21 @@ func (s *Service) InsertKey(kp crypto.Keypair) {
 	s.keys.Insert(kp)
 }
 
+// HasKey returns true if given hex encoded public key string is found in keystore, false otherwise, error if there
+//  are issues decoding string
+func (s *Service) HasKey(pubKeyStr string) (bool, error) {
+	keyBytes, err := common.HexToBytes(pubKeyStr)
+	if err != nil {
+		return false, err
+	}
+	pubKey, err := sr25519.NewPublicKey(keyBytes)
+	if err != nil {
+		return false, err
+	}
+	key := s.keys.Get(pubKey.Address())
+	return key != nil, nil
+}
+
 // GetRuntimeVersion gets the current RuntimeVersion
 func (s *Service) GetRuntimeVersion() (*runtime.VersionAPI, error) {
 	//TODO ed, change this so that it can lookup runtime by block hash

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -122,7 +122,8 @@ func TestStartService(t *testing.T) {
 	err := s.Start()
 	require.Nil(t, err)
 
-	s.Stop()
+	err = s.Stop()
+	require.NoError(t, err)
 }
 
 func TestNotAuthority(t *testing.T) {
@@ -212,7 +213,7 @@ func TestCheckForRuntimeChanges(t *testing.T) {
 
 func TestService_HasKey(t *testing.T) {
 	ks := keystore.NewKeystore()
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 	ks.Insert(kr.Alice)
 
@@ -228,7 +229,7 @@ func TestService_HasKey(t *testing.T) {
 
 func TestService_HasKey_UnknownType(t *testing.T) {
 	ks := keystore.NewKeystore()
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 	ks.Insert(kr.Alice)
 

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -209,3 +209,35 @@ func TestCheckForRuntimeChanges(t *testing.T) {
 	err = s.checkForRuntimeChanges()
 	require.Nil(t, err)
 }
+
+func TestService_HasKey(t *testing.T) {
+	ks := keystore.NewKeystore()
+	kr, err := keystore.NewKeyring()
+	require.NoError(t, err)
+	ks.Insert(kr.Alice)
+
+	cfg := &Config{
+		Keystore: ks,
+	}
+	svc := NewTestService(t, cfg)
+
+	res, err := svc.HasKey(kr.Alice.Public().Hex(), "babe")
+	require.NoError(t, err)
+	require.True(t, res)
+}
+
+func TestService_HasKey_UnknownType(t *testing.T) {
+	ks := keystore.NewKeystore()
+	kr, err := keystore.NewKeyring()
+	require.NoError(t, err)
+	ks.Insert(kr.Alice)
+
+	cfg := &Config{
+		Keystore: ks,
+	}
+	svc := NewTestService(t, cfg)
+
+	res, err := svc.HasKey(kr.Alice.Public().Hex(), "xxxx")
+	require.EqualError(t, err, "unknown key type: xxxx")
+	require.False(t, res)
+}

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -43,7 +43,7 @@ type TransactionQueueAPI interface {
 // CoreAPI is the interface for the core methods
 type CoreAPI interface {
 	InsertKey(kp crypto.Keypair)
-	HasKey(pubKeyStr string) (bool, error)
+	HasKey(pubKeyStr string, keyType string) (bool, error)
 	GetRuntimeVersion() (*runtime.VersionAPI, error)
 	IsBabeAuthority() bool
 	HandleSubmittedExtrinsic(types.Extrinsic) error

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -43,6 +43,7 @@ type TransactionQueueAPI interface {
 // CoreAPI is the interface for the core methods
 type CoreAPI interface {
 	InsertKey(kp crypto.Keypair)
+	HasKey(pubKeyStr string) (bool, error)
 	GetRuntimeVersion() (*runtime.VersionAPI, error)
 	IsBabeAuthority() bool
 	HandleSubmittedExtrinsic(types.Extrinsic) error

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -92,12 +92,12 @@ func NewAuthorModule(coreAPI CoreAPI, runtimeAPI RuntimeAPI, txQueueAPI Transact
 func (cm *AuthorModule) InsertKey(r *http.Request, req *KeyInsertRequest, res *KeyInsertResponse) error {
 	keyReq := *req
 
-	pkDec, err := common.HexToHash(keyReq[1])
+	pkDec, err := common.HexToBytes(keyReq[1])
 	if err != nil {
 		return err
 	}
 
-	privateKey, err := keystore.DecodePrivateKey(pkDec.ToBytes(), keystore.DetermineKeyType(keyReq[0]))
+	privateKey, err := keystore.DecodePrivateKey(pkDec, keystore.DetermineKeyType(keyReq[0]))
 	if err != nil {
 		return err
 	}

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -119,6 +119,13 @@ func (cm *AuthorModule) InsertKey(r *http.Request, req *KeyInsertRequest, res *K
 	return nil
 }
 
+// HasKey Checks if the keystore has private keys for the given public key and key type.
+func (cm *AuthorModule) HasKey(r *http.Request, req *[]string, res *bool) error {
+	fmt.Printf("REq %v\n", req)
+	*res = false
+	return nil
+}
+
 // PendingExtrinsics Returns all pending extrinsics
 func (cm *AuthorModule) PendingExtrinsics(r *http.Request, req *EmptyRequest, res *PendingExtrinsicsResponse) error {
 	pending := cm.txQueueAPI.Pending()

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -121,9 +121,11 @@ func (cm *AuthorModule) InsertKey(r *http.Request, req *KeyInsertRequest, res *K
 
 // HasKey Checks if the keystore has private keys for the given public key and key type.
 func (cm *AuthorModule) HasKey(r *http.Request, req *[]string, res *bool) error {
-	fmt.Printf("REq %v\n", req)
-	*res = false
-	return nil
+	// TODO: create separate keystores for different key types, issue #768
+	reqKey := *req
+	var err error
+	*res, err = cm.coreAPI.HasKey(reqKey[0])
+	return err
 }
 
 // PendingExtrinsics Returns all pending extrinsics

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -21,13 +21,10 @@ import (
 	"net/http"
 	"reflect"
 
-	"github.com/ChainSafe/gossamer/lib/crypto"
-	"github.com/ChainSafe/gossamer/lib/keystore"
-
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/transaction"
-
 	log "github.com/ChainSafe/log15"
 )
 
@@ -100,7 +97,7 @@ func (cm *AuthorModule) InsertKey(r *http.Request, req *KeyInsertRequest, res *K
 		return err
 	}
 
-	privateKey, err := keystore.DecodePrivateKey(pkDec.ToBytes(), determineKeyType(keyReq[0]))
+	privateKey, err := keystore.DecodePrivateKey(pkDec.ToBytes(), keystore.DetermineKeyType(keyReq[0]))
 	if err != nil {
 		return err
 	}
@@ -121,10 +118,9 @@ func (cm *AuthorModule) InsertKey(r *http.Request, req *KeyInsertRequest, res *K
 
 // HasKey Checks if the keystore has private keys for the given public key and key type.
 func (cm *AuthorModule) HasKey(r *http.Request, req *[]string, res *bool) error {
-	// TODO: create separate keystores for different key types, issue #768
 	reqKey := *req
 	var err error
-	*res, err = cm.coreAPI.HasKey(reqKey[0])
+	*res, err = cm.coreAPI.HasKey(reqKey[0], reqKey[1])
 	return err
 }
 
@@ -196,27 +192,4 @@ func (cm *AuthorModule) SubmitExtrinsic(r *http.Request, req *Extrinsic, res *Ex
 	}
 
 	return err
-}
-
-// determineKeyType takes string as defined in https://github.com/w3f/PSPs/blob/psp-rpc-api/psp-002.md#Key-types
-//  and returns the crypto.KeyType
-func determineKeyType(t string) crypto.KeyType {
-	// TODO: create separate keystores for different key types, issue #768
-	switch t {
-	case "babe":
-		return crypto.Sr25519Type
-	case "gran":
-		return crypto.Sr25519Type
-	case "acco":
-		return crypto.Sr25519Type
-	case "aura":
-		return crypto.Sr25519Type
-	case "imon":
-		return crypto.Sr25519Type
-	case "audi":
-		return crypto.Sr25519Type
-	case "dumy":
-		return crypto.Sr25519Type
-	}
-	return "unknown keytype"
 }

--- a/dot/rpc/modules/author_test.go
+++ b/dot/rpc/modules/author_test.go
@@ -43,7 +43,8 @@ func TestAuthorModule_Pending(t *testing.T) {
 		Validity:  new(transaction.Validity),
 	}
 
-	txQueue.Push(vtx)
+	_, err = txQueue.Push(vtx)
+	require.NoError(t, err)
 
 	err = auth.PendingExtrinsics(nil, nil, res)
 	if err != nil {
@@ -174,7 +175,7 @@ func TestAuthorModule_InsertKey_Valid_gran_keytype(t *testing.T) {
 	cs := core.NewTestService(t, nil)
 
 	auth := NewAuthorModule(cs, nil, nil)
-	req := &KeyInsertRequest{"gran", "0xb7e9185065667390d2ad952a5324e8c365c9bf503dcf97c67a5ce861afe97309", "0x6246ddf254e0b4b4e7dffefc8adf69d212b98ac2b579c362b473fec8c40b4c0a"}
+	req := &KeyInsertRequest{"gran", "0xb7e9185065667390d2ad952a5324e8c365c9bf503dcf97c67a5ce861afe97309b7e9185065667390d2ad952a5324e8c365c9bf503dcf97c67a5ce861afe97309", "0xb7e9185065667390d2ad952a5324e8c365c9bf503dcf97c67a5ce861afe97309"}
 	res := &KeyInsertResponse{}
 	err := auth.InsertKey(nil, req, res)
 	require.Nil(t, err)
@@ -205,7 +206,7 @@ func TestAuthorModule_InsertKey_UnknownKeyType(t *testing.T) {
 
 func TestAuthorModule_HasKey(t *testing.T) {
 	auth := setupAuthModule(t, nil)
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.Nil(t, err)
 
 	var res bool
@@ -217,7 +218,7 @@ func TestAuthorModule_HasKey(t *testing.T) {
 
 func TestAuthorModule_HasKey_NotFound(t *testing.T) {
 	auth := setupAuthModule(t, nil)
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.Nil(t, err)
 
 	var res bool
@@ -239,7 +240,7 @@ func TestAuthorModule_HasKey_InvalidKey(t *testing.T) {
 
 func TestAuthorModule_HasKey_InvalidKeyType(t *testing.T) {
 	auth := setupAuthModule(t, nil)
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.Nil(t, err)
 
 	var res bool
@@ -267,7 +268,7 @@ func newCoreService(t *testing.T) *core.Service {
 	ks.Insert(kp)
 
 	// insert alice key for testing
-	kr, err := keystore.NewKeyring()
+	kr, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 	ks.Insert(kr.Alice)
 

--- a/dot/rpc/service_test.go
+++ b/dot/rpc/service_test.go
@@ -29,7 +29,7 @@ func TestNewService(t *testing.T) {
 func TestService_Methods(t *testing.T) {
 	qtySystemMethods := 7
 	qtyRPCMethods := 1
-	qtyAuthorMethods := 6
+	qtyAuthorMethods := 7
 
 	rpcService := NewService()
 	sysMod := modules.NewSystemModule(nil, nil)

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -250,3 +250,26 @@ func UnlockKeys(ks *Keystore, dir string, unlock string, password string) error 
 
 	return nil
 }
+
+// DetermineKeyType takes string as defined in https://github.com/w3f/PSPs/blob/psp-rpc-api/psp-002.md#Key-types
+//  and returns the crypto.KeyType
+func DetermineKeyType(t string) crypto.KeyType {
+	// TODO: create separate keystores for different key types, issue #768
+	switch t {
+	case "babe":
+		return crypto.Sr25519Type
+	case "gran":
+		return crypto.Sr25519Type
+	case "acco":
+		return crypto.Sr25519Type
+	case "aura":
+		return crypto.Sr25519Type
+	case "imon":
+		return crypto.Sr25519Type
+	case "audi":
+		return crypto.Sr25519Type
+	case "dumy":
+		return crypto.Sr25519Type
+	}
+	return "unknown keytype"
+}

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -19,6 +19,7 @@ package keystore
 import (
 	"testing"
 
+	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,4 +28,25 @@ func TestLoadKeystore(t *testing.T) {
 	require.Nil(t, err)
 
 	require.Equal(t, 1, ks.NumSr25519Keys())
+}
+
+var testKeyTypes = []struct {
+	testType     string
+	expectedType string
+}{
+	{testType: "babe", expectedType: crypto.Sr25519Type},
+	{testType: "gran", expectedType: crypto.Sr25519Type},
+	{testType: "acco", expectedType: crypto.Sr25519Type},
+	{testType: "aura", expectedType: crypto.Sr25519Type},
+	{testType: "imon", expectedType: crypto.Sr25519Type},
+	{testType: "audi", expectedType: crypto.Sr25519Type},
+	{testType: "dumy", expectedType: crypto.Sr25519Type},
+	{testType: "xxxx", expectedType: "unknown keytype"},
+}
+
+func TestDetermineKeyType(t *testing.T) {
+	for _, test := range testKeyTypes {
+		output := DetermineKeyType(test.testType)
+		require.Equal(t, test.expectedType, output)
+	}
 }

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -35,7 +35,7 @@ var testKeyTypes = []struct {
 	expectedType string
 }{
 	{testType: "babe", expectedType: crypto.Sr25519Type},
-	{testType: "gran", expectedType: crypto.Sr25519Type},
+	{testType: "gran", expectedType: crypto.Ed25519Type},
 	{testType: "acco", expectedType: crypto.Sr25519Type},
 	{testType: "aura", expectedType: crypto.Sr25519Type},
 	{testType: "imon", expectedType: crypto.Sr25519Type},


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implement RPC method author_hasKey see: https://github.com/w3f/PSPs/blob/psp-rpc-api/psp-002.md#author_hasKey
-
-

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/rpc/... 
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #312 
