### PR TITLE
lib/grandpa: fix grandpa SIGABRT on shutdown

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -209,6 +209,10 @@ func (bs *BlockState) HasHeader(hash common.Hash) (bool, error) {
 func (bs *BlockState) GetHeader(hash common.Hash) (*types.Header, error) {
 	result := new(types.Header)
 
+	if bs.db == nil {
+		return nil, fmt.Errorf("database is nil")
+	}
+
 	data, err := bs.db.Get(headerKey(hash))
 	if err != nil {
 		return nil, err
@@ -546,6 +550,10 @@ func (bs *BlockState) HighestBlockNumber() *big.Int {
 
 // BestBlockHash returns the hash of the head of the current chain
 func (bs *BlockState) BestBlockHash() common.Hash {
+	if bs.bt == nil {
+		return common.Hash{}
+	}
+
 	return bs.bt.DeepestBlockHash()
 }
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -203,6 +203,14 @@ func (bt *BlockTree) deepestLeaf() *node { //nolint
 // DeepestBlockHash returns the hash of the deepest block in the blocktree
 // If there is multiple deepest blocks, it returns the one with the earliest arrival time.
 func (bt *BlockTree) DeepestBlockHash() Hash {
+	if bt.leaves == nil {
+		return Hash{}
+	}
+
+	if bt.leaves.deepestLeaf() == nil {
+		return Hash{}
+	}
+
 	return bt.leaves.deepestLeaf().hash
 }
 

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -67,9 +67,17 @@ func (ls *leafMap) replace(old, new *node) {
 func (ls *leafMap) deepestLeaf() *node {
 	max := big.NewInt(-1)
 
-	var dLeaf *node
+	if ls.smap == nil {
+		return nil
+	}
+
+	dLeaf := new(node)
 	ls.smap.Range(func(h, n interface{}) bool {
 		node := n.(*node)
+		if node == nil {
+			return true
+		}
+
 		if max.Cmp(node.depth) < 0 {
 			max = node.depth
 			dLeaf = node

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -73,7 +73,7 @@ func (ls *leafMap) deepestLeaf() *node {
 		if node == nil {
 			return true
 		}
-		
+
 		if max.Cmp(node.depth) < 0 {
 			max = node.depth
 			dLeaf = node

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -67,17 +67,9 @@ func (ls *leafMap) replace(old, new *node) {
 func (ls *leafMap) deepestLeaf() *node {
 	max := big.NewInt(-1)
 
-	if ls.smap == nil {
-		return nil
-	}
-
-	dLeaf := new(node)
+	var dLeaf *node
 	ls.smap.Range(func(h, n interface{}) bool {
 		node := n.(*node)
-		if node == nil {
-			return true
-		}
-
 		if max.Cmp(node.depth) < 0 {
 			max = node.depth
 			dLeaf = node

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -70,6 +70,10 @@ func (ls *leafMap) deepestLeaf() *node {
 	var dLeaf *node
 	ls.smap.Range(func(h, n interface{}) bool {
 		node := n.(*node)
+		if node == nil {
+			return true
+		}
+		
 		if max.Cmp(node.depth) < 0 {
 			max = node.depth
 			dLeaf = node

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -225,8 +225,12 @@ func (s *Service) initiate() error {
 			return nil
 		}
 
-		h := s.blockState.BestBlockHash()
-		if h != s.blockState.GenesisHash() {
+		h, err := s.blockState.BestBlockHeader()	
+		if err != nil {
+			continue
+		}
+
+		if h != nil && h.Number.Int64() > 0 {
 			break
 		}
 	}

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -18,7 +18,6 @@ package grandpa
 
 import (
 	"bytes"
-	//"math/big"
 	"os"
 	"sync"
 	"time"

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -225,7 +225,7 @@ func (s *Service) initiate() error {
 			return nil
 		}
 
-		h, err := s.blockState.BestBlockHeader()	
+		h, err := s.blockState.BestBlockHeader()
 		if err != nil {
 			continue
 		}

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -32,7 +32,7 @@ type tracker struct {
 	in         chan *types.Block      // receive imported block from BlockState
 	chanID     byte                   // BlockState channel ID
 	out        chan<- FinalityMessage // send a VoteMessage back to grandpa. corresponds to grandpa's in channel
-	stopped    bool
+	stopped    chan struct{}
 }
 
 func newTracker(bs BlockState, out chan<- FinalityMessage) (*tracker, error) {
@@ -49,19 +49,18 @@ func newTracker(bs BlockState, out chan<- FinalityMessage) (*tracker, error) {
 		in:         in,
 		chanID:     id,
 		out:        out,
-		stopped:    true,
+		stopped:    make(chan struct{}),
 	}, nil
 }
 
 func (t *tracker) start() {
-	t.stopped = false
 	go t.handleBlocks()
 }
 
 func (t *tracker) stop() {
+	close(t.stopped)
 	t.blockState.UnregisterImportedChannel(t.chanID)
 	close(t.in)
-	t.stopped = true
 }
 
 func (t *tracker) add(v *VoteMessage) {
@@ -71,20 +70,25 @@ func (t *tracker) add(v *VoteMessage) {
 }
 
 func (t *tracker) handleBlocks() {
-	for b := range t.in {
-		if t.stopped {
+	for {
+		select {
+		case b := <-t.in:
+			if b == nil {
+				continue
+			}
+			
+			t.mapLock.Lock()
+
+			h := b.Header.Hash()
+			if t.messages[h] != nil {
+				for _, v := range t.messages[h] {
+					t.out <- v
+				}
+			}
+
+			t.mapLock.Unlock()
+		case <-t.stopped:
 			return
 		}
-
-		t.mapLock.Lock()
-
-		h := b.Header.Hash()
-		if t.messages[h] != nil {
-			for _, v := range t.messages[h] {
-				t.out <- v
-			}
-		}
-
-		t.mapLock.Unlock()
 	}
 }

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -76,7 +76,7 @@ func (t *tracker) handleBlocks() {
 			if b == nil {
 				continue
 			}
-			
+
 			t.mapLock.Lock()
 
 			h := b.Header.Hash()

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 
+	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,10 +58,12 @@ func setupGrandpa(t *testing.T, kp *ed25519.Keypair) (*Service, chan FinalityMes
 		BlockState: st.Block,
 		Voters:     voters,
 		Keypair:    kp,
+		LogLvl:     log.LvlTrace,
 	}
 
 	gs, err := NewService(cfg)
 	require.NoError(t, err)
+	gs.stopped = false
 
 	return gs, gs.in, gs.out, gs.finalized
 }
@@ -433,6 +436,7 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 	wg.Wait()
 
 	for _, fb := range finalized {
+		require.NotNil(t, fb)
 		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
 		finalized[0].Justification = []*Justification{}
 		fb.Justification = []*Justification{}

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -238,6 +238,7 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 	wg.Wait()
 
 	for _, fb := range finalized {
+		require.NotNil(t, fb)
 		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
 		finalized[0].Justification = []*Justification{}
 		fb.Justification = []*Justification{}

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -25,6 +25,7 @@ import (
 
 // BlockState is the interface required by GRANDPA into the block state
 type BlockState interface {
+	GenesisHash() common.Hash
 	HasHeader(hash common.Hash) (bool, error)
 	GetHeader(hash common.Hash) (*types.Header, error)
 	GetHeaderByNumber(num *big.Int) (*types.Header, error)
@@ -33,6 +34,7 @@ type BlockState interface {
 	GetFinalizedHeader(uint64) (*types.Header, error)
 	SetFinalizedHash(common.Hash, uint64) error
 	BestBlockHeader() (*types.Header, error)
+	BestBlockHash() common.Hash
 	Leaves() []common.Hash
 	BlocktreeAsString() string
 	RegisterImportedChannel(ch chan<- *types.Block) (byte, error)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix grandpa SIGABRT on shutdown, was coming from call to `s.blockState.BestBlockHeader()` for some reason
- add some safety checks in block state, blocktree
- update grandpa message tracker to use select case to determine when stopped

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa
```

also, `make gossamer`, `./bin/gossamer --key alice`, ctrl+c and make sure there is no SIGABRT

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
