### PR TITLE
tests: add sync test that restarts nodes

### DIFF
--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -22,7 +22,7 @@ type StorageAPI interface {
 // BlockAPI is the interface for the block state
 type BlockAPI interface {
 	GetHeader(hash common.Hash) (*types.Header, error)
-	HighestBlockHash() common.Hash
+	BestBlockHash() common.Hash
 	GetBlockByHash(hash common.Hash) (*types.Block, error)
 	GetBlockHash(blockNumber *big.Int) (*common.Hash, error)
 	GetFinalizedHash(uint64) (common.Hash, error)

--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -108,7 +108,7 @@ func (cm *ChainModule) GetBlock(r *http.Request, req *ChainHashRequest, res *Cha
 func (cm *ChainModule) GetBlockHash(r *http.Request, req *ChainBlockNumberRequest, res *ChainHashResponse) error {
 	// if request is empty, return highest hash
 	if *req == nil || reflect.ValueOf(*req).Len() == 0 {
-		*res = cm.blockAPI.HighestBlockHash().String()
+		*res = cm.blockAPI.BestBlockHash().String()
 		return nil
 	}
 
@@ -185,7 +185,7 @@ func (cm *ChainModule) SubscribeNewHeads(r *http.Request, req *EmptyRequest, res
 
 func (cm *ChainModule) hashLookup(req *ChainHashRequest) (common.Hash, error) {
 	if len(*req) == 0 {
-		hash := cm.blockAPI.HighestBlockHash()
+		hash := cm.blockAPI.BestBlockHash()
 		return hash, nil
 	}
 	return common.HexToHash(string(*req))

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -3,6 +3,8 @@ package modules
 import (
 	"errors"
 	"net/http"
+
+	log "github.com/ChainSafe/log15"
 )
 
 var blockProducerStoppedMsg = "babe service stopped"

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -3,8 +3,6 @@ package modules
 import (
 	"errors"
 	"net/http"
-
-	log "github.com/ChainSafe/log15"
 )
 
 var blockProducerStoppedMsg = "babe service stopped"

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -80,7 +80,7 @@ type MockBlockAPI struct {
 func (m *MockBlockAPI) GetHeader(hash common.Hash) (*types.Header, error) {
 	return nil, nil
 }
-func (m *MockBlockAPI) HighestBlockHash() common.Hash {
+func (m *MockBlockAPI) BestBlockHash() common.Hash {
 	return common.Hash{}
 }
 func (m *MockBlockAPI) GetBlockByHash(hash common.Hash) (*types.Block, error) {

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -206,7 +206,7 @@ func TestSync_Restart(t *testing.T) {
 		}
 	}()
 
-	numCmps := 25
+	numCmps := 12
 	for i := 0; i < numCmps; i++ {
 		t.Log("comparing...", i)
 		err = compareBlocksByNumberWithRetry(t, nodes, strconv.Itoa(i))

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -18,6 +18,7 @@ package stress
 
 import (
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"strconv"
@@ -212,4 +213,57 @@ func TestSync_Restart(t *testing.T) {
 		require.NoError(t, err, i)
 		time.Sleep(time.Second)
 	}
+}
+
+func TestSync_Bench(t *testing.T) {
+	numNodes = 2
+	utils.SetLogLevel(log.LvlInfo)
+	numBlocks := 256
+
+	// start block producing node
+	// node produces 10 blocks / second
+	alice, err := utils.RunGossamer(t, 0, utils.TestDir(t, "alice"), utils.GenesisDefault, utils.ConfigBABEMaxThresholdBench)
+	require.NoError(t, err)
+	time.Sleep(time.Second*time.Duration(numBlocks/10) + time.Second)
+
+	err = utils.PauseBABE(t, alice)
+	require.NoError(t, err)
+	t.Log("BABE paused")
+
+	// start syncing node
+	bob, err := utils.RunGossamer(t, 1, utils.TestDir(t, "bob"), utils.GenesisDefault, utils.ConfigNoBABE)
+	require.NoError(t, err)
+	start := time.Now()
+
+	nodes := []*utils.Node{alice, bob}
+	defer func() {
+		errList := utils.StopNodes(t, nodes)
+		require.Len(t, errList, 0)
+	}()
+
+	// see how long it takes to sync to block 256
+	last := big.NewInt(int64(numBlocks))
+	var end time.Time
+
+	for {
+		head := utils.GetChainHead(t, bob)
+		if head.Number.Cmp(last) >= 0 {
+			end = time.Now()
+			break
+		}
+	}
+
+	maxTime := time.Second * 8
+	minBPS := float64(34)
+	totalTime := end.Sub(start)
+	bps := float64(numBlocks) / end.Sub(start).Seconds()
+	t.Log("total sync time:", totalTime)
+	t.Log("blocks per second:", bps)
+	require.LessOrEqual(t, int64(totalTime), int64(maxTime))
+	require.GreaterOrEqual(t, bps, minBPS)
+
+	// assert block is correct
+	t.Log("comparing block...", numBlocks)
+	err = compareBlocksByNumberWithRetry(t, nodes, strconv.Itoa(numBlocks))
+	require.NoError(t, err, numBlocks)
 }

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -55,7 +55,9 @@ func GetChainHead(t *testing.T, node *Node) *types.Header {
 // GetBlockHash calls the endpoint chain_getBlockHash to get the latest chain head
 func GetBlockHash(t *testing.T, node *Node, num string) (common.Hash, error) {
 	respBody, err := PostRPC(ChainGetBlockHash, NewEndpoint(node.RPCPort), "["+num+"]")
-	require.NoError(t, err)
+	if err != nil {
+		return common.Hash{}, err
+	}
 
 	var hash string
 	err = DecodeRPC(t, respBody, &hash)

--- a/tests/utils/config_babe_max_threshold_bench.toml
+++ b/tests/utils/config_babe_max_threshold_bench.toml
@@ -1,0 +1,36 @@
+[global]
+name = "gssmr"
+id = "gssmr"
+log = "crit"
+
+[log]
+babe = "info"
+sync = "debug"
+network = "debug"
+
+[init]
+genesis = "./chain/gssmr/genesis.json"
+
+[account]
+key = ""
+unlock = ""
+
+[core]
+authority = true
+roles = 4
+babe-authority = true
+grandpa-authority = true
+babe-threshold = "max"
+slot-duration = 100
+
+[network]
+bootnodes = []
+protocol = "/gossamer/gssmr/0"
+nobootstrap = false
+nomdns = false
+
+[rpc]
+enabled = false
+host = "localhost"
+modules = ["system", "author", "chain", "state"]
+ws-enabled = false

--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -16,21 +16,12 @@
 
 package utils
 
-//nolint
-var (
-	// CHAIN METHODS
-	ChainGetBlock                = "chain_getBlock"
-	ChainGetHeader               = "chain_getHeader"
-	ChainGetFinalizedHead        = "chain_getFinalizedHead"
-	ChainGetFinalizedHeadByRound = "chain_getFinalizedHeadByRound"
-	ChainGetBlockHash            = "chain_getBlockHash"
-
-	// AUTHOR METHODS
-	AuthorSubmitExtrinsic = "author_submitExtrinsic"
-
-	// STATE METHODS
-	StateGetStorage = "state_getStorage"
-
-	// DEV METHODS
-	DevControl = "dev_control"
+import (
+	"testing"
 )
+
+// PauseBABE calls the endpoint dev_control with the params ["babe", "stop"]
+func PauseBABE(t *testing.T, node *Node) error {
+	_, err := PostRPC(DevControl, NewEndpoint(node.RPCPort), "[\"babe\", \"stop\"]")
+	return err
+}

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -74,6 +74,8 @@ var (
 	ConfigNoBABE string = filepath.Join(currentDir, "../utils/config_nobabe.toml")
 	// ConfigBABEMaxThreshold is a config file with BABE threshold set to maximum (node can produce block every slot)
 	ConfigBABEMaxThreshold string = filepath.Join(currentDir, "../utils/config_babe_max_threshold.toml")
+	// ConfigBABEMaxThresholdBench is a config file with BABE threshold set to maximum (node can produce block every slot) with SlotDuration set to 100ms
+	ConfigBABEMaxThresholdBench string = filepath.Join(currentDir, "../utils/config_babe_max_threshold_bench.toml")
 )
 
 // Node represents a gossamer process
@@ -141,7 +143,7 @@ func StartGossamer(t *testing.T, node *Node) error {
 			"--rpchost", HOSTNAME,
 			"--rpcport", node.RPCPort,
 			"--ws=false",
-			"--rpcmods", "system,author,chain,state",
+			"--rpcmods", "system,author,chain,state,dev",
 			"--roles", "4", // authority node
 			"--rpc",
 			"--log", "crit",

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -304,7 +304,11 @@ func InitializeAndStartNodes(t *testing.T, num int, genesis, config string) ([]*
 
 	for i := 0; i < num; i++ {
 		go func(i int) {
-			node, err := RunGossamer(t, i, TestDir(t, keyList[i]), genesis, config)
+			name := strconv.Itoa(i)
+			if i < len(keyList) {
+				name = keyList[i]
+			}
+			node, err := RunGossamer(t, i, TestDir(t, name), genesis, config)
 			if err != nil {
 				logger.Error("failed to run gossamer", "i", i)
 			}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add sync test that randomly restarts nodes (both block producers and non-producers)
- add a test for many producers syncing, however it currently fails since nodes panic with `runtime: out of memory`. it seems like each node can't be connected to >=8 peers at once, we need to either put a cap on the # of peers a node can have or optimize the node more

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make it-stress
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #854