### PR TITLE
lib/babe, dot/rpc Implement dev rpc endpoint dev_set BABEEpochThreshold

### DIFF
--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -104,6 +104,7 @@ type BlockProducer interface {
 	SetRuntime(*runtime.Runtime) error
 	Authorities() []*types.BABEAuthorityData
 	SetAuthorities(a []*types.BABEAuthorityData) error
+	SetEpochThreshold(a *big.Int)
 }
 
 // Verifier is the interface for the block verifier

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -57,7 +57,7 @@ func (v *mockVerifier) SetAuthorityChangeAtBlock(header *types.Header, auths []*
 type mockBlockProducer struct {
 	auths          []*types.BABEAuthorityData
 	epochThreshold *big.Int
-	randomness [32]byte
+	randomness     [babe.RandomnessLength]byte
 }
 
 // Start mocks starting

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/trie"
-
 	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +54,8 @@ func (v *mockVerifier) SetAuthorityChangeAtBlock(header *types.Header, auths []*
 
 // mockBlockProducer implements the BlockProducer interface
 type mockBlockProducer struct {
-	auths []*types.BABEAuthorityData
+	auths          []*types.BABEAuthorityData
+	epochThreshold *big.Int
 }
 
 // Start mocks starting
@@ -75,6 +75,10 @@ func (bp *mockBlockProducer) Authorities() []*types.BABEAuthorityData {
 func (bp *mockBlockProducer) SetAuthorities(a []*types.BABEAuthorityData) error {
 	bp.auths = a
 	return nil
+}
+
+func (bp *mockBlockProducer) SetEpochThreshold(a *big.Int) {
+	bp.epochThreshold = a
 }
 
 // GetBlockChannel returns a new channel

--- a/dot/interface.go
+++ b/dot/interface.go
@@ -1,6 +1,8 @@
 package dot
 
 import (
+	"math/big"
+
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/services"
@@ -16,4 +18,5 @@ type BlockProducer interface {
 	Resume() error
 	Authorities() []*types.BABEAuthorityData
 	SetAuthorities(a []*types.BABEAuthorityData) error
+	SetEpochThreshold(a *big.Int)
 }

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -46,6 +46,7 @@ type BlockProducerAPI interface {
 	Pause() error
 	Resume() error
 	SetAuthorities(data []*types.BABEAuthorityData) error
+	SetEpochThreshold(a *big.Int)
 }
 
 // TransactionQueueAPI ...

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -80,4 +81,16 @@ func (m *DevModule) SetBlockProducerAuthorities(r *http.Request, req *[]interfac
 	err := m.blockProducerAPI.SetAuthorities(ab)
 	*res = fmt.Sprintf("set %v block producer authorities", len(ab))
 	return err
+}
+
+// SetBABEEpochThreshold dev rpc method that sets BABE Epoch Threshold of the BABE Producer
+func (m *DevModule) SetBABEEpochThreshold(r *http.Request, req *string, res *string) error {
+	n := new(big.Int)
+	n, ok := n.SetString(*req, 10)
+	if !ok {
+		return fmt.Errorf("error setting threshold")
+	}
+	m.blockProducerAPI.SetEpochThreshold(n)
+	*res = fmt.Sprintf("set BABE Epoch Threshold to %v", n)
+	return nil
 }

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -103,3 +103,14 @@ func TestDevModule_SetBlockProducerAuthorities_NotFound(t *testing.T) {
 	// authorities before and after should be equal since they should not have changed (due to key error)
 	require.Equal(t, aBefore, aAfter)
 }
+
+func TestDevModule_SetBABEEpochThreshold(t *testing.T) {
+	bs := newBABEService(t)
+	m := NewDevModule(bs, nil)
+	req := "123"
+	var res string
+	err := m.SetBABEEpochThreshold(nil, &req, &res)
+	require.NoError(t, err)
+
+	require.Equal(t, "set BABE Epoch Threshold to 123", res)
+}

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -278,6 +278,11 @@ func (b *Service) SetAuthorities(data []*types.BABEAuthorityData) error {
 	return b.setAuthorityIndex()
 }
 
+// SetEpochThreshold sets Epoch Threshold for BABE producer
+func (b *Service) SetEpochThreshold(a *big.Int) {
+	b.epochThreshold = a
+}
+
 // SetEpochData will set the authorityData and randomness
 func (b *Service) SetEpochData(data *NextEpochDescriptor) error {
 	b.authorityData = data.Authorities

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -342,3 +342,15 @@ func TestService_SetAuthorities_WrongKey(t *testing.T) {
 	// auths before should equal auths after since there is an error with key, auths should not change
 	require.Equal(t, aBefore, aAfter)
 }
+
+func TestService_SetEpochThreshold(t *testing.T) {
+	bs := createTestService(t, &ServiceConfig{})
+	etBefore := bs.epochThreshold
+	newThreshold := big.NewInt(1000)
+
+	bs.SetEpochThreshold(newThreshold)
+
+	etAfter := bs.epochThreshold
+	require.NotEqual(t, etBefore, etAfter)
+	require.Equal(t, newThreshold, etAfter)
+}

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -342,7 +342,6 @@ func TestService_SetAuthorities_WrongKey(t *testing.T) {
 	require.Equal(t, aBefore, aAfter)
 }
 
-
 func TestService_SetEpochThreshold(t *testing.T) {
 	bs := createTestService(t, &ServiceConfig{})
 	etBefore := bs.epochThreshold


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implemented development rpc endpoint `dev_setBABEEpochThreshold` to set Epoch Threshold value for BABE producer.
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/babe/...
go test ./dot/rpc/...

```
Or interact directly with rpc endpoint with call as follows:
```
{
    "jsonrpc": "2.0",
    "method": "dev_setBABEEpochThreshold",
    "params": ["123"],
    "id": 1
}
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1022 
