### PR TITLE
lib/babe: update threshold calculation to match spec

### DIFF
--- a/dot/core/syncer_test.go
+++ b/dot/core/syncer_test.go
@@ -644,6 +644,7 @@ func TestExecuteBlock(t *testing.T) {
 		TransactionQueue: syncer.transactionQueue,
 		Keypair:          kp,
 		BlockState:       syncer.blockState,
+		EpochThreshold:   babe.MaxThreshold,
 	}
 
 	builder := newBlockBuilder(t, bcfg)
@@ -688,6 +689,7 @@ func TestExecuteBlock_WithExtrinsic(t *testing.T) {
 		TransactionQueue: syncer.transactionQueue,
 		Keypair:          kp,
 		BlockState:       syncer.blockState,
+		EpochThreshold:   babe.MaxThreshold,
 	}
 
 	key := []byte("noot")

--- a/dot/core/syncer_test.go
+++ b/dot/core/syncer_test.go
@@ -178,6 +178,8 @@ func TestWatchForBlocks_NotHighestSeen(t *testing.T) {
 		if cmp == 0 {
 			break
 		}
+
+		time.Sleep(time.Millisecond * 10)
 	}
 
 	if cmp != 0 {
@@ -191,6 +193,8 @@ func TestWatchForBlocks_NotHighestSeen(t *testing.T) {
 		if cmp == 0 {
 			break
 		}
+
+		time.Sleep(time.Millisecond * 10)
 	}
 
 	if cmp != 0 {
@@ -224,6 +228,8 @@ func TestWatchForBlocks_GreaterThanHighestSeen_NotSynced(t *testing.T) {
 		if cmp == 0 {
 			break
 		}
+
+		time.Sleep(time.Millisecond * 10)
 	}
 
 	if cmp != 0 {

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -448,25 +448,12 @@ func (b *Service) authorityWeights() []uint64 {
 }
 
 // calculates the slot lottery threshold for the authority at authorityIndex.
-// equation: threshold = 2^128 * (1 - (1-c)^(w_k/sum(w_i)))
-// where k is the authority index, and sum(w_i) is the
-// sum of all the authority weights
-// see: https://github.com/paritytech/substrate/blob/master/core/consensus/babe/src/lib.rs#L1022
+// equation: threshold = 2^128 * (1 - (1-c)^(1/len(authorities))
 func calculateThreshold(C1, C2 uint64, numAuths int) (*big.Int, error) {
 	c := float64(C1) / float64(C2)
 	if c > 1 {
 		return nil, errors.New("invalid C1/C2: greater than 1")
 	}
-
-	// sum(w_i)
-	// var sum uint64 = 0
-	// for _, weight := range authorityWeights {
-	// 	sum += weight
-	// }
-
-	// if sum == 0 {
-	// 	return nil, errors.New("invalid authority weights: sums to zero")
-	// }
 
 	// 1 / len(authorities)
 	theta := float64(1) / float64(numAuths)

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -431,7 +431,7 @@ func (b *Service) setEpochThreshold() error {
 		return errors.New("cannot set threshold: no babe config")
 	}
 
-	b.epochThreshold, err = calculateThreshold(b.config.C1, b.config.C2, b.authorityIndex, b.authorityWeights())
+	b.epochThreshold, err = calculateThreshold(b.config.C1, b.config.C2, len(b.Authorities()))
 	if err != nil {
 		return err
 	}
@@ -452,30 +452,30 @@ func (b *Service) authorityWeights() []uint64 {
 // where k is the authority index, and sum(w_i) is the
 // sum of all the authority weights
 // see: https://github.com/paritytech/substrate/blob/master/core/consensus/babe/src/lib.rs#L1022
-func calculateThreshold(C1, C2, authorityIndex uint64, authorityWeights []uint64) (*big.Int, error) {
+func calculateThreshold(C1, C2 uint64, numAuths int) (*big.Int, error) {
 	c := float64(C1) / float64(C2)
 	if c > 1 {
 		return nil, errors.New("invalid C1/C2: greater than 1")
 	}
 
 	// sum(w_i)
-	var sum uint64 = 0
-	for _, weight := range authorityWeights {
-		sum += weight
-	}
+	// var sum uint64 = 0
+	// for _, weight := range authorityWeights {
+	// 	sum += weight
+	// }
 
-	if sum == 0 {
-		return nil, errors.New("invalid authority weights: sums to zero")
-	}
+	// if sum == 0 {
+	// 	return nil, errors.New("invalid authority weights: sums to zero")
+	// }
 
-	// w_k/sum(w_i)
-	theta := float64(authorityWeights[authorityIndex]) / float64(sum)
+	// 1 / len(authorities)
+	theta := float64(1) / float64(numAuths)
 
-	// (1-c)^(w_k/sum(w_i)))
+	// (1-c)^(theta)
 	pp := 1 - c
 	pp_exp := math.Pow(pp, theta)
 
-	// 1 - (1-c)^(w_k/sum(w_i)))
+	// 1 - (1-c)^(theta)
 	p := 1 - pp_exp
 	p_rat := new(big.Rat).SetFloat64(p)
 

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -196,7 +196,7 @@ func TestBabeAnnounceMessage(t *testing.T) {
 
 	cfg := &ServiceConfig{
 		TransactionQueue: TransactionQueue,
-		LogLvl:           3,
+		LogLvl:           log.LvlInfo,
 	}
 
 	babeService := createTestService(t, cfg)
@@ -285,7 +285,7 @@ func TestDetermineAuthorityIndex(t *testing.T) {
 
 func TestStartAndStop(t *testing.T) {
 	bs := createTestService(t, &ServiceConfig{
-		LogLvl: 0,
+		LogLvl: log.LvlCrit,
 	})
 	err := bs.Start()
 	require.NoError(t, err)

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -120,12 +120,10 @@ func TestCalculateThreshold(t *testing.T) {
 	// C = 1
 	var C1 uint64 = 1
 	var C2 uint64 = 1
-	var authorityIndex uint64 = 0
-	authorityWeights := []uint64{1, 1, 1}
 
 	expected := new(big.Int).Lsh(big.NewInt(1), 128)
 
-	threshold, err := calculateThreshold(C1, C2, authorityIndex, authorityWeights)
+	threshold, err := calculateThreshold(C1, C2, 3)
 	require.NoError(t, err)
 
 	if threshold.Cmp(expected) != 0 {
@@ -144,7 +142,7 @@ func TestCalculateThreshold(t *testing.T) {
 	q := new(big.Int).Lsh(big.NewInt(1), 128)
 	expected = q.Mul(q, p_rat.Num()).Div(q, p_rat.Denom())
 
-	threshold, err = calculateThreshold(C1, C2, authorityIndex, authorityWeights)
+	threshold, err = calculateThreshold(C1, C2, 3)
 	require.NoError(t, err)
 
 	if threshold.Cmp(expected) != 0 {
@@ -152,28 +150,13 @@ func TestCalculateThreshold(t *testing.T) {
 	}
 }
 
-func TestCalculateThreshold_AuthorityWeights(t *testing.T) {
+func TestCalculateThreshold_Failing(t *testing.T) {
 	var C1 uint64 = 5
-	var C2 uint64 = 17
-	var authorityIndex uint64 = 3
-	authorityWeights := []uint64{3, 1, 4, 6, 10}
+	var C2 uint64 = 4
 
-	theta := float64(6) / float64(24)
-	c := float64(C1) / float64(C2)
-	pp := 1 - c
-	pp_exp := math.Pow(pp, theta)
-	p := 1 - pp_exp
-	p_rat := new(big.Rat).SetFloat64(p)
-	q := new(big.Int).Lsh(big.NewInt(1), 128)
-	expected := q.Mul(q, p_rat.Num()).Div(q, p_rat.Denom())
-
-	threshold, err := calculateThreshold(C1, C2, authorityIndex, authorityWeights)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if threshold.Cmp(expected) != 0 {
-		t.Fatalf("Fail: got %d expected %d", threshold, expected)
+	_, err := calculateThreshold(C1, C2, 3)
+	if err == nil {
+		t.Fatal("Fail: did not err for c>1")
 	}
 }
 
@@ -202,18 +185,6 @@ func TestRunLottery_False(t *testing.T) {
 
 	if outAndProof != nil {
 		t.Fatal("proof was not nil when under threshold")
-	}
-}
-
-func TestCalculateThreshold_Failing(t *testing.T) {
-	var C1 uint64 = 5
-	var C2 uint64 = 4
-	var authorityIndex uint64 = 3
-	authorityWeights := []uint64{3, 1, 4, 6, 10}
-
-	_, err := calculateThreshold(C1, C2, authorityIndex, authorityWeights)
-	if err == nil {
-		t.Fatal("Fail: did not err for c>1")
 	}
 }
 

--- a/lib/babe/build_test.go
+++ b/lib/babe/build_test.go
@@ -81,7 +81,7 @@ func addAuthorshipProof(t *testing.T, babeService *Service, slotNumber uint64) {
 	}
 
 	if outAndProof == nil {
-		t.Fatal("proof was nil when over threshold")
+		t.Fatal("proof was nil when under threshold")
 	}
 
 	babeService.slotToProof[slotNumber] = outAndProof
@@ -89,7 +89,7 @@ func addAuthorshipProof(t *testing.T, babeService *Service, slotNumber uint64) {
 
 func createTestBlock(t *testing.T, babeService *Service, parent *types.Header, exts [][]byte) (*types.Block, Slot) {
 	// create proof that we can authorize this block
-	babeService.epochThreshold = big.NewInt(0)
+	babeService.epochThreshold = maxThreshold
 	babeService.authorityIndex = 0
 
 	slotNumber := uint64(1)
@@ -130,6 +130,7 @@ func TestBuildBlock_ok(t *testing.T) {
 
 	cfg := &ServiceConfig{
 		TransactionQueue: transactionQueue,
+		LogLvl:           4,
 	}
 
 	babeService := createTestService(t, cfg)

--- a/lib/babe/build_test.go
+++ b/lib/babe/build_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/transaction"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,7 +131,7 @@ func TestBuildBlock_ok(t *testing.T) {
 
 	cfg := &ServiceConfig{
 		TransactionQueue: transactionQueue,
-		LogLvl:           4,
+		LogLvl:           log.LvlDebug,
 	}
 
 	babeService := createTestService(t, cfg)

--- a/lib/babe/median_test.go
+++ b/lib/babe/median_test.go
@@ -87,7 +87,7 @@ func addBlocksToState(t *testing.T, babeService *Service, depth int, blockState 
 	for i := 1; i <= depth; i++ {
 
 		// create proof that we can authorize this block
-		babeService.epochThreshold = big.NewInt(0)
+		babeService.epochThreshold = maxThreshold
 		babeService.authorityIndex = 0
 		slotNumber := uint64(i)
 
@@ -153,7 +153,7 @@ func TestSlotTime(t *testing.T) {
 func TestEstimateCurrentSlot(t *testing.T) {
 	babeService := createTestService(t, nil)
 	// create proof that we can authorize this block
-	babeService.epochThreshold = big.NewInt(0)
+	babeService.epochThreshold = maxThreshold
 	babeService.authorityIndex = 0
 	slotNumber := uint64(17)
 

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -170,7 +170,9 @@ func TestCheckForConsensusDigest(t *testing.T) {
 }
 
 func TestVerificationManager_VerifyBlock(t *testing.T) {
-	babeService := createTestService(t, nil)
+	babeService := createTestService(t, &ServiceConfig{
+		EpochThreshold: maxThreshold,
+	})
 	descriptor := babeService.Descriptor()
 
 	vm := newTestVerificationManager(t, false, descriptor)
@@ -186,7 +188,9 @@ func TestVerificationManager_VerifyBlock(t *testing.T) {
 }
 
 func TestVerificationManager_VerifyBlock_WithDigest(t *testing.T) {
-	babeService := createTestService(t, nil)
+	babeService := createTestService(t, &ServiceConfig{
+		EpochThreshold: maxThreshold,
+	})
 	descriptor := babeService.Descriptor()
 
 	vm := newTestVerificationManager(t, false, descriptor)
@@ -264,7 +268,7 @@ func TestVerifySlotWinner(t *testing.T) {
 	babeService := createTestService(t, cfg)
 
 	// create proof that we can authorize this block
-	babeService.epochThreshold = big.NewInt(0)
+	babeService.epochThreshold = maxThreshold
 	babeService.authorityIndex = 0
 	var slotNumber uint64 = 1
 

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -70,7 +70,7 @@ func TestChainRPC(t *testing.T) {
 	}
 
 	t.Log("starting gossamer...")
-	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigDefault)
+	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigBABEMaxThreshold)
 	require.Nil(t, err)
 
 	time.Sleep(time.Second) // give server a second to start

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -98,7 +98,7 @@ func TestSync_SingleBlockProducer(t *testing.T) {
 	// only log info from 1 node
 	tmpdir, err := ioutil.TempDir("", "gossamer-stress-sync")
 	require.NoError(t, err)
-	node, err := utils.RunGossamer(t, numNodes-1, tmpdir, utils.GenesisDefault, utils.ConfigBABE)
+	node, err := utils.RunGossamer(t, numNodes-1, tmpdir, utils.GenesisDefault, utils.ConfigBABEMaxThreshold)
 	require.NoError(t, err)
 
 	// wait and start rest of nodes - if they all start at the same time the first round usually doesn't complete since

--- a/tests/utils/config_babe_max_threshold.toml
+++ b/tests/utils/config_babe_max_threshold.toml
@@ -1,0 +1,33 @@
+[global]
+name = "gssmr"
+id = "gssmr"
+log = "crit"
+
+[log]
+babe = "info"
+
+[init]
+genesis = "./chain/gssmr/genesis.json"
+
+[account]
+key = ""
+unlock = ""
+
+[core]
+authority = true
+roles = 4
+babe-authority = true
+grandpa-authority = true
+babe-threshold = "max"
+
+[network]
+bootnodes = []
+protocol = "/gossamer/gssmr/0"
+nobootstrap = false
+nomdns = false
+
+[rpc]
+enabled = false
+host = "localhost"
+modules = ["system", "author", "chain", "state"]
+ws-enabled = false

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -69,6 +69,8 @@ var (
 	ConfigBABE string = filepath.Join(currentDir, "../utils/config_babe.toml")
 	// ConfigNoBABE is a config file with BABE disabled
 	ConfigNoBABE string = filepath.Join(currentDir, "../utils/config_nobabe.toml")
+	// ConfigBABEMaxThreshold is a config file with BABE threshold set to maximum (node can produce block every slot)
+	ConfigBABEMaxThreshold string = filepath.Join(currentDir, "../utils/config_babe_max_threshold.toml")
 )
 
 // Node represents a gossamer process


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- see spec 6.2.2
- equation no longer uses authority weights, only len(authorities)
- also update lottery such that node can author block if *under* threshold (see Algorithm 6.3)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/babe/
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
