### PR TITLE
lib/blocktree: implement HighestCommonAncestor

### DIFF
--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -205,3 +205,31 @@ func (bt *BlockTree) deepestLeaf() *node { //nolint
 func (bt *BlockTree) DeepestBlockHash() Hash {
 	return bt.leaves.deepestLeaf().hash
 }
+
+// Leaves returns the leaves of the blocktree as an array
+func (bt *BlockTree) Leaves() []common.Hash {
+	lm := bt.leaves.toMap()
+	la := make([]common.Hash, len(lm))
+	i := 0
+
+	for k := range lm {
+		la[i] = k
+		i++
+	}
+
+	return la
+}
+
+// HighestCommonPredecessor returns the highest block that is a predecessor to both a and b
+func (bt *BlockTree) HighestCommonPredecessor(a, b common.Hash) (Hash, error) {
+	an := bt.getNode(a)
+	if an == nil {
+		return common.Hash{}, ErrNodeNotFound
+	}
+	bn := bt.getNode(b)
+	if bn == nil {
+		return common.Hash{}, ErrNodeNotFound
+	}
+
+	return an.highestCommonPredecessor(bn).hash, nil
+}

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -220,8 +220,8 @@ func (bt *BlockTree) Leaves() []common.Hash {
 	return la
 }
 
-// HighestCommonPredecessor returns the highest block that is a predecessor to both a and b
-func (bt *BlockTree) HighestCommonPredecessor(a, b common.Hash) (Hash, error) {
+// HighestCommonAncestor returns the highest block that is a Ancestor to both a and b
+func (bt *BlockTree) HighestCommonAncestor(a, b common.Hash) (Hash, error) {
 	an := bt.getNode(a)
 	if an == nil {
 		return common.Hash{}, ErrNodeNotFound
@@ -231,7 +231,7 @@ func (bt *BlockTree) HighestCommonPredecessor(a, b common.Hash) (Hash, error) {
 		return common.Hash{}, ErrNodeNotFound
 	}
 
-	return an.highestCommonPredecessor(bn).hash, nil
+	return an.highestCommonAncestor(bn).hash, nil
 }
 
 // IsDescendantOf returns true if the child is a descendant of parent, false otherwise.

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -318,3 +318,65 @@ func TestBlockTree_GetAllBlocksAtDepth(t *testing.T) {
 		t.Fatalf("Fail: did not get all expected hashes got %v expected %v", hashes, expected)
 	}
 }
+
+func TestBlockTree_HighestCommonPredecessor(t *testing.T) {
+	header := &types.Header{
+		ParentHash: zeroHash,
+		Number:     big.NewInt(0),
+	}
+
+	var bt *BlockTree
+	var leaves []common.Hash
+	var branches []testBranch
+
+	for {
+		bt, branches = createTestBlockTree(header, 8, nil)
+		leaves = bt.Leaves()
+		if len(leaves) == 2 {
+			break
+		}
+	}
+
+	expected := branches[0].hash
+
+	a := leaves[0]
+	b := leaves[1]
+
+	p, err := bt.HighestCommonPredecessor(a, b)
+	require.NoError(t, err)
+	require.Equal(t, expected, p)
+}
+
+func TestBlockTree_HighestCommonPredecessor_SameNode(t *testing.T) {
+	header := &types.Header{
+		ParentHash: zeroHash,
+		Number:     big.NewInt(0),
+	}
+
+	bt, _ := createTestBlockTree(header, 8, nil)
+	leaves := bt.Leaves()
+
+	a := leaves[0]
+
+	p, err := bt.HighestCommonPredecessor(a, a)
+	require.NoError(t, err)
+	require.Equal(t, a, p)
+}
+
+func TestBlockTree_HighestCommonPredecessor_SameChain(t *testing.T) {
+	header := &types.Header{
+		ParentHash: zeroHash,
+		Number:     big.NewInt(0),
+	}
+
+	bt, _ := createTestBlockTree(header, 8, nil)
+	leaves := bt.Leaves()
+
+	a := leaves[0]
+	b := bt.getNode(a).parent.hash
+
+	// b is a's parent, so their highest common predecessor is b.
+	p, err := bt.HighestCommonPredecessor(a, b)
+	require.NoError(t, err)
+	require.Equal(t, b, p)
+}

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -319,7 +319,7 @@ func TestBlockTree_GetAllBlocksAtDepth(t *testing.T) {
 	}
 }
 
-func TestBlockTree_HighestCommonPredecessor(t *testing.T) {
+func TestBlockTree_HighestCommonAncestor(t *testing.T) {
 	header := &types.Header{
 		ParentHash: zeroHash,
 		Number:     big.NewInt(0),
@@ -342,12 +342,12 @@ func TestBlockTree_HighestCommonPredecessor(t *testing.T) {
 	a := leaves[0]
 	b := leaves[1]
 
-	p, err := bt.HighestCommonPredecessor(a, b)
+	p, err := bt.HighestCommonAncestor(a, b)
 	require.NoError(t, err)
 	require.Equal(t, expected, p)
 }
 
-func TestBlockTree_HighestCommonPredecessor_SameNode(t *testing.T) {
+func TestBlockTree_HighestCommonAncestor_SameNode(t *testing.T) {
 	header := &types.Header{
 		ParentHash: zeroHash,
 		Number:     big.NewInt(0),
@@ -358,12 +358,12 @@ func TestBlockTree_HighestCommonPredecessor_SameNode(t *testing.T) {
 
 	a := leaves[0]
 
-	p, err := bt.HighestCommonPredecessor(a, a)
+	p, err := bt.HighestCommonAncestor(a, a)
 	require.NoError(t, err)
 	require.Equal(t, a, p)
 }
 
-func TestBlockTree_HighestCommonPredecessor_SameChain(t *testing.T) {
+func TestBlockTree_HighestCommonAncestor_SameChain(t *testing.T) {
 	header := &types.Header{
 		ParentHash: zeroHash,
 		Number:     big.NewInt(0),
@@ -375,8 +375,8 @@ func TestBlockTree_HighestCommonPredecessor_SameChain(t *testing.T) {
 	a := leaves[0]
 	b := bt.getNode(a).parent.hash
 
-	// b is a's parent, so their highest common predecessor is b.
-	p, err := bt.HighestCommonPredecessor(a, b)
+	// b is a's parent, so their highest common Ancestor is b.
+	p, err := bt.HighestCommonAncestor(a, b)
 	require.NoError(t, err)
 	require.Equal(t, b, p)
 }

--- a/lib/blocktree/database_test.go
+++ b/lib/blocktree/database_test.go
@@ -47,7 +47,7 @@ func createTestBlockTree(header *types.Header, depth int, db database.Database) 
 		}
 	}
 
-	num := 0
+	num := 77
 
 	// create tree branches
 	for _, branch := range branches {

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -24,3 +24,6 @@ var ErrNilDescendant = errors.New("descendant node is nil")
 
 // ErrDescendantNotFound is returned if a descendant in a subchain cannot be found
 var ErrDescendantNotFound = errors.New("could not find descendant node")
+
+// ErrNodeNotFound is returned if a node with given hash doesn't exist
+var ErrNodeNotFound = errors.New("could not find node")

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -133,7 +133,7 @@ func (n *node) isDescendantOf(parent *node) bool {
 	return false
 }
 
-func (n *node) highestCommonPredecessor(other *node) *node {
+func (n *node) highestCommonAncestor(other *node) *node {
 	for curr := n; curr != nil; curr = curr.parent {
 		if curr.hash == other.hash {
 			return curr

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -132,3 +132,17 @@ func (n *node) isDescendantOf(parent *node) bool {
 	}
 	return false
 }
+
+func (n *node) highestCommonPredecessor(other *node) *node {
+	for curr := n; curr != nil; curr = curr.parent {
+		if curr.hash == other.hash {
+			return curr
+		}
+
+		if other.isDescendantOf(curr) {
+			return curr
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement HighestCommonPrecessor which for blocks a, b, gets the block with the highest number that's a predecessor of both

- possibly rename to HighestCommonAncestor?? what does everyone think

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/blocktree
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #878 