### PR TITLE
dot/core, lib/grandpa, lib/scale: implement FinalityGadget interface, implement ability to convert grandpa messages to network messages

### DIFF
--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -19,9 +19,11 @@ package core
 import (
 	"math/big"
 
+	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/services"
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 )
@@ -77,6 +79,21 @@ type TransactionQueue interface {
 	Pop() *transaction.ValidTransaction
 	Peek() *transaction.ValidTransaction
 	RemoveExtrinsic(ext types.Extrinsic)
+}
+
+// FinalityGadget is the interface that a finality gadget must implement
+type FinalityGadget interface {
+	services.Service
+
+	GetVoteOutChannel() <-chan FinalityMessage
+	GetVoteInChannel() chan<- FinalityMessage
+	GetFinalizedChannel() <-chan FinalityMessage
+	DecodeMessage(*network.ConsensusMessage) (FinalityMessage, error)
+}
+
+// FinalityMessage is the interface a finality message must implement
+type FinalityMessage interface {
+	ToConsensusMessage() (*network.ConsensusMessage, error)
 }
 
 // BlockProducer is the interface that a block production service must implement

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -197,7 +197,11 @@ func (bs *BlockState) GetHeader(hash common.Hash) (*types.Header, error) {
 	}
 
 	rw := &bytes.Buffer{}
-	rw.Write(data)
+	_, err = rw.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
 	_, err = result.Decode(rw)
 	if err != nil {
 		return nil, err

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"math/big"
@@ -195,7 +196,9 @@ func (bs *BlockState) GetHeader(hash common.Hash) (*types.Header, error) {
 		return nil, err
 	}
 
-	err = result.Decode(data)
+	rw := &bytes.Buffer{}
+	rw.Write(data)
+	_, err = result.Decode(rw)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/types/block.go
+++ b/dot/types/block.go
@@ -17,6 +17,8 @@
 package types
 
 import (
+	"io"
+
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
@@ -64,8 +66,9 @@ func (b *Block) Encode() ([]byte, error) {
 }
 
 // Decode decodes the SCALE encoded input into this block
-func (b *Block) Decode(in []byte) error {
-	_, err := scale.Decode(in, b)
+func (b *Block) Decode(r io.Reader) error {
+	sd := scale.Decoder{Reader: r}
+	_, err := sd.Decode(b)
 	return err
 }
 

--- a/dot/types/block_test.go
+++ b/dot/types/block_test.go
@@ -72,7 +72,10 @@ func TestDecodeBlock(t *testing.T) {
 	// see https://github.com/paritytech/substrate/blob/master/test-utils/runtime/src/system.rs#L376
 	data := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 39, 71, 171, 124, 13, 195, 139, 127, 42, 251, 168, 43, 213, 226, 214, 172, 239, 140, 49, 224, 152, 0, 246, 96, 183, 94, 200, 74, 112, 5, 9, 159, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
 	bh := NewEmptyBlock()
-	err := bh.Decode(data)
+
+	rw := &bytes.Buffer{}
+	rw.Write(data)
+	err := bh.Decode(rw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +112,10 @@ func TestDecodeBlock(t *testing.T) {
 func TestDeepCopyBlock(t *testing.T) {
 	data := []byte{69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 69, 4, 39, 71, 171, 124, 13, 195, 139, 127, 42, 251, 168, 43, 213, 226, 214, 172, 239, 140, 49, 224, 152, 0, 246, 96, 183, 94, 200, 74, 112, 5, 9, 159, 3, 23, 10, 46, 117, 151, 183, 183, 227, 216, 76, 5, 57, 29, 19, 154, 98, 177, 87, 231, 135, 134, 216, 192, 130, 242, 157, 207, 76, 17, 19, 20, 0, 0}
 	block := NewEmptyBlock()
-	err := block.Decode(data)
+
+	rw := &bytes.Buffer{}
+	rw.Write(data)
+	err := block.Decode(rw)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -43,7 +43,7 @@ func (h ConsensusEngineID) ToBytes() []byte {
 var BabeEngineID = ConsensusEngineID{'B', 'A', 'B', 'E'}
 
 // GrandpaEngineID is the hard-coded grandpa ID
-var GrandpaEngineID = ConsensusEngineID{'F', 'R', 'N', 'K'} //nolint
+var GrandpaEngineID = ConsensusEngineID{'F', 'R', 'N', 'K'}
 
 // ChangesTrieRootDigestType is the byte representation of ChangesTrieRootDigest
 var ChangesTrieRootDigestType = byte(2)

--- a/dot/types/header.go
+++ b/dot/types/header.go
@@ -106,9 +106,10 @@ func (bh *Header) Encode() ([]byte, error) {
 }
 
 // Decode decodes the SCALE encoded input into this header
-func (bh *Header) Decode(in []byte) error {
-	_, err := scale.Decode(in, bh)
-	return err
+func (bh *Header) Decode(r io.Reader) (*Header, error) {
+	sd := scale.Decoder{Reader: r}
+	_, err := sd.Decode(bh)
+	return bh, err
 }
 
 // AsOptional returns the Header as an optional.Header

--- a/dot/types/header_test.go
+++ b/dot/types/header_test.go
@@ -16,4 +16,27 @@
 
 package types
 
-// TODO: improve dot tests #687
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeHeader(t *testing.T) {
+	header, err := NewHeader(common.Hash{}, big.NewInt(0), common.Hash{}, common.Hash{}, [][]byte{{}})
+	require.NoError(t, err)
+
+	enc, err := header.Encode()
+	require.NoError(t, err)
+
+	rw := &bytes.Buffer{}
+	rw.Write(enc)
+	dec, err := new(Header).Decode(rw)
+	require.NoError(t, err)
+	dec.Hash()
+	require.Equal(t, header, dec)
+}

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -19,7 +19,6 @@ package blocktree
 import (
 	"bytes"
 	"math/big"
-	"math/rand"
 	"reflect"
 	"testing"
 
@@ -202,30 +201,6 @@ func TestBlockTree_DeepestLeaf(t *testing.T) {
 	})
 
 	deepestLeaf := bt.deepestLeaf()
-	if deepestLeaf.hash != expected {
-		t.Fatalf("Fail: got %s expected %s", deepestLeaf.hash, expected)
-	}
-
-	r := *rand.New(rand.NewSource(rand.Int63()))
-	earliestTime := uint64(1 << 63)
-
-	deepest = big.NewInt(0)
-
-	bt.leaves.smap.Range(func(h, n interface{}) bool {
-		leaf := h.(Hash)
-		node := n.(*node)
-		node.arrivalTime = uint64(r.Intn(256))
-		if node.arrivalTime < earliestTime && node.depth.Cmp(deepest) >= 0 {
-			earliestTime = node.arrivalTime
-			expected = node.hash
-			deepest = node.depth
-			t.Logf("expected leaf=%s depth=%d arrivalTime=%d", leaf, node.depth, node.arrivalTime)
-		}
-		t.Logf("leaf=%s depth=%d arrivalTime=%d", leaf, node.depth, node.arrivalTime)
-		return true
-	})
-
-	deepestLeaf = bt.deepestLeaf()
 	if deepestLeaf.hash != expected {
 		t.Fatalf("Fail: got %s expected %s", deepestLeaf.hash, expected)
 	}

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -78,6 +78,31 @@ func HexToBytes(in string) ([]byte, error) {
 	return out, err
 }
 
+// MustHexToBytes turns a 0x prefixed hex string into a byte slice
+// it panic if it cannot decode the string
+func MustHexToBytes(in string) []byte {
+	if len(in) < 2 {
+		panic("invalid string")
+	}
+
+	if strings.Compare(in[:2], "0x") != 0 {
+		panic(ErrNoPrefix)
+	}
+
+	// Ensure we have an even length, otherwise hex.DecodeString will fail and return zero hash
+	if len(in)%2 != 0 {
+		panic("cannot decode a odd length string")
+	}
+
+	in = in[2:]
+	out, err := hex.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+
+	return out
+}
+
 // BytesToHex turns a byte slice into a 0x prefixed hex string
 func BytesToHex(in []byte) string {
 	s := hex.EncodeToString(in)

--- a/lib/common/hash.go
+++ b/lib/common/hash.go
@@ -101,3 +101,21 @@ func HexToHash(in string) (Hash, error) {
 	copy(buf[:], out)
 	return buf, err
 }
+
+// MustHexToHash turns a 0x prefixed hex string into type Hash
+// it panics if it cannot turn the string into a Hash
+func MustHexToHash(in string) Hash {
+	if strings.Compare(in[:2], "0x") != 0 {
+		panic("could not byteify non 0x prefixed string")
+	}
+
+	in = in[2:]
+	out, err := hex.DecodeString(in)
+	if err != nil {
+		panic(err)
+	}
+
+	var buf = [32]byte{}
+	copy(buf[:], out)
+	return buf
+}

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto"
@@ -53,6 +54,17 @@ type PublicKey ed25519.PublicKey
 
 // PublicKeyBytes is an encoded ed25519 public key
 type PublicKeyBytes [PublicKeyLength]byte
+
+// Encode returns the SCALE encoding of PublicKeyBytes
+func (b PublicKeyBytes) Encode() ([]byte, error) {
+	return b[:], nil
+}
+
+// Encode returns the SCALE encoding of PublicKeyBytes
+func (b PublicKeyBytes) Decode(r io.Reader) ([PublicKeyLength]byte, error) {
+	_, err := r.Read(b[:])
+	return b, err
+}
 
 // SignatureBytes is a ed25519 signature
 type SignatureBytes [SignatureLength]byte

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -60,7 +60,7 @@ func (b PublicKeyBytes) Encode() ([]byte, error) {
 	return b[:], nil
 }
 
-// Encode returns the SCALE encoding of PublicKeyBytes
+// Decode returns the SCALE decoded PublicKeyBytes
 func (b PublicKeyBytes) Decode(r io.Reader) ([PublicKeyLength]byte, error) {
 	_, err := r.Read(b[:])
 	return b, err

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -56,3 +56,6 @@ var ErrNoGHOST = errors.New("cannot determine grandpa-GHOST")
 
 // ErrCannotDecodeSubround is returned when a subround value cannot be decoded
 var ErrCannotDecodeSubround = errors.New("cannot decode invalid subround value")
+
+// ErrInvalidMessageType is returned when a network.Message cannot be decoded
+var ErrInvalidMessageType = errors.New("cannot decode invalid message type")

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -53,3 +53,5 @@ var ErrNoPreVotedBlock = errors.New("cannot get pre-voted block")
 // ErrNoGHOST is returned when there is no GHOST. the only case where this could happen is if there are no votes
 // at all, so it shouldn't ever happen.
 var ErrNoGHOST = errors.New("cannot determine grandpa-GHOST")
+
+var ErrCannotDecodeSubround = errors.New("cannot decode invalid subround value")

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -54,4 +54,5 @@ var ErrNoPreVotedBlock = errors.New("cannot get pre-voted block")
 // at all, so it shouldn't ever happen.
 var ErrNoGHOST = errors.New("cannot determine grandpa-GHOST")
 
+// ErrCannotDecodeSubround is returned when a subround value cannot be decoded
 var ErrCannotDecodeSubround = errors.New("cannot decode invalid subround value")

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -53,9 +53,9 @@ type Service struct {
 	bestFinalCandidate map[uint64]*Vote // map of round number -> best final candidate
 
 	// channels for communication with other services
-	in        <-chan *VoteMessage
-	out       chan<- *VoteMessage  // TODO: make this generic
-	finalized chan<- *types.Header // channel that finalized blocks are output from at the end of a round
+	in        chan FinalityMessage // only used to receive *VoteMessage
+	out       chan FinalityMessage // only used to send *VoteMessage
+	finalized chan FinalityMessage // only used to send *FinalizationMessage; channel that finalized blocks are output from at the end of a round
 }
 
 // Config represents a GRANDPA service configuration
@@ -63,9 +63,6 @@ type Config struct {
 	BlockState BlockState
 	Voters     []*Voter
 	Keypair    *ed25519.Keypair
-	In         <-chan *VoteMessage
-	Out        chan<- *VoteMessage
-	Finalized  chan<- *types.Header
 }
 
 // NewService returns a new GRANDPA Service instance.
@@ -95,13 +92,35 @@ func NewService(cfg *Config) (*Service, error) {
 		preVotedBlock:      make(map[uint64]*Vote),
 		bestFinalCandidate: make(map[uint64]*Vote),
 		head:               head,
-		in:                 cfg.In,
-		out:                cfg.Out,
-		finalized:          cfg.Finalized,
+		in:                 make(chan FinalityMessage, 128),
+		out:                make(chan FinalityMessage, 128),
+		finalized:          make(chan FinalityMessage, 128),
 		stopped:            true,
 	}
 
 	return s, nil
+}
+
+// Start begins the GRANDPA finality service
+func (s *Service) Start() error {
+	go func() {
+		err := s.initiate()
+		if err != nil {
+			log.Error("[grandpa] failed to initiate")
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the GRANDPA finality service
+func (s *Service) Stop() error {
+	s.chanLock.Lock()
+	defer s.chanLock.Unlock()
+
+	s.stopped = true
+	close(s.out)
+	return nil
 }
 
 func (s *Service) publicKeyBytes() ed25519.PublicKeyBytes {
@@ -130,6 +149,10 @@ func (s *Service) initiate() error {
 			return err
 		}
 
+		if s.stopped {
+			return nil
+		}
+
 		err = s.initiate()
 		if err != nil {
 			return err
@@ -150,7 +173,12 @@ func (s *Service) playGrandpaRound() error {
 
 	// if primary, broadcast the best final candidate from the previous round
 	if bytes.Equal(primary.key.Encode(), s.keypair.Public().Encode()) {
-		// TODO: broadcast finalization message #934
+		msg, err := s.newFinalizationMessage(s.head, s.state.round-1)
+		if err != nil {
+			return err
+		}
+
+		s.finalized <- msg
 	}
 
 	log.Debug("grandpa] receiving pre-vote messages...")
@@ -232,7 +260,7 @@ func (s *Service) playGrandpaRound() error {
 				log.Trace("[grandpa] failed to check if round is completable", "error", err)
 			}
 
-			finalizable, err := s.isFinalizable(s.state.round - 1)
+			finalizable, err := s.isFinalizable(s.state.round)
 			if err != nil {
 				log.Trace("[grandpa] failed to check if round is finalizable", "error", err)
 			}
@@ -276,10 +304,15 @@ func (s *Service) attemptToFinalize() error {
 			return err
 		}
 
-		// TODO: if we haven't received a finalization message for this block yet,
-		// broadcast a finalization message #934
+		// if we haven't received a finalization message for this block yet, broadcast a finalization message
 		log.Debug("[grandpa] finalized block!!!", "hash", s.head)
-		s.finalized <- s.head
+		msg, err := s.newFinalizationMessage(s.head, s.state.round)
+		if err != nil {
+			return err
+		}
+
+		// TODO: safety
+		s.finalized <- msg
 		return nil
 	}
 
@@ -350,7 +383,14 @@ func (s *Service) isFinalizable(round uint64) (bool, error) {
 		return false, err
 	}
 
-	if bfc.number <= pvb.number && (s.state.round == 0 || s.bestFinalCandidate[s.state.round-1].number <= bfc.number) {
+	pc, err := s.getTotalVotesForBlock(bfc.hash, precommit)
+	if err != nil {
+		return false, err
+	}
+
+	s.mapLock.Lock()
+	defer s.mapLock.Unlock()
+	if bfc.number <= pvb.number && (s.state.round == 0 || s.bestFinalCandidate[s.state.round-1].number <= bfc.number) && pc >= s.state.threshold() {
 		return true, nil
 	}
 

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -132,8 +132,10 @@ func (s *Service) initiate() error {
 	s.stopped = false
 
 	if s.state.round == 0 {
+		s.mapLock.Lock()
 		s.preVotedBlock[0] = NewVoteFromHeader(s.head)
 		s.bestFinalCandidate[0] = NewVoteFromHeader(s.head)
+		s.mapLock.Unlock()
 	}
 
 	s.state.round++
@@ -266,11 +268,15 @@ func (s *Service) playGrandpaRound() error {
 			}
 
 			// this shouldn't happen as long as playGrandpaRound is called through initiate
-			if s.bestFinalCandidate[s.state.round-1] == nil {
+			s.mapLock.Lock()
+			prevBfc := s.bestFinalCandidate[s.state.round-1]
+			s.mapLock.Unlock()
+
+			if prevBfc == nil {
 				return false
 			}
 
-			if completable && finalizable && uint64(s.head.Number.Int64()) >= s.bestFinalCandidate[s.state.round-1].number {
+			if completable && finalizable && uint64(s.head.Number.Int64()) >= prevBfc.number {
 				return true
 			}
 
@@ -371,7 +377,10 @@ func (s *Service) isFinalizable(round uint64) (bool, error) {
 			return false, err
 		}
 	} else {
+		s.mapLock.Lock()
 		v, has := s.preVotedBlock[round]
+		s.mapLock.Unlock()
+
 		if !has {
 			return false, ErrNoPreVotedBlock
 		}
@@ -389,8 +398,10 @@ func (s *Service) isFinalizable(round uint64) (bool, error) {
 	}
 
 	s.mapLock.Lock()
-	defer s.mapLock.Unlock()
-	if bfc.number <= pvb.number && (s.state.round == 0 || s.bestFinalCandidate[s.state.round-1].number <= bfc.number) && pc >= s.state.threshold() {
+	prevBfc := s.bestFinalCandidate[s.state.round-1]
+	s.mapLock.Unlock()
+
+	if bfc.number <= pvb.number && (s.state.round == 0 || prevBfc.number <= bfc.number) && pc >= s.state.threshold() {
 		return true, nil
 	}
 
@@ -409,10 +420,13 @@ func (s *Service) finalize() error {
 	if err != nil {
 		return err
 	}
+	s.mapLock.Lock()
 	s.preVotedBlock[s.state.round] = &pv
 
 	// set best final candidate
 	s.bestFinalCandidate[s.state.round] = bfc
+	s.mapLock.Unlock()
+
 	s.head, err = s.blockState.GetHeader(bfc.hash)
 	if err != nil {
 		return err

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -257,12 +257,12 @@ func (s *Service) playGrandpaRound() error {
 		s.receiveMessages(func() bool {
 			completable, err := s.isCompletable() //nolint
 			if err != nil {
-				log.Trace("[grandpa] failed to check if round is completable", "error", err)
+				return false
 			}
 
 			finalizable, err := s.isFinalizable(s.state.round)
 			if err != nil {
-				log.Trace("[grandpa] failed to check if round is finalizable", "error", err)
+				return false
 			}
 
 			// this shouldn't happen as long as playGrandpaRound is called through initiate

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -1,0 +1,136 @@
+package grandpa
+
+import (
+	"io"
+
+	"github.com/ChainSafe/gossamer/dot/core"
+	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+// FinalityMessage is an alias for the core.FinalityMessage interface
+type FinalityMessage = core.FinalityMessage
+
+// ConsensusMessage is an alias for network.ConsensusMessage
+type ConsensusMessage = network.ConsensusMessage
+
+// GetVoteOutChannel returns a read-only VoteMessage channel
+func (s *Service) GetVoteOutChannel() <-chan FinalityMessage {
+	return s.out
+}
+
+// GetVoteInChannel returns a write-only VoteMessage channel
+func (s *Service) GetVoteInChannel() chan<- FinalityMessage {
+	return s.in
+}
+
+// GetFinalizedChannel returns a read-only FinalizationMessage channel
+func (s *Service) GetFinalizedChannel() <-chan FinalityMessage {
+	return s.finalized
+}
+
+// DecodeMessage decodes a network-level consensus message into a GRANDPA VoteMessage or FinalizationMessage
+func (s *Service) DecodeMessage(msg *ConsensusMessage) (FinalityMessage, error) {
+	m, err := scale.Decode(msg.Data, &VoteMessage{Message: new(SignedMessage)})
+	if err != nil {
+		// try FinalizatioNmessage
+		// TODO: scale should be able to handle nil pointers
+		m, err = scale.Decode(msg.Data, &FinalizationMessage{
+			Vote: new(Vote),
+			//Justification: []*Justification{},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return m.(*FinalizationMessage), nil
+	}
+
+	return m.(*VoteMessage), nil
+}
+
+// FullVote represents a vote with additional information about the state
+// this is encoded and signed and the signature is included in SignedMessage
+type FullVote struct {
+	Stage subround
+	Vote  *Vote
+	Round uint64
+	SetID uint64
+}
+
+// SignedMessage represents a block hash and number signed by an authority
+type SignedMessage struct {
+	Hash        common.Hash
+	Number      uint64
+	Signature   [64]byte // ed25519.SignatureLength
+	AuthorityID ed25519.PublicKeyBytes
+}
+
+// VoteMessage represents a network-level vote message
+// https://github.com/paritytech/substrate/blob/master/client/finality-grandpa/src/communication/gossip.rs#L336
+type VoteMessage struct {
+	SetID   uint64
+	Round   uint64
+	Stage   subround // 0 for pre-vote, 1 for pre-commit
+	Message *SignedMessage
+}
+
+// ToConsensusMessage converts the VoteMessage into a network-level consensus message
+func (v *VoteMessage) ToConsensusMessage() (*ConsensusMessage, error) {
+	enc, err := scale.Encode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              enc,
+	}, nil
+}
+
+// Justification represents a justification for a finalized block
+//nolint:structcheck
+type Justification struct {
+	Vote      *Vote    //nolint:unused
+	Signature []byte   //nolint:unused
+	Pubkey    [32]byte //nolint:unused
+}
+
+// Decode returns the SCALE decoded Justification
+func (j *Justification) Decode(r io.Reader) (*Justification, error) {
+	sd := &scale.Decoder{Reader: r}
+	i, err := sd.Decode(j)
+	return i.(*Justification), err
+}
+
+// FinalizationMessage represents a network finalization message
+//nolint:structcheck
+type FinalizationMessage struct {
+	Round uint64
+	Vote  *Vote
+	//Justification []*Justification //nolint:unused
+}
+
+// ToConsensusMessage converts the FinalizationMessage into a network-level consensus message
+func (f *FinalizationMessage) ToConsensusMessage() (*ConsensusMessage, error) {
+	enc, err := scale.Encode(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              enc,
+	}, nil
+}
+
+func (s *Service) newFinalizationMessage(header *types.Header, round uint64) (*FinalizationMessage, error) { //nolint
+	return &FinalizationMessage{
+		Round: round,
+		Vote:  NewVoteFromHeader(header),
+		// TODO: add justification
+	}, nil
+}

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -1,0 +1,128 @@
+package grandpa
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeMessage_VoteMessage(t *testing.T) {
+	gs := &Service{}
+
+	cm := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x4d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000050de12b09722c4676f022d7200001b90183b3cf7e2e0a5ec009859b3c0956db6ccf35ac019ff5fd73640e3f0dcf658a92b56842b7821f4b7e77eb891931d370034602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+	}
+
+	msg, err := gs.DecodeMessage(cm)
+	require.NoError(t, err)
+
+	sigb := common.MustHexToBytes("0x50de12b09722c4676f022d7200001b90183b3cf7e2e0a5ec009859b3c0956db6ccf35ac019ff5fd73640e3f0dcf658a92b56842b7821f4b7e77eb891931d3700")
+	sig := [64]byte{}
+	copy(sig[:], sigb)
+
+	expected := &VoteMessage{
+		SetID: 77,
+		Round: 99,
+		Stage: precommit,
+		Message: &SignedMessage{
+			Hash:        common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
+			Number:      0x7777,
+			Signature:   sig,
+			AuthorityID: ed25519.PublicKeyBytes(common.MustHexToHash("0x34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691")),
+		},
+	}
+
+	require.Equal(t, expected, msg)
+}
+
+func TestDecodeMessage_FinalizationMessage(t *testing.T) {
+	gs := &Service{}
+
+	cm := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x4d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0100000000000000"),
+	}
+
+	msg, err := gs.DecodeMessage(cm)
+	require.NoError(t, err)
+
+	expected := &FinalizationMessage{
+		Round: 77,
+		Vote: &Vote{
+			hash:   common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
+			number: 1,
+		},
+	}
+
+	require.Equal(t, expected, msg)
+}
+
+func TestVoteMessageToConsensusMessage(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState: st.Block,
+		Voters:     voters,
+		Keypair:    kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	v, err := NewVoteFromHash(st.Block.BestBlockHash(), st.Block)
+	require.NoError(t, err)
+
+	gs.state.setID = 77
+	gs.state.round = 99
+	v.number = 0x7777
+	vm, err := gs.createVoteMessage(v, precommit, gs.keypair)
+	require.NoError(t, err)
+
+	cm, err := vm.ToConsensusMessage()
+	require.NoError(t, err)
+
+	expected := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x4d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000036e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+	}
+
+	require.Equal(t, expected, cm)
+}
+
+func TestFinalizationMessageToConsensusMessage(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState: st.Block,
+		Voters:     voters,
+		Keypair:    kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	fm, err := gs.newFinalizationMessage(gs.head, 77)
+	require.NoError(t, err)
+
+	cm, err := fm.ToConsensusMessage()
+	require.NoError(t, err)
+
+	expected := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x4d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0000000000000000"),
+	}
+
+	require.Equal(t, expected, cm)
+}

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -16,7 +16,7 @@ func TestDecodeMessage_VoteMessage(t *testing.T) {
 
 	cm := &ConsensusMessage{
 		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x4d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000050de12b09722c4676f022d7200001b90183b3cf7e2e0a5ec009859b3c0956db6ccf35ac019ff5fd73640e3f0dcf658a92b56842b7821f4b7e77eb891931d370034602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+		Data:              common.MustHexToBytes("0x004d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000050de12b09722c4676f022d7200001b90183b3cf7e2e0a5ec009859b3c0956db6ccf35ac019ff5fd73640e3f0dcf658a92b56842b7821f4b7e77eb891931d370034602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
 	}
 
 	msg, err := gs.DecodeMessage(cm)
@@ -46,7 +46,7 @@ func TestDecodeMessage_FinalizationMessage(t *testing.T) {
 
 	cm := &ConsensusMessage{
 		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x4d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0100000000000000"),
+		Data:              common.MustHexToBytes("0x014d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0100000000000000"),
 	}
 
 	msg, err := gs.DecodeMessage(cm)
@@ -92,7 +92,7 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 
 	expected := &ConsensusMessage{
 		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x4d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000036e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+		Data:              common.MustHexToBytes("0x004d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000036e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
 	}
 
 	require.Equal(t, expected, cm)
@@ -121,7 +121,7 @@ func TestFinalizationMessageToConsensusMessage(t *testing.T) {
 
 	expected := &ConsensusMessage{
 		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x4d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0000000000000000"),
+		Data:              common.MustHexToBytes("0x014d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0000000000000000"),
 	}
 
 	require.Equal(t, expected, cm)

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -206,7 +206,7 @@ func TestValidateMessage_InvalidSignature(t *testing.T) {
 	msg, err := gs.createVoteMessage(NewVoteFromHeader(h), prevote, kr.Alice)
 	require.NoError(t, err)
 
-	msg.message.signature[63] = 0
+	msg.Message.Signature[63] = 0
 
 	_, err = gs.validateMessage(msg)
 	require.Equal(t, err, ErrInvalidSignature)

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -131,7 +131,7 @@ func GetRuntimeVars(targetRuntime string) (string, string, func() (*wasm.Imports
 		registerImports = RegisterImports_NodeRuntime
 		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(NODE_RUNTIME_FP), NODE_RUNTIME_URL
 	case TEST_RUNTIME:
-		registerImports = RegisterImports_TestRuntime
+		registerImports = RegisterImports_NodeRuntime
 		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(TESTS_FP), TEST_WASM_URL
 	default:
 		registerImports = RegisterImports_NodeRuntime

--- a/lib/scale/decode.go
+++ b/lib/scale/decode.go
@@ -24,6 +24,8 @@ import (
 	"io"
 	"math/big"
 	"reflect"
+	"runtime"
+	"strings"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 )
@@ -70,6 +72,22 @@ func (sd *Decoder) Decode(t interface{}) (out interface{}, err error) {
 	case [][32]byte, [][]byte:
 		out, err = sd.DecodeArray(t)
 	case interface{}:
+		// check if type has a custom Decode function defined
+		// but first, make sure that the function that called this function wasn't the type's Decode function,
+		// or else we will end up in an infinite recursive loop
+		pc, _, _, ok := runtime.Caller(1)
+		details := runtime.FuncForPC(pc)
+		var caller string
+		if ok && details != nil {
+			caller = details.Name()
+		}
+
+		if !strings.Contains(caller, "Decode") || strings.Contains(caller, "scale") {
+			if o, err := sd.DecodeCustom(t); err == nil {
+				return o, nil
+			}
+		}
+
 		out, err = sd.DecodeInterface(t)
 	default:
 		return nil, errors.New("decode error: unsupported type")
@@ -466,6 +484,11 @@ func (sd *Decoder) DecodeTuple(t interface{}) (interface{}, error) { //nolint
 				if _, err = sd.Reader.Read(b); err == nil {
 					copy((*ptr)[:], b)
 				}
+			case *[64]byte:
+				b := make([]byte, 64)
+				if _, err = sd.Reader.Read(b); err == nil {
+					copy((*ptr)[:], b)
+				}
 			case *string:
 				if o, err = sd.DecodeByteArray(); err == nil {
 					// get the pointer to the value and set the value
@@ -477,6 +500,11 @@ func (sd *Decoder) DecodeTuple(t interface{}) (interface{}, error) { //nolint
 				}
 			default:
 				var o interface{}
+				if o, err := sd.DecodeCustom(fieldValue); err == nil {
+					field.Set(reflect.ValueOf(o))
+					continue
+				}
+
 				// TODO: clean up this function, can use field.Set everywhere (remove switch case?)
 				if o, err = sd.Decode(v.Field(i).Interface()); err == nil {
 					field.Set(reflect.ValueOf(o))

--- a/lib/scale/decode.go
+++ b/lib/scale/decode.go
@@ -82,7 +82,8 @@ func (sd *Decoder) Decode(t interface{}) (out interface{}, err error) {
 			caller = details.Name()
 		}
 
-		if !strings.Contains(caller, "Decode") || strings.Contains(caller, "scale") {
+		// allow the call to DecodeCustom to proceed if the call comes from inside scale, and isn't a test
+		if !strings.Contains(caller, "Decode") || (strings.Contains(caller, "scale") && !strings.Contains(caller, "test")) {
 			if out, err = sd.DecodeCustom(t); err == nil {
 				return out, nil
 			}

--- a/lib/scale/decode.go
+++ b/lib/scale/decode.go
@@ -83,8 +83,8 @@ func (sd *Decoder) Decode(t interface{}) (out interface{}, err error) {
 		}
 
 		if !strings.Contains(caller, "Decode") || strings.Contains(caller, "scale") {
-			if o, err := sd.DecodeCustom(t); err == nil {
-				return o, nil
+			if out, err = sd.DecodeCustom(t); err == nil {
+				return out, nil
 			}
 		}
 
@@ -499,8 +499,7 @@ func (sd *Decoder) DecodeTuple(t interface{}) (interface{}, error) { //nolint
 					*ptr = o.([]string)
 				}
 			default:
-				var o interface{}
-				if o, err := sd.DecodeCustom(fieldValue); err == nil {
+				if o, err = sd.DecodeCustom(fieldValue); err == nil {
 					field.Set(reflect.ValueOf(o))
 					continue
 				}

--- a/lib/scale/decode_ptr.go
+++ b/lib/scale/decode_ptr.go
@@ -75,7 +75,7 @@ func (sd *Decoder) DecodeCustom(t interface{}) (interface{}, error) {
 		return t, nil
 	}
 
-	return nil, errors.New("cannot decode custom type")
+	return nil, fmt.Errorf("cannot decode custom type %s", someType.String())
 }
 
 // DecodePtr is the high level function wrapping the specific type decoding functions

--- a/lib/scale/encode.go
+++ b/lib/scale/encode.go
@@ -51,6 +51,7 @@ func EncodeCustom(in interface{}) ([]byte, error) {
 // EncodeCustom checks if interface has method Encode, if so use that, otherwise use regular scale encoding
 func (se *Encoder) EncodeCustom(in interface{}) (int, error) {
 	someType := reflect.TypeOf(in)
+	// TODO: if not a pointer, check if type pointer has Encode method
 	_, ok := someType.MethodByName("Encode")
 	if ok {
 		res := reflect.ValueOf(in).MethodByName("Encode").Call([]reflect.Value{})

--- a/lib/scale/encode.go
+++ b/lib/scale/encode.go
@@ -48,6 +48,22 @@ func EncodeCustom(in interface{}) ([]byte, error) {
 	return Encode(in)
 }
 
+func (se *Encoder) EncodeCustom(in interface{}) (int, error) {
+	someType := reflect.TypeOf(in)
+	_, ok := someType.MethodByName("Encode")
+	if ok {
+		res := reflect.ValueOf(in).MethodByName("Encode").Call([]reflect.Value{})
+		val := res[0].Interface()
+		err := res[1].Interface()
+		if err != nil {
+			return 0, err.(error)
+		}
+		se.Writer.Write(val.([]byte))
+		return len(val.([]byte)), nil
+	}
+	return se.Encode(in)
+}
+
 // Encode to byte array
 func Encode(in interface{}) ([]byte, error) {
 	buffer := bytes.Buffer{}
@@ -57,8 +73,7 @@ func Encode(in interface{}) ([]byte, error) {
 	return output, err
 }
 
-// Encode is the top-level function which performs SCALE encoding of b which may be of type []byte, int16, int32, int64,
-// or bool
+// Encode is the top-level function which performs SCALE encoding of b which may be of type []byte, int16, int32, int64, or bool
 func (se *Encoder) Encode(b interface{}) (n int, err error) {
 	switch v := b.(type) {
 	case []byte:
@@ -73,6 +88,8 @@ func (se *Encoder) Encode(b interface{}) (n int, err error) {
 		n, err = se.encodeBool(v)
 	case common.Hash:
 		n, err = se.Writer.Write(v.ToBytes())
+	case [64]byte:
+		n, err = se.Writer.Write(v[:])
 	case interface{}:
 		t := reflect.TypeOf(b).Kind()
 		switch t {
@@ -257,7 +274,7 @@ func (se *Encoder) encodeTuple(t interface{}) (bytesEncoded int, err error) {
 	}
 
 	for _, item := range values {
-		n, err := se.Encode(item)
+		n, err := se.EncodeCustom(item)
 		if err != nil {
 			return bytesEncoded, err
 		}

--- a/lib/scale/encode.go
+++ b/lib/scale/encode.go
@@ -32,7 +32,7 @@ type Encoder struct {
 	Writer io.Writer
 }
 
-// EncodeCustom check if interface has method Encode, if so use that, otherwise use regular scale encoding
+// EncodeCustom checks if interface has method Encode, if so use that, otherwise use regular scale encoding
 func EncodeCustom(in interface{}) ([]byte, error) {
 	someType := reflect.TypeOf(in)
 	_, ok := someType.MethodByName("Encode")
@@ -48,6 +48,7 @@ func EncodeCustom(in interface{}) ([]byte, error) {
 	return Encode(in)
 }
 
+// EncodeCustom checks if interface has method Encode, if so use that, otherwise use regular scale encoding
 func (se *Encoder) EncodeCustom(in interface{}) (int, error) {
 	someType := reflect.TypeOf(in)
 	_, ok := someType.MethodByName("Encode")
@@ -58,8 +59,7 @@ func (se *Encoder) EncodeCustom(in interface{}) (int, error) {
 		if err != nil {
 			return 0, err.(error)
 		}
-		se.Writer.Write(val.([]byte))
-		return len(val.([]byte)), nil
+		return se.Writer.Write(val.([]byte))
 	}
 	return se.Encode(in)
 }


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement core.FinalityGadget and core.FinalityMessage interfaces
- update grandpa service to fulfil core.FinalityGadget
- update grandpa VoteMessage and FinalizationMessage to implement core.FinalityMessage

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #933 closes #934 
