### PR TITLE
dot/rpc: dev rpc endpoint setAuthoities

### DIFF
--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -45,6 +45,7 @@ type NetworkAPI interface {
 type BlockProducerAPI interface {
 	Pause() error
 	Resume() error
+	SetAuthorities(a []*types.BABEAuthorityData)
 }
 
 // TransactionQueueAPI ...

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -54,3 +54,8 @@ func (m *DevModule) Control(r *http.Request, req *[]string, res *string) error {
 	}
 	return err
 }
+
+func (m *DevModule) SetAuthorities(r *http.Request, req *[]string, res *string) error {
+	m.blockProducerAPI.SetAuthorities(nil)
+	return nil
+}

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -77,6 +77,6 @@ func (m *DevModule) SetAuthorities(r *http.Request, req *[]interface{}, res *str
 		ab = append(ab, bd)
 	}
 	m.blockProducerAPI.SetAuthorities(ab)
-	*res = fmt.Sprintf("Set %v block producer authorities", len(ab))
+	*res = fmt.Sprintf("set %v block producer authorities", len(ab))
 	return nil
 }

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -2,7 +2,13 @@ package modules
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto"
+	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 )
 
 var blockProducerStoppedMsg = "babe service stopped"
@@ -55,7 +61,22 @@ func (m *DevModule) Control(r *http.Request, req *[]string, res *string) error {
 	return err
 }
 
-func (m *DevModule) SetAuthorities(r *http.Request, req *[]string, res *string) error {
-	m.blockProducerAPI.SetAuthorities(nil)
+// SetAuthorities dev rpc method that sets authorities for block producer
+func (m *DevModule) SetAuthorities(r *http.Request, req *[]interface{}, res *string) error {
+	ab := []*types.BABEAuthorityData{}
+	for _, v := range *req {
+		kb := crypto.PublicAddressToByteArray(common.Address(v.([]interface{})[0].(string)))
+		pk, err := sr25519.NewPublicKey(kb)
+		if err != nil {
+			return err
+		}
+		bd := &types.BABEAuthorityData{
+			ID:     pk,
+			Weight: uint64(v.([]interface{})[1].(float64)),
+		}
+		ab = append(ab, bd)
+	}
+	m.blockProducerAPI.SetAuthorities(ab)
+	*res = fmt.Sprintf("Set %v block producer authorities", len(ab))
 	return nil
 }

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -75,3 +75,13 @@ func TestDevControl_Network(t *testing.T) {
 	require.Equal(t, networkStartedMsg, res)
 	require.False(t, net.IsStopped())
 }
+
+func TestDevModule_SetAuthorities(t *testing.T) {
+	bs := newBABEService(t)
+	m := NewDevModule(bs, nil)
+	req := &[]interface{}{[]interface{}{"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", float64(1)}}
+	var res string
+	err := m.SetAuthorities(nil, req, &res)
+	require.NoError(t, err)
+	require.Equal(t, "set 1 block producer authorities", res)
+}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implement development rpc endpoint `dev_setAuthorities` used to update authorities set for block producer.  The params for this endpoint is an array containing public addresses and weight in the form:
```
[
      ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", 1],
      ["5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty", 1]
]
``` 
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/rpc/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #1022, still to complete handling for BABE Randomness, and BABE epoch. 
