### PR TITLE
cmd, dot, dot/core: add BabeAuthority and GrandpaAuthority config options

### DIFF
--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -5,13 +5,13 @@ basepath = "~/.gossamer/gssmr"
 log = "info"
 
 [log]
-core = "info"
-network = "info"
-rpc = "info"
-state = "info"
-runtime = "info"
-babe = "info"
-grandpa = "info"
+core = ""
+network = ""
+rpc = ""
+state = ""
+runtime = ""
+babe = ""
+grandpa = ""
 
 [init]
 genesis = "./chain/gssmr/genesis.json"
@@ -23,6 +23,8 @@ unlock = ""
 [core]
 authority = true
 roles = 4
+babe-authority = true
+grandpa-authority = true
 
 [network]
 port = 7001

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -45,10 +45,14 @@ var (
 
 	// CoreConfig
 
-	// DefaultAuthority true if BABE block producer
+	// DefaultAuthority is true if the node is a block producer and a grandpa authority
 	DefaultAuthority = true
 	// DefaultRoles Default node roles
 	DefaultRoles = byte(4) // authority node (see Table D.2)
+	// DefaultBabeAuthority is true if the node is a block producer (overwrites previous settings)
+	DefaultBabeAuthority = true
+	// DefaultGrandpaAuthority is true if the node is a grandpa authority (overwrites previous settings)
+	DefaultGrandpaAuthority = true
 
 	// NetworkConfig
 

--- a/chain/ksmcc/config.toml
+++ b/chain/ksmcc/config.toml
@@ -5,13 +5,13 @@ basepath = "~/.gossamer/ksmcc"
 log = "info"
 
 [log]
-core = "info"
-network = "info"
-rpc = "info"
-state = "info"
-runtime = "info"
-babe = "info"
-grandpa = "info"
+core = ""
+network = ""
+rpc = ""
+state = ""
+runtime = ""
+babe = ""
+grandpa = ""
 
 [init]
 genesis = "./chain/ksmcc/genesis.json"
@@ -23,6 +23,8 @@ unlock = ""
 [core]
 authority = false
 roles = 1
+babe-authority = false
+grandpa-authority = false
 
 [network]
 port = 7001

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -323,10 +323,27 @@ func setDotCoreConfig(ctx *cli.Context, cfg *dot.CoreConfig) {
 		}
 	}
 
+	// to turn on BABE but not grandpa, cfg.Authority must be set to true
+	// and cfg.GrandpaAuthority must be set to false
+	if cfg.Authority && !cfg.BabeAuthority {
+		cfg.BabeAuthority = false
+	}
+
+	if cfg.Authority && !cfg.GrandpaAuthority {
+		cfg.GrandpaAuthority = false
+	}
+
+	if !cfg.Authority {
+		cfg.BabeAuthority = false
+		cfg.GrandpaAuthority = false
+	}
+
 	logger.Debug(
 		"core configuration",
-		"authority", cfg.Authority,
-		"roles", cfg.Roles,
+		// "authority", cfg.Authority,
+		// "roles", cfg.Roles,
+		"babe-authority", cfg.BabeAuthority,
+		"grandpa-authority", cfg.GrandpaAuthority,
 	)
 }
 

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -340,8 +340,6 @@ func setDotCoreConfig(ctx *cli.Context, cfg *dot.CoreConfig) {
 
 	logger.Debug(
 		"core configuration",
-		// "authority", cfg.Authority,
-		// "roles", cfg.Roles,
 		"babe-authority", cfg.BabeAuthority,
 		"grandpa-authority", cfg.GrandpaAuthority,
 	)

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/chain/gssmr"
 	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/genesis"
@@ -45,6 +46,17 @@ func TestConfigFromChainFlag(t *testing.T) {
 	testApp := cli.NewApp()
 	testApp.Writer = ioutil.Discard
 
+	gssmrCfg := dot.GssmrConfig()
+	gssmrCfg.Log = dot.LogConfig{
+		CoreLvl:           gssmr.DefaultLvl,
+		NetworkLvl:        gssmr.DefaultLvl,
+		RPCLvl:            gssmr.DefaultLvl,
+		StateLvl:          gssmr.DefaultLvl,
+		RuntimeLvl:        gssmr.DefaultLvl,
+		BlockProducerLvl:  gssmr.DefaultLvl,
+		FinalityGadgetLvl: gssmr.DefaultLvl,
+	}
+
 	testcases := []struct {
 		description string
 		flags       []string
@@ -55,7 +67,7 @@ func TestConfigFromChainFlag(t *testing.T) {
 			"Test gossamer --chain gssmr",
 			[]string{"chain"},
 			[]interface{}{"gssmr"},
-			dot.GssmrConfig(),
+			gssmrCfg,
 		},
 		{
 			"Test gossamer --chain ksmcc",
@@ -111,7 +123,6 @@ func TestInitConfigFromFlags(t *testing.T) {
 			require.Nil(t, err)
 			cfg, err := createInitConfig(ctx)
 			require.Nil(t, err)
-
 			require.Equal(t, c.expected, cfg.Init)
 		})
 	}
@@ -275,8 +286,10 @@ func TestCoreConfigFromFlags(t *testing.T) {
 			[]string{"config", "roles"},
 			[]interface{}{testCfgFile.Name(), "4"},
 			dot.CoreConfig{
-				Authority: true,
-				Roles:     4,
+				Authority:        true,
+				Roles:            4,
+				BabeAuthority:    true,
+				GrandpaAuthority: true,
 			},
 		},
 		{
@@ -284,8 +297,10 @@ func TestCoreConfigFromFlags(t *testing.T) {
 			[]string{"config", "roles"},
 			[]interface{}{testCfgFile.Name(), "0"},
 			dot.CoreConfig{
-				Authority: false,
-				Roles:     0,
+				Authority:        false,
+				Roles:            0,
+				BabeAuthority:    false,
+				GrandpaAuthority: false,
 			},
 		},
 	}

--- a/dot/config.go
+++ b/dot/config.go
@@ -127,15 +127,6 @@ func GssmrConfig() *Config {
 			BasePath: gssmr.DefaultBasePath,
 			LogLevel: gssmr.DefaultLvl,
 		},
-		// Log: LogConfig{
-		// 	CoreLvl:           gssmr.DefaultLvl,
-		// 	NetworkLvl:        gssmr.DefaultLvl,
-		// 	RPCLvl:            gssmr.DefaultLvl,
-		// 	StateLvl:          gssmr.DefaultLvl,
-		// 	RuntimeLvl:        gssmr.DefaultLvl,
-		// 	BlockProducerLvl:  gssmr.DefaultLvl,
-		// 	FinalityGadgetLvl: gssmr.DefaultLvl,
-		// },
 		Init: InitConfig{
 			Genesis: gssmr.DefaultGenesis,
 		},
@@ -177,15 +168,6 @@ func KsmccConfig() *Config {
 			ID:       ksmcc.DefaultID,
 			BasePath: ksmcc.DefaultBasePath,
 		},
-		// Log: LogConfig{
-		// 	CoreLvl:           ksmcc.DefaultLvl,
-		// 	NetworkLvl:        ksmcc.DefaultLvl,
-		// 	RPCLvl:            ksmcc.DefaultLvl,
-		// 	StateLvl:          ksmcc.DefaultLvl,
-		// 	RuntimeLvl:        ksmcc.DefaultLvl,
-		// 	BlockProducerLvl:  ksmcc.DefaultLvl,
-		// 	FinalityGadgetLvl: ksmcc.DefaultLvl,
-		// },
 		Init: InitConfig{
 			Genesis: ksmcc.DefaultGenesis,
 		},

--- a/dot/config.go
+++ b/dot/config.go
@@ -86,8 +86,10 @@ type NetworkConfig struct {
 
 // CoreConfig is to marshal/unmarshal toml core config vars
 type CoreConfig struct {
-	Authority bool `toml:"authority"`
-	Roles     byte `toml:"roles"`
+	Authority        bool `toml:"authority"`
+	Roles            byte `toml:"roles"`
+	BabeAuthority    bool `toml:"babe-authority"`
+	GrandpaAuthority bool `toml:"grandpa-authority"`
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars
@@ -125,15 +127,15 @@ func GssmrConfig() *Config {
 			BasePath: gssmr.DefaultBasePath,
 			LogLevel: gssmr.DefaultLvl,
 		},
-		Log: LogConfig{
-			CoreLvl:           gssmr.DefaultLvl,
-			NetworkLvl:        gssmr.DefaultLvl,
-			RPCLvl:            gssmr.DefaultLvl,
-			StateLvl:          gssmr.DefaultLvl,
-			RuntimeLvl:        gssmr.DefaultLvl,
-			BlockProducerLvl:  gssmr.DefaultLvl,
-			FinalityGadgetLvl: gssmr.DefaultLvl,
-		},
+		// Log: LogConfig{
+		// 	CoreLvl:           gssmr.DefaultLvl,
+		// 	NetworkLvl:        gssmr.DefaultLvl,
+		// 	RPCLvl:            gssmr.DefaultLvl,
+		// 	StateLvl:          gssmr.DefaultLvl,
+		// 	RuntimeLvl:        gssmr.DefaultLvl,
+		// 	BlockProducerLvl:  gssmr.DefaultLvl,
+		// 	FinalityGadgetLvl: gssmr.DefaultLvl,
+		// },
 		Init: InitConfig{
 			Genesis: gssmr.DefaultGenesis,
 		},
@@ -142,8 +144,10 @@ func GssmrConfig() *Config {
 			Unlock: gssmr.DefaultUnlock,
 		},
 		Core: CoreConfig{
-			Authority: gssmr.DefaultAuthority,
-			Roles:     gssmr.DefaultRoles,
+			Authority:        gssmr.DefaultAuthority,
+			Roles:            gssmr.DefaultRoles,
+			BabeAuthority:    gssmr.DefaultBabeAuthority,
+			GrandpaAuthority: gssmr.DefaultGrandpaAuthority,
 		},
 		Network: NetworkConfig{
 			Port:        gssmr.DefaultNetworkPort,
@@ -173,15 +177,15 @@ func KsmccConfig() *Config {
 			ID:       ksmcc.DefaultID,
 			BasePath: ksmcc.DefaultBasePath,
 		},
-		Log: LogConfig{
-			CoreLvl:           ksmcc.DefaultLvl,
-			NetworkLvl:        ksmcc.DefaultLvl,
-			RPCLvl:            ksmcc.DefaultLvl,
-			StateLvl:          ksmcc.DefaultLvl,
-			RuntimeLvl:        ksmcc.DefaultLvl,
-			BlockProducerLvl:  ksmcc.DefaultLvl,
-			FinalityGadgetLvl: ksmcc.DefaultLvl,
-		},
+		// Log: LogConfig{
+		// 	CoreLvl:           ksmcc.DefaultLvl,
+		// 	NetworkLvl:        ksmcc.DefaultLvl,
+		// 	RPCLvl:            ksmcc.DefaultLvl,
+		// 	StateLvl:          ksmcc.DefaultLvl,
+		// 	RuntimeLvl:        ksmcc.DefaultLvl,
+		// 	BlockProducerLvl:  ksmcc.DefaultLvl,
+		// 	FinalityGadgetLvl: ksmcc.DefaultLvl,
+		// },
 		Init: InitConfig{
 			Genesis: ksmcc.DefaultGenesis,
 		},

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -63,6 +63,7 @@ func TestDigestHandler_GrandpaScheduledChange(t *testing.T) {
 	handler := newTestDigestHandler(t, false, true)
 	handler.start()
 	defer handler.stop()
+	require.True(t, handler.isFinalityAuthority)
 
 	kr, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -45,6 +45,9 @@ var ErrNilRuntime = errors.New("cannot have nil runtime")
 // ErrNilBlockProducer is returned when trying to instantiate a block producing Service without a block producer
 var ErrNilBlockProducer = errors.New("cannot have nil BlockProducer")
 
+// ErrNilBlockProducer is returned when trying to instantiate a finalizing Service without a finality gadget
+var ErrNilFinalityGadget = errors.New("cannot have nil FinalityGadget")
+
 // ErrNilChannel is returned if a channel is nil
 func ErrNilChannel(s string) error {
 	return fmt.Errorf("cannot have nil channel %s", s)

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -45,7 +45,7 @@ var ErrNilRuntime = errors.New("cannot have nil runtime")
 // ErrNilBlockProducer is returned when trying to instantiate a block producing Service without a block producer
 var ErrNilBlockProducer = errors.New("cannot have nil BlockProducer")
 
-// ErrNilBlockProducer is returned when trying to instantiate a finalizing Service without a finality gadget
+// ErrNilFinalityGadget is returned when trying to instantiate a finalizing Service without a finality gadget
 var ErrNilFinalityGadget = errors.New("cannot have nil FinalityGadget")
 
 // ErrNilChannel is returned if a channel is nil

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -146,22 +146,23 @@ func NewService(cfg *Config) (*Service, error) {
 	var srv = &Service{}
 
 	srv = &Service{
-		logger:           logger,
-		rt:               cfg.Runtime,
-		codeHash:         codeHash,
-		keys:             cfg.Keystore,
-		msgRec:           cfg.MsgRec,
-		msgSend:          cfg.MsgSend,
-		blockState:       cfg.BlockState,
-		storageState:     cfg.StorageState,
-		transactionQueue: cfg.TransactionQueue,
-		isBlockProducer:  cfg.IsBlockProducer,
-		blockProducer:    cfg.BlockProducer,
-		finalityGadget:   cfg.FinalityGadget,
-		lock:             chanLock,
-		syncLock:         syncerLock,
-		blockNumOut:      cfg.SyncChan,
-		respOut:          respChan,
+		logger:              logger,
+		rt:                  cfg.Runtime,
+		codeHash:            codeHash,
+		keys:                cfg.Keystore,
+		msgRec:              cfg.MsgRec,
+		msgSend:             cfg.MsgSend,
+		blockState:          cfg.BlockState,
+		storageState:        cfg.StorageState,
+		transactionQueue:    cfg.TransactionQueue,
+		isBlockProducer:     cfg.IsBlockProducer,
+		blockProducer:       cfg.BlockProducer,
+		finalityGadget:      cfg.FinalityGadget,
+		isFinalityAuthority: cfg.IsFinalityAuthority,
+		lock:                chanLock,
+		syncLock:            syncerLock,
+		blockNumOut:         cfg.SyncChan,
+		respOut:             respChan,
 	}
 
 	if cfg.NewBlocks != nil {
@@ -198,7 +199,7 @@ func NewService(cfg *Config) (*Service, error) {
 	srv.started.Store(false)
 
 	var dh *digestHandler
-	if cfg.IsBlockProducer {
+	if cfg.IsBlockProducer || cfg.IsFinalityAuthority {
 		dh, err = newDigestHandler(cfg.BlockState, cfg.BlockProducer, cfg.FinalityGadget)
 		if err != nil {
 			return nil, err

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -50,7 +50,6 @@ type Service struct {
 	blockState       BlockState
 	storageState     StorageState
 	transactionQueue TransactionQueue
-	finalityGadget   FinalityGadget
 
 	// Current runtime and hash of the current runtime code
 	rt       *runtime.Runtime
@@ -59,6 +58,10 @@ type Service struct {
 	// Block production variables
 	blockProducer   BlockProducer
 	isBlockProducer bool
+
+	// Finality gadget variables
+	finalityGadget      FinalityGadget
+	isFinalityAuthority bool
 
 	// Keystore
 	keys *keystore.Keystore
@@ -81,15 +84,16 @@ type Service struct {
 
 // Config holds the configuration for the core Service.
 type Config struct {
-	LogLvl           log.Lvl
-	BlockState       BlockState
-	StorageState     StorageState
-	TransactionQueue TransactionQueue
-	FinalityGadget   FinalityGadget
-	Keystore         *keystore.Keystore
-	Runtime          *runtime.Runtime
-	BlockProducer    BlockProducer
-	IsBlockProducer  bool
+	LogLvl              log.Lvl
+	BlockState          BlockState
+	StorageState        StorageState
+	TransactionQueue    TransactionQueue
+	Keystore            *keystore.Keystore
+	Runtime             *runtime.Runtime
+	BlockProducer       BlockProducer
+	IsBlockProducer     bool
+	FinalityGadget      FinalityGadget
+	IsFinalityAuthority bool
 
 	NewBlocks chan types.Block // only used for testing purposes
 	Verifier  Verifier         // only used for testing purposes
@@ -120,6 +124,10 @@ func NewService(cfg *Config) (*Service, error) {
 
 	if cfg.IsBlockProducer && cfg.BlockProducer == nil {
 		return nil, ErrNilBlockProducer
+	}
+
+	if cfg.IsFinalityAuthority && cfg.FinalityGadget == nil {
+		return nil, ErrNilFinalityGadget
 	}
 
 	logger := log.New("pkg", "core")

--- a/dot/node.go
+++ b/dot/node.go
@@ -222,14 +222,7 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 	var bp BlockProducer
 	var fg core.FinalityGadget
 
-	if cfg.Core.Authority {
-		// create GRANDPA service
-		fg, err = createGRANDPAService(cfg, rt, stateSrvc, ks)
-		if err != nil {
-			return nil, err
-		}
-		nodeSrvcs = append(nodeSrvcs, fg)
-
+	if cfg.Core.BabeAuthority {
 		// create BABE service
 		bp, err = createBABEService(cfg, rt, stateSrvc, ks)
 		if err != nil {
@@ -237,6 +230,15 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 		}
 
 		nodeSrvcs = append(nodeSrvcs, bp)
+	}
+
+	if cfg.Core.GrandpaAuthority {
+		// create GRANDPA service
+		fg, err = createGRANDPAService(cfg, rt, stateSrvc, ks)
+		if err != nil {
+			return nil, err
+		}
+		nodeSrvcs = append(nodeSrvcs, fg)
 	}
 
 	// Syncer

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -99,6 +99,8 @@ func TestNewNode(t *testing.T) {
 
 	// TODO: improve dot tests #687
 	cfg.Core.Authority = false
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
 
 	node, err := NewNode(cfg, ks)
 	require.Nil(t, err)
@@ -160,6 +162,8 @@ func TestStartNode(t *testing.T) {
 
 	// TODO: improve dot tests #687
 	cfg.Core.Authority = false
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
 
 	node, err := NewNode(cfg, ks)
 	require.Nil(t, err)
@@ -257,6 +261,8 @@ func TestInitNode_LoadStorageRoot(t *testing.T) {
 	defer utils.RemoveTestDir(t)
 
 	cfg.Core.Authority = false
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
 	cfg.Init.Genesis = genPath
 
 	gen, err := genesis.NewGenesisFromJSON(genPath)
@@ -315,6 +321,8 @@ func TestInitNode_LoadBalances(t *testing.T) {
 	defer utils.RemoveTestDir(t)
 
 	cfg.Core.Authority = false
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
 	cfg.Init.Genesis = genPath
 
 	err := InitNode(cfg)

--- a/dot/services.go
+++ b/dot/services.go
@@ -170,18 +170,19 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 
 	// set core configuration
 	coreConfig := &core.Config{
-		LogLvl:           lvl,
-		BlockState:       stateSrvc.Block,
-		StorageState:     stateSrvc.Storage,
-		TransactionQueue: stateSrvc.TransactionQueue,
-		BlockProducer:    bp,
-		FinalityGadget:   fg,
-		Keystore:         ks,
-		Runtime:          rt,
-		MsgRec:           networkMsgs, // message channel from network service to core service
-		MsgSend:          coreMsgs,    // message channel from core service to network service
-		IsBlockProducer:  cfg.Core.Authority,
-		SyncChan:         syncChan,
+		LogLvl:              lvl,
+		BlockState:          stateSrvc.Block,
+		StorageState:        stateSrvc.Storage,
+		TransactionQueue:    stateSrvc.TransactionQueue,
+		BlockProducer:       bp,
+		FinalityGadget:      fg,
+		Keystore:            ks,
+		Runtime:             rt,
+		MsgRec:              networkMsgs, // message channel from network service to core service
+		MsgSend:             coreMsgs,    // message channel from core service to network service
+		IsBlockProducer:     cfg.Core.BabeAuthority,
+		IsFinalityAuthority: cfg.Core.GrandpaAuthority,
+		SyncChan:            syncChan,
 	}
 
 	// create new core service

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -64,6 +64,8 @@ func TestCreateCoreService(t *testing.T) {
 
 	// TODO: improve dot tests #687
 	cfg.Core.Authority = false
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
 	cfg.Init.Genesis = genFile.Name()
 
 	err := InitNode(cfg)
@@ -133,6 +135,8 @@ func TestCreateRPCService(t *testing.T) {
 
 	// TODO: improve dot tests #687
 	cfg.Core.Authority = false
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
 	cfg.Init.Genesis = genFile.Name()
 
 	err := InitNode(cfg)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add BabeAuthority and GrandpaAuthority config options so that the node can run only one or the other if specified
- update default package log settings in config so that they match the `log` option instead of defaulting to `info`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

also running gossamer with `authority = true` and `babe-authority = false` in the config to turn off babe, or `grandpa-authority = false` to turn off grandpa

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- clsoes #979