### PR TITLE
dot, dot/core: use atomic.Value 

### DIFF
--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -46,6 +46,7 @@ func TestService_ProcessBlockRequestMessage(t *testing.T) {
 	}
 
 	s := NewTestService(t, cfg)
+	s.started.Store(true)
 
 	addTestBlocksToState(t, 2, s.blockState)
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -17,7 +17,6 @@ package core
 
 import (
 	"bytes"
-	"errors"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -68,7 +67,7 @@ type Service struct {
 
 	// State variables
 	lock    *sync.Mutex
-	started uint32
+	started atomic.Value
 
 	// Block synchronization
 	blockNumOut chan<- *big.Int                      // send block numbers from peers to Syncer
@@ -154,12 +153,6 @@ func NewService(cfg *Config) (*Service, error) {
 		srv.blkRec = cfg.BlockProducer.GetBlockChannel()
 	}
 
-	// TODO: change to atomic.Value
-	canLock := atomic.CompareAndSwapUint32(&srv.started, 0, 1)
-	if !canLock {
-		return nil, errors.New("failed to change Service status from stopped to started")
-	}
-
 	// load BABE verification data from runtime
 	// TODO: authority data may change, use NextEpochDescriptor if available
 	babeCfg, err := srv.rt.BabeConfiguration()
@@ -185,8 +178,7 @@ func NewService(cfg *Config) (*Service, error) {
 		}
 	}
 
-	// only one process is starting *core.Service, don't need to use atomic here
-	srv.started = 1
+	srv.started.Store(false)
 
 	syncerCfg := &SyncerConfig{
 		BlockState:       cfg.BlockState,
@@ -212,6 +204,7 @@ func NewService(cfg *Config) (*Service, error) {
 
 // Start starts the core service
 func (s *Service) Start() error {
+	s.started.Store(true)
 
 	// start receiving blocks from BABE session
 	go s.receiveBlocks()
@@ -242,17 +235,12 @@ func (s *Service) Stop() error {
 
 	// close channel to network service
 	// TODO: change to atomic.Value
-	if atomic.LoadUint32(&s.started) == uint32(1) {
+	if s.started.Load().(bool) {
 		if s.msgSend != nil {
 			close(s.msgSend)
 		}
 
-		defer func() {
-			if ok := atomic.CompareAndSwapUint32(&s.started, 1, 0); !ok {
-				log.Error("[core] failed to change Service status from started to stopped")
-			}
-		}()
-
+		s.started.Store(false)
 	}
 
 	err := s.syncer.Stop()
@@ -275,7 +263,7 @@ func (s *Service) safeMsgSend(msg network.Message) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	if atomic.LoadUint32(&s.started) == uint32(0) {
+	if !s.started.Load().(bool) {
 		return ErrServiceStopped
 	}
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -234,7 +234,6 @@ func (s *Service) Stop() error {
 	defer s.lock.Unlock()
 
 	// close channel to network service
-	// TODO: change to atomic.Value
 	if s.started.Load().(bool) {
 		if s.msgSend != nil {
 			close(s.msgSend)

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -123,7 +123,7 @@ func TestCheckForRuntimeChanges(t *testing.T) {
 	}
 
 	s := NewTestService(t, cfg)
-	s.started = 1
+	s.started.Store(true)
 
 	_, err = runtime.GetRuntimeBlob(runtime.TESTS_FP, runtime.TEST_WASM_URL)
 	require.Nil(t, err)

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -35,7 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var maxRetries = 5
+var maxRetries = 12
 
 // testMessageTimeout is the wait time for messages to be exchanged
 var testMessageTimeout = time.Second

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"math/big"
 	"reflect"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -170,10 +169,7 @@ func TestStartNode(t *testing.T) {
 	}()
 
 	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, uint32(1), atomic.LoadUint32(&node.started))
-
 	node.Stop()
-	require.Equal(t, uint32(0), atomic.LoadUint32(&node.started))
 }
 
 // TestStopNode


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- replace uint32 with atomic.Value in dot/core
- clean up dot by removing atomic usage

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT]Noot/atomic(https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #893 