### PR TITLE
lib/babe: use estimateCurrentSlot if not enough blocks synced

### DIFF
--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -300,13 +300,18 @@ func (b *Session) invokeBlockAuthoring() {
 				log.Error("[babe] cannot get current slot", "error", err)
 				return
 			}
-
-			log.Debug("[babe]", "calculated slot", slotNum)
 		} else {
-			log.Warn("[babe] Failed to calculate slot; not enough blocks synced")
-			return
+			log.Warn("[babe] cannot use median, not enough blocks synced")
+
+			slotNum, err = b.estimateCurrentSlot()
+			if err != nil {
+				log.Error("[babe] cannot get current slot", "error", err)
+				return
+			}
 		}
 	}
+
+	log.Debug("[babe]", "calculated slot", slotNum)
 
 	for ; slotNum < b.startSlot+b.config.EpochLength; slotNum++ {
 		start := time.Now().Unix()


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `invokeBlockAuthoring` to use `estimateCurrentSlot` if there are less than `slotTail` blocks synced 

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/babe/
make gossamer
./bin/gossamer --key alice init --force
./bin/gossamer --key alice --log debug
(restart node)
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [ ] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [ ] I have provided as much information as possible and necessary
- [ ] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #927 
