### PR TITLE
dot/state: save current round to database

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -347,6 +347,7 @@ func (bs *BlockState) GetFinalizedHash(round uint64) (common.Hash, error) {
 		return common.Hash{}, err
 	}
 
+	// round that is being queried for has not yet finalized
 	if round > r {
 		return common.Hash{}, nil
 	}
@@ -372,14 +373,17 @@ func (bs *BlockState) SetFinalizedHash(hash common.Hash, round uint64) error {
 	return bs.db.Put(finalizedHashKey(round), hash[:])
 }
 
+// SetRound sets the latest finalized GRANDPA round in the db
+// TODO: this needs to use both setID and round
 func (bs *BlockState) SetRound(round uint64) error {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, round)
-	return bs.db.Put([]byte("round"), buf)
+	return bs.db.Put(common.LatestFinalizedRoundKey, buf)
 }
 
+// GetRound gets the latest finalized GRANDPA round from the db
 func (bs *BlockState) GetRound() (uint64, error) {
-	r, err := bs.db.Get([]byte("round"))
+	r, err := bs.db.Get(common.LatestFinalizedRoundKey)
 	if err != nil {
 		return 0, err
 	}

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -282,3 +282,16 @@ func TestFinalizedHash(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testhash, h)
 }
+
+func TestLatestFinalizedRound(t *testing.T) {
+	bs := newTestBlockState(t, testGenesisHeader)
+	r, err := bs.GetRound()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), r)
+
+	err = bs.SetRound(99)
+	require.NoError(t, err)
+	r, err = bs.GetRound()
+	require.NoError(t, err)
+	require.Equal(t, uint64(99), r)
+}

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -38,8 +38,17 @@ import (
 // RandomnessLength is the length of the epoch randomness (32 bytes)
 const RandomnessLength = 32
 
+var (
+	// MaxThreshold is the maximum BABE threshold (node authorized to produce a block every slot)
+	MaxThreshold = big.NewInt(0).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+	// MinThreshold is the minimum BABE threshold (node never authorized to produce a block)
+	MinThreshold = big.NewInt(0)
+)
+
+// AuthprityData is an alias for []*types.BABEAuthorityData
 type AuthorityData []*types.BABEAuthorityData
 
+// String returns the AuthorityData as a formatted string
 func (d AuthorityData) String() string {
 	str := ""
 	for _, di := range []*types.BABEAuthorityData(d) {
@@ -47,13 +56,6 @@ func (d AuthorityData) String() string {
 	}
 	return str
 }
-
-var (
-	// MaxThreshold is the maximum BABE threshold (node authorized to produce a block every slot)
-	MaxThreshold = big.NewInt(0).SetBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
-	// MinThreshold is the minimum BABE threshold (node never authorized to produce a block)
-	MinThreshold = big.NewInt(0)
-)
 
 // Service contains the VRF keys for the validator, as well as BABE configuation data
 type Service struct {
@@ -139,8 +141,6 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	logger.Info("genesis authorities", "auths", babeService.config.GenesisAuthorities)
 
 	logger.Info("config", "SlotDuration (ms)", babeService.config.SlotDuration, "EpochLength (slots)", babeService.config.EpochLength)
 

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -45,7 +45,7 @@ var (
 	MinThreshold = big.NewInt(0)
 )
 
-// AuthprityData is an alias for []*types.BABEAuthorityData
+// AuthorityData is an alias for []*types.BABEAuthorityData
 type AuthorityData []*types.BABEAuthorityData
 
 // String returns the AuthorityData as a formatted string

--- a/lib/common/db_keys.go
+++ b/lib/common/db_keys.go
@@ -27,4 +27,6 @@ var (
 	GenesisDataKey = []byte("genesis_data")
 	// BlockTreeKey is the db location of the encoded block tree structure.
 	BlockTreeKey = []byte("block_tree")
+	// LatestFinalizedRoundKey is the key where the last finalized grandpa round is stored
+	LatestFinalizedRoundKey = []byte("latest_finalized_round")
 )


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `GetRound` and `SetRound` funcs in BlockState to allow for saving latest round
- check for latest round in `GetFinalizedHash`, return empty hash if round hasn't finalized yet
- add AuthorityData type alias in BABE to allow for string formatting of authorities

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
