### PR TITLE
dot/core, lib/babe: refactor VerificationManager to track changes by block, update verifier with runtime changes

### DIFF
--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -276,7 +276,7 @@ func buildSpecAction(ctx *cli.Context) error {
 		return fmt.Errorf("error building genesis")
 	}
 
-	res := []byte{}  //nolint
+	res := []byte{} //nolint
 	if ctx.Bool(RawFlag.Name) {
 		res, err = bs.ToJSONRaw()
 	} else {

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -105,3 +105,7 @@ type BlockProducer interface {
 	Authorities() []*types.BABEAuthorityData
 	SetAuthorities(a []*types.BABEAuthorityData)
 }
+
+type Verifier interface {
+	SetRuntimeChangeAtBlock(block *big.Int, rt *runtime.Runtime)
+}

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -108,5 +108,5 @@ type BlockProducer interface {
 
 // Verifier is the interface for the block verifier
 type Verifier interface {
-	SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime)
+	SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime) error
 }

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -106,6 +106,7 @@ type BlockProducer interface {
 	SetAuthorities(a []*types.BABEAuthorityData)
 }
 
+// Verifier is the interface for the block verifier
 type Verifier interface {
-	SetRuntimeChangeAtBlock(block *big.Int, rt *runtime.Runtime)
+	SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime)
 }

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -152,6 +152,7 @@ func NewService(cfg *Config) (*Service, error) {
 		blockProducer:           cfg.BlockProducer,
 		finalityGadget:          cfg.FinalityGadget,
 		consensusMessageHandler: cfg.ConsensusMessageHandler,
+		verifier:                cfg.Verifier,
 		isFinalityAuthority:     cfg.IsFinalityAuthority,
 		lock:                    &sync.Mutex{},
 	}
@@ -279,7 +280,7 @@ func (s *Service) handleReceivedBlock(block *types.Block) (err error) {
 		return err
 	}
 
-	return s.checkForRuntimeChanges()
+	return s.HandleRuntimeChanges(block.Header)
 }
 
 // handleReceivedMessage handles messages from the network service
@@ -308,8 +309,9 @@ func (s *Service) handleReceivedMessage(msg network.Message) (err error) {
 	return err
 }
 
-// checkForRuntimeChanges checks if changes to the runtime code have occurred; if so, load the new runtime
-func (s *Service) checkForRuntimeChanges() error {
+// HandleRuntimeChanges checks if changes to the runtime code have occurred; if so, load the new runtime
+// It also updates the BABE service and block verifier with the new runtime
+func (s *Service) HandleRuntimeChanges(header *types.Header) error {
 	currentCodeHash, err := s.storageState.LoadCodeHash()
 	if err != nil {
 		return err
@@ -341,6 +343,8 @@ func (s *Service) checkForRuntimeChanges() error {
 				return err
 			}
 		}
+
+		s.verifier.SetRuntimeChangeAtBlock(header, s.rt)
 	}
 
 	return nil

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -59,6 +59,9 @@ type Service struct {
 	isFinalityAuthority     bool
 	consensusMessageHandler ConsensusMessageHandler
 
+	// Block verification
+	verifier Verifier
+
 	// Keystore
 	keys *keystore.Keystore
 
@@ -85,6 +88,7 @@ type Config struct {
 	FinalityGadget          FinalityGadget
 	IsFinalityAuthority     bool
 	ConsensusMessageHandler ConsensusMessageHandler
+	Verifier                Verifier
 
 	NewBlocks     chan types.Block // only used for testing purposes
 	BabeThreshold *big.Int         // used by Verifier, for development purposes

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -344,7 +344,10 @@ func (s *Service) HandleRuntimeChanges(header *types.Header) error {
 			}
 		}
 
-		s.verifier.SetRuntimeChangeAtBlock(header, s.rt)
+		err = s.verifier.SetRuntimeChangeAtBlock(header, s.rt)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -111,7 +111,7 @@ func TestAnnounceBlock(t *testing.T) {
 	}
 }
 
-func TestCheckForRuntimeChanges(t *testing.T) {
+func TestHandleRuntimeChanges(t *testing.T) {
 	tt := trie.NewEmptyTrie()
 	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlTrace)
 
@@ -140,7 +140,7 @@ func TestCheckForRuntimeChanges(t *testing.T) {
 	err = s.storageState.SetStorage([]byte(":code"), testRuntime)
 	require.Nil(t, err)
 
-	err = s.checkForRuntimeChanges()
+	err = s.HandleRuntimeChanges(testGenesisHeader)
 	require.Nil(t, err)
 }
 

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -43,6 +43,12 @@ var testGenesisHeader = &types.Header{
 	StateRoot: trie.EmptyHash,
 }
 
+type mockVerifier struct{}
+
+func (v *mockVerifier) SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime) {
+	return
+}
+
 // mockBlockProducer implements the BlockProducer interface
 type mockBlockProducer struct {
 	auths []*types.BABEAuthorityData
@@ -171,6 +177,10 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 
 	if cfg.MsgSend == nil {
 		cfg.MsgSend = make(chan network.Message, 10)
+	}
+
+	if cfg.Verifier == nil {
+		cfg.Verifier = new(mockVerifier)
 	}
 
 	cfg.LogLvl = 3

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -45,8 +45,8 @@ var testGenesisHeader = &types.Header{
 
 type mockVerifier struct{}
 
-func (v *mockVerifier) SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime) {
-	return
+func (v *mockVerifier) SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime) error {
+	return nil
 }
 
 // mockBlockProducer implements the BlockProducer interface

--- a/dot/node.go
+++ b/dot/node.go
@@ -217,6 +217,11 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 		return nil, err
 	}
 
+	ver, err := createBlockVerifier(cfg, stateSrvc, rt)
+	if err != nil {
+		return nil, err
+	}
+
 	var bp BlockProducer
 	var fg core.FinalityGadget
 
@@ -240,7 +245,7 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 	}
 
 	// Syncer
-	syncer, err := createSyncService(cfg, stateSrvc, bp, fg, rt)
+	syncer, err := createSyncService(cfg, stateSrvc, bp, fg, ver, rt)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +253,7 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 	// Core Service
 
 	// create core service and append core service to node services
-	coreSrvc, err := createCoreService(cfg, bp, fg, rt, ks, stateSrvc, coreMsgs, networkMsgs)
+	coreSrvc, err := createCoreService(cfg, bp, fg, ver, rt, ks, stateSrvc, coreMsgs, networkMsgs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create core service: %s", err)
 	}

--- a/dot/services.go
+++ b/dot/services.go
@@ -364,7 +364,6 @@ func createBlockVerifier(cfg *Config, st *state.Service, rt *runtime.Runtime) (*
 		Threshold:     threshold,
 	}
 
-	// TODO: load current epoch from database chain head
 	ver, err := babe.NewVerificationManager(st.Block, descriptor)
 	if err != nil {
 		return nil, err

--- a/dot/services.go
+++ b/dot/services.go
@@ -165,7 +165,7 @@ func createBABEService(cfg *Config, rt *runtime.Runtime, st *state.Service, ks *
 // Core Service
 
 // createCoreService creates the core service from the provided core configuration
-func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt *runtime.Runtime, ks *keystore.Keystore, stateSrvc *state.Service, coreMsgs chan network.Message, networkMsgs chan network.Message) (*core.Service, error) {
+func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, verifier *babe.VerificationManager, rt *runtime.Runtime, ks *keystore.Keystore, stateSrvc *state.Service, coreMsgs chan network.Message, networkMsgs chan network.Message) (*core.Service, error) {
 	logger.Info(
 		"creating core service...",
 		"authority", cfg.Core.Authority,
@@ -198,6 +198,7 @@ func createCoreService(cfg *Config, bp BlockProducer, fg core.FinalityGadget, rt
 		MsgSend:                 coreMsgs,    // message channel from core service to network service
 		IsBlockProducer:         cfg.Core.BabeAuthority,
 		IsFinalityAuthority:     cfg.Core.GrandpaAuthority,
+		Verifier:                verifier,
 	}
 
 	// create new core service
@@ -330,18 +331,8 @@ func createGRANDPAService(cfg *Config, rt *runtime.Runtime, st *state.Service, k
 	return grandpa.NewService(gsCfg)
 }
 
-func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core.FinalityGadget, rt *runtime.Runtime) (*sync.Service, error) {
-	var dh *core.DigestHandler
-	var err error
-	if cfg.Core.BabeAuthority || cfg.Core.GrandpaAuthority {
-		dh, err = core.NewDigestHandler(st.Block, bp, fg)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+func createBlockVerifier(cfg *Config, st *state.Service, rt *runtime.Runtime) (*babe.VerificationManager, error) {
 	// load BABE verification data from runtime
-	// TODO: authority data may change
 	babeCfg, err := rt.BabeConfiguration()
 	if err != nil {
 		return nil, err
@@ -354,6 +345,7 @@ func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core
 
 	var threshold *big.Int
 	var ok bool
+	// TODO: remove config options, directly set storage values in genesis
 	if cfg.Core.BabeThreshold != nil {
 		threshold, ok = cfg.Core.BabeThreshold.(*big.Int)
 		if !ok {
@@ -366,19 +358,31 @@ func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core
 		}
 	}
 
-	descriptor := &babe.EpochDescriptor{
+	descriptor := &babe.Descriptor{
 		AuthorityData: ad,
 		Randomness:    babeCfg.Randomness,
 		Threshold:     threshold,
 	}
 
 	// TODO: load current epoch from database chain head
-	ver, err := babe.NewVerificationManager(st.Block, 1, descriptor)
+	ver, err := babe.NewVerificationManager(st.Block, descriptor)
 	if err != nil {
 		return nil, err
 	}
 
 	logger.Info("verifier", "threshold", threshold)
+	return ver, nil
+}
+
+func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core.FinalityGadget, verifier *babe.VerificationManager, rt *runtime.Runtime) (*sync.Service, error) {
+	var dh *core.DigestHandler
+	var err error
+	if cfg.Core.BabeAuthority || cfg.Core.GrandpaAuthority {
+		dh, err = core.NewDigestHandler(st.Block, bp, fg)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	lvl, err := log.LvlFromString(cfg.Log.SyncLvl)
 	if err != nil {
@@ -390,7 +394,7 @@ func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core
 		BlockState:       st.Block,
 		TransactionQueue: st.TransactionQueue,
 		BlockProducer:    bp,
-		Verifier:         ver,
+		Verifier:         verifier,
 		Runtime:          rt,
 		DigestHandler:    dh,
 	}

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -246,9 +246,9 @@ func (b *Service) GetBlockChannel() <-chan types.Block {
 	return b.blockChan
 }
 
-// Descriptor returns the EpochDescriptor for the current Service.
-func (b *Service) Descriptor() *EpochDescriptor {
-	return &EpochDescriptor{
+// Descriptor returns the Descriptor for the current Service.
+func (b *Service) Descriptor() *Descriptor {
+	return &Descriptor{
 		AuthorityData: b.authorityData,
 		Randomness:    b.randomness,
 		Threshold:     b.epochThreshold,

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -43,6 +43,7 @@ type BlockState interface {
 	HighestBlockHash() common.Hash
 	HighestBlockNumber() *big.Int
 	GetFinalizedHeader(uint64) (*types.Header, error)
+	IsDescendantOf(parent, child common.Hash) (bool, error)
 }
 
 // StorageState interface for storage state methods

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -47,19 +47,24 @@ type VerificationManager struct {
 	verifier *verifier // current chain head verifier TODO: remove, or keep historical verifiers
 }
 
-// NewVerificationManager returns a new VerificationManager
-func NewVerificationManager(blockState BlockState, rt *runtime.Runtime) (*VerificationManager, error) {
+// NewVerificationManagerFromRuntime returns a new VerificationManager
+func NewVerificationManagerFromRuntime(blockState BlockState, rt *runtime.Runtime) (*VerificationManager, error) {
+	descriptor, err := descriptorFromRuntime(rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewVerificationManager(blockState, descriptor)
+}
+
+// NewVerificationManager returns a new NewVerificationManager
+func NewVerificationManager(blockState BlockState, descriptor *Descriptor) (*VerificationManager, error) {
 	if blockState == nil {
 		return nil, ErrNilBlockState
 	}
 
 	descriptors := make(map[common.Hash]*Descriptor)
 	branches := make(map[int64][]common.Hash)
-
-	descriptor, err := descriptorFromRuntime(rt)
-	if err != nil {
-		return nil, err
-	}
 
 	// TODO: save VerificationManager in database when node shuts down, reload upon startup
 	descriptors[blockState.GenesisHash()] = descriptor

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -22,10 +22,12 @@ import (
 	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/runtime"
 )
 
-// EpochDescriptor contains the information needed to verify blocks within a BABE epoch
-type EpochDescriptor struct {
+// Descriptor contains the information needed to verify blocks
+type Descriptor struct {
 	AuthorityData []*types.BABEAuthorityData
 	Randomness    [RandomnessLength]byte
 	Threshold     *big.Int
@@ -34,142 +36,163 @@ type EpochDescriptor struct {
 // VerificationManager assists the syncer in keeping track of what epoch is it currently syncing and verifying,
 // as well as keeping track of the NextEpochDesciptor which is required to create a Verifier for an epoch.
 type VerificationManager struct {
-	epochDescriptors map[uint64]*EpochDescriptor
-	blockState       BlockState
-	// TODO: map of epochs to epoch length changes, for use in determining block epoch
-	// TODO: BABE should signal to the verifier when the epoch changes and send it the current EpochDescriptor
+	descriptors map[common.Hash]*Descriptor
+	branchNums  []int64                 // descending slice of branch numbers, for quicker access
+	branches    map[int64][]common.Hash // a map of block numbers -> block hashes, needed to check what chain a block is on when verifying ie. what descriptor to use
+	blockState  BlockState
+	// TODO: BABE should signal to the verifier when the epoch changes and send it the current Descriptor
+	// TODO: when a block is finalized, update branches/descriptors to delete any block data w/ number < finalized block number
 
 	// current epoch information
-	currentEpoch uint64
-	verifier     *epochVerifier // TODO: may need to keep historical verifiers
+	verifier *verifier // current chain head verifier TODO: remove, or keep historical verifiers
 }
 
 // NewVerificationManager returns a new VerificationManager
-func NewVerificationManager(blockState BlockState, currentEpoch uint64, descriptor *EpochDescriptor) (*VerificationManager, error) {
+func NewVerificationManager(blockState BlockState, rt *runtime.Runtime) (*VerificationManager, error) {
 	if blockState == nil {
 		return nil, ErrNilBlockState
 	}
 
-	verifier, err := newEpochVerifier(blockState, descriptor)
+	descriptors := make(map[common.Hash]*Descriptor)
+	branches := make(map[int64][]common.Hash)
+
+	descriptor, err := descriptorFromRuntime(rt)
 	if err != nil {
 		return nil, err
 	}
 
-	desciptors := make(map[uint64]*EpochDescriptor)
-	desciptors[currentEpoch] = descriptor
+	// TODO: save VerificationManager in database when node shuts down, reload upon startup
+	descriptors[blockState.GenesisHash()] = descriptor
+	branches[0] = []common.Hash{blockState.GenesisHash()}
+
+	verifier, err := newVerifier(blockState, descriptor)
+	if err != nil {
+		return nil, err
+	}
 
 	return &VerificationManager{
-		blockState:       blockState,
-		epochDescriptors: desciptors,
-		currentEpoch:     currentEpoch,
-		verifier:         verifier,
+		blockState:  blockState,
+		descriptors: descriptors,
+		branchNums:  []int64{0},
+		branches:    branches,
+		verifier:    verifier,
 	}, nil
+}
+
+// SetRuntimeChangeAtBlock sets a runtime change at the given block
+// Blocks that are descendants of this block will be verified using the given runtime
+func (v *VerificationManager) SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime) error {
+	descriptor, err := descriptorFromRuntime(rt)
+	if err != nil {
+		return err
+	}
+
+	v.setDescriptorChangeAtBlock(header, descriptor)
+	return nil
+}
+
+func (v *VerificationManager) setDescriptorChangeAtBlock(header *types.Header, descriptor *Descriptor) {
+	num := header.Number.Int64()
+	if v.branches[num] == nil {
+		v.branches[num] = []common.Hash{}
+	}
+
+	for i, bn := range v.branchNums {
+		if num < bn || i == len(v.branchNums)-1 {
+			pre := make([]int64, len(v.branchNums[:i]))
+			copy(pre, v.branchNums[:i])
+			post := make([]int64, len(v.branchNums[i:]))
+			copy(pre, v.branchNums[i:])
+			v.branchNums = append(append(pre, num), post...)
+			break
+		}
+	}
+
+	v.branches[num] = append(v.branches[num], header.Hash())
+	v.descriptors[header.Hash()] = descriptor
 }
 
 // VerifyBlock verifies the given header with verifyAuthorshipRight.
 func (v *VerificationManager) VerifyBlock(header *types.Header) (bool, error) {
-	epoch, err := v.getBlockEpoch(header)
-	if err != nil {
-		return false, err
-	}
+	var (
+		desc     *Descriptor
+		verifier *verifier
+		err      error
+	)
 
-	if epoch == v.currentEpoch {
-		return v.verifier.verifyAuthorshipRight(header)
-	}
+	// iterate through descending list of blocktree branches
+	for _, n := range v.branchNums {
 
-	if v.epochDescriptors[epoch] == nil {
-		// TODO: return an error here once updating of the verifier's epoch data is implemented
-		return v.verifier.verifyAuthorshipRight(header)
-	}
+		if header.Number.Int64() > n {
+			// get block hashes at most recent branch
+			brs := v.branches[n]
 
-	verifier, err := newEpochVerifier(v.blockState, v.epochDescriptors[epoch])
-	if err != nil {
-		return false, err
-	}
+			// check which branch this block is a descendant of
+			for _, hash := range brs {
+				// can only compare ParentHash, since current block isn't in blockState yet
+				if is, _ := v.blockState.IsDescendantOf(hash, header.ParentHash); is {
+					desc = v.descriptors[hash]
+					break
+				}
+			}
 
-	return verifier.verifyAuthorshipRight(header)
-}
-
-// getBlockEpoch gets the epoch number using the provided block hash
-func (v *VerificationManager) getBlockEpoch(header *types.Header) (epoch uint64, err error) {
-	// get slot number to determine epoch number
-	if len(header.Digest) == 0 {
-		return 0, fmt.Errorf("chain head missing digest")
-	}
-
-	preDigestBytes := header.Digest[0]
-
-	digestItem, err := types.DecodeDigestItem(preDigestBytes)
-	if err != nil {
-		return 0, err
-	}
-
-	preDigest, ok := digestItem.(*types.PreRuntimeDigest)
-	if !ok {
-		return 0, fmt.Errorf("first digest item is not pre-digest")
-	}
-
-	babeHeader := new(types.BabeHeader)
-	err = babeHeader.Decode(preDigest.Data)
-	if err != nil {
-		return 0, fmt.Errorf("cannot decode babe header from pre-digest: %s", err)
-	}
-
-	slot := babeHeader.SlotNumber
-
-	if slot != 0 {
-		// epoch number = (slot - genesis slot) / epoch length
-		epoch = (slot - 1) / 6 // TODO: use epoch length from babe or core config #762
-	}
-
-	return epoch, nil
-}
-
-// checkForConsensusDigest returns a consensus digest from the header, if it exists.
-func checkForConsensusDigest(header *types.Header) (*types.ConsensusDigest, error) {
-	// check if block header digest items exist
-	if header.Digest == nil || len(header.Digest) == 0 {
-		return nil, fmt.Errorf("header digest is not set")
-	}
-
-	// declare digest item
-	var consensusDigest *types.ConsensusDigest
-
-	// decode each digest item and check its type
-	for _, digest := range header.Digest {
-		item, err := types.DecodeDigestItem(digest)
-		if err != nil {
-			return nil, err
-		}
-
-		// check if digest item is consensus digest type
-		if item.Type() == types.ConsensusDigestType {
-			var ok bool
-			consensusDigest, ok = item.(*types.ConsensusDigest)
-			if ok {
+			if desc != nil {
 				break
 			}
 		}
 	}
 
-	return consensusDigest, nil
+	if desc == nil {
+		// we didn't find any data for the chain that this block is on, try to verify it with the current verifier anyways
+		verifier = v.verifier
+	} else {
+		verifier, err = newVerifier(v.blockState, desc)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return verifier.verifyAuthorshipRight(header)
 }
 
-// epochVerifier represents a BABE verifier for a specific epoch
-type epochVerifier struct {
+func descriptorFromRuntime(rt *runtime.Runtime) (*Descriptor, error) {
+	cfg, err := rt.BabeConfiguration()
+	if err != nil {
+		return nil, err
+	}
+
+	auths, err := types.BABEAuthorityDataRawToAuthorityData(cfg.GenesisAuthorities)
+	if err != nil {
+		return nil, err
+	}
+
+	threshold, err := CalculateThreshold(cfg.C1, cfg.C2, len(auths))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Descriptor{
+		AuthorityData: auths,
+		Randomness:    cfg.Randomness,
+		Threshold:     threshold,
+	}, nil
+}
+
+// verifier is a BABE verifier for a specific authority set, randomness, and threshold
+type verifier struct {
 	blockState    BlockState
 	authorityData []*types.BABEAuthorityData
 	randomness    [RandomnessLength]byte
 	threshold     *big.Int
 }
 
-// newEpochVerifier returns a Verifier for the epoch described by the given descriptor
-func newEpochVerifier(blockState BlockState, descriptor *EpochDescriptor) (*epochVerifier, error) {
+// newVerifier returns a Verifier for the epoch described by the given descriptor
+func newVerifier(blockState BlockState, descriptor *Descriptor) (*verifier, error) {
 	if blockState == nil {
 		return nil, ErrNilBlockState
 	}
 
-	return &epochVerifier{
+	return &verifier{
 		blockState:    blockState,
 		authorityData: descriptor.AuthorityData,
 		randomness:    descriptor.Randomness,
@@ -178,7 +201,7 @@ func newEpochVerifier(blockState BlockState, descriptor *EpochDescriptor) (*epoc
 }
 
 // verifySlotWinner verifies the claim for a slot, given the BabeHeader for that slot.
-func (b *epochVerifier) verifySlotWinner(slot uint64, header *types.BabeHeader) (bool, error) {
+func (b *verifier) verifySlotWinner(slot uint64, header *types.BabeHeader) (bool, error) {
 	if len(b.authorityData) <= int(header.BlockProducerIndex) {
 		return false, fmt.Errorf("no authority data for index %d", header.BlockProducerIndex)
 	}
@@ -200,7 +223,7 @@ func (b *epochVerifier) verifySlotWinner(slot uint64, header *types.BabeHeader) 
 }
 
 // verifyAuthorshipRight verifies that the authority that produced a block was authorized to produce it.
-func (b *epochVerifier) verifyAuthorshipRight(header *types.Header) (bool, error) {
+func (b *verifier) verifyAuthorshipRight(header *types.Header) (bool, error) {
 	// header should have 2 digest items (possibly more in the future)
 	// first item should be pre-digest, second should be seal
 	if len(header.Digest) < 2 {

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -112,7 +112,7 @@ func (v *VerificationManager) setDescriptorChangeAtBlock(header *types.Header, d
 			pre := make([]int64, len(v.branchNums[:i]))
 			copy(pre, v.branchNums[:i])
 			post := make([]int64, len(v.branchNums[i:]))
-			copy(pre, v.branchNums[i:])
+			copy(post, v.branchNums[i:])
 			v.branchNums = append(append(pre, num), post...)
 			break
 		}

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -49,7 +49,7 @@ func newTestVerificationManager(t *testing.T, descriptor *Descriptor) *Verificat
 	err = dbSrv.Start()
 	require.NoError(t, err)
 
-	vm, err := NewVerificationManager(dbSrv.Block, rt)
+	vm, err := NewVerificationManagerFromRuntime(dbSrv.Block, rt)
 	require.NoError(t, err)
 
 	if descriptor != nil {
@@ -129,7 +129,6 @@ func TestVerificationManager_VerifyBlock_Branches(t *testing.T) {
 
 	// create and verify block that's descendant of block B, should verify
 	block, _ := createTestBlock(t, babeService, block1b, [][]byte{})
-	//err = vm.blockState.AddBlock(block)
 	require.NoError(t, err)
 
 	ok, err := vm.VerifyBlock(block.Header)
@@ -139,7 +138,6 @@ func TestVerificationManager_VerifyBlock_Branches(t *testing.T) {
 	// create and verify block that's descendant of block A, should verify
 	babeService.randomness = randomnessA
 	block, _ = createTestBlock(t, babeService, block1a, [][]byte{})
-	//err = vm.blockState.AddBlock(block)
 	require.NoError(t, err)
 
 	ok, err = vm.VerifyBlock(block.Header)

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -28,125 +28,35 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/trie"
 
 	log "github.com/ChainSafe/log15"
 )
 
-func newTestVerificationManager(t *testing.T, withBlock bool, epoch uint64, descriptor *EpochDescriptor) *VerificationManager {
+func newTestVerificationManager(t *testing.T, descriptor *Descriptor) *VerificationManager {
 	dbSrv := state.NewService("", log.LvlInfo)
 	dbSrv.UseMemDB()
+
+	tt := trie.NewEmptyTrie()
+	rt := runtime.NewTestRuntimeWithTrie(t, runtime.NODE_RUNTIME, tt, log.LvlCrit)
 
 	genesisData := new(genesis.Data)
 
 	err := dbSrv.Initialize(genesisData, genesisHeader, trie.NewEmptyTrie())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = dbSrv.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if descriptor == nil {
-		descriptor = &EpochDescriptor{}
-	}
+	vm, err := NewVerificationManager(dbSrv.Block, rt)
+	require.NoError(t, err)
 
-	vm, err := NewVerificationManager(dbSrv.Block, epoch, descriptor)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if withBlock {
-		// preDigest with slot in epoch testEpoch = 2
-		// TODO: use BABE functions to do calculate pre-digest dynamically
-		preDigest, err := common.HexToBytes("0x064241424538e93dcef2efc275b72b4fa748332dc4c9f13be1125909cf90c8e9109c45da16b04bc5fdf9fe06a4f35e4ae4ed7e251ff9ee3d0d840c8237c9fb9057442dbf00f210d697a7b4959f792a81b948ff88937e30bf9709a8ab1314f71284da89a40000000000000000001100000000000000")
-		require.Nil(t, err)
-
-		nextEpochData := &NextEpochDescriptor{
-			Authorities: []*types.BABEAuthorityData{},
-		}
-
-		consensusDigest := &types.ConsensusDigest{
-			ConsensusEngineID: types.BabeEngineID,
-			Data:              nextEpochData.Encode(),
-		}
-
-		conDigest := consensusDigest.Encode()
-
-		header := &types.Header{
-			ParentHash: genesisHeader.Hash(),
-			Number:     big.NewInt(1),
-			Digest:     [][]byte{preDigest, conDigest},
-		}
-
-		firstBlock := &types.Block{
-			Header: header,
-			Body:   &types.Body{},
-		}
-
-		err = vm.blockState.AddBlock(firstBlock)
-		require.Nil(t, err)
+	if descriptor != nil {
+		vm.descriptors[dbSrv.Block.GenesisHash()] = descriptor
 	}
 
 	return vm
-}
-
-func TestGetBlockEpoch(t *testing.T) {
-	vm := newTestVerificationManager(t, true, 2, nil)
-
-	header, err := vm.blockState.BestBlockHeader()
-	require.Nil(t, err)
-
-	epoch, err := vm.getBlockEpoch(header)
-	require.Nil(t, err)
-
-	require.Equal(t, vm.currentEpoch, epoch)
-}
-
-func TestCheckForConsensusDigest_NoDigest(t *testing.T) {
-	header := &types.Header{
-		ParentHash: genesisHeader.Hash(),
-		Number:     big.NewInt(1),
-	}
-
-	_, err := checkForConsensusDigest(header)
-	require.NotNil(t, err)
-}
-
-func TestCheckForConsensusDigest_NoConsensusDigest(t *testing.T) {
-	vm := newTestVerificationManager(t, true, 2, nil)
-
-	header, err := vm.blockState.BestBlockHeader()
-	require.Nil(t, err)
-
-	header.Digest = header.Digest[:1]
-
-	digest, err := checkForConsensusDigest(header)
-	require.Nil(t, err)
-	require.Nil(t, digest)
-}
-
-func TestCheckForConsensusDigest(t *testing.T) {
-	vm := newTestVerificationManager(t, true, 2, nil)
-
-	header, err := vm.blockState.BestBlockHeader()
-	require.Nil(t, err)
-
-	digest, err := checkForConsensusDigest(header)
-	require.Nil(t, err)
-
-	nextEpochData := &NextEpochDescriptor{
-		Authorities: []*types.BABEAuthorityData{},
-	}
-
-	expected := &types.ConsensusDigest{
-		ConsensusEngineID: types.BabeEngineID,
-		Data:              nextEpochData.Encode(),
-	}
-
-	require.Equal(t, expected, digest)
 }
 
 func TestVerificationManager_VerifyBlock(t *testing.T) {
@@ -155,14 +65,85 @@ func TestVerificationManager_VerifyBlock(t *testing.T) {
 	})
 	descriptor := babeService.Descriptor()
 
-	vm := newTestVerificationManager(t, false, 0, descriptor)
+	vm := newTestVerificationManager(t, descriptor)
 
 	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
 	err := vm.blockState.AddBlock(block)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ok, err := vm.VerifyBlock(block.Header)
-	require.Nil(t, err)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+}
+
+func TestVerificationManager_VerifyBlock_Branches(t *testing.T) {
+	babeService := createTestService(t, &ServiceConfig{
+		EpochThreshold: maxThreshold,
+	})
+	descriptor := babeService.Descriptor()
+
+	block1a := &types.Header{
+		Number:     big.NewInt(1),
+		ParentHash: babeService.blockState.GenesisHash(),
+	}
+
+	block1b := &types.Header{
+		ExtrinsicsRoot: common.Hash{0x8},
+		Number:         big.NewInt(1),
+		ParentHash:     babeService.blockState.GenesisHash(),
+	}
+
+	vm := newTestVerificationManager(t, descriptor)
+	err := babeService.blockState.AddBlock(&types.Block{
+		Header: block1a,
+		Body:   &types.Body{},
+	})
+	require.NoError(t, err)
+	err = babeService.blockState.AddBlock(&types.Block{
+		Header: block1b,
+		Body:   &types.Body{},
+	})
+	require.NoError(t, err)
+	err = vm.blockState.AddBlock(&types.Block{
+		Header: block1a,
+		Body:   &types.Body{},
+	})
+	require.NoError(t, err)
+	err = vm.blockState.AddBlock(&types.Block{
+		Header: block1b,
+		Body:   &types.Body{},
+	})
+	require.NoError(t, err)
+
+	// create a branch at block 1 on chain A
+	randomnessA := [RandomnessLength]byte{0x77}
+
+	descriptorA := &Descriptor{
+		AuthorityData: descriptor.AuthorityData,
+		Randomness:    randomnessA,
+		Threshold:     maxThreshold,
+	}
+
+	vm.setDescriptorChangeAtBlock(block1a, descriptorA)
+	require.Equal(t, []int64{1, 0}, vm.branchNums)
+
+	// create and verify block that's descendant of block B, should verify
+	block, _ := createTestBlock(t, babeService, block1b, [][]byte{})
+	//err = vm.blockState.AddBlock(block)
+	require.NoError(t, err)
+
+	ok, err := vm.VerifyBlock(block.Header)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+
+	// create and verify block that's descendant of block A, should verify
+	babeService.randomness = randomnessA
+	block, _ = createTestBlock(t, babeService, block1a, [][]byte{})
+	//err = vm.blockState.AddBlock(block)
+	require.NoError(t, err)
+
+	ok, err = vm.VerifyBlock(block.Header)
+	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
 
@@ -203,8 +184,7 @@ func TestVerifySlotWinner(t *testing.T) {
 	}
 	babeService.authorityData = authorityData
 
-	verifier, err := newEpochVerifier(babeService.blockState, babeService.Descriptor())
-
+	verifier, err := newVerifier(babeService.blockState, babeService.Descriptor())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +203,7 @@ func TestVerifyAuthorshipRight(t *testing.T) {
 	babeService := createTestService(t, nil)
 	block, _ := createTestBlock(t, babeService, genesisHeader, [][]byte{})
 
-	verifier, err := newEpochVerifier(babeService.blockState, babeService.Descriptor())
+	verifier, err := newVerifier(babeService.blockState, babeService.Descriptor())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +244,7 @@ func TestVerifyAuthorshipRight_Equivocation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	verifier, err := newEpochVerifier(babeService.blockState, babeService.Descriptor())
+	verifier, err := newVerifier(babeService.blockState, babeService.Descriptor())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `VerificationManager` to track changes in verification data via block (ie. by hash, so when verifying a block, it uses the data from the most recent descendant it has)
- update `core.checkForRuntimeChanges` to notify `VerificationManager` if there is a runtime change
- update dot startup as needed

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/babe ./dot/... 
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #762 closes #1023