### PR TITLE
dot/state: rename import database -> chaindb

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -29,14 +29,14 @@ import (
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 
-	database "github.com/ChainSafe/chaindb"
+	"github.com/ChainSafe/chaindb"
 )
 
 var blockPrefix = []byte("block")
 
 // BlockDB stores block's in an underlying Database
 type BlockDB struct {
-	db database.Database
+	db chaindb.Database
 }
 
 // Put appends `block` to the key and sets the key-value pair in the db
@@ -69,14 +69,14 @@ type BlockState struct {
 }
 
 // NewBlockDB instantiates a badgerDB instance for storing relevant BlockData
-func NewBlockDB(db database.Database) *BlockDB {
+func NewBlockDB(db chaindb.Database) *BlockDB {
 	return &BlockDB{
 		db,
 	}
 }
 
 // NewBlockState will create a new BlockState backed by the database located at basePath
-func NewBlockState(db database.Database, bt *blocktree.BlockTree) (*BlockState, error) {
+func NewBlockState(db chaindb.Database, bt *blocktree.BlockTree) (*BlockState, error) {
 	if bt == nil {
 		return nil, fmt.Errorf("block tree is nil")
 	}
@@ -106,7 +106,7 @@ func NewBlockState(db database.Database, bt *blocktree.BlockTree) (*BlockState, 
 }
 
 // NewBlockStateFromGenesis initializes a BlockState from a genesis header, saving it to the database located at basePath
-func NewBlockStateFromGenesis(db database.Database, header *types.Header) (*BlockState, error) {
+func NewBlockStateFromGenesis(db chaindb.Database, header *types.Header) (*BlockState, error) {
 	bs := &BlockState{
 		bt: blocktree.NewBlockTreeFromGenesis(header, db),
 		db: NewBlockDB(db),

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
-	database "github.com/ChainSafe/chaindb"
+	"github.com/ChainSafe/chaindb"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConcurrencySetHeader(t *testing.T) {
-	db := database.NewMemDatabase()
+	db := chaindb.NewMemDatabase()
 	blockDB := NewBlockDB(db)
 
 	threads := runtime.NumCPU()

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
-	database "github.com/ChainSafe/chaindb"
+	"github.com/ChainSafe/chaindb"
 	"github.com/stretchr/testify/require"
 )
 
 func newTestBlockState(t *testing.T, header *types.Header) *BlockState {
-	db := database.NewMemDatabase()
+	db := chaindb.NewMemDatabase()
 	blockDb := NewBlockDB(db)
 
 	if header == nil {

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -25,14 +25,14 @@ import (
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
-	database "github.com/ChainSafe/chaindb"
+	"github.com/ChainSafe/chaindb"
 	log "github.com/ChainSafe/log15"
 )
 
 // Service is the struct that holds storage, block and network states
 type Service struct {
 	dbPath           string
-	db               database.Database
+	db               chaindb.Database
 	isMemDB          bool // set to true if using an in-memory database; only used for testing.
 	Storage          *StorageState
 	Block            *BlockState
@@ -60,20 +60,20 @@ func (s *Service) UseMemDB() {
 }
 
 // DB returns the Service's database
-func (s *Service) DB() database.Database {
+func (s *Service) DB() chaindb.Database {
 	return s.db
 }
 
 // Initialize initializes the genesis state of the DB using the given storage trie. The trie should be loaded with the genesis storage state.
 // This only needs to be called during genesis initialization of the node; it doesn't need to be called during normal startup.
 func (s *Service) Initialize(data *genesis.Data, header *types.Header, t *trie.Trie) error {
-	var db database.Database
+	var db chaindb.Database
 
 	// check database type
 	if s.isMemDB {
 
 		// create memory database
-		db = database.NewMemDatabase()
+		db = chaindb.NewMemDatabase()
 
 	} else {
 
@@ -84,7 +84,7 @@ func (s *Service) Initialize(data *genesis.Data, header *types.Header, t *trie.T
 		}
 
 		// initialize database using data directory
-		db, err = database.NewBadgerDB(basepath)
+		db, err = chaindb.NewBadgerDB(basepath)
 		if err != nil {
 			return fmt.Errorf("failed to create database: %s", err)
 		}
@@ -138,7 +138,7 @@ func (s *Service) Initialize(data *genesis.Data, header *types.Header, t *trie.T
 }
 
 // storeInitialValues writes initial genesis values to the state database
-func (s *Service) storeInitialValues(db database.Database, data *genesis.Data, header *types.Header, t *trie.Trie) error {
+func (s *Service) storeInitialValues(db chaindb.Database, data *genesis.Data, header *types.Header, t *trie.Trie) error {
 
 	// write genesis trie to database
 	err := StoreTrie(db, t)
@@ -181,7 +181,7 @@ func (s *Service) Start() error {
 		}
 
 		// initialize database
-		db, err = database.NewBadgerDB(basepath)
+		db, err = chaindb.NewBadgerDB(basepath)
 		if err != nil {
 			return err
 		}

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
-	database "github.com/ChainSafe/chaindb"
+	"github.com/ChainSafe/chaindb"
 )
 
 var storagePrefix = []byte("storage")
@@ -32,7 +32,7 @@ var codeKey = []byte(":code")
 
 // StorageDB stores trie structure in an underlying database
 type StorageDB struct {
-	db database.Database
+	db chaindb.Database
 }
 
 // Put appends `storage` to the key and sets the key-value pair in the db
@@ -55,14 +55,14 @@ type StorageState struct {
 }
 
 // NewStorageDB instantiates badgerDB instance for storing trie structure
-func NewStorageDB(db database.Database) *StorageDB {
+func NewStorageDB(db chaindb.Database) *StorageDB {
 	return &StorageDB{
 		db,
 	}
 }
 
 // NewStorageState creates a new StorageState backed by the given trie and database located at basePath.
-func NewStorageState(db database.Database, t *trie.Trie) (*StorageState, error) {
+func NewStorageState(db chaindb.Database, t *trie.Trie) (*StorageState, error) {
 	if db == nil {
 		return nil, fmt.Errorf("cannot have nil database")
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- for some reason, go doesn't allow for `chaindb.Database` to be used as `database.Database` when we alias the package as `database`. so, I got rid of the chaindb import alias in `state`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/state
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing


