### PR TITLE
dot, lib/babe: add SlotDuration config option

### DIFF
--- a/dot/config.go
+++ b/dot/config.go
@@ -91,7 +91,7 @@ type CoreConfig struct {
 	BabeAuthority    bool        `toml:"babe-authority"`
 	GrandpaAuthority bool        `toml:"grandpa-authority"`
 	BabeThreshold    interface{} `toml:"babe-threshold"`
-	SlotDuration 	uint64			`toml:"slot-duration"`
+	SlotDuration     uint64      `toml:"slot-duration"`
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars

--- a/dot/config.go
+++ b/dot/config.go
@@ -91,6 +91,7 @@ type CoreConfig struct {
 	BabeAuthority    bool        `toml:"babe-authority"`
 	GrandpaAuthority bool        `toml:"grandpa-authority"`
 	BabeThreshold    interface{} `toml:"babe-threshold"`
+	SlotDuration 	uint64			`toml:"slot-duration"`
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars

--- a/dot/services.go
+++ b/dot/services.go
@@ -148,6 +148,7 @@ func createBABEService(cfg *Config, rt *runtime.Runtime, st *state.Service, ks *
 		TransactionQueue: st.TransactionQueue,
 		StartSlot:        bestSlot + 1,
 		EpochThreshold:   threshold,
+		SlotDuration:	cfg.Core.SlotDuration,
 	}
 
 	// create new BABE service

--- a/dot/services.go
+++ b/dot/services.go
@@ -148,7 +148,7 @@ func createBABEService(cfg *Config, rt *runtime.Runtime, st *state.Service, ks *
 		TransactionQueue: st.TransactionQueue,
 		StartSlot:        bestSlot + 1,
 		EpochThreshold:   threshold,
-		SlotDuration:	cfg.Core.SlotDuration,
+		SlotDuration:     cfg.Core.SlotDuration,
 	}
 
 	// create new BABE service

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -99,7 +99,7 @@ type ServiceConfig struct {
 	Runtime          *runtime.Runtime
 	AuthData         []*types.BABEAuthorityData
 	EpochThreshold   *big.Int // for development purposes
-	SlotDuration      uint64 // for development purposes; in milliseconds
+	SlotDuration     uint64   // for development purposes; in milliseconds
 	StartSlot        uint64   // slot to start at
 }
 

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -98,7 +98,8 @@ type ServiceConfig struct {
 	Keypair          *sr25519.Keypair
 	Runtime          *runtime.Runtime
 	AuthData         []*types.BABEAuthorityData
-	EpochThreshold   *big.Int // should only be used for testing
+	EpochThreshold   *big.Int // for development purposes
+	SlotDuration      uint64 // for development purposes; in milliseconds
 	StartSlot        uint64   // slot to start at
 }
 
@@ -142,7 +143,12 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		return nil, err
 	}
 
-	logger.Info("config", "SlotDuration (ms)", babeService.config.SlotDuration, "EpochLength (slots)", babeService.config.EpochLength)
+	// if slot duration is set via the config file, overwrite the runtime value
+	if cfg.SlotDuration > 0 {
+		babeService.config.SlotDuration = cfg.SlotDuration
+	}
+
+	logger.Info("config", "slot duration (ms)", babeService.config.SlotDuration, "epoch length (slots)", babeService.config.EpochLength)
 
 	if babeService.authorityData == nil {
 		logger.Info("setting authority data to genesis authorities", "authorities", babeService.config.GenesisAuthorities)
@@ -153,7 +159,6 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		}
 	}
 
-	// TODO: format this
 	logger.Info("created BABE service", "authorities", AuthorityData(babeService.authorityData))
 
 	babeService.randomness = babeService.config.Randomness
@@ -163,7 +168,7 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		return nil, err
 	}
 
-	logger.Trace("created BABE service", "authority index", babeService.authorityIndex, "threshold", babeService.epochThreshold)
+	logger.Debug("created BABE service", "authority index", babeService.authorityIndex, "threshold", babeService.epochThreshold)
 
 	return babeService, nil
 }

--- a/lib/runtime/imports_old.go
+++ b/lib/runtime/imports_old.go
@@ -150,13 +150,13 @@ func ext_get_storage_into(context unsafe.Pointer, keyData, keyLen, valueData, va
 		ret := 1<<32 - 1
 		return int32(ret)
 	} else if val == nil {
-		logger.Warn("[ext_get_storage_into]", "err", "value is nil")
+		logger.Debug("[ext_get_storage_into]", "err", "value is nil")
 		ret := 1<<32 - 1
 		return int32(ret)
 	}
 
 	if len(val) > int(valueLen) {
-		logger.Warn("[ext_get_storage_into]", "error", "value exceeds allocated buffer length")
+		logger.Debug("[ext_get_storage_into]", "error", "value exceeds allocated buffer length")
 		return 0
 	}
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add SlotDuration option to config, check if this is set (ie. non-zero) when initializing BABE

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
```

add `slot-duration = 100` under `[core]` in the config, and run ` ./bin/gossamer --key alice --config chain/gssmr/config.toml ` you should see blocks being produced more quickly (can also set `babe-threshold = "max"`)

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1005