### PR TITLE
lib/grandpa: handle runtime-to-consensus engine digests, add ability to update authorities and setID to grandpa

### DIFF
--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -35,10 +35,10 @@ type digestHandler struct {
 	stopped bool
 
 	// BABE changes
-	babeScheduledChange *babeChange
-	babeForcedChange    *babeChange
-	babePause           *pause
-	babeResume          *resume
+	babeScheduledChange *babeChange //nolint
+	babeForcedChange    *babeChange //nolint
+	babePause           *pause      //nolint
+	babeResume          *resume     //nolint
 
 	// GRANDPA changes
 	grandpaScheduledChange *grandpaChange
@@ -49,8 +49,8 @@ type digestHandler struct {
 }
 
 type babeChange struct {
-	auths   []*types.BABEAuthorityData
-	atBlock *big.Int
+	auths   []*types.BABEAuthorityData //nolint
+	atBlock *big.Int                   //nolint
 }
 
 type grandpaChange struct {
@@ -147,8 +147,6 @@ func (h *digestHandler) handleConsensusDigest(d *types.ConsensusDigest) error {
 	default:
 		return errors.New("invalid consensus digest data")
 	}
-
-	return nil
 }
 
 func (h *digestHandler) handleScheduledChange(d *types.ConsensusDigest) error {

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -32,6 +32,7 @@ type digestHandler struct {
 	grandpaForcedChange    *grandpaChange
 	grandpaPause           *pause
 	grandpaResume          *resume
+	grandpaAuths           []*types.GrandpaAuthorityData // saved in case of pause
 }
 
 type babeChange struct {
@@ -52,8 +53,13 @@ type resume struct {
 	atBlock *big.Int
 }
 
-func newDigestHandler() *digestHandler {
-	return &digestHandler{}
+func newDigestHandler(blockState BlockState, babe BlockProducer, grandpa FinalityGadget) *digestHandler {
+	return &digestHandler{
+		blockState: blockState,
+		grandpa:    grandpa,
+		babe:       babe,
+		stopped:    true,
+	}
 }
 
 func (h *digestHandler) start() {
@@ -76,18 +82,29 @@ func (h *digestHandler) handleGrandpaChanges() {
 			continue
 		}
 
-		sc := h.grandpaScheduledChange
-		if sc != nil {
-			if curr.Number.Cmp(sc.atBlock) == 0 {
-				h.grandpa.UpdateAuthorities(sc.auths)
-			}
+		pause := h.grandpaPause
+		if pause != nil && curr.Number.Cmp(pause.atBlock) == 0 {
+			// save authority data for Resume
+			h.grandpaAuths = h.grandpa.Authorities()
+			h.grandpa.UpdateAuthorities([]*types.GrandpaAuthorityData{})
+			continue
+		}
+
+		resume := h.grandpaResume
+		if resume != nil && curr.Number.Cmp(resume.atBlock) == 0 {
+			h.grandpa.UpdateAuthorities(h.grandpaAuths)
+			continue
 		}
 
 		fc := h.grandpaForcedChange
-		if fc != nil {
-			if curr.Number.Cmp(fc.atBlock) == 0 {
-				h.grandpa.UpdateAuthorities(fc.auths)
-			}
+		if fc != nil && curr.Number.Cmp(fc.atBlock) == 0 {
+			h.grandpa.UpdateAuthorities(fc.auths)
+			continue
+		}
+
+		sc := h.grandpaScheduledChange
+		if sc != nil && curr.Number.Cmp(sc.atBlock) == 0 {
+			h.grandpa.UpdateAuthorities(sc.auths)
 		}
 	}
 }
@@ -100,9 +117,12 @@ func (h *digestHandler) handleConsensusDigest(d *types.ConsensusDigest) error {
 		return h.handleScheduledChange(d)
 	case types.ForcedChangeType:
 		return h.handleForcedChange(d)
-	case types.DisabledType:
+	case types.OnDisabledType:
+		return h.handleOnDisabled(d)
 	case types.PauseType:
+		return h.handlePause(d)
 	case types.ResumeType:
+		return h.handleResume(d)
 	default:
 		return errors.New("invalid consensus digest data")
 	}
@@ -167,6 +187,84 @@ func (h *digestHandler) handleForcedChange(d *types.ConsensusDigest) error {
 		}
 
 		h.grandpaForcedChange = c
+	}
+
+	return nil
+}
+
+func (h *digestHandler) handleOnDisabled(d *types.ConsensusDigest) error {
+	od := &types.OnDisabled{}
+	dec, err := scale.Decode(d.Data, od)
+	if err != nil {
+		return err
+	}
+	od = dec.(*types.OnDisabled)
+
+	if d.ConsensusEngineID == types.BabeEngineID {
+		// TODO
+	} else {
+		curr := h.grandpa.Authorities()
+		next := []*types.GrandpaAuthorityData{}
+
+		for _, auth := range curr {
+			if auth.ID != od.ID {
+				next = append(next, auth)
+			}
+		}
+
+		h.grandpa.UpdateAuthorities(next)
+	}
+
+	return nil
+}
+
+func (h *digestHandler) handlePause(d *types.ConsensusDigest) error {
+	curr, err := h.blockState.BestBlockHeader()
+	if err != nil {
+		return err
+	}
+
+	p := &types.Pause{}
+	dec, err := scale.Decode(d.Data, p)
+	if err != nil {
+		return err
+	}
+	p = dec.(*types.Pause)
+
+	delay := big.NewInt(int64(p.Delay))
+
+	if d.ConsensusEngineID == types.BabeEngineID {
+		// TODO
+	} else {
+		h.grandpaPause = &pause{
+			atBlock: big.NewInt(0).Add(curr.Number, delay),
+		}
+	}
+
+	return nil
+}
+
+func (h *digestHandler) handleResume(d *types.ConsensusDigest) error {
+	curr, err := h.blockState.BestBlockHeader()
+	if err != nil {
+		return err
+	}
+
+	p := &types.Resume{}
+	dec, err := scale.Decode(d.Data, p)
+	if err != nil {
+		return err
+	}
+	p = dec.(*types.Resume)
+
+	delay := big.NewInt(int64(p.Delay))
+
+	if d.ConsensusEngineID == types.BabeEngineID {
+		// TODO
+	} else {
+		h.grandpaResume = &resume{
+			atBlock: big.NewInt(0).Add(curr.Number, delay),
+		}
 	}
 
 	return nil

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -77,6 +77,7 @@ func (h *digestHandler) handleGrandpaChanges() {
 			return
 		}
 
+		// TODO: update block state to register new channels for added blocks
 		curr, err := h.blockState.BestBlockHeader()
 		if err != nil {
 			continue

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -1,0 +1,187 @@
+package core
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+type digestHandlerI interface {
+	handleConsensusDigest(*types.ConsensusDigest) error
+}
+
+type digestHandler struct {
+	// interfaces
+	blockState BlockState
+	grandpa    FinalityGadget
+	babe       BlockProducer
+
+	// state variables
+	stopped bool
+
+	// BABE changes
+	babeScheduledChange *babeChange
+	babeForcedChange    *babeChange
+	babePause           *pause
+	babeResume          *resume
+
+	// GRANDPA changes
+	grandpaScheduledChange *grandpaChange
+	grandpaForcedChange    *grandpaChange
+	grandpaPause           *pause
+	grandpaResume          *resume
+}
+
+type babeChange struct {
+	auths   []*types.BABEAuthorityData
+	atBlock *big.Int
+}
+
+type grandpaChange struct {
+	auths   []*types.GrandpaAuthorityData
+	atBlock *big.Int
+}
+
+type pause struct {
+	atBlock *big.Int
+}
+
+type resume struct {
+	atBlock *big.Int
+}
+
+func newDigestHandler() *digestHandler {
+	return &digestHandler{}
+}
+
+func (h *digestHandler) start() {
+	go h.handleGrandpaChanges()
+	h.stopped = false
+}
+
+func (h *digestHandler) stop() {
+	h.stopped = true
+}
+
+func (h *digestHandler) handleGrandpaChanges() {
+	for {
+		if h.stopped {
+			return
+		}
+
+		curr, err := h.blockState.BestBlockHeader()
+		if err != nil {
+			continue
+		}
+
+		sc := h.grandpaScheduledChange
+		if sc != nil {
+			if curr.Number.Cmp(sc.atBlock) == 0 {
+				h.grandpa.UpdateAuthorities(sc.auths)
+			}
+		}
+
+		fc := h.grandpaForcedChange
+		if fc != nil {
+			if curr.Number.Cmp(fc.atBlock) == 0 {
+				h.grandpa.UpdateAuthorities(fc.auths)
+			}
+		}
+	}
+}
+
+func (h *digestHandler) handleConsensusDigest(d *types.ConsensusDigest) error {
+	t := d.DataType()
+
+	switch t {
+	case types.ScheduledChangeType:
+		return h.handleScheduledChange(d)
+	case types.ForcedChangeType:
+		return h.handleForcedChange(d)
+	case types.DisabledType:
+	case types.PauseType:
+	case types.ResumeType:
+	default:
+		return errors.New("invalid consensus digest data")
+	}
+
+	return nil
+}
+
+func (h *digestHandler) handleScheduledChange(d *types.ConsensusDigest) error {
+	curr, err := h.blockState.BestBlockHeader()
+	if err != nil {
+		return err
+	}
+
+	if d.ConsensusEngineID == types.BabeEngineID {
+		// TODO
+	} else {
+		if h.grandpaScheduledChange != nil {
+			return errors.New("already have scheduled change scheduled")
+		}
+
+		sc := &types.GrandpaScheduledChange{}
+		dec, err := scale.Decode(d.Data, sc)
+		if err != nil {
+			return err
+		}
+		sc = dec.(*types.GrandpaScheduledChange)
+
+		c, err := newGrandpaChange(sc.Auths, sc.Delay, curr.Number)
+		if err != nil {
+			return err
+		}
+
+		h.grandpaScheduledChange = c
+	}
+
+	return nil
+}
+
+func (h *digestHandler) handleForcedChange(d *types.ConsensusDigest) error {
+	curr, err := h.blockState.BestBlockHeader()
+	if err != nil {
+		return err
+	}
+
+	if d.ConsensusEngineID == types.BabeEngineID {
+		// TODO
+	} else {
+		if h.grandpaForcedChange != nil {
+			return errors.New("already have forced change scheduled")
+		}
+
+		fc := &types.GrandpaForcedChange{}
+		dec, err := scale.Decode(d.Data, fc)
+		if err != nil {
+			return err
+		}
+		fc = dec.(*types.GrandpaForcedChange)
+
+		c, err := newGrandpaChange(fc.Auths, fc.Delay, curr.Number)
+		if err != nil {
+			return err
+		}
+
+		h.grandpaForcedChange = c
+	}
+
+	return nil
+}
+
+func newGrandpaChange(raw []*types.GrandpaAuthorityDataRaw, delay uint32, currBlock *big.Int) (*grandpaChange, error) {
+	auths, err := types.GrandpaAuthorityDataRawToAuthorityData(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	d := big.NewInt(int64(delay))
+
+	return &grandpaChange{
+		auths:   auths,
+		atBlock: big.NewInt(0).Add(currBlock, d),
+	}, nil
+}

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -48,7 +48,7 @@ type digestHandler struct {
 	grandpaAuths           []*types.GrandpaAuthorityData // saved in case of pause
 }
 
-type babeChange struct {
+type babeChange struct { //nolint
 	auths   []*types.BABEAuthorityData //nolint
 	atBlock *big.Int                   //nolint
 }

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -1,0 +1,1 @@
+package core

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -1,1 +1,220 @@
 package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ChainSafe/gossamer/dot/state"
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/keystore"
+	"github.com/ChainSafe/gossamer/lib/trie"
+
+	log "github.com/ChainSafe/log15"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDigestHandler(t *testing.T, withBABE, withGrandpa bool) *digestHandler {
+	stateSrvc := state.NewService("", log.LvlInfo)
+	stateSrvc.UseMemDB()
+
+	genesisData := new(genesis.Data)
+
+	err := stateSrvc.Initialize(genesisData, testGenesisHeader, trie.NewEmptyTrie())
+	require.NoError(t, err)
+
+	err = stateSrvc.Start()
+	require.NoError(t, err)
+
+	var bp BlockProducer
+	if withBABE {
+		// TODO
+	}
+
+	var fg FinalityGadget
+	if withGrandpa {
+		fg = &mockFinalityGadget{}
+	}
+
+	time.Sleep(time.Second)
+	return newDigestHandler(stateSrvc.Block, bp, fg)
+}
+
+func TestDigestHandler_GrandpaScheduledChange(t *testing.T) {
+	handler := newTestDigestHandler(t, false, true)
+	handler.start()
+	defer handler.stop()
+
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	sc := &types.GrandpaScheduledChange{
+		Auths: []*types.GrandpaAuthorityDataRaw{
+			{Key: kr.Alice.Public().(*ed25519.PublicKey).AsBytes(), ID: 0},
+		},
+		Delay: 3,
+	}
+
+	data, err := sc.Encode()
+	require.NoError(t, err)
+
+	d := &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.handleConsensusDigest(d)
+	require.NoError(t, err)
+
+	addTestBlocksToState(t, 2, handler.blockState)
+	auths := handler.grandpa.Authorities()
+	require.Nil(t, auths)
+
+	// authorities should change on start of block 3 from start
+	addTestBlocksToState(t, 1, handler.blockState)
+	time.Sleep(time.Millisecond * 100)
+	auths = handler.grandpa.Authorities()
+	require.Equal(t, 1, len(auths))
+}
+
+func TestDigestHandler_GrandpaForcedChange(t *testing.T) {
+	handler := newTestDigestHandler(t, false, true)
+	handler.start()
+	defer handler.stop()
+
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	fc := &types.GrandpaForcedChange{
+		Auths: []*types.GrandpaAuthorityDataRaw{
+			{Key: kr.Alice.Public().(*ed25519.PublicKey).AsBytes(), ID: 0},
+		},
+		Delay: 3,
+	}
+
+	data, err := fc.Encode()
+	require.NoError(t, err)
+
+	d := &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.handleConsensusDigest(d)
+	require.NoError(t, err)
+
+	addTestBlocksToState(t, 2, handler.blockState)
+	auths := handler.grandpa.Authorities()
+	require.Nil(t, auths)
+
+	// authorities should change on start of block 3 from start
+	addTestBlocksToState(t, 1, handler.blockState)
+	time.Sleep(time.Millisecond * 100)
+	auths = handler.grandpa.Authorities()
+	require.Equal(t, 1, len(auths))
+}
+
+func TestDigestHandler_GrandpaOnDisabled(t *testing.T) {
+	handler := newTestDigestHandler(t, false, true)
+	handler.start()
+	defer handler.stop()
+
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	handler.grandpa.UpdateAuthorities([]*types.GrandpaAuthorityData{
+		{Key: kr.Alice.Public().(*ed25519.PublicKey), ID: 0},
+	})
+
+	// try with ID that doesn't exist
+	od := &types.OnDisabled{
+		ID: 1,
+	}
+
+	data, err := od.Encode()
+	require.NoError(t, err)
+
+	d := &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.handleConsensusDigest(d)
+	require.NoError(t, err)
+
+	auths := handler.grandpa.Authorities()
+	require.Equal(t, 1, len(auths))
+
+	// try with ID that does exist
+	od = &types.OnDisabled{
+		ID: 0,
+	}
+
+	data, err = od.Encode()
+	require.NoError(t, err)
+
+	d = &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.handleConsensusDigest(d)
+	require.NoError(t, err)
+
+	auths = handler.grandpa.Authorities()
+	require.Equal(t, 0, len(auths))
+}
+
+func TestDigestHandler_GrandpaPauseAndResume(t *testing.T) {
+	handler := newTestDigestHandler(t, false, true)
+	handler.start()
+	defer handler.stop()
+
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	handler.grandpa.UpdateAuthorities([]*types.GrandpaAuthorityData{
+		{Key: kr.Alice.Public().(*ed25519.PublicKey), ID: 0},
+	})
+
+	p := &types.Pause{
+		Delay: 3,
+	}
+
+	data, err := p.Encode()
+	require.NoError(t, err)
+
+	d := &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.handleConsensusDigest(d)
+	require.NoError(t, err)
+
+	addTestBlocksToState(t, 3, handler.blockState)
+	time.Sleep(time.Millisecond * 100)
+	auths := handler.grandpa.Authorities()
+	require.Equal(t, 0, len(auths))
+
+	r := &types.Resume{
+		Delay: 3,
+	}
+
+	data, err = r.Encode()
+	require.NoError(t, err)
+
+	d = &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.handleConsensusDigest(d)
+	require.NoError(t, err)
+
+	addTestBlocksToState(t, 3, handler.blockState)
+	time.Sleep(time.Millisecond * 110)
+	auths = handler.grandpa.Authorities()
+	require.Equal(t, 1, len(auths))
+}

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestDigestHandler(t *testing.T, withBABE, withGrandpa bool) *digestHandler {
+func newTestDigestHandler(t *testing.T, withBABE, withGrandpa bool) *digestHandler { //nolint
 	stateSrvc := state.NewService("", log.LvlInfo)
 	stateSrvc.UseMemDB()
 

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -1,3 +1,19 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package core
 
 import (

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -91,6 +91,7 @@ type FinalityGadget interface {
 	GetVoteInChannel() chan<- FinalityMessage
 	GetFinalizedChannel() <-chan FinalityMessage
 	DecodeMessage(*network.ConsensusMessage) (FinalityMessage, error)
+	UpdateAuthorities(ad []*types.GrandpaAuthorityData)
 }
 
 // FinalityMessage is the interface a finality message must implement

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -92,6 +92,7 @@ type FinalityGadget interface {
 	GetFinalizedChannel() <-chan FinalityMessage
 	DecodeMessage(*network.ConsensusMessage) (FinalityMessage, error)
 	UpdateAuthorities(ad []*types.GrandpaAuthorityData)
+	Authorities() []*types.GrandpaAuthorityData
 }
 
 // FinalityMessage is the interface a finality message must implement

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -189,6 +189,11 @@ func NewService(cfg *Config) (*Service, error) {
 
 	srv.started.Store(false)
 
+	var dh digestHandlerI
+	if cfg.IsBlockProducer {
+		dh = newDigestHandler(cfg.BlockState, cfg.BlockProducer, cfg.FinalityGadget)
+	}
+
 	syncerCfg := &SyncerConfig{
 		logger:           logger,
 		BlockState:       cfg.BlockState,
@@ -199,6 +204,7 @@ func NewService(cfg *Config) (*Service, error) {
 		TransactionQueue: cfg.TransactionQueue,
 		Verifier:         cfg.Verifier,
 		Runtime:          cfg.Runtime,
+		DigestHandler:    dh,
 	}
 
 	syncer, err := NewSyncer(syncerCfg)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -189,7 +189,7 @@ func NewService(cfg *Config) (*Service, error) {
 
 	srv.started.Store(false)
 
-	var dh digestHandlerI
+	var dh *digestHandler
 	if cfg.IsBlockProducer {
 		dh = newDigestHandler(cfg.BlockState, cfg.BlockProducer, cfg.FinalityGadget)
 	}

--- a/dot/core/syncer.go
+++ b/dot/core/syncer.go
@@ -71,6 +71,9 @@ type Syncer struct {
 
 	// BABE verification
 	verifier Verifier
+
+	// Consensus digest handling
+	digestHandler digestHandler
 }
 
 // SyncerConfig is the configuration for the Syncer.
@@ -86,6 +89,7 @@ type SyncerConfig struct {
 	TransactionQueue TransactionQueue
 	Runtime          *runtime.Runtime
 	Verifier         Verifier
+	DigestHandler    digestHandler
 }
 
 var responseTimeout = 3 * time.Second
@@ -130,6 +134,7 @@ func NewSyncer(cfg *SyncerConfig) (*Syncer, error) {
 		transactionQueue: cfg.TransactionQueue,
 		runtime:          cfg.Runtime,
 		verifier:         cfg.Verifier,
+		digestHandler:    cfg.DigestHandler,
 	}, nil
 }
 
@@ -440,6 +445,9 @@ func (s *Syncer) handleBlock(block *types.Block) error {
 
 	// TODO: if block is from the next epoch, increment epoch
 
+	// handle consensus digest for authority changes
+	err = s.handleDigests(block.Header)
+
 	return nil
 }
 
@@ -461,4 +469,27 @@ func (s *Syncer) executeBlock(block *types.Block) ([]byte, error) {
 
 func (s *Syncer) executeBlockBytes(bd []byte) ([]byte, error) {
 	return s.runtime.Exec(runtime.CoreExecuteBlock, bd)
+}
+
+func (s *Syncer) handleDigests(header *types.Header) error {
+	for _, d := range header.Digest {
+		dg, err := types.DecodeDigestItem(d)
+		if err != nil {
+			return err
+		}
+
+		if dg.Type() == types.ConsensusDigestType {
+			cd, ok := dg.(*types.ConsensusDigest)
+			if !ok {
+				return errors.New("cannot cast invalid consensus digest item")
+			}
+
+			err = s.digestHandler.handleConsensusDigest(cd)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/dot/core/syncer.go
+++ b/dot/core/syncer.go
@@ -73,7 +73,7 @@ type Syncer struct {
 	verifier Verifier
 
 	// Consensus digest handling
-	digestHandler digestHandlerI
+	digestHandler *digestHandler
 }
 
 // SyncerConfig is the configuration for the Syncer.
@@ -89,7 +89,7 @@ type SyncerConfig struct {
 	TransactionQueue TransactionQueue
 	Runtime          *runtime.Runtime
 	Verifier         Verifier
-	DigestHandler    digestHandlerI
+	DigestHandler    *digestHandler
 }
 
 var responseTimeout = 3 * time.Second

--- a/dot/core/syncer.go
+++ b/dot/core/syncer.go
@@ -73,7 +73,7 @@ type Syncer struct {
 	verifier Verifier
 
 	// Consensus digest handling
-	digestHandler digestHandler
+	digestHandler digestHandlerI
 }
 
 // SyncerConfig is the configuration for the Syncer.
@@ -89,7 +89,7 @@ type SyncerConfig struct {
 	TransactionQueue TransactionQueue
 	Runtime          *runtime.Runtime
 	Verifier         Verifier
-	DigestHandler    digestHandler
+	DigestHandler    digestHandlerI
 }
 
 var responseTimeout = 3 * time.Second
@@ -446,7 +446,12 @@ func (s *Syncer) handleBlock(block *types.Block) error {
 	// TODO: if block is from the next epoch, increment epoch
 
 	// handle consensus digest for authority changes
-	err = s.handleDigests(block.Header)
+	if s.digestHandler != nil {
+		err = s.handleDigests(block.Header)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -135,6 +135,9 @@ func (fg *mockFinalityGadget) DecodeMessage(*network.ConsensusMessage) (Finality
 	return &mockFinalityMessage{}, nil
 }
 
+func (fg *mockFinalityGadget) UpdateAuthorities(ad []*types.GrandpaAuthorityData) {
+}
+
 var testConsensusMessage = &network.ConsensusMessage{
 	ConsensusEngineID: types.GrandpaEngineID,
 	Data:              []byte("nootwashere"),

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -103,6 +103,7 @@ type mockFinalityGadget struct {
 	in        chan FinalityMessage
 	out       chan FinalityMessage
 	finalized chan FinalityMessage
+	auths     []*types.GrandpaAuthorityData
 }
 
 // Start mocks starting
@@ -136,10 +137,11 @@ func (fg *mockFinalityGadget) DecodeMessage(*network.ConsensusMessage) (Finality
 }
 
 func (fg *mockFinalityGadget) UpdateAuthorities(ad []*types.GrandpaAuthorityData) {
+	fg.auths = ad
 }
 
 func (fg *mockFinalityGadget) Authorities() []*types.GrandpaAuthorityData {
-	return nil
+	return fg.auths
 }
 
 var testConsensusMessage = &network.ConsensusMessage{

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -138,6 +138,10 @@ func (fg *mockFinalityGadget) DecodeMessage(*network.ConsensusMessage) (Finality
 func (fg *mockFinalityGadget) UpdateAuthorities(ad []*types.GrandpaAuthorityData) {
 }
 
+func (fg *mockFinalityGadget) Authorities() []*types.GrandpaAuthorityData {
+	return nil
+}
+
 var testConsensusMessage = &network.ConsensusMessage{
 	ConsensusEngineID: types.GrandpaEngineID,
 	Data:              []byte("nootwashere"),

--- a/dot/types/consensus_digest.go
+++ b/dot/types/consensus_digest.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
 // ScheduledChangeType identifies a ScheduledChange consensus digest
 var ScheduledChangeType = byte(1)
 
@@ -21,10 +25,30 @@ type GrandpaScheduledChange struct {
 	Delay uint32
 }
 
+// Encode returns a SCALE encoded GrandpaScheduledChange with first type byte
+func (sc *GrandpaScheduledChange) Encode() ([]byte, error) {
+	d, err := scale.Encode(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte{ScheduledChangeType}, d...), nil
+}
+
 // GrandpaForcedChange represents a GRANDPA forced authority change
 type GrandpaForcedChange struct {
 	Auths []*GrandpaAuthorityDataRaw
 	Delay uint32
+}
+
+// Encode returns a SCALE encoded GrandpaForcedChange with first type byte
+func (fc *GrandpaForcedChange) Encode() ([]byte, error) {
+	d, err := scale.Encode(fc)
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte{ForcedChangeType}, d...), nil
 }
 
 // OnDisabled represents a GRANDPA authority being disabled
@@ -32,12 +56,42 @@ type OnDisabled struct {
 	ID uint64
 }
 
+// Encode returns a SCALE encoded OnDisabled with first type byte
+func (od *OnDisabled) Encode() ([]byte, error) {
+	d, err := scale.Encode(od)
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte{OnDisabledType}, d...), nil
+}
+
 // Pause represents an authority set pause
 type Pause struct {
 	Delay uint32
 }
 
+// Encode returns a SCALE encoded Pause with first type byte
+func (p *Pause) Encode() ([]byte, error) {
+	d, err := scale.Encode(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte{PauseType}, d...), nil
+}
+
 // Resume represents an authority set resume
 type Resume struct {
 	Delay uint32
+}
+
+// Encode returns a SCALE encoded Resume with first type byte
+func (r *Resume) Encode() ([]byte, error) {
+	d, err := scale.Encode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return append([]byte{ResumeType}, d...), nil
 }

--- a/dot/types/consensus_digest.go
+++ b/dot/types/consensus_digest.go
@@ -1,0 +1,43 @@
+package types
+
+// ScheduledChangeType identifies a ScheduledChange consensus digest
+var ScheduledChangeType = byte(1)
+
+// ForcedChangeType identifies a ForcedChange consensus digest
+var ForcedChangeType = byte(2)
+
+// OnDisabledType identifies a DisabledChange consensus digest
+var OnDisabledType = byte(3)
+
+// PauseType identifies a Pause consensus digest
+var PauseType = byte(4)
+
+// ResumeType identifies a Resume consensus digest
+var ResumeType = byte(5)
+
+// GrandpaScheduledChange represents a GRANDPA scheduled authority change
+type GrandpaScheduledChange struct {
+	Auths []*GrandpaAuthorityDataRaw
+	Delay uint32
+}
+
+// GrandpaForcedChange represents a GRANDPA forced authority change
+type GrandpaForcedChange struct {
+	Auths []*GrandpaAuthorityDataRaw
+	Delay uint32
+}
+
+// OnDisabled represents a GRANDPA authority being disabled
+type OnDisabled struct {
+	ID uint64
+}
+
+// Pause represents an authority set pause
+type Pause struct {
+	Delay uint32
+}
+
+// Resume represents an authority set resume
+type Resume struct {
+	Delay uint32
+}

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -176,6 +176,39 @@ func (d *ConsensusDigest) Decode(in []byte) error {
 	return nil
 }
 
+// DataType returns the data type of the runtime-to-consensus engine message
+func (d *ConsensusDigest) DataType() byte {
+	return d.Data[0]
+}
+
+var ScheduledChangeType = byte(1)
+var ForcedChangeType = byte(2)
+var DisabledType = byte(3)
+var PauseType = byte(4)
+var ResumeType = byte(5)
+
+type GrandpaScheduledChange struct {
+	Auths []*GrandpaAuthorityDataRaw
+	Delay uint32
+}
+
+type GrandpaForcedChange struct {
+	Auths []*GrandpaAuthorityDataRaw
+	Delay uint32
+}
+
+type Disabled struct {
+	Auth *GrandpaAuthorityDataRaw
+}
+
+type Pause struct {
+	Delay uint32
+}
+
+type Resume struct {
+	Delay uint32
+}
+
 // SealDigest contains the seal or signature. This is only used by native code.
 type SealDigest struct {
 	ConsensusEngineID ConsensusEngineID

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -181,34 +181,6 @@ func (d *ConsensusDigest) DataType() byte {
 	return d.Data[0]
 }
 
-var ScheduledChangeType = byte(1)
-var ForcedChangeType = byte(2)
-var DisabledType = byte(3)
-var PauseType = byte(4)
-var ResumeType = byte(5)
-
-type GrandpaScheduledChange struct {
-	Auths []*GrandpaAuthorityDataRaw
-	Delay uint32
-}
-
-type GrandpaForcedChange struct {
-	Auths []*GrandpaAuthorityDataRaw
-	Delay uint32
-}
-
-type Disabled struct {
-	Auth *GrandpaAuthorityDataRaw
-}
-
-type Pause struct {
-	Delay uint32
-}
-
-type Resume struct {
-	Delay uint32
-}
-
 // SealDigest contains the seal or signature. This is only used by native code.
 type SealDigest struct {
 	ConsensusEngineID ConsensusEngineID

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -146,6 +146,19 @@ func (s *Service) Stop() error {
 	return nil
 }
 
+// Authorities returns the current grandpa authorities
+func (s *Service) Authorities() []*types.GrandpaAuthorityData {
+	ad := make([]*types.GrandpaAuthorityData, len(s.state.voters))
+	for i, v := range s.state.voters {
+		ad[i] = &types.GrandpaAuthorityData{
+			Key: v.key,
+			ID:  v.id,
+		}
+	}
+
+	return ad
+}
+
 // UpdateAuthorities schedules an update to the grandpa voter set and increments the setID at the end of the current round
 func (s *Service) UpdateAuthorities(ad []*types.GrandpaAuthorityData) {
 	v := make([]*Voter, len(ad))

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -52,6 +52,7 @@ type Service struct {
 	pcEquivocations  map[ed25519.PublicKeyBytes][]*Vote // equivocatory votes for current pre-commit stage
 	tracker          *tracker                           // tracker of vote messages we may need in the future
 	head             *types.Header                      // most recently finalized block
+	nextAuthorities  []*Voter                           // if not nil, the updated authorities for the next round
 
 	// historical information
 	preVotedBlock      map[uint64]*Vote            // map of round number -> pre-voted block
@@ -69,6 +70,7 @@ type Config struct {
 	LogLvl     log.Lvl
 	BlockState BlockState
 	Voters     []*Voter
+	SetID      uint64
 	Keypair    *ed25519.Keypair
 }
 
@@ -99,7 +101,7 @@ func NewService(cfg *Config) (*Service, error) {
 
 	s := &Service{
 		logger:             logger,
-		state:              NewState(cfg.Voters, 0, 0),
+		state:              NewState(cfg.Voters, cfg.SetID, 0),
 		blockState:         cfg.BlockState,
 		keypair:            cfg.Keypair,
 		prevotes:           make(map[ed25519.PublicKeyBytes]*Vote),
@@ -144,6 +146,21 @@ func (s *Service) Stop() error {
 	return nil
 }
 
+// UpdateAuthorities schedules an update to the grandpa voter set and increments the setID at the end of the current round
+func (s *Service) UpdateAuthorities(v []*Voter) {
+	s.nextAuthorities = v
+}
+
+// updateAuthorities updates the grandpa voter set, increments the setID, and resets the round numbers
+func (s *Service) updateAuthorities() {
+	if s.nextAuthorities != nil {
+		s.state.voters = s.nextAuthorities
+		s.state.setID++
+		s.state.round = 0
+		s.nextAuthorities = nil
+	}
+}
+
 func (s *Service) publicKeyBytes() ed25519.PublicKeyBytes {
 	return s.keypair.Public().(*ed25519.PublicKey).AsBytes()
 }
@@ -151,6 +168,9 @@ func (s *Service) publicKeyBytes() ed25519.PublicKeyBytes {
 // initiate initates a GRANDPA round
 func (s *Service) initiate() error {
 	s.stopped = false
+
+	// if there is an authority change, execute it
+	s.updateAuthorities()
 
 	if s.state.round == 0 {
 		s.mapLock.Lock()

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -147,7 +147,15 @@ func (s *Service) Stop() error {
 }
 
 // UpdateAuthorities schedules an update to the grandpa voter set and increments the setID at the end of the current round
-func (s *Service) UpdateAuthorities(v []*Voter) {
+func (s *Service) UpdateAuthorities(ad []*types.GrandpaAuthorityData) {
+	v := make([]*Voter, len(ad))
+	for i, a := range ad {
+		v[i] = &Voter{
+			key: a.Key,
+			id:  a.ID,
+		}
+	}
+
 	s.nextAuthorities = v
 }
 

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -86,8 +86,8 @@ func (m *SignedMessage) String() string {
 // VoteMessage represents a network-level vote message
 // https://github.com/paritytech/substrate/blob/master/client/finality-grandpa/src/communication/gossip.rs#L336
 type VoteMessage struct {
-	SetID   uint64
 	Round   uint64
+	SetID   uint64
 	Stage   subround // 0 for pre-vote, 1 for pre-commit
 	Message *SignedMessage
 }

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -37,8 +37,8 @@ func TestDecodeMessage_VoteMessage(t *testing.T) {
 	copy(sig[:], sigb)
 
 	expected := &VoteMessage{
-		Round: 99,
-		SetID: 77,
+		Round: 77,
+		SetID: 99,
 		Stage: precommit,
 		Message: &SignedMessage{
 			Hash:        common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -37,8 +37,8 @@ func TestDecodeMessage_VoteMessage(t *testing.T) {
 	copy(sig[:], sigb)
 
 	expected := &VoteMessage{
-		SetID: 77,
 		Round: 99,
+		SetID: 77,
 		Stage: precommit,
 		Message: &SignedMessage{
 			Hash:        common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
@@ -103,8 +103,8 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 	v, err := NewVoteFromHash(st.Block.BestBlockHash(), st.Block)
 	require.NoError(t, err)
 
-	gs.state.setID = 77
-	gs.state.round = 99
+	gs.state.setID = 99
+	gs.state.round = 77
 	v.number = 0x7777
 	vm, err := gs.createVoteMessage(v, precommit, gs.keypair)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 
 	expected := &ConsensusMessage{
 		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x004d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000036e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+		Data:              common.MustHexToBytes("0x004d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a7777000000000000a28633c3a1046351931209fe9182fd530dc659d54ece48e9f88f4277e47f39eb78a84d50e3d37e1b50786d88abafceb5137044b6122fb6b7b5ae8ff62787cc0e34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
 	}
 
 	require.Equal(t, expected, cm)

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -204,7 +204,6 @@ func (s *Service) checkForEquivocation(voter *Voter, vote *Vote, stage subround)
 		votes = s.precommits
 	}
 
-	// TODO: check for votes we've already seen #923
 	if eq[v] != nil {
 		// if the voter has already equivocated, every vote in that round is an equivocatory vote
 		eq[v] = append(eq[v], vote)

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -106,8 +106,8 @@ func (s *Service) createVoteMessage(vote *Vote, stage subround, kp crypto.Keypai
 	}
 
 	return &VoteMessage{
-		SetID:   s.state.setID,
 		Round:   s.state.round,
+		SetID:   s.state.setID,
 		Stage:   stage,
 		Message: sm,
 	}, nil

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -72,13 +72,10 @@ func TestCheckForEquivocation_WithEquivocation(t *testing.T) {
 	gs, err := NewService(cfg)
 	require.NoError(t, err)
 
-	var branches []*types.Header
-	for {
-		_, branches = state.AddBlocksToState(t, st.Block, 3)
-		if len(branches) != 0 {
-			break
-		}
-	}
+	branches := make(map[int]int)
+	branches[6] = 1
+	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches, 0)
+	leaves := gs.blockState.Leaves()
 
 	h, err := st.Block.BestBlockHeader()
 	require.NoError(t, err)
@@ -90,7 +87,7 @@ func TestCheckForEquivocation_WithEquivocation(t *testing.T) {
 
 	gs.prevotes[voter.key.AsBytes()] = vote
 
-	vote2 := NewVoteFromHeader(branches[0])
+	vote2, err := NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	equivocated := gs.checkForEquivocation(voter, vote2, prevote)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add digestHandler which is called when a block is imported to handle any consensus digests (see spec 5.1.2) and update grandpa authorities accordingly
- add functionality to update authority set and increment setID at end of current round
- switch setID and round in VoteMessage to conform to spec
- some testing cleanup

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #972