### PR TITLE
lib/runtime: implement ext_twox_256

### DIFF
--- a/lib/runtime/imports.go
+++ b/lib/runtime/imports.go
@@ -73,8 +73,11 @@ package runtime
 import "C"
 
 import (
+	"encoding/binary"
+	"fmt"
 	"unsafe"
 
+	"github.com/OneOfOne/xxhash"
 	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 )
 
@@ -167,7 +170,52 @@ func ext_log(context unsafe.Pointer, a, b, c, d, e C.int32_t) {
 //export ext_twox_256
 func ext_twox_256(context unsafe.Pointer, data, len, out C.int32_t) {
 	logger.Trace("[ext_twox_256] executing...")
-	logger.Warn("[ext_twox_256] not yet implemented")
+	instanceContext := wasm.IntoInstanceContext(context)
+	memory := instanceContext.Memory().Data()
+	logger.Trace("[ext_twox_256] hashing...", "value", fmt.Sprintf("%s", memory[data:data+len]))
+
+	h0 := xxhash.NewS64(0)
+	_, err := h0.Write(memory[data : data+len])
+	if err != nil {
+		logger.Error("[ext_twox_256]", "error", err)
+		return
+	}
+	res0 := h0.Sum64()
+	hash0 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(hash0, res0)
+
+	h1 := xxhash.NewS64(1)
+	_, err = h1.Write(memory[data : data+len])
+	if err != nil {
+		logger.Error("[ext_twox_256]", "error", err)
+		return
+	}
+	res1 := h1.Sum64()
+	hash1 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(hash1, res1)
+
+	h2 := xxhash.NewS64(2)
+	_, err = h2.Write(memory[data : data+len])
+	if err != nil {
+		logger.Error("[ext_twox_256]", "error", err)
+		return
+	}
+	res2 := h2.Sum64()
+	hash2 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(hash2, res2)
+
+	h3 := xxhash.NewS64(3)
+	_, err = h3.Write(memory[data : data+len])
+	if err != nil {
+		logger.Error("[ext_twox_256]", "error", err)
+		return
+	}
+	res3 := h3.Sum64()
+	hash3 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(hash3, res3)
+
+	fin := append(append(append(hash0, hash1...), hash2...), hash3...)
+	copy(memory[out:out+32], fin)
 }
 
 //export ext_exists_storage

--- a/lib/runtime/imports_old.go
+++ b/lib/runtime/imports_old.go
@@ -429,6 +429,7 @@ func ext_blake2_128(context unsafe.Pointer, data, length, out int32) {
 		return
 	}
 
+	logger.Trace("[ext_blake2_128]", "hash", fmt.Sprintf("0x%x", hash))
 	copy(memory[out:out+16], hash[:])
 }
 
@@ -438,6 +439,7 @@ func ext_keccak_256(context unsafe.Pointer, data, length, out int32) {
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
 	hash := common.Keccak256(memory[data : data+length])
+	logger.Trace("[ext_keccak_256]", "hash", hash)
 	copy(memory[out:out+32], hash[:])
 }
 

--- a/lib/runtime/imports_old_test.go
+++ b/lib/runtime/imports_old_test.go
@@ -653,7 +653,7 @@ func TestExt_keccak_256(t *testing.T) {
 
 	mem := runtime.vm.Memory.Data()
 
-	data := []byte("hello")
+	data := []byte(nil)
 	pos := 170
 	out := pos + len(data)
 	copy(mem[pos:pos+len(data)], data)
@@ -668,8 +668,7 @@ func TestExt_keccak_256(t *testing.T) {
 	require.Nil(t, err)
 
 	// test case from https://github.com/debris/tiny-keccak/blob/master/tests/keccak.rs#L4
-	//expected, err := common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
-	expected, err := common.HexToHash("0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8")
+	expected, err := common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 	require.Nil(t, err)
 
 	if !bytes.Equal(expected[:], mem[out:out+32]) {

--- a/lib/runtime/imports_old_test.go
+++ b/lib/runtime/imports_old_test.go
@@ -653,7 +653,7 @@ func TestExt_keccak_256(t *testing.T) {
 
 	mem := runtime.vm.Memory.Data()
 
-	data := []byte(nil)
+	data := []byte("hello")
 	pos := 170
 	out := pos + len(data)
 	copy(mem[pos:pos+len(data)], data)
@@ -668,11 +668,12 @@ func TestExt_keccak_256(t *testing.T) {
 	require.Nil(t, err)
 
 	// test case from https://github.com/debris/tiny-keccak/blob/master/tests/keccak.rs#L4
-	expected, err := common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+	//expected, err := common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+	expected, err := common.HexToHash("0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8")
 	require.Nil(t, err)
 
 	if !bytes.Equal(expected[:], mem[out:out+32]) {
-		t.Fatalf("fail: got %x expected %x", mem[out:out+32], expected)
+		t.Fatalf("fail: got %x expected %x", mem[out:out+32], expected[:])
 	}
 }
 

--- a/lib/runtime/imports_test.go
+++ b/lib/runtime/imports_test.go
@@ -1,0 +1,38 @@
+package runtime
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ext_twox_256(t *testing.T) {
+	runtime := NewTestRuntime(t, TEST_RUNTIME)
+
+	mem := runtime.vm.Memory.Data()
+
+	data := []byte("hello")
+	pos := 170
+	out := pos + len(data)
+	copy(mem[pos:pos+len(data)], data)
+
+	// call wasm function
+	testFunc, ok := runtime.vm.Exports["test_ext_twox_256"]
+	if !ok {
+		t.Fatal("could not find exported function")
+	}
+
+	_, err := testFunc(pos, len(data), out)
+	require.Nil(t, err)
+
+	// test case from https://github.com/w3f/polkadot-spec/tree/master/test
+	expected, err := common.HexToHash("0xa36d9f887d82c726b2a1d004cb71dd231fe2fb3bf584fc533914a80e276583e0")
+	require.Nil(t, err)
+
+	if !bytes.Equal(expected[:], mem[out:out+32]) {
+		t.Fatalf("fail: got %x expected %x", mem[out:out+32], expected[:])
+	}
+}

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -59,7 +59,7 @@ func NewTestRuntimeWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie) *
 		Storage:  rs,
 		Keystore: keystore.NewKeystore(),
 		Imports:  importsFunc,
-		LogLvl:   log.LvlInfo,
+		LogLvl:   log.LvlTrace,
 	}
 
 	r, err := NewRuntimeFromFile(fp, cfg)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement ext_twox_256

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #905
