### PR TITLE
dot/core, lib/grandpa: implement MessageHandler for grandpa messages

### DIFF
--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -48,6 +48,9 @@ var ErrNilBlockProducer = errors.New("cannot have nil BlockProducer")
 // ErrNilFinalityGadget is returned when trying to instantiate a finalizing Service without a finality gadget
 var ErrNilFinalityGadget = errors.New("cannot have nil FinalityGadget")
 
+// ErrNilFinalityMessageHandler is returned when trying to instantiate a Service without a FinalityMessageHandler
+var ErrNilFinalityMessageHandler = errors.New("cannot have nil ErrNilFinalityMessageHandler")
+
 // ErrNilChannel is returned if a channel is nil
 func ErrNilChannel(s string) error {
 	return fmt.Errorf("cannot have nil channel %s", s)

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -48,8 +48,8 @@ var ErrNilBlockProducer = errors.New("cannot have nil BlockProducer")
 // ErrNilFinalityGadget is returned when trying to instantiate a finalizing Service without a finality gadget
 var ErrNilFinalityGadget = errors.New("cannot have nil FinalityGadget")
 
-// ErrNilFinalityMessageHandler is returned when trying to instantiate a Service without a FinalityMessageHandler
-var ErrNilFinalityMessageHandler = errors.New("cannot have nil ErrNilFinalityMessageHandler")
+// ErrNilConsensusMessageHandler is returned when trying to instantiate a Service without a FinalityMessageHandler
+var ErrNilConsensusMessageHandler = errors.New("cannot have nil ErrNilFinalityMessageHandler")
 
 // ErrNilChannel is returned if a channel is nil
 func ErrNilChannel(s string) error {

--- a/dot/core/finality.go
+++ b/dot/core/finality.go
@@ -22,23 +22,26 @@ import (
 
 // processConsensusMessage routes a consensus message from the network to the finality gadget
 func (s *Service) processConsensusMessage(msg *network.ConsensusMessage) error {
-	in := s.finalityGadget.GetVoteInChannel()
-	fm, err := s.finalityGadget.DecodeMessage(msg)
-	if err != nil {
-		return err
-	}
+	//if !s.isFinalityAuthority {
+	return s.finalityMessageHandler.HandleMessage(msg)
+	// }
 
-	// TODO: safety
-	s.logger.Debug("sending VoteMessage to FinalityGadget", "msg", msg)
-	in <- fm
-	return nil
+	// in := s.finalityGadget.GetVoteInChannel()
+	// fm, err := s.finalityGadget.DecodeMessage(msg)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// // TODO: safety
+	// s.logger.Debug("sending VoteMessage to FinalityGadget", "msg", msg)
+	// in <- fm
+	// return nil
 }
 
 // sendVoteMessages routes a VoteMessage from the finality gadget to the network
 func (s *Service) sendVoteMessages() {
 	out := s.finalityGadget.GetVoteOutChannel()
 	for v := range out {
-		// TODO: safety
 		msg, err := v.ToConsensusMessage()
 		if err != nil {
 			s.logger.Error("failed to convert VoteMessage to ConsensusMessage", "msg", msg)
@@ -46,7 +49,10 @@ func (s *Service) sendVoteMessages() {
 		}
 
 		s.logger.Debug("sending VoteMessage to network", "msg", msg)
-		s.msgSend <- msg
+		err = s.safeMsgSend(msg)
+		if err != nil {
+			s.logger.Error("failed to send grandpa vote message to network", "error", err)
+		}
 	}
 }
 
@@ -63,18 +69,18 @@ func (s *Service) sendFinalizationMessages() {
 
 		// update finalized hash for this round in database
 		// TODO: this also happens in grandpa.finalize(); decide which is preferred
-		hash, err := v.GetFinalizedHash()
-		if err == nil {
-			err = s.blockState.SetFinalizedHash(hash, v.GetRound())
-			if err != nil {
-				s.logger.Error("could not set finalized block hash", "hash", hash, "error", err)
-			}
+		// hash, err := v.GetFinalizedHash()
+		// if err == nil {
+		// 	err = s.blockState.SetFinalizedHash(hash, v.GetRound())
+		// 	if err != nil {
+		// 		s.logger.Error("could not set finalized block hash", "hash", hash, "error", err)
+		// 	}
 
-			err = s.blockState.SetFinalizedHash(hash, 0)
-			if err != nil {
-				s.logger.Error("could not set finalized block hash", "hash", hash, "error", err)
-			}
-		}
+		// 	err = s.blockState.SetFinalizedHash(hash, 0)
+		// 	if err != nil {
+		// 		s.logger.Error("could not set finalized block hash", "hash", hash, "error", err)
+		// 	}
+		// }
 
 		s.logger.Debug("sending FinalityMessage to network", "msg", v)
 		err = s.safeMsgSend(msg)

--- a/dot/core/finality.go
+++ b/dot/core/finality.go
@@ -22,20 +22,7 @@ import (
 
 // processConsensusMessage routes a consensus message from the network to the finality gadget
 func (s *Service) processConsensusMessage(msg *network.ConsensusMessage) error {
-	//if !s.isFinalityAuthority {
 	return s.finalityMessageHandler.HandleMessage(msg)
-	// }
-
-	// in := s.finalityGadget.GetVoteInChannel()
-	// fm, err := s.finalityGadget.DecodeMessage(msg)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// // TODO: safety
-	// s.logger.Debug("sending VoteMessage to FinalityGadget", "msg", msg)
-	// in <- fm
-	// return nil
 }
 
 // sendVoteMessages routes a VoteMessage from the finality gadget to the network
@@ -66,21 +53,6 @@ func (s *Service) sendFinalizationMessages() {
 			s.logger.Error("failed to convert FinalizationMessage to ConsensusMessage", "msg", msg)
 			continue
 		}
-
-		// update finalized hash for this round in database
-		// TODO: this also happens in grandpa.finalize(); decide which is preferred
-		// hash, err := v.GetFinalizedHash()
-		// if err == nil {
-		// 	err = s.blockState.SetFinalizedHash(hash, v.GetRound())
-		// 	if err != nil {
-		// 		s.logger.Error("could not set finalized block hash", "hash", hash, "error", err)
-		// 	}
-
-		// 	err = s.blockState.SetFinalizedHash(hash, 0)
-		// 	if err != nil {
-		// 		s.logger.Error("could not set finalized block hash", "hash", hash, "error", err)
-		// 	}
-		// }
 
 		s.logger.Debug("sending FinalityMessage to network", "msg", v)
 		err = s.safeMsgSend(msg)

--- a/dot/core/finality.go
+++ b/dot/core/finality.go
@@ -22,7 +22,7 @@ import (
 
 // processConsensusMessage routes a consensus message from the network to the finality gadget
 func (s *Service) processConsensusMessage(msg *network.ConsensusMessage) error {
-	return s.finalityMessageHandler.HandleMessage(msg)
+	return s.consensusMessageHandler.HandleMessage(msg)
 }
 
 // sendVoteMessages routes a VoteMessage from the finality gadget to the network

--- a/dot/core/finality_test.go
+++ b/dot/core/finality_test.go
@@ -37,13 +37,6 @@ func TestProcessConsensusMessage(t *testing.T) {
 	})
 	err := s.processConsensusMessage(testConsensusMessage)
 	require.NoError(t, err)
-
-	select {
-	case f := <-fg.in:
-		require.Equal(t, &mockFinalityMessage{}, f)
-	case <-time.After(testMessageTimeout):
-		t.Fatal("did not receive finality message")
-	}
 }
 
 func TestSendVoteMessages(t *testing.T) {
@@ -59,6 +52,7 @@ func TestSendVoteMessages(t *testing.T) {
 		MsgSend:        msgSend,
 		FinalityGadget: fg,
 	})
+	s.started.Store(true)
 
 	go s.sendVoteMessages()
 	fg.out <- &mockFinalityMessage{}

--- a/dot/core/finality_test.go
+++ b/dot/core/finality_test.go
@@ -95,8 +95,4 @@ func TestSendFinalizationMessages(t *testing.T) {
 	case <-time.After(testMessageTimeout):
 		t.Fatal("did not receive finality message")
 	}
-
-	h, err := s.blockState.GetFinalizedHash(1)
-	require.NoError(t, err)
-	require.Equal(t, testFinalizedHash, h)
 }

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -94,7 +94,7 @@ type FinalityGadget interface {
 	GetVoteOutChannel() <-chan FinalityMessage
 	GetVoteInChannel() chan<- FinalityMessage
 	GetFinalizedChannel() <-chan FinalityMessage
-	DecodeMessage(*network.ConsensusMessage) (FinalityMessage, error)
+	//DecodeMessage(*network.ConsensusMessage) (FinalityMessage, error)
 	UpdateAuthorities(ad []*types.GrandpaAuthorityData)
 	Authorities() []*types.GrandpaAuthorityData
 }
@@ -102,8 +102,12 @@ type FinalityGadget interface {
 // FinalityMessage is the interface a finality message must implement
 type FinalityMessage interface {
 	ToConsensusMessage() (*network.ConsensusMessage, error)
-	GetFinalizedHash() (common.Hash, error)
-	GetRound() uint64
+	//GetFinalizedHash() (common.Hash, error)
+	//GetRound() uint64
+}
+
+type FinalityMessageHandler interface {
+	HandleMessage(*network.ConsensusMessage) error
 }
 
 // BlockProducer is the interface that a block production service must implement

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -103,7 +103,8 @@ type FinalityMessage interface {
 	ToConsensusMessage() (*network.ConsensusMessage, error)
 }
 
-type FinalityMessageHandler interface {
+// ConsensusMessageHandler is the interface a consensus message handler must implement
+type ConsensusMessageHandler interface {
 	HandleMessage(*network.ConsensusMessage) error
 }
 

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -94,7 +94,6 @@ type FinalityGadget interface {
 	GetVoteOutChannel() <-chan FinalityMessage
 	GetVoteInChannel() chan<- FinalityMessage
 	GetFinalizedChannel() <-chan FinalityMessage
-	//DecodeMessage(*network.ConsensusMessage) (FinalityMessage, error)
 	UpdateAuthorities(ad []*types.GrandpaAuthorityData)
 	Authorities() []*types.GrandpaAuthorityData
 }
@@ -102,8 +101,6 @@ type FinalityGadget interface {
 // FinalityMessage is the interface a finality message must implement
 type FinalityMessage interface {
 	ToConsensusMessage() (*network.ConsensusMessage, error)
-	//GetFinalizedHash() (common.Hash, error)
-	//GetRound() uint64
 }
 
 type FinalityMessageHandler interface {

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -60,9 +60,9 @@ type Service struct {
 	isBlockProducer bool
 
 	// Finality gadget variables
-	finalityGadget         FinalityGadget
-	isFinalityAuthority    bool
-	finalityMessageHandler FinalityMessageHandler
+	finalityGadget          FinalityGadget
+	isFinalityAuthority     bool
+	consensusMessageHandler ConsensusMessageHandler
 
 	// Keystore
 	keys *keystore.Keystore
@@ -85,17 +85,17 @@ type Service struct {
 
 // Config holds the configuration for the core Service.
 type Config struct {
-	LogLvl                 log.Lvl
-	BlockState             BlockState
-	StorageState           StorageState
-	TransactionQueue       TransactionQueue
-	Keystore               *keystore.Keystore
-	Runtime                *runtime.Runtime
-	BlockProducer          BlockProducer
-	IsBlockProducer        bool
-	FinalityGadget         FinalityGadget
-	IsFinalityAuthority    bool
-	FinalityMessageHandler FinalityMessageHandler
+	LogLvl                  log.Lvl
+	BlockState              BlockState
+	StorageState            StorageState
+	TransactionQueue        TransactionQueue
+	Keystore                *keystore.Keystore
+	Runtime                 *runtime.Runtime
+	BlockProducer           BlockProducer
+	IsBlockProducer         bool
+	FinalityGadget          FinalityGadget
+	IsFinalityAuthority     bool
+	ConsensusMessageHandler ConsensusMessageHandler
 
 	NewBlocks chan types.Block // only used for testing purposes
 	Verifier  Verifier         // only used for testing purposes
@@ -132,8 +132,8 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, ErrNilFinalityGadget
 	}
 
-	if cfg.FinalityMessageHandler == nil {
-		return nil, ErrNilFinalityMessageHandler
+	if cfg.ConsensusMessageHandler == nil {
+		return nil, ErrNilConsensusMessageHandler
 	}
 
 	logger := log.New("pkg", "core")
@@ -152,25 +152,25 @@ func NewService(cfg *Config) (*Service, error) {
 	var srv = &Service{}
 
 	srv = &Service{
-		logger:                 logger,
-		rt:                     cfg.Runtime,
-		codeHash:               codeHash,
-		keys:                   cfg.Keystore,
-		msgRec:                 cfg.MsgRec,
-		msgSend:                cfg.MsgSend,
-		blkRec:                 cfg.NewBlocks,
-		blockState:             cfg.BlockState,
-		storageState:           cfg.StorageState,
-		transactionQueue:       cfg.TransactionQueue,
-		isBlockProducer:        cfg.IsBlockProducer,
-		blockProducer:          cfg.BlockProducer,
-		finalityGadget:         cfg.FinalityGadget,
-		finalityMessageHandler: cfg.FinalityMessageHandler,
-		isFinalityAuthority:    cfg.IsFinalityAuthority,
-		lock:                   chanLock,
-		syncLock:               syncerLock,
-		blockNumOut:            cfg.SyncChan,
-		respOut:                respChan,
+		logger:                  logger,
+		rt:                      cfg.Runtime,
+		codeHash:                codeHash,
+		keys:                    cfg.Keystore,
+		msgRec:                  cfg.MsgRec,
+		msgSend:                 cfg.MsgSend,
+		blkRec:                  cfg.NewBlocks,
+		blockState:              cfg.BlockState,
+		storageState:            cfg.StorageState,
+		transactionQueue:        cfg.TransactionQueue,
+		isBlockProducer:         cfg.IsBlockProducer,
+		blockProducer:           cfg.BlockProducer,
+		finalityGadget:          cfg.FinalityGadget,
+		consensusMessageHandler: cfg.ConsensusMessageHandler,
+		isFinalityAuthority:     cfg.IsFinalityAuthority,
+		lock:                    chanLock,
+		syncLock:                syncerLock,
+		blockNumOut:             cfg.SyncChan,
+		respOut:                 respChan,
 	}
 
 	if cfg.NewBlocks != nil {

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -60,8 +60,9 @@ type Service struct {
 	isBlockProducer bool
 
 	// Finality gadget variables
-	finalityGadget      FinalityGadget
-	isFinalityAuthority bool
+	finalityGadget         FinalityGadget
+	isFinalityAuthority    bool
+	finalityMessageHandler FinalityMessageHandler
 
 	// Keystore
 	keys *keystore.Keystore
@@ -84,16 +85,17 @@ type Service struct {
 
 // Config holds the configuration for the core Service.
 type Config struct {
-	LogLvl              log.Lvl
-	BlockState          BlockState
-	StorageState        StorageState
-	TransactionQueue    TransactionQueue
-	Keystore            *keystore.Keystore
-	Runtime             *runtime.Runtime
-	BlockProducer       BlockProducer
-	IsBlockProducer     bool
-	FinalityGadget      FinalityGadget
-	IsFinalityAuthority bool
+	LogLvl                 log.Lvl
+	BlockState             BlockState
+	StorageState           StorageState
+	TransactionQueue       TransactionQueue
+	Keystore               *keystore.Keystore
+	Runtime                *runtime.Runtime
+	BlockProducer          BlockProducer
+	IsBlockProducer        bool
+	FinalityGadget         FinalityGadget
+	IsFinalityAuthority    bool
+	FinalityMessageHandler FinalityMessageHandler
 
 	NewBlocks chan types.Block // only used for testing purposes
 	Verifier  Verifier         // only used for testing purposes
@@ -130,6 +132,10 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, ErrNilFinalityGadget
 	}
 
+	if cfg.FinalityMessageHandler == nil {
+		return nil, ErrNilFinalityMessageHandler
+	}
+
 	logger := log.New("pkg", "core")
 	h := log.StreamHandler(os.Stdout, log.TerminalFormat())
 	logger.SetHandler(log.LvlFilterHandler(cfg.LogLvl, h))
@@ -146,23 +152,25 @@ func NewService(cfg *Config) (*Service, error) {
 	var srv = &Service{}
 
 	srv = &Service{
-		logger:              logger,
-		rt:                  cfg.Runtime,
-		codeHash:            codeHash,
-		keys:                cfg.Keystore,
-		msgRec:              cfg.MsgRec,
-		msgSend:             cfg.MsgSend,
-		blockState:          cfg.BlockState,
-		storageState:        cfg.StorageState,
-		transactionQueue:    cfg.TransactionQueue,
-		isBlockProducer:     cfg.IsBlockProducer,
-		blockProducer:       cfg.BlockProducer,
-		finalityGadget:      cfg.FinalityGadget,
-		isFinalityAuthority: cfg.IsFinalityAuthority,
-		lock:                chanLock,
-		syncLock:            syncerLock,
-		blockNumOut:         cfg.SyncChan,
-		respOut:             respChan,
+		logger:                 logger,
+		rt:                     cfg.Runtime,
+		codeHash:               codeHash,
+		keys:                   cfg.Keystore,
+		msgRec:                 cfg.MsgRec,
+		msgSend:                cfg.MsgSend,
+		blkRec:                 cfg.NewBlocks,
+		blockState:             cfg.BlockState,
+		storageState:           cfg.StorageState,
+		transactionQueue:       cfg.TransactionQueue,
+		isBlockProducer:        cfg.IsBlockProducer,
+		blockProducer:          cfg.BlockProducer,
+		finalityGadget:         cfg.FinalityGadget,
+		finalityMessageHandler: cfg.FinalityMessageHandler,
+		isFinalityAuthority:    cfg.IsFinalityAuthority,
+		lock:                   chanLock,
+		syncLock:               syncerLock,
+		blockNumOut:            cfg.SyncChan,
+		respOut:                respChan,
 	}
 
 	if cfg.NewBlocks != nil {
@@ -209,6 +217,7 @@ func NewService(cfg *Config) (*Service, error) {
 	syncerCfg := &SyncerConfig{
 		logger:           logger,
 		BlockState:       cfg.BlockState,
+		BlockProducer:    cfg.BlockProducer,
 		BlockNumIn:       cfg.SyncChan,
 		RespIn:           respChan,
 		MsgOut:           cfg.MsgSend,
@@ -247,7 +256,7 @@ func (s *Service) Start() error {
 		return err
 	}
 
-	if s.finalityGadget != nil {
+	if s.isFinalityAuthority && s.finalityGadget != nil {
 		s.logger.Debug("routing finality gadget messages")
 		go s.sendVoteMessages()
 		go s.sendFinalizationMessages()

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/babe"
-	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/keystore"
@@ -164,8 +163,6 @@ var testConsensusMessage = &network.ConsensusMessage{
 	ConsensusEngineID: types.GrandpaEngineID,
 	Data:              []byte("nootwashere"),
 }
-
-var testFinalizedHash = common.NewHash([]byte("finalized"))
 
 type mockFinalityMessage struct{}
 

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -174,9 +174,9 @@ func (fm *mockFinalityMessage) ToConsensusMessage() (*network.ConsensusMessage, 
 	return testConsensusMessage, nil
 }
 
-type mockFinalityMessageHandler struct{}
+type mockConsensusMessageHandler struct{}
 
-func (h *mockFinalityMessageHandler) HandleMessage(msg *network.ConsensusMessage) error {
+func (h *mockConsensusMessageHandler) HandleMessage(msg *network.ConsensusMessage) error {
 	return nil
 }
 
@@ -239,8 +239,8 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 		cfg.StorageState = stateSrvc.Storage
 	}
 
-	if cfg.FinalityMessageHandler == nil {
-		cfg.FinalityMessageHandler = &mockFinalityMessageHandler{}
+	if cfg.ConsensusMessageHandler == nil {
+		cfg.ConsensusMessageHandler = &mockConsensusMessageHandler{}
 	}
 
 	s, err := NewService(cfg)

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -174,15 +174,6 @@ func (fm *mockFinalityMessage) ToConsensusMessage() (*network.ConsensusMessage, 
 	return testConsensusMessage, nil
 }
 
-// GetFinalizedHash returns testFinalizedHash
-func (fm *mockFinalityMessage) GetFinalizedHash() (common.Hash, error) {
-	return testFinalizedHash, nil
-}
-
-func (fm *mockFinalityMessage) GetRound() uint64 {
-	return 1
-}
-
 type mockFinalityMessageHandler struct{}
 
 func (h *mockFinalityMessageHandler) HandleMessage(msg *network.ConsensusMessage) error {

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -70,6 +70,12 @@ type mockBlockProducer struct {
 	auths []*types.BABEAuthorityData
 }
 
+func newMockBlockProducer() *mockBlockProducer {
+	return &mockBlockProducer{
+		auths: []*types.BABEAuthorityData{},
+	}
+}
+
 // Start mocks starting
 func (bp *mockBlockProducer) Start() error {
 	return nil
@@ -177,6 +183,12 @@ func (fm *mockFinalityMessage) GetRound() uint64 {
 	return 1
 }
 
+type mockFinalityMessageHandler struct{}
+
+func (h *mockFinalityMessageHandler) HandleMessage(msg *network.ConsensusMessage) error {
+	return nil
+}
+
 // NewTestService creates a new test core service
 func NewTestService(t *testing.T, cfg *Config) *Service {
 	if cfg == nil {
@@ -234,6 +246,10 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 
 	if cfg.StorageState == nil {
 		cfg.StorageState = stateSrvc.Storage
+	}
+
+	if cfg.FinalityMessageHandler == nil {
+		cfg.FinalityMessageHandler = &mockFinalityMessageHandler{}
 	}
 
 	s, err := NewService(cfg)

--- a/dot/services.go
+++ b/dot/services.go
@@ -168,7 +168,7 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 		return nil, err
 	}
 
-	var handler core.FinalityMessageHandler
+	var handler core.ConsensusMessageHandler
 	if gs, ok := fg.(*grandpa.Service); ok {
 		handler = grandpa.NewMessageHandler(gs, stateSrvc.Block)
 	} else {
@@ -177,20 +177,20 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 
 	// set core configuration
 	coreConfig := &core.Config{
-		LogLvl:                 lvl,
-		BlockState:             stateSrvc.Block,
-		StorageState:           stateSrvc.Storage,
-		TransactionQueue:       stateSrvc.TransactionQueue,
-		BlockProducer:          bp,
-		FinalityGadget:         fg,
-		FinalityMessageHandler: handler,
-		Keystore:               ks,
-		Runtime:                rt,
-		MsgRec:                 networkMsgs, // message channel from network service to core service
-		MsgSend:                coreMsgs,    // message channel from core service to network service
-		IsBlockProducer:        cfg.Core.BabeAuthority,
-		IsFinalityAuthority:    cfg.Core.GrandpaAuthority,
-		SyncChan:               syncChan,
+		LogLvl:                  lvl,
+		BlockState:              stateSrvc.Block,
+		StorageState:            stateSrvc.Storage,
+		TransactionQueue:        stateSrvc.TransactionQueue,
+		BlockProducer:           bp,
+		FinalityGadget:          fg,
+		ConsensusMessageHandler: handler,
+		Keystore:                ks,
+		Runtime:                 rt,
+		MsgRec:                  networkMsgs, // message channel from network service to core service
+		MsgSend:                 coreMsgs,    // message channel from core service to network service
+		IsBlockProducer:         cfg.Core.BabeAuthority,
+		IsFinalityAuthority:     cfg.Core.GrandpaAuthority,
+		SyncChan:                syncChan,
 	}
 
 	// create new core service

--- a/dot/services.go
+++ b/dot/services.go
@@ -168,21 +168,29 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 		return nil, err
 	}
 
+	var handler core.FinalityMessageHandler
+	if gs, ok := fg.(*grandpa.Service); ok {
+		handler = grandpa.NewMessageHandler(gs, stateSrvc.Block)
+	} else {
+		handler = grandpa.NewMessageHandler(nil, stateSrvc.Block)
+	}
+
 	// set core configuration
 	coreConfig := &core.Config{
-		LogLvl:              lvl,
-		BlockState:          stateSrvc.Block,
-		StorageState:        stateSrvc.Storage,
-		TransactionQueue:    stateSrvc.TransactionQueue,
-		BlockProducer:       bp,
-		FinalityGadget:      fg,
-		Keystore:            ks,
-		Runtime:             rt,
-		MsgRec:              networkMsgs, // message channel from network service to core service
-		MsgSend:             coreMsgs,    // message channel from core service to network service
-		IsBlockProducer:     cfg.Core.BabeAuthority,
-		IsFinalityAuthority: cfg.Core.GrandpaAuthority,
-		SyncChan:            syncChan,
+		LogLvl:                 lvl,
+		BlockState:             stateSrvc.Block,
+		StorageState:           stateSrvc.Storage,
+		TransactionQueue:       stateSrvc.TransactionQueue,
+		BlockProducer:          bp,
+		FinalityGadget:         fg,
+		FinalityMessageHandler: handler,
+		Keystore:               ks,
+		Runtime:                rt,
+		MsgRec:                 networkMsgs, // message channel from network service to core service
+		MsgSend:                coreMsgs,    // message channel from core service to network service
+		IsBlockProducer:        cfg.Core.BabeAuthority,
+		IsFinalityAuthority:    cfg.Core.GrandpaAuthority,
+		SyncChan:               syncChan,
 	}
 
 	// create new core service

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -1,3 +1,19 @@
+// Copyright 2020 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -1,0 +1,74 @@
+package grandpa
+
+import (
+	"github.com/ChainSafe/gossamer/lib/scale"
+)
+
+// MessageHandler handles GRANDPA consensus messages
+type MessageHandler struct {
+	grandpa    *Service
+	blockState BlockState
+}
+
+// NewMessageHandler returns a new MessageHandler
+func NewMessageHandler(grandpa *Service, blockState BlockState) *MessageHandler {
+	return &MessageHandler{
+		grandpa:    grandpa,
+		blockState: blockState,
+	}
+}
+
+// HandleMessage handles a GRANDPA consensus message
+// if it is a FinalizationMessage, it updates the BlockState
+// if it is a VoteMessage, it sends it to the GRANDPA service
+func (h *MessageHandler) HandleMessage(msg *ConsensusMessage) error {
+	m, err := decodeMessage(msg)
+	if err != nil {
+		return err
+	}
+
+	fm, ok := m.(*FinalizationMessage)
+	if ok {
+		// set finalized head for round in db
+		err = h.blockState.SetFinalizedHash(fm.Vote.hash, fm.Round)
+		if err != nil {
+			return err
+		}
+
+		// set latest finalized head in db
+		err = h.blockState.SetFinalizedHash(fm.Vote.hash, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	vm, ok := m.(*VoteMessage)
+	if h.grandpa != nil && ok {
+		// send vote message to grandpa service
+		h.grandpa.in <- vm
+	}
+
+	return nil
+}
+
+// decodeMessage decodes a network-level consensus message into a GRANDPA VoteMessage or FinalizationMessage
+func decodeMessage(msg *ConsensusMessage) (m FinalityMessage, err error) {
+	var mi interface{}
+
+	switch msg.Data[0] {
+	case voteType:
+		mi, err = scale.Decode(msg.Data[1:], &VoteMessage{Message: new(SignedMessage)})
+		m = mi.(*VoteMessage)
+	case finalizationType:
+		mi, err = scale.Decode(msg.Data[1:], &FinalizationMessage{})
+		m = mi.(*FinalizationMessage)
+	default:
+		return nil, ErrInvalidMessageType
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -1,3 +1,19 @@
+// Copyright 2020 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -1,0 +1,150 @@
+package grandpa
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeMessage_VoteMessage(t *testing.T) {
+	cm := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x004d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000036e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+	}
+
+	msg, err := decodeMessage(cm)
+	require.NoError(t, err)
+
+	sigb := common.MustHexToBytes("0x36e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f")
+	sig := [64]byte{}
+	copy(sig[:], sigb)
+
+	expected := &VoteMessage{
+		Round: 77,
+		SetID: 99,
+		Stage: precommit,
+		Message: &SignedMessage{
+			Hash:        common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
+			Number:      0x7777,
+			Signature:   sig,
+			AuthorityID: ed25519.PublicKeyBytes(common.MustHexToHash("0x34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691")),
+		},
+	}
+
+	require.Equal(t, expected, msg)
+}
+
+func TestDecodeMessage_FinalizationMessage(t *testing.T) {
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cm := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x014d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0000000000000000040a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000000000000102030400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
+	}
+
+	msg, err := decodeMessage(cm)
+	require.NoError(t, err)
+
+	expected := &FinalizationMessage{
+		Round: 77,
+		Vote: &Vote{
+			hash:   common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
+			number: 0,
+		},
+		Justification: []*Justification{
+			{
+				Vote:        testVote,
+				Signature:   testSignature,
+				AuthorityID: kr.Alice.Public().(*ed25519.PublicKey).AsBytes(),
+			},
+		},
+	}
+
+	require.Equal(t, expected, msg)
+}
+
+func TestMessageHandler_VoteMessage(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState: st.Block,
+		Voters:     voters,
+		Keypair:    kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	v, err := NewVoteFromHash(st.Block.BestBlockHash(), st.Block)
+	require.NoError(t, err)
+
+	gs.state.setID = 99
+	gs.state.round = 77
+	v.number = 0x7777
+	vm, err := gs.createVoteMessage(v, precommit, gs.keypair)
+	require.NoError(t, err)
+
+	cm, err := vm.ToConsensusMessage()
+	require.NoError(t, err)
+
+	h := NewMessageHandler(gs, st.Block)
+	err = h.HandleMessage(cm)
+	require.NoError(t, err)
+
+	select {
+	case vote := <-gs.in:
+		require.Equal(t, vm, vote)
+	case <-time.After(time.Second):
+		t.Fatal("did not receive VoteMessage")
+	}
+}
+
+func TestMessageHandler_FinalizationMessage(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState: st.Block,
+		Voters:     voters,
+		Keypair:    kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	gs.justification[77] = []*Justification{
+		{
+			Vote:        testVote,
+			Signature:   testSignature,
+			AuthorityID: gs.publicKeyBytes(),
+		},
+	}
+
+	fm := gs.newFinalizationMessage(gs.head, 77)
+	cm, err := fm.ToConsensusMessage()
+	require.NoError(t, err)
+
+	h := NewMessageHandler(nil, st.Block)
+	err = h.HandleMessage(cm)
+	require.NoError(t, err)
+
+	hash, err := st.Block.GetFinalizedHash(0)
+	require.NoError(t, err)
+	require.Equal(t, fm.Vote.hash, hash)
+
+	hash, err = st.Block.GetFinalizedHash(fm.Round)
+	require.NoError(t, err)
+	require.Equal(t, fm.Vote.hash, hash)
+}

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/scale"
 
@@ -20,70 +19,6 @@ var testVote = &Vote{
 
 var testSignature = [64]byte{1, 2, 3, 4}
 var testAuthorityID = [32]byte{5, 6, 7, 8}
-
-func TestDecodeMessage_VoteMessage(t *testing.T) {
-	gs := &Service{}
-
-	cm := &ConsensusMessage{
-		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x004d000000000000006300000000000000017db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a777700000000000036e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
-	}
-
-	msg, err := gs.DecodeMessage(cm)
-	require.NoError(t, err)
-
-	sigb := common.MustHexToBytes("0x36e6eca85489bebbb0f687ca5404748d5aa2ffabee34e3ed272cc7b2f6d0a82c65b99bc7cd90dbc21bb528289ebf96705dbd7d96918d34d815509b4e0e2a030f")
-	sig := [64]byte{}
-	copy(sig[:], sigb)
-
-	expected := &VoteMessage{
-		Round: 77,
-		SetID: 99,
-		Stage: precommit,
-		Message: &SignedMessage{
-			Hash:        common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
-			Number:      0x7777,
-			Signature:   sig,
-			AuthorityID: ed25519.PublicKeyBytes(common.MustHexToHash("0x34602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691")),
-		},
-	}
-
-	require.Equal(t, expected, msg)
-}
-
-func TestDecodeMessage_FinalizationMessage(t *testing.T) {
-	kr, err := keystore.NewEd25519Keyring()
-	require.NoError(t, err)
-
-	gs := &Service{
-		keypair: kr.Alice,
-	}
-
-	cm := &ConsensusMessage{
-		ConsensusEngineID: types.GrandpaEngineID,
-		Data:              common.MustHexToBytes("0x014d000000000000007db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a0000000000000000040a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000000000000102030400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034602b88f60513f1c805d87ef52896934baf6a662bc37414dbdbf69356b1a691"),
-	}
-
-	msg, err := gs.DecodeMessage(cm)
-	require.NoError(t, err)
-
-	expected := &FinalizationMessage{
-		Round: 77,
-		Vote: &Vote{
-			hash:   common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
-			number: 0,
-		},
-		Justification: []*Justification{
-			{
-				Vote:        testVote,
-				Signature:   testSignature,
-				AuthorityID: gs.publicKeyBytes(),
-			},
-		},
-	}
-
-	require.Equal(t, expected, msg)
-}
 
 func TestVoteMessageToConsensusMessage(t *testing.T) {
 	st := newTestState(t)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement grandpa message handler so that nodes that don't run grandpa can still process grandpa messages (FinalizationMessage)
- add interface to core, cleanup existing core interfaces
- initialize message handler in startup and pass to core

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa ./dot/core
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #981
