### PR TITLE
dot/core: add benchmarker to syncer

### DIFF
--- a/dot/core/syncer.go
+++ b/dot/core/syncer.go
@@ -132,7 +132,7 @@ func NewSyncer(cfg *SyncerConfig) (*Syncer, error) {
 		runtime:          cfg.Runtime,
 		verifier:         cfg.Verifier,
 		digestHandler:    cfg.DigestHandler,
-		benchmarker: 	newBenchmarker(cfg.logger),
+		benchmarker:      newBenchmarker(cfg.logger),
 	}, nil
 }
 

--- a/dot/core/syncer_benchmark.go
+++ b/dot/core/syncer_benchmark.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"time"
+
+	log "github.com/ChainSafe/log15"
+)
+
+type benchmarker struct {
+	logger log.Logger
+	start time.Time
+	startBlock uint64
+	blocksPerSecond []float64
+}
+
+func newBenchmarker(logger log.Logger) *benchmarker {
+	return &benchmarker{
+		logger: logger.New("module", "benchmarker"),
+		blocksPerSecond: []float64{},
+	}
+}
+
+func (b *benchmarker) begin(block uint64) {
+	b.start = time.Now()
+	b.startBlock = block
+}
+
+func (b *benchmarker) end(block uint64) {
+	duration := time.Since(b.start)
+	blocks := block - b.startBlock
+	bps := float64(blocks) / duration.Seconds()
+	b.blocksPerSecond = append(b.blocksPerSecond, bps)
+
+	b.logger.Info("added sync time", "avg blocks/second", b.average())
+}
+
+func (b *benchmarker) average() float64 {
+	sum := float64(0)
+	for _, bps := range b.blocksPerSecond {
+		sum += bps
+	}
+	return sum/float64(len(b.blocksPerSecond))
+}

--- a/dot/core/syncer_benchmark.go
+++ b/dot/core/syncer_benchmark.go
@@ -7,15 +7,15 @@ import (
 )
 
 type benchmarker struct {
-	logger log.Logger
-	start time.Time
-	startBlock uint64
+	logger          log.Logger
+	start           time.Time
+	startBlock      uint64
 	blocksPerSecond []float64
 }
 
 func newBenchmarker(logger log.Logger) *benchmarker {
 	return &benchmarker{
-		logger: logger.New("module", "benchmarker"),
+		logger:          logger.New("module", "benchmarker"),
 		blocksPerSecond: []float64{},
 	}
 }
@@ -39,5 +39,5 @@ func (b *benchmarker) average() float64 {
 	for _, bps := range b.blocksPerSecond {
 		sum += bps
 	}
-	return sum/float64(len(b.blocksPerSecond))
+	return sum / float64(len(b.blocksPerSecond))
 }


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `benchmarker` to syncer which keeps track of duration of each sync and how many blocks were synced and logs the average time

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
```

run alice as a block producer with `babe-threshold = "max"` in the config, then run bob as a non-authority node and see logs

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #990 