### PR TITLE
dot/state: implement ability to register channels for block import, finalization 

### DIFF
--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -22,8 +22,9 @@ type BlockAPI interface {
 	HighestBlockHash() common.Hash
 	GetBlockByHash(hash common.Hash) (*types.Block, error)
 	GetBlockHash(blockNumber *big.Int) (*common.Hash, error)
-	SetBlockAddedChannel(chan<- *types.Block, <-chan struct{})
 	GetFinalizedHash(uint64) (common.Hash, error)
+	RegisterImportedChannel(ch chan<- *types.Block) (byte, error)
+	UnregisterImportedChannel(id byte)
 }
 
 // NetworkAPI interface for network state methods

--- a/dot/rpc/websocket.go
+++ b/dot/rpc/websocket.go
@@ -212,7 +212,7 @@ func (h *HTTPServer) blockReceivedListener() {
 		return
 	}
 
-	for block := range h.serverConfig.BlockAddedReceiver {
+	for block := range h.blockChan {
 		if block != nil {
 			for i, sub := range h.serverConfig.WSSubscriptions {
 				if sub.SubscriptionType == SUB_NEW_HEAD {

--- a/dot/state/block_notify.go
+++ b/dot/state/block_notify.go
@@ -1,0 +1,126 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"errors"
+	"math/rand"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+)
+
+// RegisterImportedChannel registers a channel for block notification upon block import.
+// It returns the channel ID (used for unregistering the channel)
+func (bs *BlockState) RegisterImportedChannel(ch chan<- *types.Block) (byte, error) {
+	bs.importedLock.RLock()
+
+	if len(bs.imported) == 256 {
+		return 0, errors.New("channel limit reached")
+	}
+
+	var id byte
+	for {
+		id = generateID()
+		if bs.imported[id] == nil {
+			break
+		}
+	}
+
+	bs.importedLock.RUnlock()
+
+	bs.importedLock.Lock()
+	bs.imported[id] = ch
+	bs.importedLock.Unlock()
+	return id, nil
+}
+
+// RegisterFinalizedChannel registers a channel for block notification upon block finalization.
+// It returns the channel ID (used for unregistering the channel)
+func (bs *BlockState) RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error) {
+	bs.finalizedLock.RLock()
+
+	if len(bs.finalized) == 256 {
+		return 0, errors.New("channel limit reached")
+	}
+
+	var id byte
+	for {
+		id = generateID()
+		if bs.finalized[id] == nil {
+			break
+		}
+	}
+
+	bs.finalizedLock.RUnlock()
+
+	bs.finalizedLock.Lock()
+	bs.finalized[id] = ch
+	bs.finalizedLock.Unlock()
+	return id, nil
+}
+
+// UnregisterImportedChannel removes the block import notification channel with the given ID.
+// A channel must be unregistered before closing it.
+func (bs *BlockState) UnregisterImportedChannel(id byte) {
+	bs.importedLock.Lock()
+	defer bs.importedLock.Unlock()
+
+	delete(bs.imported, id)
+}
+
+// UnregisterFinalizedChannel removes the block finalization notification channel with the given ID.
+// A channel must be unregistered before closing it.
+func (bs *BlockState) UnregisterFinalizedChannel(id byte) {
+	bs.finalizedLock.Lock()
+	defer bs.finalizedLock.Unlock()
+
+	delete(bs.finalized, id)
+}
+
+func (bs *BlockState) notifyImported(block *types.Block) {
+	bs.importedLock.RLock()
+	defer bs.importedLock.RUnlock()
+
+	for _, ch := range bs.imported {
+		go func() {
+			ch <- block
+		}()
+	}
+}
+
+func (bs *BlockState) notifyFinalized(hash common.Hash) {
+	header, err := bs.GetHeader(hash)
+	if err != nil {
+		logger.Error("failed to get finalized header", "hash", hash, "error", err)
+		return
+	}
+
+	bs.finalizedLock.RLock()
+	defer bs.finalizedLock.RUnlock()
+
+	for _, ch := range bs.finalized {
+		go func() {
+			ch <- header
+		}()
+	}
+}
+
+func generateID() byte {
+	id := rand.Intn(256)
+	return byte(id)
+}

--- a/dot/state/block_notify.go
+++ b/dot/state/block_notify.go
@@ -93,12 +93,12 @@ func (bs *BlockState) UnregisterFinalizedChannel(id byte) {
 }
 
 func (bs *BlockState) notifyImported(block *types.Block) {
+	bs.importedLock.RLock()
+	defer bs.importedLock.RUnlock()
+
 	if len(bs.imported) == 0 {
 		return
 	}
-
-	bs.importedLock.RLock()
-	defer bs.importedLock.RUnlock()
 
 	logger.Trace("notifying imported block chans...", "chans", bs.imported)
 
@@ -110,6 +110,9 @@ func (bs *BlockState) notifyImported(block *types.Block) {
 }
 
 func (bs *BlockState) notifyFinalized(hash common.Hash) {
+	bs.finalizedLock.RLock()
+	defer bs.finalizedLock.RUnlock()
+
 	if len(bs.finalized) == 0 {
 		return
 	}
@@ -121,9 +124,6 @@ func (bs *BlockState) notifyFinalized(hash common.Hash) {
 	}
 
 	logger.Trace("notifying finalized block chans...", "chans", bs.finalized)
-
-	bs.finalizedLock.RLock()
-	defer bs.finalizedLock.RUnlock()
 
 	for _, ch := range bs.finalized {
 		go func(ch chan<- *types.Header) {

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -1,0 +1,78 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package state
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testMessageTimeout = time.Second * 3
+
+func TestImportChannel(t *testing.T) {
+	bs := newTestBlockState(t, testGenesisHeader)
+
+	ch := make(chan *types.Block)
+	id, err := bs.RegisterImportedChannel(ch)
+	require.NoError(t, err)
+
+	defer bs.UnregisterImportedChannel(id)
+
+	AddBlocksToState(t, bs, 3)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case b := <-ch:
+			require.Equal(t, big.NewInt(int64(i+1)), b.Header.Number)
+		case <-time.After(testMessageTimeout):
+			t.Fatal("did not receive finality message")
+		}
+	}
+}
+
+func TestFinalizedChannel(t *testing.T) {
+	bs := newTestBlockState(t, testGenesisHeader)
+
+	ch := make(chan *types.Header, 3)
+	id, err := bs.RegisterFinalizedChannel(ch)
+	require.NoError(t, err)
+
+	defer bs.UnregisterFinalizedChannel(id)
+
+	chain, _ := AddBlocksToState(t, bs, 3)
+
+	for _, b := range chain {
+		bs.SetFinalizedHash(b.Hash(), 0)
+	}
+
+	for i := 0; i < 1; i++ {
+		select {
+		case b := <-ch:
+			// ignore genesis block
+			if b.Number.Cmp(big.NewInt(0)) == 1 {
+				require.Equal(t, big.NewInt(int64(i+1)), b.Number, b)	
+			}
+		case <-time.After(testMessageTimeout):
+			t.Fatal("did not receive finality message")
+		}
+	}
+}

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -104,7 +104,7 @@ func TestImportChannel_Multi(t *testing.T) {
 				require.Equal(t, big.NewInt(1), b.Header.Number)
 				wg.Done()
 			case <-time.After(testMessageTimeout):
-				t.Fatal("did not receive imported block: ch=", i)
+				t.Error("did not receive imported block: ch=", i)
 			}
 		}(i, ch)
 
@@ -144,7 +144,7 @@ func TestFinalizedChannel_Multi(t *testing.T) {
 			case <-ch:
 				wg.Done()
 			case <-time.After(testMessageTimeout):
-				t.Fatal("did not receive finalized block: ch=", i)
+				t.Error("did not receive finalized block: ch=", i)
 			}
 		}(i, ch)
 

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -66,11 +66,7 @@ func TestFinalizedChannel(t *testing.T) {
 
 	for i := 0; i < 1; i++ {
 		select {
-		case b := <-ch:
-			// ignore genesis block
-			if b.Number.Cmp(big.NewInt(0)) == 1 {
-				require.Equal(t, big.NewInt(int64(i+1)), b.Number, b)
-			}
+		case <-ch:
 		case <-time.After(testMessageTimeout):
 			t.Fatal("did not receive finalized block")
 		}

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -28,6 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testGenesisHeader = &types.Header{
+	Number:    big.NewInt(0),
+	StateRoot: trie.EmptyHash,
+}
+
 func newTestBlockState(t *testing.T, header *types.Header) *BlockState {
 	db := chaindb.NewMemDatabase()
 	blockDb := NewBlockDB(db)
@@ -78,14 +83,10 @@ func TestHasHeader(t *testing.T) {
 }
 
 func TestGetBlockByNumber(t *testing.T) {
-	genesisHeader := &types.Header{
-		Number: big.NewInt(0),
-	}
-
-	bs := newTestBlockState(t, genesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader)
 
 	blockHeader := &types.Header{
-		ParentHash: genesisHeader.Hash(),
+		ParentHash: testGenesisHeader.Hash(),
 		Number:     big.NewInt(1),
 		Digest:     [][]byte{},
 	}
@@ -105,17 +106,13 @@ func TestGetBlockByNumber(t *testing.T) {
 }
 
 func TestAddBlock(t *testing.T) {
-	genesisHeader := &types.Header{
-		Number: big.NewInt(0),
-	}
-
-	bs := newTestBlockState(t, genesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader)
 
 	// Create header
 	header0 := &types.Header{
 		Number:     big.NewInt(0),
 		Digest:     [][]byte{},
-		ParentHash: genesisHeader.Hash(),
+		ParentHash: testGenesisHeader.Hash(),
 	}
 	// Create blockHash
 	blockHash0 := header0.Hash()
@@ -178,12 +175,7 @@ func TestAddBlock(t *testing.T) {
 }
 
 func TestGetSlotForBlock(t *testing.T) {
-	genesisHeader := &types.Header{
-		Number:    big.NewInt(0),
-		StateRoot: trie.EmptyHash,
-	}
-
-	bs := newTestBlockState(t, genesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader)
 
 	preDigest, err := common.HexToBytes("0x064241424538e93dcef2efc275b72b4fa748332dc4c9f13be1125909cf90c8e9109c45da16b04bc5fdf9fe06a4f35e4ae4ed7e251ff9ee3d0d840c8237c9fb9057442dbf00f210d697a7b4959f792a81b948ff88937e30bf9709a8ab1314f71284da89a40000000000000000001100000000000000")
 	require.NoError(t, err)
@@ -192,7 +184,7 @@ func TestGetSlotForBlock(t *testing.T) {
 
 	block := &types.Block{
 		Header: &types.Header{
-			ParentHash: genesisHeader.Hash(),
+			ParentHash: testGenesisHeader.Hash(),
 			Number:     big.NewInt(int64(1)),
 			Digest:     [][]byte{preDigest},
 		},
@@ -208,12 +200,7 @@ func TestGetSlotForBlock(t *testing.T) {
 }
 
 func TestIsBlockOnCurrentChain(t *testing.T) {
-	genesisHeader := &types.Header{
-		Number:    big.NewInt(0),
-		StateRoot: trie.EmptyHash,
-	}
-
-	bs := newTestBlockState(t, genesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader)
 	currChain, branchChains := AddBlocksToState(t, bs, 8)
 
 	for _, header := range currChain {
@@ -236,12 +223,7 @@ func TestIsBlockOnCurrentChain(t *testing.T) {
 }
 
 func TestAddBlock_BlockNumberToHash(t *testing.T) {
-	genesisHeader := &types.Header{
-		Number:    big.NewInt(0),
-		StateRoot: trie.EmptyHash,
-	}
-
-	bs := newTestBlockState(t, genesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader)
 	currChain, branchChains := AddBlocksToState(t, bs, 8)
 
 	bestHash := bs.BestBlockHash()
@@ -287,15 +269,10 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 }
 
 func TestFinalizedHash(t *testing.T) {
-	genesisHeader := &types.Header{
-		Number:    big.NewInt(0),
-		StateRoot: trie.EmptyHash,
-	}
-
-	bs := newTestBlockState(t, genesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader)
 	h, err := bs.GetFinalizedHash(0)
 	require.NoError(t, err)
-	require.Equal(t, genesisHeader.Hash(), h)
+	require.Equal(t, testGenesisHeader.Hash(), h)
 
 	testhash := common.Hash{1, 2, 3, 4}
 	err = bs.SetFinalizedHash(testhash, 1)

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -30,9 +30,10 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
+var logger = log.New("pkg", "state")
+
 // Service is the struct that holds storage, block and network states
 type Service struct {
-	logger           log.Logger
 	dbPath           string
 	db               chaindb.Database
 	isMemDB          bool // set to true if using an in-memory database; only used for testing.
@@ -44,12 +45,10 @@ type Service struct {
 
 // NewService create a new instance of Service
 func NewService(path string, lvl log.Lvl) *Service {
-	logger := log.New("pkg", "state")
 	handler := log.StreamHandler(os.Stdout, log.TerminalFormat())
 	logger.SetHandler(log.LvlFilterHandler(lvl, handler))
 
 	return &Service{
-		logger:  logger,
 		dbPath:  path,
 		db:      nil,
 		isMemDB: false,
@@ -202,7 +201,7 @@ func (s *Service) Start() error {
 		return fmt.Errorf("failed to get best block hash: %s", err)
 	}
 
-	s.logger.Trace("start", "best block hash", fmt.Sprintf("0x%x", bestHash))
+	logger.Trace("start", "best block hash", fmt.Sprintf("0x%x", bestHash))
 
 	// create storage state
 	s.Storage, err = NewStorageState(db, trie.NewEmptyTrie())
@@ -228,7 +227,7 @@ func (s *Service) Start() error {
 		return fmt.Errorf("cannot load latest storage root: %s", err)
 	}
 
-	s.logger.Debug("start", "latest state root", stateRoot)
+	logger.Debug("start", "latest state root", stateRoot)
 
 	// load current storage state
 	err = s.Storage.LoadFromDB(stateRoot)
@@ -273,7 +272,7 @@ func (s *Service) Stop() error {
 		return err
 	}
 
-	s.logger.Debug("stop", "best block hash", hash)
+	logger.Debug("stop", "best block hash", hash)
 
 	return s.db.Close()
 }

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -205,6 +205,7 @@ func (s *Service) initiate() error {
 		s.tracker.stop()
 	}
 
+	var err error
 	s.prevotes = make(map[ed25519.PublicKeyBytes]*Vote)
 	s.precommits = make(map[ed25519.PublicKeyBytes]*Vote)
 	s.pvJustifications = []*Justification{}
@@ -212,7 +213,10 @@ func (s *Service) initiate() error {
 	s.pvEquivocations = make(map[ed25519.PublicKeyBytes][]*Vote)
 	s.pcEquivocations = make(map[ed25519.PublicKeyBytes][]*Vote)
 	s.justification = make(map[uint64][]*Justification)
-	s.tracker = newTracker(s.blockState, s.in)
+	s.tracker, err = newTracker(s.blockState, s.in)
+	if err != nil {
+		return err
+	}
 	s.tracker.start()
 	log.Trace("[grandpa] started message tracker")
 

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -35,7 +35,8 @@ func TestMessageTracker_ValidateMessage(t *testing.T) {
 
 	gs, _, _, _ := setupGrandpa(t, kr.Bob)
 	state.AddBlocksToState(t, gs.blockState.(*state.BlockState), 3)
-	gs.tracker = newTracker(gs.blockState, gs.in)
+	gs.tracker, err = newTracker(gs.blockState, gs.in)
+	require.NoError(t, err)
 	gs.tracker.start()
 
 	fake := &types.Header{
@@ -56,7 +57,8 @@ func TestMessageTracker_SendMessage(t *testing.T) {
 
 	gs, in, _, _ := setupGrandpa(t, kr.Bob)
 	state.AddBlocksToState(t, gs.blockState.(*state.BlockState), 3)
-	gs.tracker = newTracker(gs.blockState, gs.in)
+	gs.tracker, err = newTracker(gs.blockState, gs.in)
+	require.NoError(t, err)
 	gs.tracker.start()
 
 	parent, err := gs.blockState.BestBlockHeader()

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -335,6 +335,7 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 	wg.Wait()
 
 	for _, fb := range finalized {
+		require.NotNil(t, fb)
 		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
 		finalized[0].Justification = []*Justification{}
 		fb.Justification = []*Justification{}

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -35,5 +35,6 @@ type BlockState interface {
 	BestBlockHeader() (*types.Header, error)
 	Leaves() []common.Hash
 	BlocktreeAsString() string
-	SetHashChannel(h chan<- common.Hash)
+	RegisterImportedChannel(ch chan<- *types.Block) (byte, error)
+	UnregisterImportedChannel(id byte)
 }

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -293,7 +293,8 @@ func TestValidateMessage_BlockDoesNotExist(t *testing.T) {
 	gs, err := NewService(cfg)
 	require.NoError(t, err)
 	state.AddBlocksToState(t, st.Block, 3)
-	gs.tracker = newTracker(st.Block, gs.in)
+	gs.tracker, err = newTracker(st.Block, gs.in)
+	require.NoError(t, err)
 
 	fake := &types.Header{
 		Number: big.NewInt(77),


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add functionality to register/unregister notification channels for imported and finalized blocks in BlockState
- update rpc and grandpa accordingly

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #973