### PR TITLE
cmd, dot: add BabeThreshold config option

### DIFF
--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -25,6 +25,7 @@ authority = true
 roles = 4
 babe-authority = true
 grandpa-authority = true
+babe-threshold = ""
 
 [network]
 port = 7001

--- a/chain/ksmcc/config.toml
+++ b/chain/ksmcc/config.toml
@@ -25,6 +25,7 @@ authority = false
 roles = 1
 babe-authority = false
 grandpa-authority = false
+babe-threshold = ""
 
 [network]
 port = 7001

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -24,6 +24,7 @@ import (
 	database "github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/dot/state"
+	"github.com/ChainSafe/gossamer/lib/babe"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 
@@ -165,6 +166,10 @@ func createExportConfig(ctx *cli.Context) (*dot.Config, error) {
 	setDotCoreConfig(ctx, &cfg.Core)
 	setDotNetworkConfig(ctx, &cfg.Network)
 	setDotRPCConfig(ctx, &cfg.RPC)
+
+	if cfg.Core.BabeThreshold == nil {
+		cfg.Core.BabeThreshold = ""
+	}
 
 	// set system info
 	setSystemInfoConfig(ctx, cfg)
@@ -338,10 +343,24 @@ func setDotCoreConfig(ctx *cli.Context, cfg *dot.CoreConfig) {
 		cfg.GrandpaAuthority = false
 	}
 
+	if thresholdStr, ok := cfg.BabeThreshold.(string); ok {
+		switch thresholdStr {
+		case "max":
+			cfg.BabeThreshold = babe.MaxThreshold
+		case "min":
+			cfg.BabeThreshold = babe.MinThreshold
+		default:
+			cfg.BabeThreshold = nil
+		}
+	} else {
+		cfg.BabeThreshold = nil
+	}
+
 	logger.Debug(
 		"core configuration",
 		"babe-authority", cfg.BabeAuthority,
 		"grandpa-authority", cfg.GrandpaAuthority,
+		"babe-threshold", cfg.BabeThreshold,
 	)
 }
 

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -582,6 +582,7 @@ func TestUpdateConfigFromGenesisJSON(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg.Init.Genesis = genFile.Name()
+	expected.Core.BabeThreshold = nil
 
 	updateDotConfigFromGenesisJSON(ctx, cfg)
 
@@ -628,6 +629,8 @@ func TestUpdateConfigFromGenesisJSON_Default(t *testing.T) {
 		RPC:     testCfg.RPC,
 		System:  testCfg.System,
 	}
+
+	expected.Core.BabeThreshold = nil
 
 	cfg, err := createDotConfig(ctx)
 	require.Nil(t, err)
@@ -686,6 +689,7 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg.Init.Genesis = genFile.Name()
+	expected.Core.BabeThreshold = nil
 
 	db, err := database.NewBadgerDB(cfg.Global.BasePath)
 	require.Nil(t, err)

--- a/dot/config.go
+++ b/dot/config.go
@@ -86,10 +86,11 @@ type NetworkConfig struct {
 
 // CoreConfig is to marshal/unmarshal toml core config vars
 type CoreConfig struct {
-	Authority        bool `toml:"authority"`
-	Roles            byte `toml:"roles"`
-	BabeAuthority    bool `toml:"babe-authority"`
-	GrandpaAuthority bool `toml:"grandpa-authority"`
+	Authority        bool        `toml:"authority"`
+	Roles            byte        `toml:"roles"`
+	BabeAuthority    bool        `toml:"babe-authority"`
+	GrandpaAuthority bool        `toml:"grandpa-authority"`
+	BabeThreshold    interface{} `toml:"babe-threshold"`
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars
@@ -139,6 +140,7 @@ func GssmrConfig() *Config {
 			Roles:            gssmr.DefaultRoles,
 			BabeAuthority:    gssmr.DefaultBabeAuthority,
 			GrandpaAuthority: gssmr.DefaultGrandpaAuthority,
+			//BabeThreshold: "",
 		},
 		Network: NetworkConfig{
 			Port:        gssmr.DefaultNetworkPort,
@@ -178,6 +180,7 @@ func KsmccConfig() *Config {
 		Core: CoreConfig{
 			Authority: ksmcc.DefaultAuthority,
 			Roles:     ksmcc.DefaultRoles,
+			//BabeThreshold: "",
 		},
 		Network: NetworkConfig{
 			Port:        ksmcc.DefaultNetworkPort,

--- a/dot/config.go
+++ b/dot/config.go
@@ -140,7 +140,6 @@ func GssmrConfig() *Config {
 			Roles:            gssmr.DefaultRoles,
 			BabeAuthority:    gssmr.DefaultBabeAuthority,
 			GrandpaAuthority: gssmr.DefaultGrandpaAuthority,
-			//BabeThreshold: "",
 		},
 		Network: NetworkConfig{
 			Port:        gssmr.DefaultNetworkPort,
@@ -180,7 +179,6 @@ func KsmccConfig() *Config {
 		Core: CoreConfig{
 			Authority: ksmcc.DefaultAuthority,
 			Roles:     ksmcc.DefaultRoles,
-			//BabeThreshold: "",
 		},
 		Network: NetworkConfig{
 			Port:        ksmcc.DefaultNetworkPort,

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -112,6 +112,7 @@ func TestExportConfigGssmr(t *testing.T) {
 
 	cfg.Init.Genesis = gssmrGenesis
 	cfg.Global.BasePath = gssmrBasePath
+	cfg.Core.BabeThreshold = ""
 
 	file := ExportConfig(cfg, GssmrConfigPath)
 
@@ -157,6 +158,7 @@ func TestExportConfigKsmcc(t *testing.T) {
 
 	cfg.Init.Genesis = ksmccGenesis
 	cfg.Global.BasePath = ksmccBasePath
+	cfg.Core.BabeThreshold = ""
 
 	file := ExportConfig(cfg, KsmccConfigPath)
 

--- a/dot/services.go
+++ b/dot/services.go
@@ -134,6 +134,11 @@ func createBABEService(cfg *Config, rt *runtime.Runtime, st *state.Service, ks *
 		return nil, err
 	}
 
+	threshold, ok := cfg.Core.BabeThreshold.(*big.Int)
+	if !ok && threshold != nil {
+		return nil, errors.New("invalid BabeThreshold in configuration")
+	}
+
 	bcfg := &babe.ServiceConfig{
 		LogLvl:           lvl,
 		Keypair:          kps[0].(*sr25519.Keypair),
@@ -142,6 +147,7 @@ func createBABEService(cfg *Config, rt *runtime.Runtime, st *state.Service, ks *
 		StorageState:     st.Storage,
 		TransactionQueue: st.TransactionQueue,
 		StartSlot:        bestSlot + 1,
+		EpochThreshold:   threshold,
 	}
 
 	// create new BABE service

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -55,7 +55,7 @@ func NewTestConfig(t *testing.T) *Config {
 
 	// TODO: use default config instead of gssmr config for test config #776
 
-	return &Config{
+	cfg := &Config{
 		Global: GlobalConfig{
 			Name:     GssmrConfig().Global.Name,
 			ID:       GssmrConfig().Global.ID,
@@ -78,6 +78,9 @@ func NewTestConfig(t *testing.T) *Config {
 		RPC:     GssmrConfig().RPC,
 		System:  GssmrConfig().System,
 	}
+
+	cfg.Core.BabeThreshold = ""
+	return cfg
 }
 
 // NewTestConfigWithFile returns a new test configuration and a temporary configuration file
@@ -87,7 +90,7 @@ func NewTestConfigWithFile(t *testing.T) (*Config, *os.File) {
 	file, err := ioutil.TempFile(cfg.Global.BasePath, "config-")
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to create temporary file: %s", err))
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	cfgFile := ExportConfig(cfg, file.Name())

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -38,6 +38,13 @@ import (
 // RandomnessLength is the length of the epoch randomness (32 bytes)
 const RandomnessLength = 32
 
+var (
+	// MaxThreshold is the maximum BABE threshold (node authorized to produce a block every slot)
+	MaxThreshold = big.NewInt(0).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	// MinThreshold is the minimum BABE threshold (node never authorized to produce a block)
+	MinThreshold = big.NewInt(0)
+)
+
 // Service contains the VRF keys for the validator, as well as BABE configuation data
 type Service struct {
 	logger log.Logger


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `BabeThreshold` configuration value, can be "max", "min", or nil
- set `BabeThreshold` when starting BABE service

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./...
```

also, can run gossamer with `BabeThreshold` in config set to "max", should not allow blocks to be built

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #854 
