### PR TITLE
dot/core, lib/babe: add SetAuthorityChangeAtBlock to verifier, set change through digestHandler

### DIFF
--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -55,7 +55,7 @@ func newTestDigestHandler(t *testing.T, withBABE, withGrandpa bool) *DigestHandl
 	}
 
 	time.Sleep(time.Second)
-	dh, err := NewDigestHandler(stateSrvc.Block, bp, fg)
+	dh, err := NewDigestHandler(stateSrvc.Block, bp, fg, &mockVerifier{})
 	require.NoError(t, err)
 	return dh
 }

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -109,4 +109,5 @@ type BlockProducer interface {
 // Verifier is the interface for the block verifier
 type Verifier interface {
 	SetRuntimeChangeAtBlock(header *types.Header, rt *runtime.Runtime) error
+	SetAuthorityChangeAtBlock(header *types.Header, authorities []*types.BABEAuthorityData)
 }

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -49,6 +49,10 @@ func (v *mockVerifier) SetRuntimeChangeAtBlock(header *types.Header, rt *runtime
 	return nil
 }
 
+func (v *mockVerifier) SetAuthorityChangeAtBlock(header *types.Header, auths []*types.BABEAuthorityData) {
+
+}
+
 // mockBlockProducer implements the BlockProducer interface
 type mockBlockProducer struct {
 	auths []*types.BABEAuthorityData

--- a/dot/services.go
+++ b/dot/services.go
@@ -377,7 +377,7 @@ func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core
 	var dh *core.DigestHandler
 	var err error
 	if cfg.Core.BabeAuthority || cfg.Core.GrandpaAuthority {
-		dh, err = core.NewDigestHandler(st.Block, bp, fg)
+		dh, err = core.NewDigestHandler(st.Block, bp, fg, verifier)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `SetAuthorityChangeAtBlock` to verifier
- update `digestHandler` to call verifier on authority change
- update service initialization

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #997