### PR TITLE
fix github pages deployment - third attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,6 @@ jobs:
     before_install:
     - gem update --system
     - gem --version
-    branches:
-      only:
-      - development  # build and deploy on merge into development
     cache: bundler # caching bundler gem packages will speed up build
     script:
     - cd docs
@@ -79,7 +76,7 @@ jobs:
       local_dir: docs
       target_branch: gh-pages
       on:
-        branch: development
+        branch: development # deploy on merge into development
   allow_failures:
     - stage: build
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ cache:
   - $GOPATH/pkg/mod
 before_cache:
 - rm -f ./trie/failing_test_data
-matrix:
+jobs:
   include:
   - name: Go Linter
     script: make lint
@@ -53,11 +53,29 @@ matrix:
     script:
     - make docker-build
     - make docker-version
-  - name: Deploy Gossamer Docs
+  - name: Build Gossamer Docs
+    language: ruby
+    rvm:
+    - 2.6.3
+    gemfile:
+    - docs/Gemfile
+    before_install:
+    - gem update --system
+    - gem --version
+    branches:
+      only:
+      - development  # build and deploy on merge into development
+    cache: bundler # caching bundler gem packages will speed up build
+    script:
+    - cd docs
+    - bundle exec jekyll build
     deploy:
+      os: linux
+      dist: xenial
+      strategy: git
       provider: pages
-      skip_cleanup: true
-      github_token: $GITHUB_TOKEN # set in settings on travis as a secure variable
+      cleanup: true
+      token: $GITHUB_TOKEN # set in settings on travis as a secure variable
       local_dir: docs
       target_branch: gh-pages
       on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@
 
 language: go
 
+os: linux
+dist: xenial
 go:
 - 1.13.x
 env:
@@ -70,8 +72,6 @@ jobs:
     - cd docs
     - bundle exec jekyll build
     deploy:
-      os: linux
-      dist: xenial
       strategy: git
       provider: pages
       cleanup: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
       dist: xenial
       strategy: git
       provider: pages
-      cleanup: true
+      cleanup: false
       token: $GITHUB_TOKEN # set in settings on travis as a secure variable
       local_dir: docs
       target_branch: gh-pages


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix travis configuration warning messages (ie, `matrix`, `cleanup`, `token`)

- build site with travis using updated bundler and specific ruby environment needed for build (GitHub failed to build on second attempt because environment was not properly set up)

- then deploy to GitHub using the full `docs` directory as the `local_dir` (GitHub stalled on build the first attempt when I used `docs/_site` (only the built site directory))

- GitHub should recognize the `docs` directory as a jekyll project (it did so with the second attempt) and the `_site` directory as the built site (GitHub _should_ use the site built by travis rather than trying to build without the proper environment settings)

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

