### PR TITLE
lib/grandpa, lib/scale: add justification handling to grandpa, add to FinalizationMessage

### DIFF
--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -184,11 +184,7 @@ func (s *Service) playGrandpaRound() error {
 
 	// if primary, broadcast the best final candidate from the previous round
 	if bytes.Equal(primary.key.Encode(), s.keypair.Public().Encode()) {
-		msg, err := s.newFinalizationMessage(s.head, s.state.round-1)
-		if err != nil {
-			return err
-		}
-
+		msg := s.newFinalizationMessage(s.head, s.state.round-1)
 		s.finalized <- msg
 	}
 
@@ -321,10 +317,7 @@ func (s *Service) attemptToFinalize() error {
 
 		// if we haven't received a finalization message for this block yet, broadcast a finalization message
 		log.Debug("[grandpa] finalized block!!!", "hash", s.head)
-		msg, err := s.newFinalizationMessage(s.head, s.state.round)
-		if err != nil {
-			return err
-		}
+		msg := s.newFinalizationMessage(s.head, s.state.round)
 
 		// TODO: safety
 		s.finalized <- msg

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -41,16 +41,19 @@ type Service struct {
 	stopped    bool
 
 	// current state information
-	state           *State                             // current state
-	prevotes        map[ed25519.PublicKeyBytes]*Vote   // pre-votes for next state
-	precommits      map[ed25519.PublicKeyBytes]*Vote   // pre-commits for next state
-	pvEquivocations map[ed25519.PublicKeyBytes][]*Vote // equivocatory votes for current pre-vote stage
-	pcEquivocations map[ed25519.PublicKeyBytes][]*Vote // equivocatory votes for current pre-commit stage
-	head            *types.Header                      // most recently finalized block
+	state            *State                             // current state
+	prevotes         map[ed25519.PublicKeyBytes]*Vote   // pre-votes for the current round
+	precommits       map[ed25519.PublicKeyBytes]*Vote   // pre-commits for the current round
+	pvJustifications []*Justification                   // pre-vote justifications for the current round TODO: is this used anywhere?
+	pcJustifications []*Justification                   // pre-commit justifications for the current round
+	pvEquivocations  map[ed25519.PublicKeyBytes][]*Vote // equivocatory votes for current pre-vote stage
+	pcEquivocations  map[ed25519.PublicKeyBytes][]*Vote // equivocatory votes for current pre-commit stage
+	head             *types.Header                      // most recently finalized block
 
 	// historical information
-	preVotedBlock      map[uint64]*Vote // map of round number -> pre-voted block
-	bestFinalCandidate map[uint64]*Vote // map of round number -> best final candidate
+	preVotedBlock      map[uint64]*Vote            // map of round number -> pre-voted block
+	bestFinalCandidate map[uint64]*Vote            // map of round number -> best final candidate
+	justification      map[uint64][]*Justification // map of round number -> round justification
 
 	// channels for communication with other services
 	in        chan FinalityMessage // only used to receive *VoteMessage
@@ -87,10 +90,13 @@ func NewService(cfg *Config) (*Service, error) {
 		keypair:            cfg.Keypair,
 		prevotes:           make(map[ed25519.PublicKeyBytes]*Vote),
 		precommits:         make(map[ed25519.PublicKeyBytes]*Vote),
+		pvJustifications:   []*Justification{},
+		pcJustifications:   []*Justification{},
 		pvEquivocations:    make(map[ed25519.PublicKeyBytes][]*Vote),
 		pcEquivocations:    make(map[ed25519.PublicKeyBytes][]*Vote),
 		preVotedBlock:      make(map[uint64]*Vote),
 		bestFinalCandidate: make(map[uint64]*Vote),
+		justification:      make(map[uint64][]*Justification),
 		head:               head,
 		in:                 make(chan FinalityMessage, 128),
 		out:                make(chan FinalityMessage, 128),
@@ -142,8 +148,11 @@ func (s *Service) initiate() error {
 
 	s.prevotes = make(map[ed25519.PublicKeyBytes]*Vote)
 	s.precommits = make(map[ed25519.PublicKeyBytes]*Vote)
+	s.pvJustifications = []*Justification{}
+	s.pcJustifications = []*Justification{}
 	s.pvEquivocations = make(map[ed25519.PublicKeyBytes][]*Vote)
 	s.pcEquivocations = make(map[ed25519.PublicKeyBytes][]*Vote)
+	s.justification = make(map[uint64][]*Justification)
 
 	for {
 		err := s.playGrandpaRound()
@@ -425,6 +434,9 @@ func (s *Service) finalize() error {
 
 	// set best final candidate
 	s.bestFinalCandidate[s.state.round] = bfc
+
+	// set justification
+	s.justification[s.state.round] = s.pcJustifications
 	s.mapLock.Unlock()
 
 	s.head, err = s.blockState.GetHeader(bfc.hash)

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -145,10 +145,10 @@ func (f *FinalizationMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 	}, nil
 }
 
-func (s *Service) newFinalizationMessage(header *types.Header, round uint64) (*FinalizationMessage, error) {
+func (s *Service) newFinalizationMessage(header *types.Header, round uint64) *FinalizationMessage {
 	return &FinalizationMessage{
 		Round:         round,
 		Vote:          NewVoteFromHeader(header),
 		Justification: s.justification[round],
-	}, nil
+	}
 }

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testVote = &Vote{
+	hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+	number: 999,
+}
+
+var testSignature = [64]byte{1, 2, 3, 4}
+var testAuthorityID = [32]byte{5, 6, 7, 8}
+
 func TestDecodeMessage_VoteMessage(t *testing.T) {
 	gs := &Service{}
 
@@ -67,11 +75,8 @@ func TestDecodeMessage_FinalizationMessage(t *testing.T) {
 		},
 		Justification: []*Justification{
 			{
-				Vote: &Vote{
-					hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
-					number: 999,
-				},
-				Signature:   [64]byte{1, 2, 3, 4},
+				Vote:        testVote,
+				Signature:   testSignature,
 				AuthorityID: gs.publicKeyBytes(),
 			},
 		},
@@ -132,11 +137,8 @@ func TestFinalizationMessageToConsensusMessage(t *testing.T) {
 
 	gs.justification[77] = []*Justification{
 		{
-			Vote: &Vote{
-				hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
-				number: 999,
-			},
-			Signature:   [64]byte{1, 2, 3, 4},
+			Vote:        testVote,
+			Signature:   testSignature,
 			AuthorityID: gs.publicKeyBytes(),
 		},
 	}
@@ -155,12 +157,9 @@ func TestFinalizationMessageToConsensusMessage(t *testing.T) {
 
 func TestJustificationEncoding(t *testing.T) {
 	just := &Justification{
-		Vote: &Vote{
-			hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
-			number: 999,
-		},
-		Signature:   [64]byte{1, 2, 3, 4},
-		AuthorityID: [32]byte{5, 6, 7, 8},
+		Vote:        testVote,
+		Signature:   testSignature,
+		AuthorityID: testAuthorityID,
 	}
 
 	enc, err := just.Encode()
@@ -176,12 +175,9 @@ func TestJustificationEncoding(t *testing.T) {
 func TestJustificationArrayEncoding(t *testing.T) {
 	just := []*Justification{
 		{
-			Vote: &Vote{
-				hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
-				number: 999,
-			},
-			Signature:   [64]byte{1, 2, 3, 4},
-			AuthorityID: [32]byte{5, 6, 7, 8},
+			Vote:        testVote,
+			Signature:   testSignature,
+			AuthorityID: testAuthorityID,
 		},
 	}
 

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -141,9 +141,7 @@ func TestFinalizationMessageToConsensusMessage(t *testing.T) {
 		},
 	}
 
-	fm, err := gs.newFinalizationMessage(gs.head, 77)
-	require.NoError(t, err)
-
+	fm := gs.newFinalizationMessage(gs.head, 77)
 	cm, err := fm.ToConsensusMessage()
 	require.NoError(t, err)
 

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -233,6 +233,9 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 	wg.Wait()
 
 	for _, fb := range finalized {
+		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
+		finalized[0].Justification = []*Justification{}
+		fb.Justification = []*Justification{}
 		require.Equal(t, finalized[0], fb)
 	}
 }
@@ -310,6 +313,9 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 	wg.Wait()
 
 	for _, fb := range finalized {
+		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
+		finalized[0].Justification = []*Justification{}
+		fb.Justification = []*Justification{}
 		require.Equal(t, finalized[0], fb)
 	}
 }
@@ -399,6 +405,9 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 	wg.Wait()
 
 	for _, fb := range finalized {
+		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
+		finalized[0].Justification = []*Justification{}
+		fb.Justification = []*Justification{}
 		require.Equal(t, finalized[0], fb)
 	}
 }
@@ -475,6 +484,9 @@ func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
 		for _, fb := range finalized {
 			require.NotNil(t, fb)
 			require.Equal(t, head, fb.Vote.hash)
+			require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
+			finalized[0].Justification = []*Justification{}
+			fb.Justification = []*Justification{}
 			require.Equal(t, finalized[0], fb)
 		}
 

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -169,6 +169,10 @@ func cleanup(gs *Service, in, out chan FinalityMessage, done *bool) { //nolint
 }
 
 func TestPlayGrandpaRound_BaseCase(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	// this asserts that all validators finalize the same block if they all see the
 	// same pre-votes and pre-commits, even if their chains are different lengths
 	kr, err := keystore.NewEd25519Keyring()
@@ -241,6 +245,10 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 }
 
 func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	// this asserts that all validators finalize the same block if they all see the
 	// same pre-votes and pre-commits, even if their chains are different lengths
 
@@ -321,6 +329,10 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 }
 
 func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	// this asserts that all validators finalize the same block even if 1/3 of voters equivocate
 	kr, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)
@@ -413,6 +425,10 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 }
 
 func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	// this asserts that all validators finalize the same block in successive rounds
 	kr, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -180,6 +180,11 @@ func (v *Vote) Encode() ([]byte, error) {
 
 // Decode returns the SCALE decoded Vote
 func (v *Vote) Decode(r io.Reader) (*Vote, error) {
+	// TODO: scale should handle nil pointers that are typed
+	if v == nil {
+		v = new(Vote)
+	}
+
 	var err error
 	v.hash, err = common.ReadHash(r)
 	if err != nil {

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -180,7 +180,6 @@ func (v *Vote) Encode() ([]byte, error) {
 
 // Decode returns the SCALE decoded Vote
 func (v *Vote) Decode(r io.Reader) (*Vote, error) {
-	// TODO: scale should handle nil pointers that are typed
 	if v == nil {
 		v = new(Vote)
 	}

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -160,10 +160,18 @@ func (s *Service) validateMessage(m *VoteMessage) (*Vote, error) {
 	s.mapLock.Lock()
 	defer s.mapLock.Unlock()
 
+	just := &Justification{
+		Vote:        vote,
+		Signature:   m.Message.Signature,
+		AuthorityID: pk.AsBytes(),
+	}
+
 	if m.Stage == prevote {
 		s.prevotes[pk.AsBytes()] = vote
+		s.pvJustifications = append(s.pvJustifications, just)
 	} else if m.Stage == precommit {
 		s.precommits[pk.AsBytes()] = vote
+		s.pcJustifications = append(s.pcJustifications, just)
 	}
 
 	return vote, nil

--- a/lib/scale/decode_ptr.go
+++ b/lib/scale/decode_ptr.go
@@ -60,6 +60,11 @@ func DecodePtr(in []byte, t interface{}) error {
 // DecodeCustom check if interface has method Decode(io.Reader), if so use that, otherwise use regular scale decoding
 func (sd *Decoder) DecodeCustom(t interface{}) (interface{}, error) {
 	someType := reflect.TypeOf(t)
+	val := reflect.ValueOf(t)
+	if val.IsNil() {
+		n := reflect.New(someType.Elem())
+		t = n.Interface()
+	}
 	_, ok := someType.MethodByName("Decode")
 	if ok {
 		meth := reflect.ValueOf(t).MethodByName("Decode")

--- a/lib/scale/decode_ptr.go
+++ b/lib/scale/decode_ptr.go
@@ -60,11 +60,11 @@ func DecodePtr(in []byte, t interface{}) error {
 // DecodeCustom check if interface has method Decode(io.Reader), if so use that, otherwise use regular scale decoding
 func (sd *Decoder) DecodeCustom(t interface{}) (interface{}, error) {
 	someType := reflect.TypeOf(t)
-	// val := reflect.ValueOf(t)
-	// if val.IsNil() {
-	// 	n := reflect.New(someType.Elem())
-	// 	t = n.Interface()
-	// }
+	val := reflect.ValueOf(t)
+	if val.IsNil() {
+		n := reflect.New(someType.Elem())
+		t = n.Interface()
+	}
 	_, ok := someType.MethodByName("Decode")
 	if ok {
 		meth := reflect.ValueOf(t).MethodByName("Decode")

--- a/lib/scale/decode_ptr.go
+++ b/lib/scale/decode_ptr.go
@@ -60,11 +60,11 @@ func DecodePtr(in []byte, t interface{}) error {
 // DecodeCustom check if interface has method Decode(io.Reader), if so use that, otherwise use regular scale decoding
 func (sd *Decoder) DecodeCustom(t interface{}) (interface{}, error) {
 	someType := reflect.TypeOf(t)
-	val := reflect.ValueOf(t)
-	if val.IsNil() {
-		n := reflect.New(someType.Elem())
-		t = n.Interface()
-	}
+	// val := reflect.ValueOf(t)
+	// if val.IsNil() {
+	// 	n := reflect.New(someType.Elem())
+	// 	t = n.Interface()
+	// }
 	_, ok := someType.MethodByName("Decode")
 	if ok {
 		meth := reflect.ValueOf(t).MethodByName("Decode")

--- a/lib/scale/encode.go
+++ b/lib/scale/encode.go
@@ -287,13 +287,9 @@ func (se *Encoder) encodeTuple(t interface{}) (bytesEncoded int, err error) {
 	}
 
 	for _, item := range values {
-		n, err := se.EncodeCustom(item)
+		n, err := se.encodeCustomOrEncode(item)
 		if err != nil {
-			n, err = se.Encode(item)
-			if err != nil {
-				return bytesEncoded, err
-			}
-			//return bytesEncoded, err
+			return bytesEncoded, err
 		}
 
 		bytesEncoded += n

--- a/lib/scale/encode_test.go
+++ b/lib/scale/encode_test.go
@@ -182,7 +182,7 @@ func TestEncode(t *testing.T) {
 	for _, test := range encodeTests {
 
 		buffer := bytes.Buffer{}
-		se := Encoder{&buffer}
+		se := Encoder{Writer: &buffer}
 		bytesEncoded, err := se.Encode(test.val)
 		output := buffer.Bytes()
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add justification maps to grandpa for keeping track of justifications for that round
- add justifications to `FinalizationMessage`
- implement encode, decode for `Justification`
- update scale to use `EncodeCustom`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #945 