### PR TITLE
dot/rpc, dot/network: Implement RPC system_nodeRoles 

### DIFF
--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -410,3 +410,8 @@ func (s *Service) Peers() []common.PeerInfo {
 	}
 	return peers
 }
+
+// NodeRoles Returns the roles the node is running as.
+func (s *Service) NodeRoles() byte {
+	return s.cfg.Roles
+}

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"reflect"
 	"strings"
@@ -258,4 +259,16 @@ func TestHandleMessage_BlockResponse(t *testing.T) {
 	case <-time.After(TestMessageTimeout):
 		t.Error("timeout waiting for message")
 	}
+}
+
+func TestService_NodeRoles(t *testing.T) {
+	dataDir := utils.NewTestDataDir(t, "node")
+	cfg := &Config{
+		DataDir: dataDir,
+		Roles:   1,
+	}
+	svc := createTestService(t, cfg)
+
+	role := svc.NodeRoles()
+	require.Equal(t, cfg.Roles, role)
 }

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -17,7 +17,6 @@
 package network
 
 import (
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"reflect"
 	"strings"
@@ -29,6 +28,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common/variadic"
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
 )
 
 var TestProtocolID = "/gossamer/test/0"

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -30,6 +30,7 @@ type NetworkAPI interface {
 	Health() common.Health
 	NetworkState() common.NetworkState
 	Peers() []common.PeerInfo
+	NodeRoles() byte
 }
 
 // TransactionQueueAPI ...

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -101,3 +101,26 @@ func (sm *SystemModule) Peers(r *http.Request, req *EmptyRequest, res *SystemPee
 	res.Peers = peers
 	return nil
 }
+
+// NodeRoles Returns the roles the node is running as.
+func (sm *SystemModule) NodeRoles(r *http.Request, req *EmptyRequest, res *[]interface{}) error {
+	resultArray := []interface{}{}
+
+	role := sm.networkAPI.NodeRoles()
+	switch role {
+	case 1:
+		resultArray = append(resultArray, "Full")
+	case 2:
+		resultArray = append(resultArray, "LightClient")
+	case 4:
+		resultArray = append(resultArray, "Authority")
+	default:
+		resultArray = append(resultArray, "UnknownRole")
+		uknrole := []interface{}{}
+		uknrole = append(uknrole, role)
+		resultArray = append(resultArray, uknrole)
+	}
+
+	*res = resultArray
+	return nil
+}

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -17,6 +17,7 @@
 package modules
 
 import (
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"os"
 	"path"
@@ -95,4 +96,15 @@ func TestSystemModule_Peers(t *testing.T) {
 	if len(res.Peers) != len(testPeers) {
 		t.Errorf("System.Peers: expected: %+v got: %+v\n", testPeers, res.Peers)
 	}
+}
+
+func TestSystemModule_NodeRoles(t *testing.T) {
+	net := newNetworkService(t)
+	sys := NewSystemModule(net, nil)
+	expected := []interface{}{"Full"}
+
+	var res []interface{}
+	err := sys.NodeRoles(nil, nil, &res)
+	require.NoError(t, err)
+	require.Equal(t, expected, res)
 }

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -17,7 +17,6 @@
 package modules
 
 import (
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"os"
 	"path"
@@ -26,6 +25,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -63,7 +63,8 @@ func TestSystemModule_Health(t *testing.T) {
 	sys := NewSystemModule(net, nil)
 
 	res := &SystemHealthResponse{}
-	sys.Health(nil, nil, res)
+	err := sys.Health(nil, nil, res)
+	require.NoError(t, err)
 
 	if res.Health != testHealth {
 		t.Errorf("System.Health.: expected: %+v got: %+v\n", testHealth, res.Health)
@@ -76,7 +77,8 @@ func TestSystemModule_NetworkState(t *testing.T) {
 	sys := NewSystemModule(net, nil)
 
 	res := &SystemNetworkStateResponse{}
-	sys.NetworkState(nil, nil, res)
+	err := sys.NetworkState(nil, nil, res)
+	require.NoError(t, err)
 
 	testNetworkState := net.NetworkState()
 
@@ -91,7 +93,8 @@ func TestSystemModule_Peers(t *testing.T) {
 	sys := NewSystemModule(net, nil)
 
 	res := &SystemPeersResponse{}
-	sys.Peers(nil, nil, res)
+	err := sys.Peers(nil, nil, res)
+	require.NoError(t, err)
 
 	if len(res.Peers) != len(testPeers) {
 		t.Errorf("System.Peers: expected: %+v got: %+v\n", testPeers, res.Peers)

--- a/dot/rpc/service_test.go
+++ b/dot/rpc/service_test.go
@@ -27,7 +27,7 @@ func TestNewService(t *testing.T) {
 }
 
 func TestService_Methods(t *testing.T) {
-	qtySystemMethods := 7
+	qtySystemMethods := 8
 	qtyRPCMethods := 1
 	qtyAuthorMethods := 6
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implement RPC function for system_nodeRoles see: https://github.com/w3f/PSPs/blob/psp-rpc-api/psp-002.md#system_nodeRoles
- Added function NodeRoles to network service

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/rpc/...
go test ./dot/network/...
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [ ] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #731 
