### PR TITLE
cmd/gossamer: rename datadir to basepath

### DIFF
--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -1,7 +1,7 @@
 [global]
 name = "gssmr"
 id = "gssmr"
-datadir = "~/.gossamer/gssmr"
+basepath = "~/.gossamer/gssmr"
 
 [init]
 genesis = "./chain/gssmr/genesis.json"

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -25,8 +25,8 @@ var (
 	DefaultID = string("gssmr")
 	// DefaultConfig Default toml configuration path
 	DefaultConfig = string("./chain/gssmr/config.toml")
-	// DefaultDataDir Default node data directory
-	DefaultDataDir = string("~/.gossamer/gssmr")
+	// DefaultBasePath Default node base directory path
+	DefaultBasePath = string("~/.gossamer/gssmr")
 
 	// InitConfig
 

--- a/chain/ksmcc/config.toml
+++ b/chain/ksmcc/config.toml
@@ -1,7 +1,7 @@
 [global]
 name = "ksmcc"
 id = "ksmcc"
-datadir = "~/.gossamer/ksmcc"
+basepath = "~/.gossamer/ksmcc"
 
 [init]
 genesis = "./chain/ksmcc/genesis.json"

--- a/chain/ksmcc/defaults.go
+++ b/chain/ksmcc/defaults.go
@@ -25,8 +25,8 @@ var (
 	DefaultID = string("ksmcc")
 	// DefaultConfig Default toml configuration path
 	DefaultConfig = string("./chain/ksmcc/config.toml")
-	// DefaultDataDir Default node data directory
-	DefaultDataDir = string("~/.gossamer/ksmcc")
+	// DefaultBasePath Default node base directory path
+	DefaultBasePath = string("~/.gossamer/ksmcc")
 
 	// InitConfig
 

--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -48,7 +48,7 @@ func accountAction(ctx *cli.Context) error {
 		return err
 	}
 
-	datadir := cfg.Global.DataDir
+	basepath := cfg.Global.BasePath
 
 	// check --generate flag and generate new keypair
 	if keygen := ctx.Bool(GenerateFlag.Name); keygen {
@@ -75,7 +75,7 @@ func accountAction(ctx *cli.Context) error {
 		}
 
 		var file string
-		file, err = keystore.GenerateKeypair(keytype, datadir, password)
+		file, err = keystore.GenerateKeypair(keytype, basepath, password)
 		if err != nil {
 			log.Error("[cmd] failed to generate keypair", "error", err)
 			return err
@@ -89,7 +89,7 @@ func accountAction(ctx *cli.Context) error {
 		log.Info("[cmd] importing keypair...")
 
 		// import keypair
-		_, err = keystore.ImportKeypair(keyimport, datadir)
+		_, err = keystore.ImportKeypair(keyimport, basepath)
 		if err != nil {
 			log.Error("[cmd] failed to import key", "error", err)
 			return err
@@ -98,7 +98,7 @@ func accountAction(ctx *cli.Context) error {
 
 	// check if --list is set
 	if keylist := ctx.Bool(ListFlag.Name); keylist {
-		_, err = utils.KeystoreFilepaths(datadir)
+		_, err = utils.KeystoreFilepaths(basepath)
 		if err != nil {
 			log.Error("[cmd] failed to list keys", "error", err)
 			return err
@@ -111,7 +111,7 @@ func accountAction(ctx *cli.Context) error {
 // unlockKeystore compares the length of passwords to the length of accounts,
 // prompts the user for a password if no password is provided, and then unlocks
 // the accounts within the provided keystore
-func unlockKeystore(ks *keystore.Keystore, datadir string, unlock string, password string) error {
+func unlockKeystore(ks *keystore.Keystore, basepath string, unlock string, password string) error {
 	var passwords []string
 
 	if password != "" {
@@ -130,7 +130,7 @@ func unlockKeystore(ks *keystore.Keystore, datadir string, unlock string, passwo
 			password = string(bytes)
 		}
 
-		err := keystore.UnlockKeys(ks, datadir, unlock, password)
+		err := keystore.UnlockKeys(ks, basepath, unlock, password)
 		if err != nil {
 			return fmt.Errorf("failed to unlock keys: %s", err)
 		}

--- a/cmd/gossamer/account_test.go
+++ b/cmd/gossamer/account_test.go
@@ -29,7 +29,7 @@ func TestAccountGenerate(t *testing.T) {
 
 	ctx, err := newTestContext(
 		"Test gossamer account --generate",
-		[]string{"datadir", "generate"},
+		[]string{"basepath", "generate"},
 		[]interface{}{testDir, "true"},
 	)
 	if err != nil {
@@ -52,7 +52,7 @@ func TestAccountGeneratePassword(t *testing.T) {
 
 	ctx, err := newTestContext(
 		"Test gossamer account --generate --password",
-		[]string{"datadir", "generate", "password"},
+		[]string{"basepath", "generate", "password"},
 		[]interface{}{testDir, "true", "1234"},
 	)
 	if err != nil {
@@ -75,7 +75,7 @@ func TestAccountGenerateType(t *testing.T) {
 
 	ctx, err := newTestContext(
 		"Test gossamer account --generate --type",
-		[]string{"datadir", "generate", "type"},
+		[]string{"basepath", "generate", "type"},
 		[]interface{}{testDir, "true", "ed25519"},
 	)
 	if err != nil {
@@ -98,7 +98,7 @@ func TestAccountImport(t *testing.T) {
 
 	ctx, err := newTestContext(
 		"Test gossamer account --import",
-		[]string{"datadir", "import"},
+		[]string{"basepath", "import"},
 		[]interface{}{testDir, "testfile"},
 	)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestAccountList(t *testing.T) {
 
 	ctx, err := newTestContext(
 		"Test gossamer account --list",
-		[]string{"datadir", "list"},
+		[]string{"basepath", "list"},
 		[]interface{}{testDir, "true"},
 	)
 	if err != nil {

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -173,16 +173,16 @@ func setDotGlobalConfig(ctx *cli.Context, cfg *dot.GlobalConfig) {
 		cfg.ID = id
 	}
 
-	// check --datadir flag and update node configuration
-	if datadir := ctx.GlobalString(DataDirFlag.Name); datadir != "" {
-		cfg.DataDir = datadir
+	// check --basepath flag and update node configuration
+	if basepath := ctx.GlobalString(BasePathFlag.Name); basepath != "" {
+		cfg.BasePath = basepath
 	}
 
 	log.Debug(
 		"[cmd] global configuration",
 		"name", cfg.Name,
 		"id", cfg.ID,
-		"datadir", cfg.DataDir,
+		"basepath", cfg.BasePath,
 	)
 }
 
@@ -419,7 +419,7 @@ func updateDotConfigFromGenesisJSON(ctx *cli.Context, cfg *dot.Config) {
 func updateDotConfigFromGenesisData(ctx *cli.Context, cfg *dot.Config) error {
 
 	// initialize database using data directory
-	db, err := database.NewBadgerDB(cfg.Global.DataDir)
+	db, err := database.NewBadgerDB(cfg.Global.BasePath)
 	if err != nil {
 		return fmt.Errorf("failed to create database: %s", err)
 	}

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -139,9 +139,9 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			[]string{"config"},
 			[]interface{}{testCfgFile.Name()},
 			dot.GlobalConfig{
-				Name:    testCfg.Global.Name,
-				ID:      testCfg.Global.ID,
-				DataDir: testCfg.Global.DataDir,
+				Name:     testCfg.Global.Name,
+				ID:       testCfg.Global.ID,
+				BasePath: testCfg.Global.BasePath,
 			},
 		},
 		{
@@ -149,9 +149,9 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			[]string{"config", "chain"},
 			[]interface{}{testCfgFile.Name(), "ksmcc"},
 			dot.GlobalConfig{
-				Name:    testCfg.Global.Name,
-				ID:      "ksmcc",
-				DataDir: testCfg.Global.DataDir,
+				Name:     testCfg.Global.Name,
+				ID:       "ksmcc",
+				BasePath: testCfg.Global.BasePath,
 			},
 		},
 		{
@@ -159,19 +159,19 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			[]string{"config", "name"},
 			[]interface{}{testCfgFile.Name(), "test_name"},
 			dot.GlobalConfig{
-				Name:    "test_name",
-				ID:      testCfg.Global.ID,
-				DataDir: testCfg.Global.DataDir,
+				Name:     "test_name",
+				ID:       testCfg.Global.ID,
+				BasePath: testCfg.Global.BasePath,
 			},
 		},
 		{
-			"Test gossamer --datadir",
-			[]string{"config", "datadir"},
-			[]interface{}{testCfgFile.Name(), "test_datadir"},
+			"Test gossamer --basepath",
+			[]string{"config", "basepath"},
+			[]interface{}{testCfgFile.Name(), "test_basepath"},
 			dot.GlobalConfig{
-				Name:    testCfg.Global.Name,
-				ID:      testCfg.Global.ID,
-				DataDir: "test_datadir",
+				Name:     testCfg.Global.Name,
+				ID:       testCfg.Global.ID,
+				BasePath: "test_basepath",
 			},
 		},
 		{
@@ -179,9 +179,9 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			[]string{"config", "roles"},
 			[]interface{}{testCfgFile.Name(), "1"},
 			dot.GlobalConfig{
-				Name:    testCfg.Global.Name,
-				ID:      testCfg.Global.ID,
-				DataDir: testCfg.Global.DataDir,
+				Name:     testCfg.Global.Name,
+				ID:       testCfg.Global.ID,
+				BasePath: testCfg.Global.BasePath,
 			},
 		},
 	}
@@ -534,9 +534,9 @@ func TestUpdateConfigFromGenesisJSON(t *testing.T) {
 
 	expected := &dot.Config{
 		Global: dot.GlobalConfig{
-			Name:    testCfg.Global.Name,
-			ID:      testCfg.Global.ID,
-			DataDir: testCfg.Global.DataDir,
+			Name:     testCfg.Global.Name,
+			ID:       testCfg.Global.ID,
+			BasePath: testCfg.Global.BasePath,
 		},
 		Init: dot.InitConfig{
 			Genesis: genFile.Name(),
@@ -575,9 +575,9 @@ func TestUpdateConfigFromGenesisJSON_Default(t *testing.T) {
 
 	expected := &dot.Config{
 		Global: dot.GlobalConfig{
-			Name:    testCfg.Global.Name,
-			ID:      testCfg.Global.ID,
-			DataDir: testCfg.Global.DataDir,
+			Name:     testCfg.Global.Name,
+			ID:       testCfg.Global.ID,
+			BasePath: testCfg.Global.BasePath,
 		},
 		Init: dot.InitConfig{
 			Genesis: DefaultCfg.Init.Genesis,
@@ -612,9 +612,9 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 
 	expected := &dot.Config{
 		Global: dot.GlobalConfig{
-			Name:    testCfg.Global.Name,
-			ID:      testCfg.Global.ID,
-			DataDir: testCfg.Global.DataDir,
+			Name:     testCfg.Global.Name,
+			ID:       testCfg.Global.ID,
+			BasePath: testCfg.Global.BasePath,
 		},
 		Init: dot.InitConfig{
 			Genesis: genFile.Name(),
@@ -637,7 +637,7 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 
 	cfg.Init.Genesis = genFile.Name()
 
-	db, err := database.NewBadgerDB(cfg.Global.DataDir)
+	db, err := database.NewBadgerDB(cfg.Global.BasePath)
 	require.Nil(t, err)
 
 	gen, err := genesis.NewGenesisFromJSON(genFile.Name())

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -52,14 +52,14 @@ func TestExportCommand(t *testing.T) {
 		expected    *dot.Config
 	}{
 		{
-			"Test gossamer export --config --genesis --datadir --name --verbosity",
-			[]string{"config", "genesis", "datadir", "name", "verbosity"},
+			"Test gossamer export --config --genesis --basepath --name --verbosity",
+			[]string{"config", "genesis", "basepath", "name", "verbosity"},
 			[]interface{}{testConfig, genFile.Name(), testDir, testName, "trace"},
 			&dot.Config{
 				Global: dot.GlobalConfig{
-					Name:    testName,
-					ID:      testCfg.Global.ID,
-					DataDir: testCfg.Global.DataDir,
+					Name:     testName,
+					ID:       testCfg.Global.ID,
+					BasePath: testCfg.Global.BasePath,
 				},
 				Init: dot.InitConfig{
 					Genesis: genFile.Name(),

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -68,9 +68,9 @@ var (
 		Name:  "config",
 		Usage: "TOML configuration file",
 	}
-	// DataDirFlag data directory for node
-	DataDirFlag = cli.StringFlag{
-		Name:  "datadir",
+	// BasePathFlag data directory for node
+	BasePathFlag = cli.StringFlag{
+		Name:  "basepath",
 		Usage: "Data directory for the node",
 	}
 )
@@ -192,7 +192,7 @@ var (
 		NameFlag,
 		ChainFlag,
 		ConfigFlag,
-		DataDirFlag,
+		BasePathFlag,
 	}
 
 	// StartupFlags are flags that are valid for use with the root command and the export subcommand

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -41,7 +41,7 @@ var (
 		Flags:     ExportFlags,
 		Category:  "EXPORT",
 		Description: "The export command exports configuration values from the command flags to a TOML configuration file.\n" +
-			"\tUsage: gossamer export --config chain/test/config.toml --datadir ~/.gossamer/test",
+			"\tUsage: gossamer export --config chain/test/config.toml --basepath ~/.gossamer/test",
 	}
 	// initCommand defines the "init" subcommand (ie, `gossamer init`)
 	initCommand = cli.Command{
@@ -121,10 +121,10 @@ func gossamerAction(ctx *cli.Context) error {
 
 	// expand data directory and update node configuration (performed separately
 	// from createDotConfig because dot config should not include expanded path)
-	cfg.Global.DataDir = utils.ExpandDir(cfg.Global.DataDir)
+	cfg.Global.BasePath = utils.ExpandDir(cfg.Global.BasePath)
 
 	// check if node has not been initialized (expected true - add warning log)
-	if !dot.NodeInitialized(cfg.Global.DataDir, true) {
+	if !dot.NodeInitialized(cfg.Global.BasePath, true) {
 
 		// initialize node (initialize state database and load genesis data)
 		err = dot.InitNode(cfg)
@@ -148,7 +148,7 @@ func gossamerAction(ctx *cli.Context) error {
 		return err
 	}
 
-	err = unlockKeystore(ks, cfg.Global.DataDir, cfg.Account.Unlock, ctx.String(PasswordFlag.Name))
+	err = unlockKeystore(ks, cfg.Global.BasePath, cfg.Account.Unlock, ctx.String(PasswordFlag.Name))
 	if err != nil {
 		log.Error("[cmd] failed to unlock keystore", "error", err)
 		return err
@@ -188,10 +188,10 @@ func initAction(ctx *cli.Context) error {
 
 	// expand data directory and update node configuration (performed separately
 	// from createDotConfig because dot config should not include expanded path)
-	cfg.Global.DataDir = utils.ExpandDir(cfg.Global.DataDir)
+	cfg.Global.BasePath = utils.ExpandDir(cfg.Global.BasePath)
 
 	// check if node has been initialized (expected false - no warning log)
-	if dot.NodeInitialized(cfg.Global.DataDir, false) {
+	if dot.NodeInitialized(cfg.Global.BasePath, false) {
 
 		// use --force value to force initialize the node
 		force := ctx.Bool(ForceFlag.Name)
@@ -200,12 +200,12 @@ func initAction(ctx *cli.Context) error {
 		if force || confirmMessage("Are you sure you want to reinitialize the node? [Y/n]") {
 			log.Info(
 				"[cmd] reinitializing node...",
-				"datadir", cfg.Global.DataDir,
+				"basepath", cfg.Global.BasePath,
 			)
 		} else {
 			log.Warn(
 				"[cmd] exiting without reinitializing the node",
-				"datadir", cfg.Global.DataDir,
+				"basepath", cfg.Global.BasePath,
 			)
 			return nil // exit if reinitialization is not confirmed
 		}

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -236,7 +236,7 @@ func TestGossamerCommand(t *testing.T) {
 
 	gossamer := runTestGossamer(t,
 		"init",
-		"--datadir", tempDir,
+		"--basepath", tempDir,
 		"--genesis", genesisPath,
 		"--force",
 	)
@@ -260,7 +260,7 @@ func TestGossamerCommand(t *testing.T) {
 		gossamer = runTestGossamer(t,
 			"--port", strconv.Itoa(basePort),
 			"--key", "alice",
-			"--datadir", tempDir,
+			"--basepath", tempDir,
 			"--roles", "4",
 		)
 

--- a/dot/config.go
+++ b/dot/config.go
@@ -45,9 +45,9 @@ type Config struct {
 
 // GlobalConfig is to marshal/unmarshal toml global config vars
 type GlobalConfig struct {
-	Name    string `toml:"name"`
-	ID      string `toml:"id"`
-	DataDir string `toml:"datadir"`
+	Name     string `toml:"name"`
+	ID       string `toml:"id"`
+	BasePath string `toml:"basepath"`
 }
 
 // InitConfig is the configuration for the node initialization
@@ -102,13 +102,13 @@ func RPCServiceEnabled(cfg *Config) bool {
 	return cfg.RPC.Enabled
 }
 
-// GssmrConfig returns a new test configuration using the provided datadir
+// GssmrConfig returns a new test configuration using the provided basepath
 func GssmrConfig() *Config {
 	return &Config{
 		Global: GlobalConfig{
-			Name:    gssmr.DefaultName,
-			ID:      gssmr.DefaultID,
-			DataDir: gssmr.DefaultDataDir,
+			Name:     gssmr.DefaultName,
+			ID:       gssmr.DefaultID,
+			BasePath: gssmr.DefaultBasePath,
 		},
 		Init: InitConfig{
 			Genesis: gssmr.DefaultGenesis,
@@ -145,9 +145,9 @@ func GssmrConfig() *Config {
 func KsmccConfig() *Config {
 	return &Config{
 		Global: GlobalConfig{
-			Name:    ksmcc.DefaultName,
-			ID:      ksmcc.DefaultID,
-			DataDir: ksmcc.DefaultDataDir,
+			Name:     ksmcc.DefaultName,
+			ID:       ksmcc.DefaultID,
+			BasePath: ksmcc.DefaultBasePath,
 		},
 		Init: InitConfig{
 			Genesis: ksmcc.DefaultGenesis,

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -80,7 +80,7 @@ func TestLoadConfigGssmr(t *testing.T) {
 	cfg := GssmrConfig()
 	require.NotNil(t, cfg)
 
-	cfg.Global.DataDir = utils.NewTestDir(t)
+	cfg.Global.BasePath = utils.NewTestDir(t)
 	cfg.Init.Genesis = GssmrGenesisPath
 
 	defer utils.RemoveTestDir(t)
@@ -101,8 +101,8 @@ func TestExportConfigGssmr(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	gssmrGenesis := cfg.Init.Genesis
-	gssmrDataDir := cfg.Global.DataDir
-	cfg.Global.DataDir = utils.NewTestDir(t)
+	gssmrBasePath := cfg.Global.BasePath
+	cfg.Global.BasePath = utils.NewTestDir(t)
 	cfg.Init.Genesis = GssmrGenesisPath
 
 	defer utils.RemoveTestDir(t)
@@ -111,7 +111,7 @@ func TestExportConfigGssmr(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg.Init.Genesis = gssmrGenesis
-	cfg.Global.DataDir = gssmrDataDir
+	cfg.Global.BasePath = gssmrBasePath
 
 	file := ExportConfig(cfg, GssmrConfigPath)
 
@@ -126,7 +126,7 @@ func TestLoadConfigKsmcc(t *testing.T) {
 	cfg := KsmccConfig()
 	require.NotNil(t, cfg)
 
-	cfg.Global.DataDir = utils.NewTestDir(t)
+	cfg.Global.BasePath = utils.NewTestDir(t)
 	cfg.Init.Genesis = KsmccGenesisPath
 
 	defer utils.RemoveTestDir(t)
@@ -146,8 +146,8 @@ func TestExportConfigKsmcc(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	ksmccGenesis := cfg.Init.Genesis
-	ksmccDataDir := cfg.Global.DataDir
-	cfg.Global.DataDir = utils.NewTestDir(t)
+	ksmccBasePath := cfg.Global.BasePath
+	cfg.Global.BasePath = utils.NewTestDir(t)
 	cfg.Init.Genesis = KsmccGenesisPath
 
 	defer utils.RemoveTestDir(t)
@@ -156,7 +156,7 @@ func TestExportConfigKsmcc(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg.Init.Genesis = ksmccGenesis
-	cfg.Global.DataDir = ksmccDataDir
+	cfg.Global.BasePath = ksmccBasePath
 
 	file := ExportConfig(cfg, KsmccConfigPath)
 

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -30,8 +30,8 @@ import (
 // DefaultKeyFile the default value for KeyFile
 const DefaultKeyFile = "node.key"
 
-// DefaultDataDir the default value for Config.DataDir
-const DefaultDataDir = "~/.gossamer/gssmr"
+// DefaultBasePath the default value for Config.BasePath
+const DefaultBasePath = "~/.gossamer/gssmr"
 
 // DefaultPort the default value for Config.Port
 const DefaultPort = uint32(7000)
@@ -53,8 +53,8 @@ var DefaultBootnodes = []string(nil)
 
 // Config is used to configure a network service
 type Config struct {
-	// DataDir the data directory for the node
-	DataDir string
+	// BasePath the data directory for the node
+	BasePath string
 	// Roles a bitmap value that represents the different roles for the sender node (see Table D.2)
 	Roles byte
 
@@ -103,8 +103,8 @@ func (c *Config) build() error {
 		return err
 	}
 
-	if c.DataDir == "" {
-		c.DataDir = DefaultDataDir
+	if c.BasePath == "" {
+		c.BasePath = DefaultBasePath
 	}
 
 	if c.Roles == 0 {
@@ -155,7 +155,7 @@ func (c *Config) buildIdentity() error {
 	if c.RandSeed == 0 {
 
 		// attempt to load existing key
-		key, err := loadKey(c.DataDir)
+		key, err := loadKey(c.BasePath)
 		if err != nil {
 			return err
 		}
@@ -165,11 +165,11 @@ func (c *Config) buildIdentity() error {
 			log.Info(
 				"[network] Generating p2p identity",
 				"RandSeed", c.RandSeed,
-				"KeyFile", path.Join(c.DataDir, DefaultKeyFile),
+				"KeyFile", path.Join(c.BasePath, DefaultKeyFile),
 			)
 
 			// generate key
-			key, err = generateKey(c.RandSeed, c.DataDir)
+			key, err = generateKey(c.RandSeed, c.BasePath)
 			if err != nil {
 				return err
 			}
@@ -181,11 +181,11 @@ func (c *Config) buildIdentity() error {
 		log.Info(
 			"[network] Generating p2p identity from seed",
 			"RandSeed", c.RandSeed,
-			"KeyFile", path.Join(c.DataDir, DefaultKeyFile),
+			"KeyFile", path.Join(c.BasePath, DefaultKeyFile),
 		)
 
 		// generate temporary deterministic key
-		key, err := generateKey(c.RandSeed, c.DataDir)
+		key, err := generateKey(c.RandSeed, c.BasePath)
 		if err != nil {
 			return err
 		}

--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -32,7 +32,7 @@ func TestBuildIdentity(t *testing.T) {
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir: testDir,
+		BasePath: testDir,
 	}
 
 	err := configA.buildIdentity()
@@ -41,7 +41,7 @@ func TestBuildIdentity(t *testing.T) {
 	}
 
 	configB := &Config{
-		DataDir: testDir,
+		BasePath: testDir,
 	}
 
 	err = configB.buildIdentity()
@@ -78,7 +78,7 @@ func TestBuildIdentity(t *testing.T) {
 
 // test build configuration method
 func TestBuild(t *testing.T) {
-	testDataDir := utils.NewTestDataDir(t, "node")
+	testBasePath := utils.NewTestBasePath(t, "node")
 	defer utils.RemoveTestDir(t)
 
 	testBlockState := &state.BlockState{}
@@ -89,7 +89,7 @@ func TestBuild(t *testing.T) {
 	cfg := &Config{
 		BlockState:   testBlockState,
 		NetworkState: testNetworkState,
-		DataDir:      testDataDir,
+		BasePath:     testBasePath,
 		RandSeed:     testRandSeed,
 	}
 
@@ -100,7 +100,7 @@ func TestBuild(t *testing.T) {
 
 	require.Equal(t, testBlockState, cfg.BlockState)
 	require.Equal(t, testNetworkState, cfg.NetworkState)
-	require.Equal(t, testDataDir, cfg.DataDir)
+	require.Equal(t, testBasePath, cfg.BasePath)
 	require.Equal(t, DefaultRoles, cfg.Roles)
 	require.Equal(t, DefaultPort, cfg.Port)
 	require.Equal(t, testRandSeed, cfg.RandSeed)

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -25,7 +25,7 @@ import (
 
 // test gossip messages to connected peers
 func TestGossip(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
@@ -33,7 +33,7 @@ func TestGossip(t *testing.T) {
 	msgSendA := make(chan Message)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -46,12 +46,12 @@ func TestGossip(t *testing.T) {
 
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	msgSendB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,
@@ -79,12 +79,12 @@ func TestGossip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dataDirC := utils.NewTestDataDir(t, "nodeC")
+	basePathC := utils.NewTestBasePath(t, "nodeC")
 
 	msgSendC := make(chan Message)
 
 	configC := &Config{
-		DataDir:     dataDirC,
+		BasePath:    basePathC,
 		Port:        7003,
 		RandSeed:    3,
 		NoBootstrap: true,

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -26,13 +26,13 @@ import (
 
 // test host connect method
 func TestConnect(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -45,10 +45,10 @@ func TestConnect(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,
@@ -98,13 +98,13 @@ func TestConnect(t *testing.T) {
 
 // test host bootstrap method on start
 func TestBootstrap(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -119,10 +119,10 @@ func TestBootstrap(t *testing.T) {
 
 	addrA := nodeA.host.multiaddrs()[0]
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	configB := &Config{
-		DataDir:   dataDirB,
+		BasePath:  basePathB,
 		Port:      7002,
 		RandSeed:  2,
 		Bootnodes: []string{addrA.String()},
@@ -165,13 +165,13 @@ func TestBootstrap(t *testing.T) {
 
 // test host ping method
 func TestPing(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -184,10 +184,10 @@ func TestPing(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,
@@ -233,13 +233,13 @@ func TestPing(t *testing.T) {
 
 // test host send method
 func TestSend(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -252,12 +252,12 @@ func TestSend(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	msgSendB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,
@@ -307,13 +307,13 @@ func TestSend(t *testing.T) {
 
 // test host broadcast method
 func TestBroadcast(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -326,12 +326,12 @@ func TestBroadcast(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	msgSendB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,
@@ -360,12 +360,12 @@ func TestBroadcast(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dataDirC := utils.NewTestDataDir(t, "")
+	basePathC := utils.NewTestBasePath(t, "")
 
 	msgSendC := make(chan Message)
 
 	configC := &Config{
-		DataDir:     dataDirC,
+		BasePath:    basePathC,
 		Port:        7003,
 		RandSeed:    3,
 		NoBootstrap: true,
@@ -426,7 +426,7 @@ func TestBroadcast(t *testing.T) {
 
 // test host send method with existing stream
 func TestExistingStream(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
@@ -434,7 +434,7 @@ func TestExistingStream(t *testing.T) {
 	msgSendA := make(chan Message)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -453,12 +453,12 @@ func TestExistingStream(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	msgSendB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,

--- a/dot/network/mdns_test.go
+++ b/dot/network/mdns_test.go
@@ -28,13 +28,13 @@ var TestMDNSTimeout = time.Second
 
 // test mdns discovery service (discovers and connects)
 func TestMDNS(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -46,10 +46,10 @@ func TestMDNS(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -94,13 +94,13 @@ func createTestService(t *testing.T, cfg *Config) (srvc *Service) {
 
 // test network service starts
 func TestStartService(t *testing.T) {
-	dataDir := utils.NewTestDataDir(t, "node")
+	basePath := utils.NewTestBasePath(t, "node")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	config := &Config{
-		DataDir:     dataDir,
+		BasePath:    basePath,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -112,7 +112,7 @@ func TestStartService(t *testing.T) {
 
 // test broacast messages from core service
 func TestBroadcastMessages(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
@@ -120,7 +120,7 @@ func TestBroadcastMessages(t *testing.T) {
 	msgRecA := make(chan Message)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -134,12 +134,12 @@ func TestBroadcastMessages(t *testing.T) {
 	nodeA.noGossip = true
 	nodeA.noStatus = true
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	msgSendB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,
@@ -186,7 +186,7 @@ func TestBroadcastMessages(t *testing.T) {
 }
 
 func TestHandleMessage_BlockResponse(t *testing.T) {
-	dataDir := utils.NewTestDataDir(t, "nodeA")
+	basePath := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
@@ -194,7 +194,7 @@ func TestHandleMessage_BlockResponse(t *testing.T) {
 	msgSend := make(chan Message, 4)
 
 	config := &Config{
-		DataDir:     dataDir,
+		BasePath:    basePath,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -262,10 +262,10 @@ func TestHandleMessage_BlockResponse(t *testing.T) {
 }
 
 func TestService_NodeRoles(t *testing.T) {
-	dataDir := utils.NewTestDataDir(t, "node")
+	basePath := utils.NewTestBasePath(t, "node")
 	cfg := &Config{
-		DataDir: dataDir,
-		Roles:   1,
+		BasePath: basePath,
+		Roles:    1,
 	}
 	svc := createTestService(t, cfg)
 

--- a/dot/network/status_test.go
+++ b/dot/network/status_test.go
@@ -29,7 +29,7 @@ var TestStatusTimeout = time.Second
 
 // test exchange status messages after peer connected
 func TestStatus(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
@@ -37,7 +37,7 @@ func TestStatus(t *testing.T) {
 	msgRecA := make(chan Message)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -73,12 +73,12 @@ func TestStatus(t *testing.T) {
 	// simulate host status message sent from core service on startup
 	msgRecA <- testStatusMessage
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	msgRecB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		Port:        7002,
 		RandSeed:    2,
 		NoBootstrap: true,

--- a/dot/network/syncer_test.go
+++ b/dot/network/syncer_test.go
@@ -29,13 +29,13 @@ import (
 
 // TestRequestedBlockIDs tests adding and removing block ids from requestedBlockIDs
 func TestRequestedBlockIDs(t *testing.T) {
-	dataDir := utils.NewTestDataDir(t, "node")
+	basePath := utils.NewTestBasePath(t, "node")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
 
 	config := &Config{
-		DataDir:     dataDir,
+		BasePath:    basePath,
 		Port:        7001,
 		RandSeed:    1,
 		NoBootstrap: true,
@@ -61,7 +61,7 @@ func TestRequestedBlockIDs(t *testing.T) {
 // have a peer send a message status with a block ahead
 // test exchanged messages after peer connected are correct
 func TestHandleStatusMessage(t *testing.T) {
-	dataDirA := utils.NewTestDataDir(t, "nodeA")
+	basePathA := utils.NewTestBasePath(t, "nodeA")
 
 	// removes all data directories created within test directory
 	defer utils.RemoveTestDir(t)
@@ -71,7 +71,7 @@ func TestHandleStatusMessage(t *testing.T) {
 	syncChan := make(chan *big.Int)
 
 	configA := &Config{
-		DataDir:     dataDirA,
+		BasePath:    basePathA,
 		BlockState:  newMockBlockState(heightA),
 		Port:        7001,
 		RandSeed:    1,
@@ -105,13 +105,13 @@ func TestHandleStatusMessage(t *testing.T) {
 	// simulate host status message sent from core service on startup
 	msgRecA <- testStatusMessage
 
-	dataDirB := utils.NewTestDataDir(t, "nodeB")
+	basePathB := utils.NewTestBasePath(t, "nodeB")
 
 	heightB := big.NewInt(1)
 	msgRecB := make(chan Message)
 
 	configB := &Config{
-		DataDir:     dataDirB,
+		BasePath:    basePathB,
 		BlockState:  newMockBlockState(heightB),
 		Port:        7002,
 		RandSeed:    2,

--- a/dot/node.go
+++ b/dot/node.go
@@ -54,7 +54,7 @@ func InitNode(cfg *Config) error {
 		"[dot] initializing node...",
 		"name", cfg.Global.Name,
 		"id", cfg.Global.ID,
-		"datadir", cfg.Global.DataDir,
+		"basepath", cfg.Global.BasePath,
 		"genesis", cfg.Init.Genesis,
 	)
 
@@ -77,7 +77,7 @@ func InitNode(cfg *Config) error {
 	}
 
 	// create new state service
-	stateSrvc := state.NewService(cfg.Global.DataDir)
+	stateSrvc := state.NewService(cfg.Global.BasePath)
 
 	// declare genesis data
 	data := gen.GenesisData()
@@ -101,7 +101,7 @@ func InitNode(cfg *Config) error {
 		"[dot] node initialized",
 		"name", cfg.Global.Name,
 		"id", cfg.Global.ID,
-		"datadir", cfg.Global.DataDir,
+		"basepath", cfg.Global.BasePath,
 		"genesis", cfg.Init.Genesis,
 		"block", header.Number,
 	)
@@ -111,16 +111,16 @@ func InitNode(cfg *Config) error {
 
 // NodeInitialized returns true if, within the configured data directory for the
 // node, the state database has been created and the genesis data has been loaded
-func NodeInitialized(datadir string, expected bool) bool {
+func NodeInitialized(basepath string, expected bool) bool {
 
 	// check if key registry exists
-	registry := path.Join(datadir, "KEYREGISTRY")
+	registry := path.Join(basepath, "KEYREGISTRY")
 	_, err := os.Stat(registry)
 	if os.IsNotExist(err) {
 		if expected {
 			log.Warn(
 				"[dot] node has not been initialized",
-				"datadir", datadir,
+				"basepath", basepath,
 				"error", "failed to locate KEYREGISTRY file in data directory",
 			)
 		}
@@ -128,13 +128,13 @@ func NodeInitialized(datadir string, expected bool) bool {
 	}
 
 	// check if manifest exists
-	manifest := path.Join(datadir, "MANIFEST")
+	manifest := path.Join(basepath, "MANIFEST")
 	_, err = os.Stat(manifest)
 	if os.IsNotExist(err) {
 		if expected {
 			log.Warn(
 				"[dot] node has not been initialized",
-				"datadir", datadir,
+				"basepath", basepath,
 				"error", "failed to locate MANIFEST file in data directory",
 			)
 		}
@@ -142,11 +142,11 @@ func NodeInitialized(datadir string, expected bool) bool {
 	}
 
 	// initialize database using data directory
-	db, err := database.NewBadgerDB(datadir)
+	db, err := database.NewBadgerDB(basepath)
 	if err != nil {
 		log.Error(
 			"[dot] failed to create database",
-			"datadir", datadir,
+			"basepath", basepath,
 			"error", err,
 		)
 		return false
@@ -157,7 +157,7 @@ func NodeInitialized(datadir string, expected bool) bool {
 	if err != nil {
 		log.Warn(
 			"[dot] node has not been initialized",
-			"datadir", datadir,
+			"basepath", basepath,
 			"error", err,
 		)
 		return false
@@ -186,7 +186,7 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 		"[dot] initializing node services...",
 		"name", cfg.Global.Name,
 		"id", cfg.Global.ID,
-		"datadir", cfg.Global.DataDir,
+		"basepath", cfg.Global.BasePath,
 	)
 
 	var nodeSrvcs []services.Service

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -65,13 +65,13 @@ func TestNodeInitialized(t *testing.T) {
 
 	cfg.Init.Genesis = genFile.Name()
 
-	expected := NodeInitialized(cfg.Global.DataDir, false)
+	expected := NodeInitialized(cfg.Global.BasePath, false)
 	require.Equal(t, expected, false)
 
 	err := InitNode(cfg)
 	require.Nil(t, err)
 
-	expected = NodeInitialized(cfg.Global.DataDir, true)
+	expected = NodeInitialized(cfg.Global.BasePath, true)
 	require.Equal(t, expected, true)
 }
 
@@ -157,7 +157,7 @@ func TestInitNode_LoadGenesisData(t *testing.T) {
 	err := InitNode(cfg)
 	require.Nil(t, err)
 
-	stateSrvc := state.NewService(cfg.Global.DataDir)
+	stateSrvc := state.NewService(cfg.Global.BasePath)
 
 	header := &types.Header{
 		Number:         big.NewInt(0),

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -43,7 +43,7 @@ func newNetworkService(t *testing.T) *network.Service {
 	cfg := &network.Config{
 		NoStatus:     true,
 		NetworkState: &state.NetworkState{},
-		DataDir:      testDir,
+		BasePath:     testDir,
 		MsgRec:       make(chan network.Message),
 		MsgSend:      make(chan network.Message),
 		SyncChan:     make(chan *big.Int),

--- a/dot/services.go
+++ b/dot/services.go
@@ -37,7 +37,7 @@ import (
 func createStateService(cfg *Config) (*state.Service, error) {
 	log.Info("[dot] creating state service...")
 
-	stateSrvc := state.NewService(cfg.Global.DataDir)
+	stateSrvc := state.NewService(cfg.Global.BasePath)
 
 	// start state service (initialize state database)
 	err := stateSrvc.Start()
@@ -122,7 +122,7 @@ func createNetworkService(cfg *Config, stateSrvc *state.Service, coreMsgs chan n
 	networkConfig := network.Config{
 		BlockState:   stateSrvc.Block,
 		NetworkState: stateSrvc.Network,
-		DataDir:      cfg.Global.DataDir,
+		BasePath:     cfg.Global.BasePath,
 		Roles:        cfg.Core.Roles,
 		Port:         cfg.Network.Port,
 		Bootnodes:    cfg.Network.Bootnodes,

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -74,7 +74,7 @@ func NewBlockDB(db database.Database) *BlockDB {
 	}
 }
 
-// NewBlockState will create a new BlockState backed by the database located at dataDir
+// NewBlockState will create a new BlockState backed by the database located at basePath
 func NewBlockState(db database.Database, bt *blocktree.BlockTree) (*BlockState, error) {
 	if bt == nil {
 		return nil, fmt.Errorf("block tree is nil")
@@ -95,7 +95,7 @@ func NewBlockState(db database.Database, bt *blocktree.BlockTree) (*BlockState, 
 	return bs, nil
 }
 
-// NewBlockStateFromGenesis initializes a BlockState from a genesis header, saving it to the database located at dataDir
+// NewBlockStateFromGenesis initializes a BlockState from a genesis header, saving it to the database located at basePath
 func NewBlockStateFromGenesis(db database.Database, header *types.Header) (*BlockState, error) {
 	bs := &BlockState{
 		bt: blocktree.NewBlockTreeFromGenesis(header, db),

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -78,13 +78,13 @@ func (s *Service) Initialize(data *genesis.Data, header *types.Header, t *trie.T
 	} else {
 
 		// get data directory from service
-		datadir, err := filepath.Abs(s.dbPath)
+		basepath, err := filepath.Abs(s.dbPath)
 		if err != nil {
-			return fmt.Errorf("failed to read datadir: %s", err)
+			return fmt.Errorf("failed to read basepath: %s", err)
 		}
 
 		// initialize database using data directory
-		db, err = database.NewBadgerDB(datadir)
+		db, err = database.NewBadgerDB(basepath)
 		if err != nil {
 			return fmt.Errorf("failed to create database: %s", err)
 		}
@@ -175,13 +175,13 @@ func (s *Service) Start() error {
 
 	db := s.db
 	if !s.isMemDB {
-		datadir, err := filepath.Abs(s.dbPath)
+		basepath, err := filepath.Abs(s.dbPath)
 		if err != nil {
 			return err
 		}
 
 		// initialize database
-		db, err = database.NewBadgerDB(datadir)
+		db, err = database.NewBadgerDB(basepath)
 		if err != nil {
 			return err
 		}

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -61,7 +61,7 @@ func NewStorageDB(db database.Database) *StorageDB {
 	}
 }
 
-// NewStorageState creates a new StorageState backed by the given trie and database located at dataDir.
+// NewStorageState creates a new StorageState backed by the given trie and database located at basePath.
 func NewStorageState(db database.Database, t *trie.Trie) (*StorageState, error) {
 	if db == nil {
 		return nil, fmt.Errorf("cannot have nil database")

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// NewTestConfig returns a new test configuration using the provided datadir
+// NewTestConfig returns a new test configuration using the provided basepath
 func NewTestConfig(t *testing.T) *Config {
 	dir := utils.NewTestDir(t)
 
@@ -38,9 +38,9 @@ func NewTestConfig(t *testing.T) *Config {
 
 	return &Config{
 		Global: GlobalConfig{
-			Name:    GssmrConfig().Global.Name,
-			ID:      GssmrConfig().Global.ID,
-			DataDir: dir,
+			Name:     GssmrConfig().Global.Name,
+			ID:       GssmrConfig().Global.ID,
+			BasePath: dir,
 		},
 		Init:    GssmrConfig().Init,
 		Account: GssmrConfig().Account,
@@ -55,7 +55,7 @@ func NewTestConfig(t *testing.T) *Config {
 func NewTestConfigWithFile(t *testing.T) (*Config, *os.File) {
 	cfg := NewTestConfig(t)
 
-	file, err := ioutil.TempFile(cfg.Global.DataDir, "config-")
+	file, err := ioutil.TempFile(cfg.Global.BasePath, "config-")
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to create temporary file: %s", err))
 		require.Nil(t, err)

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -65,9 +65,9 @@ func DecodePrivateKey(in []byte, keytype crypto.KeyType) (priv crypto.PrivateKey
 }
 
 // GenerateKeypair create a new keypair with the corresponding type and saves
-// it to datadir/keystore/[public key].key in json format encrypted using the
+// it to basepath/keystore/[public key].key in json format encrypted using the
 // specified password and returns the resulting filepath of the new key
-func GenerateKeypair(keytype string, datadir string, password []byte) (string, error) {
+func GenerateKeypair(keytype string, basepath string, password []byte) (string, error) {
 	if keytype == "" {
 		keytype = crypto.Sr25519Type
 	}
@@ -91,7 +91,7 @@ func GenerateKeypair(keytype string, datadir string, password []byte) (string, e
 		}
 	}
 
-	keyPath, err := utils.KeystoreDir(datadir)
+	keyPath, err := utils.KeystoreDir(basepath)
 	if err != nil {
 		return "", fmt.Errorf("failed to get keystore directory: %s", err)
 	}

--- a/lib/keystore/keystore_test.go
+++ b/lib/keystore/keystore_test.go
@@ -297,10 +297,10 @@ func TestImportKey_ShouldFail(t *testing.T) {
 }
 
 func TestImportKey(t *testing.T) {
-	dataDir := utils.NewTestDataDir(t, "keystore")
+	basePath := utils.NewTestBasePath(t, "keystore")
 	defer utils.RemoveTestDir(t)
 
-	keypath := dataDir
+	keypath := basePath
 
 	importkeyfile, err := GenerateKeypair("sr25519", keypath, testPassword)
 	if err != nil {
@@ -309,12 +309,12 @@ func TestImportKey(t *testing.T) {
 
 	defer os.RemoveAll(importkeyfile)
 
-	keyfile, err := ImportKeypair(importkeyfile, dataDir)
+	keyfile, err := ImportKeypair(importkeyfile, basePath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	keys, err := utils.KeystoreFilepaths(dataDir)
+	keys, err := utils.KeystoreFilepaths(basePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/utils/test_utils.go
+++ b/lib/utils/test_utils.go
@@ -43,10 +43,10 @@ func NewTestDir(t *testing.T) string {
 	return testDir
 }
 
-// NewTestDataDir create new test data directory
-func NewTestDataDir(t *testing.T, name string) string {
+// NewTestBasePath create new test data directory
+func NewTestBasePath(t *testing.T, name string) string {
 	testDir := path.Join(TestDir, t.Name())
-	dataDir := path.Join(testDir, name)
+	basePath := path.Join(testDir, name)
 
 	err := os.Mkdir(TestDir, os.ModePerm)
 	if err != nil && !PathExists(TestDir) {
@@ -58,12 +58,12 @@ func NewTestDataDir(t *testing.T, name string) string {
 		fmt.Println(fmt.Errorf("failed to create test directory: %s", err))
 	}
 
-	err = os.Mkdir(dataDir, os.ModePerm)
-	if err != nil && !PathExists(dataDir) {
+	err = os.Mkdir(basePath, os.ModePerm)
+	if err != nil && !PathExists(basePath) {
 		fmt.Println(fmt.Errorf("failed to create test data directory: %s", err))
 	}
 
-	return dataDir
+	return basePath
 }
 
 // RemoveTestDir removes the test data directory

--- a/lib/utils/test_utils_test.go
+++ b/lib/utils/test_utils_test.go
@@ -35,13 +35,13 @@ func TestNewTestDir(t *testing.T) {
 	RemoveTestDir(t)
 }
 
-// TestNewTestDataDir tests the NewTestDataDir method
-func TestNewTestDataDir(t *testing.T) {
-	dataDir := "test"
+// TestNewTestBasePath tests the NewTestBasePath method
+func TestNewTestBasePath(t *testing.T) {
+	basePath := "test"
 
-	testDir := NewTestDataDir(t, dataDir)
+	testDir := NewTestBasePath(t, basePath)
 
-	expected := path.Join(TestDir, t.Name(), dataDir)
+	expected := path.Join(TestDir, t.Name(), basePath)
 
 	require.Equal(t, expected, testDir)
 	require.Equal(t, PathExists(testDir), true)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -60,10 +60,10 @@ func ExpandDir(targetPath string) string {
 	return path.Clean(os.ExpandEnv(targetPath))
 }
 
-// DataDir attempts to create a data directory using the given name within the
+// BasePath attempts to create a data directory using the given name within the
 // gossamer directory within the user's HOME directory, returns absolute path
 // or, if unable to locate HOME directory, returns within current directory
-func DataDir(name string) string {
+func BasePath(name string) string {
 	home := HomeDir()
 	if home != "" {
 		if runtime.GOOS == "darwin" {
@@ -78,17 +78,17 @@ func DataDir(name string) string {
 }
 
 // KeystoreDir returns the absolute filepath of the keystore directory
-func KeystoreDir(datadir string) (keystorepath string, err error) {
-	// datadir specified, set keystore filepath to absolute path of [datadir]/keystore
-	if datadir != "" {
-		datadir = ExpandDir(datadir)
-		keystorepath, err = filepath.Abs(datadir + "/keystore")
+func KeystoreDir(basepath string) (keystorepath string, err error) {
+	// basepath specified, set keystore filepath to absolute path of [basepath]/keystore
+	if basepath != "" {
+		basepath = ExpandDir(basepath)
+		keystorepath, err = filepath.Abs(basepath + "/keystore")
 		if err != nil {
 			return "", fmt.Errorf("failed to create absolute filepath: %s", err)
 		}
 	}
 
-	// if datadir does not exist, create it
+	// if basepath does not exist, create it
 	if _, err = os.Stat(keystorepath); os.IsNotExist(err) {
 		err = os.Mkdir(keystorepath, os.ModePerm)
 		if err != nil {
@@ -96,7 +96,7 @@ func KeystoreDir(datadir string) (keystorepath string, err error) {
 		}
 	}
 
-	// if datadir/keystore does not exist, create it
+	// if basepath/keystore does not exist, create it
 	if _, err = os.Stat(keystorepath); os.IsNotExist(err) {
 		err = os.Mkdir(keystorepath, os.ModePerm)
 		if err != nil {
@@ -107,9 +107,9 @@ func KeystoreDir(datadir string) (keystorepath string, err error) {
 	return keystorepath, nil
 }
 
-// KeystoreFiles returns the filenames of all the keys in the datadir's keystore
-func KeystoreFiles(datadir string) ([]string, error) {
-	keystorepath, err := KeystoreDir(datadir)
+// KeystoreFiles returns the filenames of all the keys in the basepath's keystore
+func KeystoreFiles(basepath string) ([]string, error) {
+	keystorepath, err := KeystoreDir(basepath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get keystore directory: %s", err)
 	}
@@ -131,9 +131,9 @@ func KeystoreFiles(datadir string) ([]string, error) {
 	return keys, nil
 }
 
-// KeystoreFilepaths lists all the keys in the datadir/keystore/ directory and returns them as a list of filepaths
-func KeystoreFilepaths(datadir string) ([]string, error) {
-	keys, err := KeystoreFiles(datadir)
+// KeystoreFilepaths lists all the keys in the basepath/keystore/ directory and returns them as a list of filepaths
+func KeystoreFilepaths(basepath string) ([]string, error) {
+	keys, err := KeystoreFiles(basepath)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -44,7 +44,7 @@ func TestExpandDir(t *testing.T) {
 	require.NotEqual(t, testDirA, expandedDirA)
 	require.Equal(t, strings.Contains(expandedDirA, homeDir), true)
 
-	testDirB := NewTestDataDir(t, "test")
+	testDirB := NewTestBasePath(t, "test")
 	defer RemoveTestDir(t)
 
 	expandedDirB := ExpandDir(testDirB)
@@ -53,29 +53,29 @@ func TestExpandDir(t *testing.T) {
 	require.Equal(t, strings.Contains(expandedDirB, homeDir), false)
 }
 
-// TestDataDir tests the DataDir method
-func TestDataDir(t *testing.T) {
-	testDir := NewTestDataDir(t, "test")
+// TestBasePath tests the BasePath method
+func TestBasePath(t *testing.T) {
+	testDir := NewTestBasePath(t, "test")
 	defer RemoveTestDir(t)
 
 	homeDir := HomeDir()
-	dataDir := DataDir(testDir)
+	basePath := BasePath(testDir)
 
-	require.NotEqual(t, testDir, dataDir)
-	require.Equal(t, strings.Contains(dataDir, homeDir), true)
+	require.NotEqual(t, testDir, basePath)
+	require.Equal(t, strings.Contains(basePath, homeDir), true)
 }
 
 // TestKeystoreDir tests the KeystoreDir method
 func TestKeystoreDir(t *testing.T) {
-	testDir := NewTestDataDir(t, "test")
+	testDir := NewTestBasePath(t, "test")
 	defer RemoveTestDir(t)
 
 	homeDir := HomeDir()
-	dataDir := DataDir(testDir)
+	basePath := BasePath(testDir)
 
 	keystoreDir, err := KeystoreDir(testDir)
 	require.Nil(t, err)
 
-	require.NotEqual(t, testDir, dataDir)
+	require.NotEqual(t, testDir, basePath)
 	require.Equal(t, strings.Contains(keystoreDir, homeDir), true)
 }

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -17,13 +17,13 @@
 # along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 
 mkdir -p ~/gossamer-dev;
-DATA_DIR=~/gossamer-dev
+BASE_PATH=~/gossamer-dev
 
 set -euxo pipefail
 
-if [ ! -f $DATA_DIR/genesis_created ]; then
+if [ ! -f $BASE_PATH/genesis_created ]; then
 	/usr/local/gossamer init --genesis=/gocode/src/github.com/ChainSafe/gossamer/chain/gssmr/genesis.json
-	touch $DATA_DIR/genesis_created;
+	touch $BASE_PATH/genesis_created;
 fi;
 
 exec "$@"

--- a/scripts/integration-test-all.sh
+++ b/scripts/integration-test-all.sh
@@ -40,10 +40,10 @@ done
 
 set -euxo pipefail
 
-DATA_DIR=$(mktemp -d -t gossamer-datadir.XXXXX)
+BASE_PATH=$(mktemp -d -t gossamer-basepath.XXXXX)
 
-if [[ ! "$DATA_DIR" ]]; then
-  echo "Could not create $DATA_DIR"
+if [[ ! "$BASE_PATH" ]]; then
+  echo "Could not create $BASE_PATH"
   exit 1
 fi
 
@@ -56,8 +56,8 @@ arr=()
 
 start_func() {
   echo "starting gossamer node $i in background ..."
-  "$PWD"/bin/gossamer --port=$(($PORT + $i)) --key=$KEY --datadir="$DATA_DIR$i" \
-    --rpc --rpchost=$HOSTNAME --rpcport=$(($RPC_PORT + $i)) --rpcmods=system,author,chain >"$DATA_DIR"/node"$i".log 2>&1 & disown
+  "$PWD"/bin/gossamer --port=$(($PORT + $i)) --key=$KEY --basepath="$BASE_PATH$i" \
+    --rpc --rpchost=$HOSTNAME --rpcport=$(($RPC_PORT + $i)) --rpcmods=system,author,chain >"$BASE_PATH"/node"$i".log 2>&1 & disown
 
   GOSSAMER_PID=$!
   echo "started gossamer node, pid=$GOSSAMER_PID"

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -49,7 +49,7 @@ type Node struct {
 }
 
 // RunGossamer will start a gossamer instance and check if its online and returns CMD, otherwise return err
-func RunGossamer(t *testing.T, idx int, dataDir string) (*Node, error) {
+func RunGossamer(t *testing.T, idx int, basePath string) (*Node, error) {
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func RunGossamer(t *testing.T, idx int, dataDir string) (*Node, error) {
 
 	//nolint
 	cmdInit := exec.Command(gossamerCMD, "init",
-		"--datadir", dataDir+strconv.Itoa(idx),
+		"--basepath", basePath+strconv.Itoa(idx),
 		"--genesis", genesisPath,
 		"--force",
 	)
@@ -83,7 +83,7 @@ func RunGossamer(t *testing.T, idx int, dataDir string) (*Node, error) {
 	if idx >= len(keyList) {
 		//nolint
 		cmd = exec.Command(gossamerCMD, "--port", strconv.Itoa(basePort+idx),
-			"--datadir", dataDir+strconv.Itoa(idx),
+			"--basepath", basePath+strconv.Itoa(idx),
 			"--rpchost", HOSTNAME,
 			"--rpcport", rpcPort,
 			"--rpcmods", "system,author,chain,state",
@@ -95,7 +95,7 @@ func RunGossamer(t *testing.T, idx int, dataDir string) (*Node, error) {
 		//nolint
 		cmd = exec.Command(gossamerCMD, "--port", strconv.Itoa(basePort+idx),
 			"--key", key,
-			"--datadir", dataDir+strconv.Itoa(idx),
+			"--basepath", basePath+strconv.Itoa(idx),
 			"--rpchost", HOSTNAME,
 			"--rpcport", rpcPort,
 			"--rpcmods", "system,author,chain,state",
@@ -105,7 +105,7 @@ func RunGossamer(t *testing.T, idx int, dataDir string) (*Node, error) {
 	}
 
 	// a new file will be created, it will be used for log the outputs from the node
-	f, err := os.Create(filepath.Join(dataDir+strconv.Itoa(idx), "gossamer.log"))
+	f, err := os.Create(filepath.Join(basePath+strconv.Itoa(idx), "gossamer.log"))
 	if err != nil {
 		log.Error("Error when trying to set a log file for gossamer output", "error", err)
 		return nil, err


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `--datadir` flag to `--basepath`
- update `datadir` to `basepath`
- update `dataDir` to `basePath`
- update `DataDir` to `BasePath`

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [x] All integration tests and required coverage checks are passing

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #772 and #857
