### PR TITLE
dot, dot/core: set verifier threshold from config or babe.CalculateThreshold

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -97,8 +97,9 @@ type Config struct {
 	IsFinalityAuthority     bool
 	ConsensusMessageHandler ConsensusMessageHandler
 
-	NewBlocks chan types.Block // only used for testing purposes
-	Verifier  Verifier         // only used for testing purposes
+	NewBlocks     chan types.Block // only used for testing purposes
+	Verifier      Verifier         // only used for testing purposes
+	BabeThreshold *big.Int         // used by Verifier, for development purposes
 
 	MsgRec   <-chan network.Message
 	MsgSend  chan<- network.Message
@@ -191,10 +192,20 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, err
 	}
 
+	var threshold *big.Int
+	if cfg.BabeThreshold != nil {
+		threshold = cfg.BabeThreshold
+	} else {
+		threshold, err = babe.CalculateThreshold(babeCfg.C1, babeCfg.C2, len(babeCfg.GenesisAuthorities))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	descriptor := &babe.EpochDescriptor{
 		AuthorityData: ad,
 		Randomness:    babeCfg.Randomness,
-		Threshold:     babe.MaxThreshold, // TODO: calculate threshold from config, however also need to have dev options for setting max and min
+		Threshold:     threshold,
 	}
 
 	if cfg.Verifier == nil {

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -216,6 +216,8 @@ func NewService(cfg *Config) (*Service, error) {
 		}
 	}
 
+	log.Info("verifier", "threshold", threshold)
+
 	srv.started.Store(false)
 
 	var dh *digestHandler

--- a/dot/services.go
+++ b/dot/services.go
@@ -181,6 +181,11 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 		handler = grandpa.NewMessageHandler(nil, stateSrvc.Block)
 	}
 
+	threshold, ok := cfg.Core.BabeThreshold.(*big.Int)
+	if !ok && threshold != nil {
+		return nil, errors.New("invalid BabeThreshold in configuration")
+	}
+
 	// set core configuration
 	coreConfig := &core.Config{
 		LogLvl:                  lvl,
@@ -197,6 +202,7 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 		IsBlockProducer:         cfg.Core.BabeAuthority,
 		IsFinalityAuthority:     cfg.Core.GrandpaAuthority,
 		SyncChan:                syncChan,
+		BabeThreshold:           threshold,
 	}
 
 	// create new core service

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -349,7 +349,7 @@ func (bs *BlockState) GetFinalizedHash(round uint64) (common.Hash, error) {
 
 	// round that is being queried for has not yet finalized
 	if round > r {
-		return common.Hash{}, nil
+		return common.Hash{}, fmt.Errorf("round not yet finalized")
 	}
 
 	h, err := bs.db.Get(finalizedHashKey(round))

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -480,7 +480,7 @@ func (b *Service) setEpochThreshold() error {
 	return nil
 }
 
-// calculates the slot lottery threshold for the authority at authorityIndex.
+// CalculateThreshold calculates the slot lottery threshold
 // equation: threshold = 2^128 * (1 - (1-c)^(1/len(authorities))
 func CalculateThreshold(C1, C2 uint64, numAuths int) (*big.Int, error) {
 	c := float64(C1) / float64(C2)

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -451,7 +451,7 @@ func (b *Service) setEpochThreshold() error {
 		return errors.New("cannot set threshold: no babe config")
 	}
 
-	b.epochThreshold, err = calculateThreshold(b.config.C1, b.config.C2, len(b.Authorities()))
+	b.epochThreshold, err = CalculateThreshold(b.config.C1, b.config.C2, len(b.Authorities()))
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func (b *Service) setEpochThreshold() error {
 
 // calculates the slot lottery threshold for the authority at authorityIndex.
 // equation: threshold = 2^128 * (1 - (1-c)^(1/len(authorities))
-func calculateThreshold(C1, C2 uint64, numAuths int) (*big.Int, error) {
+func CalculateThreshold(C1, C2 uint64, numAuths int) (*big.Int, error) {
 	c := float64(C1) / float64(C2)
 	if c > 1 {
 		return nil, errors.New("invalid C1/C2: greater than 1")

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -126,7 +126,7 @@ func TestCalculateThreshold(t *testing.T) {
 
 	expected := new(big.Int).Lsh(big.NewInt(1), 256)
 
-	threshold, err := calculateThreshold(C1, C2, 3)
+	threshold, err := CalculateThreshold(C1, C2, 3)
 	require.NoError(t, err)
 
 	if threshold.Cmp(expected) != 0 {
@@ -145,7 +145,7 @@ func TestCalculateThreshold(t *testing.T) {
 	q := new(big.Int).Lsh(big.NewInt(1), 256)
 	expected = q.Mul(q, p_rat.Num()).Div(q, p_rat.Denom())
 
-	threshold, err = calculateThreshold(C1, C2, 3)
+	threshold, err = CalculateThreshold(C1, C2, 3)
 	require.NoError(t, err)
 
 	if threshold.Cmp(expected) != 0 {
@@ -157,7 +157,7 @@ func TestCalculateThreshold_Failing(t *testing.T) {
 	var C1 uint64 = 5
 	var C2 uint64 = 4
 
-	_, err := calculateThreshold(C1, C2, 3)
+	_, err := CalculateThreshold(C1, C2, 3)
 	if err == nil {
 		t.Fatal("Fail: did not err for c>1")
 	}

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -98,12 +98,13 @@ func TestSync_SingleBlockProducer(t *testing.T) {
 	// only log info from 1 node
 	tmpdir, err := ioutil.TempDir("", "gossamer-stress-sync")
 	require.NoError(t, err)
+	defer os.Remove(tmpdir)
 	node, err := utils.RunGossamer(t, numNodes-1, tmpdir, utils.GenesisSixAuths, utils.ConfigBABEMaxThreshold)
 	require.NoError(t, err)
 
 	// wait and start rest of nodes - if they all start at the same time the first round usually doesn't complete since
 	// all nodes vote for different blocks.
-	time.Sleep(time.Second * 3)
+	time.Sleep(time.Second * 5)
 	nodes, err := utils.InitializeAndStartNodes(t, numNodes-1, utils.GenesisSixAuths, utils.ConfigNoBABE)
 	require.NoError(t, err)
 	nodes = append(nodes, node)

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -68,7 +68,7 @@ func TestRestartNode(t *testing.T) {
 	err = utils.StartNodes(t, nodes)
 	require.NoError(t, err)
 
-	errList := utils.TearDown(t, nodes)
+	errList := utils.StopNodes(t, nodes)
 	require.Len(t, errList, 0)
 
 	err = utils.StartNodes(t, nodes)

--- a/tests/utils/config_nobabe.toml
+++ b/tests/utils/config_nobabe.toml
@@ -18,6 +18,7 @@ authority = true
 roles = 4
 babe-authority = false
 grandpa-authority = true
+babe-threshold = "max"
 
 [network]
 bootnodes = []

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -300,7 +300,21 @@ func InitializeAndStartNodes(t *testing.T, num int, genesis, config string) ([]*
 	return nodes, nil
 }
 
-// TearDown will stop gossamer nodes
+// StopNodes stops the given nodes
+func StopNodes(t *testing.T, nodes []*Node) (errs []error) {
+	for i := range nodes {
+		cmd := nodes[i].Process
+		err := KillProcess(t, cmd)
+		if err != nil {
+			logger.Error("failed to kill gossamer", "i", i, "cmd", cmd)
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// TearDown stops the given nodes and remove their datadir
 func TearDown(t *testing.T, nodes []*Node) (errorList []error) {
 	for i, node := range nodes {
 		cmd := nodes[i].Process

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -96,7 +96,7 @@ func InitGossamer(idx int, basePath, genesis, config string) (*Node, error) {
 	)
 
 	//add step for init
-	logger.Info("initializing gossamer...", "cmdInit", cmdInit)
+	logger.Info("initializing gossamer...", "cmd", cmdInit)
 	stdOutInit, err := cmdInit.CombinedOutput()
 	if err != nil {
 		fmt.Println(stdOutInit)
@@ -162,7 +162,7 @@ func StartGossamer(t *testing.T, node *Node) error {
 	node.Process.Stdout = multiWriter
 	node.Process.Stderr = multiWriter
 
-	logger.Debug("Going to execute gossamer", "cmd", node.Process)
+	logger.Info("starting gossamer...", "cmd", node.Process)
 	err = node.Process.Start()
 	if err != nil {
 		logger.Error("Could not execute gossamer cmd", "err", err)
@@ -302,11 +302,17 @@ func InitializeAndStartNodes(t *testing.T, num int, genesis, config string) ([]*
 
 // TearDown will stop gossamer nodes
 func TearDown(t *testing.T, nodes []*Node) (errorList []error) {
-	for i := range nodes {
+	for i, node := range nodes {
 		cmd := nodes[i].Process
 		err := KillProcess(t, cmd)
 		if err != nil {
 			logger.Error("failed to kill gossamer", "i", i, "cmd", cmd)
+			errorList = append(errorList, err)
+		}
+
+		err = os.RemoveAll(node.basePath)
+		if err != nil {
+			logger.Error("failed to remove directory", "basepath", node.basePath)
 			errorList = append(errorList, err)
 		}
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- in core.NewService, set babe verifier threshold from config if set, otherwise set it using `babe.CalculateThreshold`
- update stress sync test config to set threshold to max if block producer threshold is also max

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
make it-stress
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #998