### PR TITLE
cmd/gossamer: rename verbosity to log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build:
 
 # init: Initialize gossamer using the default genesis and toml configuration files
 init:
-	./bin/gossamer init --verbosity debug
+	./bin/gossamer init --log debug
 
 ## start: Starts application from binary executable in `./bin/gossamer`
 start:

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -52,8 +52,8 @@ func TestExportCommand(t *testing.T) {
 		expected    *dot.Config
 	}{
 		{
-			"Test gossamer export --config --genesis --basepath --name --verbosity",
-			[]string{"config", "genesis", "basepath", "name", "verbosity"},
+			"Test gossamer export --config --genesis --basepath --name --log",
+			[]string{"config", "genesis", "basepath", "name", "log"},
 			[]interface{}{testConfig, genFile.Name(), testDir, testName, "trace"},
 			&dot.Config{
 				Global: dot.GlobalConfig{
@@ -77,8 +77,8 @@ func TestExportCommand(t *testing.T) {
 			},
 		},
 		{
-			"Test gossamer export --config --genesis --bootnodes --verbsoity --force",
-			[]string{"config", "genesis", "bootnodes", "verbosity", "force"},
+			"Test gossamer export --config --genesis --bootnodes --log --force",
+			[]string{"config", "genesis", "bootnodes", "log", "force"},
 			[]interface{}{testConfig, genFile.Name(), testBootnode, "trace", "true"},
 			&dot.Config{
 				Global: testCfg.Global,
@@ -98,8 +98,8 @@ func TestExportCommand(t *testing.T) {
 			},
 		},
 		{
-			"Test gossamer export --config --genesis --protocol --verbosity --force",
-			[]string{"config", "genesis", "protocol", "verbosity", "force"},
+			"Test gossamer export --config --genesis --protocol --log --force",
+			[]string{"config", "genesis", "protocol", "log", "force"},
 			[]interface{}{testConfig, genFile.Name(), testProtocol, "trace", "true"},
 			&dot.Config{
 				Global: testCfg.Global,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -94,7 +94,7 @@ var (
 	// BootnodesFlag Network service settings
 	BootnodesFlag = cli.StringFlag{
 		Name:  "bootnodes",
-		Usage: "Comma separated enode URLs for network discovery bootstrap",
+		Usage: "Comma separated encode URLs for network discovery bootstrap",
 	}
 	// ProtocolFlag Set protocol id
 	ProtocolFlag = cli.StringFlag{
@@ -104,12 +104,12 @@ var (
 	// NoBootstrapFlag Disables network bootstrapping
 	NoBootstrapFlag = cli.BoolFlag{
 		Name:  "nobootstrap",
-		Usage: "Disables network bootstrapping (mdns still enabled)",
+		Usage: "Disables network bootstrapping (mDNS still enabled)",
 	}
-	// NoMDNSFlag Disables network mdns
+	// NoMDNSFlag Disables network mDNS
 	NoMDNSFlag = cli.BoolFlag{
 		Name:  "nomdns",
-		Usage: "Disables network mdns discovery",
+		Usage: "Disables network mDNS discovery",
 	}
 )
 

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -94,7 +94,7 @@ var (
 	// BootnodesFlag Network service settings
 	BootnodesFlag = cli.StringFlag{
 		Name:  "bootnodes",
-		Usage: "Comma separated encode URLs for network discovery bootstrap",
+		Usage: "Comma separated node URLs for network discovery bootstrap",
 	}
 	// ProtocolFlag Set protocol id
 	ProtocolFlag = cli.StringFlag{

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -47,9 +47,9 @@ var (
 
 // Global node configuration flags
 var (
-	// VerbosityFlag cli service settings
-	VerbosityFlag = cli.StringFlag{
-		Name:  "verbosity",
+	// LogFlag cli service settings
+	LogFlag = cli.StringFlag{
+		Name:  "log",
 		Usage: "Supports levels crit (silent) to trce (trace)",
 		Value: log.LvlInfo.String(),
 	}
@@ -188,7 +188,7 @@ var (
 var (
 	// GlobalFlags are flags that are valid for use with the root command and all subcommands
 	GlobalFlags = []cli.Flag{
-		VerbosityFlag,
+		LogFlag,
 		NameFlag,
 		ChainFlag,
 		ConfigFlag,
@@ -262,21 +262,21 @@ func FixFlagOrder(f func(ctx *cli.Context) error) func(*cli.Context) error {
 
 			// check if flag is set as global or local flag
 			if ctx.GlobalIsSet(flagName) {
-				// log global flag if verbosity equals trace
-				if ctx.String(VerbosityFlag.Name) == trace {
+				// log global flag if log equals trace
+				if ctx.String(LogFlag.Name) == trace {
 					log.Trace("[cmd] global flag set", "name", flagName)
 				}
 			} else if ctx.IsSet(flagName) {
 				// check if global flag using set as global flag
 				err := ctx.GlobalSet(flagName, ctx.String(flagName))
 				if err == nil {
-					// log fixed global flag if verbosity equals trace
-					if ctx.String(VerbosityFlag.Name) == trace {
+					// log fixed global flag if log equals trace
+					if ctx.String(LogFlag.Name) == trace {
 						log.Trace("[cmd] global flag fixed", "name", flagName)
 					}
 				} else {
-					// if not global flag, log local flag if verbosity equals trace
-					if ctx.String(VerbosityFlag.Name) == trace {
+					// if not global flag, log local flag if log equals trace
+					if ctx.String(LogFlag.Name) == trace {
 						log.Trace("[cmd] local flag set", "name", flagName)
 					}
 				}

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -43,23 +43,23 @@ func TestFixFlagOrder(t *testing.T) {
 		values      []interface{}
 	}{
 		{
-			"Test gossamer --config --genesis --verbosity --force",
-			[]string{"config", "genesis", "verbosity", "force"},
+			"Test gossamer --config --genesis --log --force",
+			[]string{"config", "genesis", "log", "force"},
 			[]interface{}{testConfig.Name(), genFile.Name(), "trace", true},
 		},
 		{
-			"Test gossamer --config --genesis --force --verbosity",
-			[]string{"config", "genesis", "force", "verbosity"},
+			"Test gossamer --config --genesis --force --log",
+			[]string{"config", "genesis", "force", "log"},
 			[]interface{}{testConfig.Name(), genFile.Name(), true, "trace"},
 		},
 		{
-			"Test gossamer --config --force --genesis --verbosity",
-			[]string{"config", "force", "genesis", "verbosity"},
+			"Test gossamer --config --force --genesis --log",
+			[]string{"config", "force", "genesis", "log"},
 			[]interface{}{testConfig.Name(), true, genFile.Name(), "trace"},
 		},
 		{
-			"Test gossamer --force --config --genesis --verbosity",
-			[]string{"force", "config", "genesis", "verbosity"},
+			"Test gossamer --force --config --genesis --log",
+			[]string{"force", "config", "genesis", "log"},
 			[]interface{}{true, testConfig.Name(), genFile.Name(), "trace"},
 		},
 	}

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -50,7 +50,7 @@ var (
 		Usage:     "Initialize node databases and load genesis data to state",
 		ArgsUsage: "",
 		Flags:     InitFlags,
-		Category:  "INITIALIZATION",
+		Category:  "INIT",
 		Description: "The init command initializes the node databases and loads the genesis data from the genesis configuration file to state.\n" +
 			"\tUsage: gossamer init --genesis genesis.json",
 	}
@@ -58,9 +58,9 @@ var (
 	accountCommand = cli.Command{
 		Action:   FixFlagOrder(accountAction),
 		Name:     "account",
-		Usage:    "manage gossamer keystore",
+		Usage:    "Create and manage node keystore accounts",
 		Flags:    AccountFlags,
-		Category: "KEYSTORE",
+		Category: "ACCOUNT",
 		Description: "The account command is used to manage the gossamer keystore.\n" +
 			"\tTo generate a new sr25519 account: gossamer account --generate\n" +
 			"\tTo generate a new ed25519 account: gossamer account --generate --ed25519\n" +

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -36,9 +36,9 @@ func startLogger(ctx *cli.Context) error {
 
 	var lvl log.Lvl
 
-	if lvlToInt, err := strconv.Atoi(ctx.String(VerbosityFlag.Name)); err == nil {
+	if lvlToInt, err := strconv.Atoi(ctx.String(LogFlag.Name)); err == nil {
 		lvl = log.Lvl(lvlToInt)
-	} else if lvl, err = log.LvlFromString(ctx.String(VerbosityFlag.Name)); err != nil {
+	} else if lvl, err = log.LvlFromString(ctx.String(LogFlag.Name)); err != nil {
 		return err
 	}
 

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -88,26 +88,26 @@ func TestStartLogger(t *testing.T) {
 		expected    error
 	}{
 		{
-			"Test gossamer --verbosity info",
-			[]string{"verbosity"},
+			"Test gossamer --log info",
+			[]string{"log"},
 			[]interface{}{"info"},
 			nil,
 		},
 		{
-			"Test gossamer --verbosity debug",
-			[]string{"verbosity"},
+			"Test gossamer --log debug",
+			[]string{"log"},
 			[]interface{}{"debug"},
 			nil,
 		},
 		{
-			"Test gossamer --verbosity trace",
-			[]string{"verbosity"},
+			"Test gossamer --log trace",
+			[]string{"log"},
 			[]interface{}{"trace"},
 			nil,
 		},
 		{
-			"Test gossamer --verbosity blah",
-			[]string{"verbosity"},
+			"Test gossamer --log blah",
+			[]string{"log"},
 			[]interface{}{"blah"},
 			fmt.Errorf("Unknown level: blah"),
 		},


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- rename `verbosity` to `log`
- rename `--verbosity` to `--log`
- rename `VerbosityFlag` to `LogFlag`
- some minor cli formatting / cleanup

## Tests:

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist:

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CONTRIBUTING](CONTRIBUTING.md) and [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] I have linked any relevant issues in my pull request comments
- [ ] All integration tests and required coverage checks are passing - ***needs approval***

## Issues:

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #772 and #857
