### PR TITLE
fix: WebSocket enabled setting in toml not working

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -436,7 +436,7 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 
 	if wsenabled := ctx.GlobalBool(WSEnabledFlag.Name); wsenabled {
 		cfg.WSEnabled = true
-	} else {
+	} else if ctx.IsSet(WSEnabledFlag.Name) && !wsenabled {
 		cfg.WSEnabled = false
 	}
 

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -411,8 +411,6 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 	// check --rpc flag and update node configuration
 	if enabled := ctx.GlobalBool(RPCEnabledFlag.Name); enabled {
 		cfg.Enabled = true
-	} else if ctx.IsSet(RPCEnabledFlag.Name) && !enabled {
-		cfg.Enabled = false
 	}
 
 	// check --rpcport flag and update node configuration
@@ -436,8 +434,6 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 
 	if wsenabled := ctx.GlobalBool(WSEnabledFlag.Name); wsenabled {
 		cfg.WSEnabled = true
-	} else if ctx.IsSet(WSEnabledFlag.Name) && !wsenabled {
-		cfg.WSEnabled = false
 	}
 
 	// format rpc modules

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -412,7 +412,7 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 	if enabled := ctx.GlobalBool(RPCEnabledFlag.Name); enabled {
 		cfg.Enabled = true
 	} else if ctx.IsSet(RPCEnabledFlag.Name) && !enabled {
-		cfg.WSEnabled = false
+		cfg.Enabled = false
 	}
 
 	// check --rpcport flag and update node configuration

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -411,6 +411,8 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 	// check --rpc flag and update node configuration
 	if enabled := ctx.GlobalBool(RPCEnabledFlag.Name); enabled {
 		cfg.Enabled = true
+	} else if ctx.IsSet(RPCEnabledFlag.Name) && !enabled {
+		cfg.WSEnabled = false
 	}
 
 	// check --rpcport flag and update node configuration
@@ -434,6 +436,8 @@ func setDotRPCConfig(ctx *cli.Context, cfg *dot.RPCConfig) {
 
 	if wsenabled := ctx.GlobalBool(WSEnabledFlag.Name); wsenabled {
 		cfg.WSEnabled = true
+	} else if ctx.IsSet(WSEnabledFlag.Name) && !wsenabled {
+		cfg.WSEnabled = false
 	}
 
 	// format rpc modules


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Added check to see if cli flag has been set, otherwise the code used toml setting.
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->
- Create toml config file with [rpc] ws-enabled = true
- Start node with toml config file, and no cli --ws flag and confim websocket server has started.
```

```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
