### PR TITLE
lib/babe: add threshold check to verifier

### DIFF
--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -247,7 +248,7 @@ func TestService_ProcessBlockRequestMessage(t *testing.T) {
 // tests the ProcessBlockResponseMessage method
 func TestService_ProcessBlockResponseMessage(t *testing.T) {
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlTrace)
 
 	kp, err := sr25519.GenerateKeypair()
 	require.Nil(t, err)
@@ -376,7 +377,7 @@ func TestService_ProcessTransactionMessage(t *testing.T) {
 
 	t.Skip()
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlTrace)
 
 	kp, err := sr25519.GenerateKeypair()
 	require.Nil(t, err)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -191,14 +191,15 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, err
 	}
 
-	currentDescriptor := &babe.NextEpochDescriptor{
-		Authorities: ad,
-		Randomness:  babeCfg.Randomness,
+	descriptor := &babe.EpochDescriptor{
+		AuthorityData: ad,
+		Randomness:    babeCfg.Randomness,
+		Threshold:     babe.MaxThreshold, // TODO: calculate threshold from config, however also need to have dev options for setting max and min
 	}
 
 	if cfg.Verifier == nil {
 		// TODO: load current epoch from database chain head
-		cfg.Verifier, err = babe.NewVerificationManager(cfg.BlockState, 0, currentDescriptor)
+		cfg.Verifier, err = babe.NewVerificationManager(cfg.BlockState, 0, descriptor)
 		if err != nil {
 			return nil, err
 		}

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -199,7 +199,7 @@ func NewService(cfg *Config) (*Service, error) {
 
 	if cfg.Verifier == nil {
 		// TODO: load current epoch from database chain head
-		cfg.Verifier, err = babe.NewVerificationManager(cfg.BlockState, 0, descriptor)
+		cfg.Verifier, err = babe.NewVerificationManager(cfg.BlockState, 1, descriptor)
 		if err != nil {
 			return nil, err
 		}

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,7 +113,7 @@ func TestAnnounceBlock(t *testing.T) {
 
 func TestCheckForRuntimeChanges(t *testing.T) {
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlTrace)
 
 	kp, err := sr25519.GenerateKeypair()
 	require.Nil(t, err)

--- a/dot/core/syncer.go
+++ b/dot/core/syncer.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
-	"github.com/ChainSafe/gossamer/lib/babe"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/optional"
@@ -37,14 +36,9 @@ import (
 	"golang.org/x/exp/rand"
 )
 
-// Verifier deals with block verification, as well as NextEpochDescriptors.
+// Verifier deals with block verification
 type Verifier interface {
 	VerifyBlock(header *types.Header) (bool, error)
-
-	// IncrementEpoch is called when we have received all the blocks for an epoch.
-	IncrementEpoch() (*babe.NextEpochDescriptor, error)
-
-	EpochNumber() uint64
 }
 
 // Syncer deals with chain syncing by sending block request messages and watching for responses.

--- a/dot/core/syncer_test.go
+++ b/dot/core/syncer_test.go
@@ -629,7 +629,7 @@ func newBlockBuilder(t *testing.T, cfg *babe.ServiceConfig) *babe.Service {
 
 func TestExecuteBlock(t *testing.T) {
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.SUBSTRATE_TEST_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.SUBSTRATE_TEST_RUNTIME, tt, log.LvlTrace)
 
 	// load authority into runtime
 	kp, err := sr25519.GenerateKeypair()
@@ -674,7 +674,7 @@ func TestExecuteBlock(t *testing.T) {
 
 func TestExecuteBlock_WithExtrinsic(t *testing.T) {
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.SUBSTRATE_TEST_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.SUBSTRATE_TEST_RUNTIME, tt, log.LvlTrace)
 
 	// load authority into runtime
 	kp, err := sr25519.GenerateKeypair()

--- a/dot/rpc/modules/author_test.go
+++ b/dot/rpc/modules/author_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -253,7 +254,7 @@ func TestAuthorModule_HasKey_InvalidKeyType(t *testing.T) {
 func newCoreService(t *testing.T) *core.Service {
 	// setup service
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlInfo)
 	ks := keystore.NewKeystore()
 
 	// insert alice key for testing

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/trie"
 
 	"github.com/ChainSafe/chaindb"
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +28,7 @@ func newBABEService(t *testing.T) *babe.Service {
 
 	bs := newBlockState(t)
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlInfo)
 
 	err = tt.Put(common.MustHexToBytes("0x886726f904d8372fdabb7707870c2fad"), common.MustHexToBytes("0x24d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01000000000000008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48010000000000000090b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe220100000000000000306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc200100000000000000e659a7a1628cdd93febc04a4e0646ea20e9f5f0ce097d9a05290d4a9e054df4e01000000000000001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c01000000000000004603307f855321776922daeea21ee31720388d097cdaac66f05a6f8462b317570100000000000000be1d9d59de1283380100550a7b024501cb62d6cc40e3db35fcc5cf341814986e01000000000000001206960f920a23f7f4c43cc9081ec2ed0721f31a9bef2c10fd7602e16e08a32c0100000000000000"))
 	require.NoError(t, err)

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -93,7 +93,6 @@ func NewTestConfigWithFile(t *testing.T) (*Config, *os.File) {
 		require.NoError(t, err)
 	}
 
-	fmt.Println(file.Name())
 	cfgFile := ExportConfig(cfg, file.Name())
 
 	return cfg, cfgFile

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -93,6 +93,7 @@ func NewTestConfigWithFile(t *testing.T) (*Config, *os.File) {
 		require.NoError(t, err)
 	}
 
+	fmt.Println(file.Name())
 	cfgFile := ExportConfig(cfg, file.Name())
 
 	return cfg, cfgFile

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -241,11 +241,12 @@ func (b *Service) GetBlockChannel() <-chan types.Block {
 	return b.blockChan
 }
 
-// Descriptor returns the NextEpochDescriptor for the current Service.
-func (b *Service) Descriptor() *NextEpochDescriptor {
-	return &NextEpochDescriptor{
-		Authorities: b.authorityData,
-		Randomness:  b.randomness,
+// Descriptor returns the EpochDescriptor for the current Service.
+func (b *Service) Descriptor() *EpochDescriptor {
+	return &EpochDescriptor{
+		AuthorityData: b.authorityData,
+		Randomness:    b.randomness,
+		Threshold:     b.epochThreshold,
 	}
 }
 

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -48,7 +48,7 @@ var emptyHeader = &types.Header{
 
 func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 	tt := trie.NewEmptyTrie()
-	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt)
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlCrit)
 
 	babeCfg, err := rt.BabeConfiguration()
 	require.NoError(t, err)

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -18,15 +18,11 @@ package babe
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 )
-
-// ErrNoDescriptor is returned when attempting to get a EpochDescriptor that isn't set for an epoch
-var ErrNoDescriptor = errors.New("nil EpochDescriptor for epoch")
 
 // EpochDescriptor contains the information needed to verify blocks within a BABE epoch
 type EpochDescriptor struct {
@@ -82,7 +78,8 @@ func (v *VerificationManager) VerifyBlock(header *types.Header) (bool, error) {
 	}
 
 	if v.epochDescriptors[epoch] == nil {
-		return false, fmt.Errorf("epoch %d: %w", epoch, ErrNoDescriptor)
+		// TODO: return an error here once updating of the verifier's epoch data is implemented
+		return v.verifier.verifyAuthorshipRight(header)
 	}
 
 	verifier, err := newEpochVerifier(v.blockState, v.epochDescriptors[epoch])

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -20,136 +20,78 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 )
 
-// ErrNilNextEpochDescriptor is returned when attempting to get a NextEpochDescriptor that isn't set for an epoch
-var ErrNilNextEpochDescriptor = errors.New("nil NextEpochDescriptor for epoch")
+// ErrNoDescriptor is returned when attempting to get a EpochDescriptor that isn't set for an epoch
+var ErrNoDescriptor = errors.New("nil EpochDescriptor for epoch")
+
+// EpochDescriptor contains the information needed to verify blocks within a BABE epoch
+type EpochDescriptor struct {
+	AuthorityData []*types.BABEAuthorityData
+	Randomness    [RandomnessLength]byte
+	Threshold     *big.Int
+}
 
 // VerificationManager assists the syncer in keeping track of what epoch is it currently syncing and verifying,
 // as well as keeping track of the NextEpochDesciptor which is required to create a Verifier for an epoch.
 type VerificationManager struct {
-	epochToNextEpochDescriptor map[uint64]*NextEpochDescriptor
-	blockState                 BlockState
+	epochDescriptors map[uint64]*EpochDescriptor
+	blockState       BlockState
 	// TODO: map of epochs to epoch length changes, for use in determining block epoch
+	// TODO: BABE should signal to the verifier when the epoch changes and send it the current EpochDescriptor
 
 	// current epoch information
 	currentEpoch uint64
-	firstBlock   *types.Header  // first block of current epoch, may change over course of epoch
-	verifier     *epochVerifier // TODO: may need to keep historical verifiers
+	verifier *epochVerifier // TODO: may need to keep historical verifiers
 }
 
 // NewVerificationManager returns a new VerificationManager
-func NewVerificationManager(blockState BlockState, currentEpoch uint64, currentDescriptor *NextEpochDescriptor) (*VerificationManager, error) {
+func NewVerificationManager(blockState BlockState, currentEpoch uint64, descriptor *EpochDescriptor) (*VerificationManager, error) {
 	if blockState == nil {
 		return nil, ErrNilBlockState
 	}
 
-	verifier, err := newEpochVerifier(blockState, currentDescriptor)
+	verifier, err := newEpochVerifier(blockState, descriptor)
 	if err != nil {
 		return nil, err
 	}
 
+	desciptors := make(map[uint64]*EpochDescriptor)
+	desciptors[currentEpoch] = descriptor
+
 	return &VerificationManager{
-		blockState:                 blockState,
-		epochToNextEpochDescriptor: make(map[uint64]*NextEpochDescriptor),
-		currentEpoch:               currentEpoch,
-		verifier:                   verifier,
+		blockState:       blockState,
+		epochDescriptors: desciptors,
+		currentEpoch:     currentEpoch,
+		verifier:         verifier,
 	}, nil
 }
 
-// EpochNumber returns the current epoch number
-func (v *VerificationManager) EpochNumber() uint64 {
-	return v.currentEpoch
-}
-
-// IncrementEpoch sets the NextEpochDescriptor for the current epoch and returns it.
-// It also increments the epoch number.
-func (v *VerificationManager) IncrementEpoch() (*NextEpochDescriptor, error) {
-	var nextEpochDescriptor *NextEpochDescriptor
-
-	if v.firstBlock != nil {
-		consensusDigest, err := checkForConsensusDigest(v.firstBlock)
-		if err != nil {
-			return nil, err
-		}
-
-		if consensusDigest == nil {
-			return nil, errors.New("first block for next epoch doesn't have consensus digest")
-		}
-
-		nextEpochDescriptor = new(NextEpochDescriptor)
-		err = nextEpochDescriptor.Decode(consensusDigest.Data)
-		if err != nil {
-			return nil, err
-		}
-
-		v.epochToNextEpochDescriptor[v.currentEpoch] = nextEpochDescriptor
-		v.verifier, err = newEpochVerifier(v.blockState, nextEpochDescriptor)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	v.firstBlock = nil
-	v.currentEpoch++
-	return nextEpochDescriptor, nil
-}
-
 // VerifyBlock verifies the given header with verifyAuthorshipRight.
-// It also checks for a NextEpochDescriptor for the current epoch.
 func (v *VerificationManager) VerifyBlock(header *types.Header) (bool, error) {
-	fromEpoch, err := v.isBlockFromEpoch(header, v.currentEpoch)
+	epoch, err := v.getBlockEpoch(header)
 	if err != nil {
 		return false, err
 	}
 
-	digest, err := checkForConsensusDigest(header)
-	if err != nil {
-		return false, err
-	}
-
-	ok, err := v.verifier.verifyAuthorshipRight(header)
-	if err != nil {
-		return false, err
-	}
-
-	if digest == nil {
-		// verify and return
-		return ok, nil
-	}
-
-	// check if first block has been set for current epoch
-	if fromEpoch && v.firstBlock != nil {
-
-		// check if block header has lower block number than current first block
-		if header.Number.Cmp(v.firstBlock.Number) < 0 {
-			v.firstBlock = header
+	if epoch == v.currentEpoch {
+		return v.verifier.verifyAuthorshipRight(header)
+	} else {
+		if v.epochDescriptors[epoch] == nil {
+			return false, fmt.Errorf("epoch %d: %w", epoch, ErrNoDescriptor)
 		}
 
-	} else if fromEpoch {
-		// set first block in current epoch
-		v.firstBlock = header
+		verifier, err := newEpochVerifier(v.blockState, v.epochDescriptors[epoch])
+		if err != nil {
+			return false, err
+		}
+		return verifier.verifyAuthorshipRight(header)
 	}
 
-	return ok, nil
-}
-
-// isBlockFromEpoch checks if the provided block hash is from given epoch
-func (v *VerificationManager) isBlockFromEpoch(header *types.Header, epoch uint64) (bool, error) {
-	// get epoch number of block header
-	blockEpoch, err := v.getBlockEpoch(header)
-	if err != nil {
-		return false, fmt.Errorf("failed to get epoch from block header: %s", err)
-	}
-
-	// check if block epoch number matches given epoch number
-	if blockEpoch != epoch {
-		return false, nil
-	}
-
-	return true, nil
+	return false, nil
 }
 
 // getBlockEpoch gets the epoch number using the provided block hash
@@ -181,7 +123,7 @@ func (v *VerificationManager) getBlockEpoch(header *types.Header) (epoch uint64,
 
 	if slot != 0 {
 		// epoch number = (slot - genesis slot) / epoch length
-		epoch = (slot - 1) / 6 // TODO: use epoch length from babe or core config
+		epoch = (slot - 1) / 6 // TODO: use epoch length from babe or core config #762
 	}
 
 	return epoch, nil
@@ -219,31 +161,40 @@ func checkForConsensusDigest(header *types.Header) (*types.ConsensusDigest, erro
 
 // epochVerifier represents a BABE verifier for a specific epoch
 type epochVerifier struct {
-	blockState        BlockState
-	BABEAuthorityData []*types.BABEAuthorityData
-	randomness        [RandomnessLength]byte
+	blockState    BlockState
+	authorityData []*types.BABEAuthorityData
+	randomness    [RandomnessLength]byte
+	threshold     *big.Int
 }
 
 // newEpochVerifier returns a Verifier for the epoch described by the given descriptor
-func newEpochVerifier(blockState BlockState, descriptor *NextEpochDescriptor) (*epochVerifier, error) {
+func newEpochVerifier(blockState BlockState, descriptor *EpochDescriptor) (*epochVerifier, error) {
 	if blockState == nil {
 		return nil, ErrNilBlockState
 	}
 
 	return &epochVerifier{
-		blockState:        blockState,
-		BABEAuthorityData: descriptor.Authorities,
-		randomness:        descriptor.Randomness,
+		blockState:    blockState,
+		authorityData: descriptor.AuthorityData,
+		randomness:    descriptor.Randomness,
+		threshold:     descriptor.Threshold,
 	}, nil
 }
 
 // verifySlotWinner verifies the claim for a slot, given the BabeHeader for that slot.
 func (b *epochVerifier) verifySlotWinner(slot uint64, header *types.BabeHeader) (bool, error) {
-	if len(b.BABEAuthorityData) <= int(header.BlockProducerIndex) {
+	if len(b.authorityData) <= int(header.BlockProducerIndex) {
 		return false, fmt.Errorf("no authority data for index %d", header.BlockProducerIndex)
 	}
 
-	pub := b.BABEAuthorityData[header.BlockProducerIndex].ID
+	// check that vrf output is under threshold
+	// if not, then return an error
+	output := big.NewInt(0).SetBytes(header.VrfOutput[:])
+	if output.Cmp(b.threshold) >= 0 {
+		return false, fmt.Errorf("vrf output over threshold")
+	}
+
+	pub := b.authorityData[header.BlockProducerIndex].ID
 
 	slotBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(slotBytes, slot)
@@ -290,13 +241,13 @@ func (b *epochVerifier) verifyAuthorshipRight(header *types.Header) (bool, error
 		return false, fmt.Errorf("cannot decode babe header from pre-digest: %s", err)
 	}
 
-	if len(b.BABEAuthorityData) <= int(babeHeader.BlockProducerIndex) {
+	if len(b.authorityData) <= int(babeHeader.BlockProducerIndex) {
 		return false, fmt.Errorf("no authority data for index %d", babeHeader.BlockProducerIndex)
 	}
 
 	slot := babeHeader.SlotNumber
 
-	authorPub := b.BABEAuthorityData[babeHeader.BlockProducerIndex].ID
+	authorPub := b.authorityData[babeHeader.BlockProducerIndex].ID
 	// remove seal before verifying
 	header.Digest = header.Digest[:len(header.Digest)-1]
 	encHeader, err := header.Encode()

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -45,7 +45,7 @@ type VerificationManager struct {
 
 	// current epoch information
 	currentEpoch uint64
-	verifier *epochVerifier // TODO: may need to keep historical verifiers
+	verifier     *epochVerifier // TODO: may need to keep historical verifiers
 }
 
 // NewVerificationManager returns a new VerificationManager
@@ -79,19 +79,18 @@ func (v *VerificationManager) VerifyBlock(header *types.Header) (bool, error) {
 
 	if epoch == v.currentEpoch {
 		return v.verifier.verifyAuthorshipRight(header)
-	} else {
-		if v.epochDescriptors[epoch] == nil {
-			return false, fmt.Errorf("epoch %d: %w", epoch, ErrNoDescriptor)
-		}
-
-		verifier, err := newEpochVerifier(v.blockState, v.epochDescriptors[epoch])
-		if err != nil {
-			return false, err
-		}
-		return verifier.verifyAuthorshipRight(header)
 	}
 
-	return false, nil
+	if v.epochDescriptors[epoch] == nil {
+		return false, fmt.Errorf("epoch %d: %w", epoch, ErrNoDescriptor)
+	}
+
+	verifier, err := newEpochVerifier(v.blockState, v.epochDescriptors[epoch])
+	if err != nil {
+		return false, err
+	}
+
+	return verifier.verifyAuthorshipRight(header)
 }
 
 // getBlockEpoch gets the epoch number using the provided block hash

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -33,9 +33,7 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
-var testEpoch = uint64(2)
-
-func newTestVerificationManager(t *testing.T, withBlock bool, descriptor *NextEpochDescriptor) *VerificationManager {
+func newTestVerificationManager(t *testing.T, withBlock bool, epoch uint64, descriptor *EpochDescriptor) *VerificationManager {
 	dbSrv := state.NewService("", log.LvlInfo)
 	dbSrv.UseMemDB()
 
@@ -52,11 +50,10 @@ func newTestVerificationManager(t *testing.T, withBlock bool, descriptor *NextEp
 	}
 
 	if descriptor == nil {
-		descriptor = &NextEpochDescriptor{}
+		descriptor = &EpochDescriptor{}
 	}
 
-	// currentEpoch = 2
-	vm, err := NewVerificationManager(dbSrv.Block, testEpoch, descriptor)
+	vm, err := NewVerificationManager(dbSrv.Block, epoch, descriptor)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,9 +93,8 @@ func newTestVerificationManager(t *testing.T, withBlock bool, descriptor *NextEp
 	return vm
 }
 
-// test getBlockEpoch
 func TestGetBlockEpoch(t *testing.T) {
-	vm := newTestVerificationManager(t, true, nil)
+	vm := newTestVerificationManager(t, true, 2, nil)
 
 	header, err := vm.blockState.BestBlockHeader()
 	require.Nil(t, err)
@@ -109,21 +105,21 @@ func TestGetBlockEpoch(t *testing.T) {
 	require.Equal(t, vm.currentEpoch, epoch)
 }
 
-// test isBlockFromEpoch
-func TestIsBlockFromEpoch(t *testing.T) {
-	vm := newTestVerificationManager(t, true, nil)
+// // test isBlockFromEpoch
+// func TestIsBlockFromEpoch(t *testing.T) {
+// 	vm := newTestVerificationManager(t, true, nil)
 
-	header, err := vm.blockState.BestBlockHeader()
-	require.Nil(t, err)
+// 	header, err := vm.blockState.BestBlockHeader()
+// 	require.Nil(t, err)
 
-	ok, err := vm.isBlockFromEpoch(header, testEpoch)
-	require.Nil(t, err)
-	require.Equal(t, true, ok)
+// 	ok, err := vm.isBlockFromEpoch(header, testEpoch)
+// 	require.Nil(t, err)
+// 	require.Equal(t, true, ok)
 
-	ok, err = vm.isBlockFromEpoch(header, 1)
-	require.Nil(t, err)
-	require.Equal(t, false, ok)
-}
+// 	ok, err = vm.isBlockFromEpoch(header, 1)
+// 	require.Nil(t, err)
+// 	require.Equal(t, false, ok)
+// }
 
 func TestCheckForConsensusDigest_NoDigest(t *testing.T) {
 	header := &types.Header{
@@ -136,7 +132,7 @@ func TestCheckForConsensusDigest_NoDigest(t *testing.T) {
 }
 
 func TestCheckForConsensusDigest_NoConsensusDigest(t *testing.T) {
-	vm := newTestVerificationManager(t, true, nil)
+	vm := newTestVerificationManager(t, true, 2, nil)
 
 	header, err := vm.blockState.BestBlockHeader()
 	require.Nil(t, err)
@@ -149,7 +145,7 @@ func TestCheckForConsensusDigest_NoConsensusDigest(t *testing.T) {
 }
 
 func TestCheckForConsensusDigest(t *testing.T) {
-	vm := newTestVerificationManager(t, true, nil)
+	vm := newTestVerificationManager(t, true, 2, nil)
 
 	header, err := vm.blockState.BestBlockHeader()
 	require.Nil(t, err)
@@ -175,7 +171,7 @@ func TestVerificationManager_VerifyBlock(t *testing.T) {
 	})
 	descriptor := babeService.Descriptor()
 
-	vm := newTestVerificationManager(t, false, descriptor)
+	vm := newTestVerificationManager(t, false, 0, descriptor)
 
 	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
 	err := vm.blockState.AddBlock(block)
@@ -184,76 +180,75 @@ func TestVerificationManager_VerifyBlock(t *testing.T) {
 	ok, err := vm.VerifyBlock(block.Header)
 	require.Nil(t, err)
 	require.Equal(t, true, ok)
-	require.Equal(t, (*types.Header)(nil), vm.firstBlock)
 }
 
-func TestVerificationManager_VerifyBlock_WithDigest(t *testing.T) {
-	babeService := createTestService(t, &ServiceConfig{
-		EpochThreshold: maxThreshold,
-	})
-	descriptor := babeService.Descriptor()
+// func TestVerificationManager_VerifyBlock_WithDigest(t *testing.T) {
+// 	babeService := createTestService(t, &ServiceConfig{
+// 		EpochThreshold: maxThreshold,
+// 	})
+// 	descriptor := babeService.Descriptor()
 
-	vm := newTestVerificationManager(t, false, descriptor)
-	vm.currentEpoch = 0
+// 	vm := newTestVerificationManager(t, false, descriptor)
+// 	vm.currentEpoch = 0
 
-	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
+// 	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
 
-	consensusDigest := &types.ConsensusDigest{
-		ConsensusEngineID: types.BabeEngineID,
-		Data:              descriptor.Encode(),
-	}
+// 	consensusDigest := &types.ConsensusDigest{
+// 		ConsensusEngineID: types.BabeEngineID,
+// 		Data:              descriptor.Encode(),
+// 	}
 
-	conDigest := consensusDigest.Encode()
-	block.Header.Digest = [][]byte{block.Header.Digest[0], conDigest}
-	block.Header.Number = big.NewInt(2)
+// 	conDigest := consensusDigest.Encode()
+// 	block.Header.Digest = [][]byte{block.Header.Digest[0], conDigest}
+// 	block.Header.Number = big.NewInt(2)
 
-	// re-sign block
-	seal, err := babeService.buildBlockSeal(block.Header)
-	require.Nil(t, err)
+// 	// re-sign block
+// 	seal, err := babeService.buildBlockSeal(block.Header)
+// 	require.Nil(t, err)
 
-	encSeal := seal.Encode()
-	block.Header.Digest = append(block.Header.Digest, encSeal)
+// 	encSeal := seal.Encode()
+// 	block.Header.Digest = append(block.Header.Digest, encSeal)
 
-	err = vm.blockState.AddBlock(block)
-	require.Nil(t, err)
+// 	err = vm.blockState.AddBlock(block)
+// 	require.Nil(t, err)
 
-	ok, err := vm.VerifyBlock(block.Header)
-	require.Nil(t, err)
-	require.Equal(t, true, ok)
-	require.Equal(t, block.Header, vm.firstBlock)
+// 	ok, err := vm.VerifyBlock(block.Header)
+// 	require.Nil(t, err)
+// 	require.Equal(t, true, ok)
+// 	require.Equal(t, block.Header, vm.firstBlock)
 
-	// create block with lower number, check that it's chosen as first block of epoch
-	block.Header.Number = big.NewInt(1)
+// 	// create block with lower number, check that it's chosen as first block of epoch
+// 	block.Header.Number = big.NewInt(1)
 
-	seal, err = babeService.buildBlockSeal(block.Header)
-	require.Nil(t, err)
+// 	seal, err = babeService.buildBlockSeal(block.Header)
+// 	require.Nil(t, err)
 
-	encSeal = seal.Encode()
-	block.Header.Digest = append(block.Header.Digest, encSeal)
+// 	encSeal = seal.Encode()
+// 	block.Header.Digest = append(block.Header.Digest, encSeal)
 
-	ok, err = vm.VerifyBlock(block.Header)
-	require.Nil(t, err)
-	require.Equal(t, true, ok)
-	require.Equal(t, block.Header, vm.firstBlock)
+// 	ok, err = vm.VerifyBlock(block.Header)
+// 	require.Nil(t, err)
+// 	require.Equal(t, true, ok)
+// 	require.Equal(t, block.Header, vm.firstBlock)
 
-	// create block with higher number, check that it's not chosen as first block of epoch
-	expected := block.Header.DeepCopy()
-	newBlock := &types.Block{
-		Header: block.Header.DeepCopy(),
-	}
+// 	// create block with higher number, check that it's not chosen as first block of epoch
+// 	expected := block.Header.DeepCopy()
+// 	newBlock := &types.Block{
+// 		Header: block.Header.DeepCopy(),
+// 	}
 
-	newBlock.Header.Number = big.NewInt(99)
-	seal, err = babeService.buildBlockSeal(newBlock.Header)
-	require.Nil(t, err)
+// 	newBlock.Header.Number = big.NewInt(99)
+// 	seal, err = babeService.buildBlockSeal(newBlock.Header)
+// 	require.Nil(t, err)
 
-	encSeal = seal.Encode()
-	newBlock.Header.Digest = append(newBlock.Header.Digest, encSeal)
+// 	encSeal = seal.Encode()
+// 	newBlock.Header.Digest = append(newBlock.Header.Digest, encSeal)
 
-	ok, err = vm.VerifyBlock(newBlock.Header)
-	require.Nil(t, err)
-	require.Equal(t, true, ok)
-	require.Equal(t, expected, vm.firstBlock)
-}
+// 	ok, err = vm.VerifyBlock(newBlock.Header)
+// 	require.Nil(t, err)
+// 	require.Equal(t, true, ok)
+// 	require.Equal(t, expected, vm.firstBlock)
+// }
 
 func TestVerifySlotWinner(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
@@ -292,10 +287,7 @@ func TestVerifySlotWinner(t *testing.T) {
 	}
 	babeService.authorityData = authorityData
 
-	verifier, err := newEpochVerifier(babeService.blockState, &NextEpochDescriptor{
-		Authorities: babeService.authorityData,
-		Randomness:  babeService.config.Randomness,
-	})
+	verifier, err := newEpochVerifier(babeService.blockState, babeService.Descriptor())
 
 	if err != nil {
 		t.Fatal(err)
@@ -315,10 +307,7 @@ func TestVerifyAuthorshipRight(t *testing.T) {
 	babeService := createTestService(t, nil)
 	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
 
-	verifier, err := newEpochVerifier(babeService.blockState, &NextEpochDescriptor{
-		Authorities: babeService.authorityData,
-		Randomness:  babeService.config.Randomness,
-	})
+	verifier, err := newEpochVerifier(babeService.blockState, babeService.Descriptor())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,10 +348,7 @@ func TestVerifyAuthorshipRight_Equivocation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	verifier, err := newEpochVerifier(babeService.blockState, &NextEpochDescriptor{
-		Authorities: babeService.authorityData,
-		Randomness:  babeService.config.Randomness,
-	})
+	verifier, err := newEpochVerifier(babeService.blockState, babeService.Descriptor())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -105,22 +105,6 @@ func TestGetBlockEpoch(t *testing.T) {
 	require.Equal(t, vm.currentEpoch, epoch)
 }
 
-// // test isBlockFromEpoch
-// func TestIsBlockFromEpoch(t *testing.T) {
-// 	vm := newTestVerificationManager(t, true, nil)
-
-// 	header, err := vm.blockState.BestBlockHeader()
-// 	require.Nil(t, err)
-
-// 	ok, err := vm.isBlockFromEpoch(header, testEpoch)
-// 	require.Nil(t, err)
-// 	require.Equal(t, true, ok)
-
-// 	ok, err = vm.isBlockFromEpoch(header, 1)
-// 	require.Nil(t, err)
-// 	require.Equal(t, false, ok)
-// }
-
 func TestCheckForConsensusDigest_NoDigest(t *testing.T) {
 	header := &types.Header{
 		ParentHash: genesisHeader.Hash(),
@@ -181,74 +165,6 @@ func TestVerificationManager_VerifyBlock(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, true, ok)
 }
-
-// func TestVerificationManager_VerifyBlock_WithDigest(t *testing.T) {
-// 	babeService := createTestService(t, &ServiceConfig{
-// 		EpochThreshold: maxThreshold,
-// 	})
-// 	descriptor := babeService.Descriptor()
-
-// 	vm := newTestVerificationManager(t, false, descriptor)
-// 	vm.currentEpoch = 0
-
-// 	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
-
-// 	consensusDigest := &types.ConsensusDigest{
-// 		ConsensusEngineID: types.BabeEngineID,
-// 		Data:              descriptor.Encode(),
-// 	}
-
-// 	conDigest := consensusDigest.Encode()
-// 	block.Header.Digest = [][]byte{block.Header.Digest[0], conDigest}
-// 	block.Header.Number = big.NewInt(2)
-
-// 	// re-sign block
-// 	seal, err := babeService.buildBlockSeal(block.Header)
-// 	require.Nil(t, err)
-
-// 	encSeal := seal.Encode()
-// 	block.Header.Digest = append(block.Header.Digest, encSeal)
-
-// 	err = vm.blockState.AddBlock(block)
-// 	require.Nil(t, err)
-
-// 	ok, err := vm.VerifyBlock(block.Header)
-// 	require.Nil(t, err)
-// 	require.Equal(t, true, ok)
-// 	require.Equal(t, block.Header, vm.firstBlock)
-
-// 	// create block with lower number, check that it's chosen as first block of epoch
-// 	block.Header.Number = big.NewInt(1)
-
-// 	seal, err = babeService.buildBlockSeal(block.Header)
-// 	require.Nil(t, err)
-
-// 	encSeal = seal.Encode()
-// 	block.Header.Digest = append(block.Header.Digest, encSeal)
-
-// 	ok, err = vm.VerifyBlock(block.Header)
-// 	require.Nil(t, err)
-// 	require.Equal(t, true, ok)
-// 	require.Equal(t, block.Header, vm.firstBlock)
-
-// 	// create block with higher number, check that it's not chosen as first block of epoch
-// 	expected := block.Header.DeepCopy()
-// 	newBlock := &types.Block{
-// 		Header: block.Header.DeepCopy(),
-// 	}
-
-// 	newBlock.Header.Number = big.NewInt(99)
-// 	seal, err = babeService.buildBlockSeal(newBlock.Header)
-// 	require.Nil(t, err)
-
-// 	encSeal = seal.Encode()
-// 	newBlock.Header.Digest = append(newBlock.Header.Digest, encSeal)
-
-// 	ok, err = vm.VerifyBlock(newBlock.Header)
-// 	require.Nil(t, err)
-// 	require.Equal(t, true, ok)
-// 	require.Equal(t, expected, vm.firstBlock)
-// }
 
 func TestVerifySlotWinner(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()

--- a/lib/runtime/helpers_test.go
+++ b/lib/runtime/helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,7 @@ func TestGrandpaAuthorities(t *testing.T) {
 	err = tt.Put(TestAuthorityDataKey, value)
 	require.NoError(t, err)
 
-	rt := NewTestRuntimeWithTrie(t, NODE_RUNTIME, tt)
+	rt := NewTestRuntimeWithTrie(t, NODE_RUNTIME, tt, log.LvlTrace)
 
 	auths, err := rt.GrandpaAuthorities()
 	require.NoError(t, err)
@@ -116,7 +117,7 @@ func TestConfigurationFromRuntime_withAuthorities(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rt := NewTestRuntimeWithTrie(t, NODE_RUNTIME, tt)
+	rt := NewTestRuntimeWithTrie(t, NODE_RUNTIME, tt, log.LvlTrace)
 
 	cfg, err := rt.BabeConfiguration()
 	if err != nil {

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -40,11 +40,11 @@ var TestAuthorityDataKey, _ = common.HexToBytes("0x3a6772616e6470615f617574686f7
 
 // NewTestRuntime will create a new runtime (polkadot/test)
 func NewTestRuntime(t *testing.T, targetRuntime string) *Runtime {
-	return NewTestRuntimeWithTrie(t, targetRuntime, nil)
+	return NewTestRuntimeWithTrie(t, targetRuntime, nil, log.LvlInfo)
 }
 
 // NewTestRuntimeWithTrie will create a new runtime (polkadot/test) with the supplied trie as the storage
-func NewTestRuntimeWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie) *Runtime {
+func NewTestRuntimeWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie, lvl log.Lvl) *Runtime {
 	testRuntimeFilePath, testRuntimeURL, importsFunc := GetRuntimeVars(targetRuntime)
 
 	_, err := GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL)
@@ -59,7 +59,7 @@ func NewTestRuntimeWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie) *
 		Storage:  rs,
 		Keystore: keystore.NewKeystore(),
 		Imports:  importsFunc,
-		LogLvl:   log.LvlTrace,
+		LogLvl:   lvl,
 	}
 
 	r, err := NewRuntimeFromFile(fp, cfg)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- change `NextEpochDesciptor` in verifier to `EpochDescriptor` which contains threshold information
- use this in verification to check that block vrf output is under threshold when verifying
- remove `NextEpochDescriptor` usages since it's not used 

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #998