### PR TITLE
dot/rpc/modules, lib/runtime: fix failing tests

### DIFF
--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -17,6 +17,7 @@ package modules
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -57,6 +58,9 @@ func TestStateModule_GetPairs_All(t *testing.T) {
 
 	err := sm.GetPairs(nil, &req, &res)
 	require.NoError(t, err)
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].([]string)[0] < res[j].([]string)[0]
+	})
 	require.Equal(t, expected, res)
 
 }


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add sort.Slice to TestStateModule_GetPairs_All to prevent failures
- add retries around calls to finalize_block in runtime tests

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #858
