### PR TITLE
lib/grandpa, dot/core: update grandpa not to vote on block higher than next scheduled authority change

### DIFF
--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -25,6 +25,8 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
+var maxUint64 = uint64(2^64) - 1
+
 // DigestHandler is used to handle consensus messages and relevant authority updates to BABE and GRANDPA
 type DigestHandler struct {
 	// interfaces
@@ -128,7 +130,7 @@ func (h *DigestHandler) Stop() {
 // NextGrandpaAuthorityChange returns the block number of the next upcoming grandpa authorities change.
 // It returns 0 if no change is scheduled.
 func (h *DigestHandler) NextGrandpaAuthorityChange() uint64 {
-	next := uint64(0)
+	next := maxUint64
 
 	if h.grandpaScheduledChange != nil {
 		next = h.grandpaScheduledChange.atBlock.Uint64()

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -141,15 +141,15 @@ func (h *DigestHandler) NextGrandpaAuthorityChange() uint64 {
 		next = h.grandpaScheduledChange.atBlock.Uint64()
 	}
 
-	if h.grandpaForcedChange != nil && h.grandpaForcedChange.atBlock.Uint64() > next {
+	if h.grandpaForcedChange != nil && h.grandpaForcedChange.atBlock.Uint64() < next {
 		next = h.grandpaForcedChange.atBlock.Uint64()
 	}
 
-	if h.grandpaPause != nil && h.grandpaPause.atBlock.Uint64() > next {
+	if h.grandpaPause != nil && h.grandpaPause.atBlock.Uint64() < next {
 		next = h.grandpaPause.atBlock.Uint64()
 	}
 
-	if h.grandpaResume != nil && h.grandpaResume.atBlock.Uint64() > next {
+	if h.grandpaResume != nil && h.grandpaResume.atBlock.Uint64() < next {
 		next = h.grandpaResume.atBlock.Uint64()
 	}
 

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -125,6 +125,30 @@ func (h *DigestHandler) Stop() {
 	close(h.finalized)
 }
 
+// NextGrandpaAuthorityChange returns the block number of the next upcoming grandpa authorities change.
+// It returns 0 if no change is scheduled.
+func (h *DigestHandler) NextGrandpaAuthorityChange() uint64 {
+	next := uint64(0)
+
+	if h.grandpaScheduledChange != nil {
+		next = h.grandpaScheduledChange.atBlock.Uint64()
+	}
+
+	if h.grandpaForcedChange != nil && h.grandpaForcedChange.atBlock.Uint64() > next {
+		next = h.grandpaForcedChange.atBlock.Uint64()
+	}
+
+	if h.grandpaPause != nil && h.grandpaPause.atBlock.Uint64() > next {
+		next = h.grandpaPause.atBlock.Uint64()
+	}
+
+	if h.grandpaResume != nil && h.grandpaResume.atBlock.Uint64() > next {
+		next = h.grandpaResume.atBlock.Uint64()
+	}
+
+	return next
+}
+
 // HandleConsensusDigest is the function used by the syncer to handle a consensus digest
 func (h *DigestHandler) HandleConsensusDigest(d *types.ConsensusDigest) error {
 	t := d.DataType()

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -127,6 +127,11 @@ func (h *DigestHandler) Stop() {
 	close(h.finalized)
 }
 
+// SetFinalityGadget sets the digest handler's grandpa instance
+func (h *DigestHandler) SetFinalityGadget(grandpa FinalityGadget) {
+	h.grandpa = grandpa
+}
+
 // NextGrandpaAuthorityChange returns the block number of the next upcoming grandpa authorities change.
 // It returns 0 if no change is scheduled.
 func (h *DigestHandler) NextGrandpaAuthorityChange() uint64 {

--- a/dot/core/digest_test.go
+++ b/dot/core/digest_test.go
@@ -440,3 +440,72 @@ func TestDigestHandler_GrandpaPauseAndResume(t *testing.T) {
 	auths = handler.grandpa.Authorities()
 	require.Equal(t, 1, len(auths))
 }
+
+func TestNextGrandpaAuthorityChange_OneChange(t *testing.T) {
+	handler := newTestDigestHandler(t, false, true)
+	handler.Start()
+	defer handler.Stop()
+
+	block := uint32(3)
+	sc := &types.GrandpaScheduledChange{
+		Auths: []*types.GrandpaAuthorityDataRaw{},
+		Delay: block,
+	}
+
+	data, err := sc.Encode()
+	require.NoError(t, err)
+
+	d := &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.HandleConsensusDigest(d)
+	require.NoError(t, err)
+
+	next := handler.NextGrandpaAuthorityChange()
+	require.Equal(t, uint64(block), next)
+}
+
+func TestNextGrandpaAuthorityChange_MultipleChanges(t *testing.T) {
+	handler := newTestDigestHandler(t, false, true)
+	handler.Start()
+	defer handler.Stop()
+
+	later := uint32(5)
+	sc := &types.GrandpaScheduledChange{
+		Auths: []*types.GrandpaAuthorityDataRaw{},
+		Delay: later,
+	}
+
+	data, err := sc.Encode()
+	require.NoError(t, err)
+
+	d := &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.HandleConsensusDigest(d)
+	require.NoError(t, err)
+
+	earlier := uint32(3)
+	fc := &types.GrandpaForcedChange{
+		Auths: []*types.GrandpaAuthorityDataRaw{},
+		Delay: earlier,
+	}
+
+	data, err = fc.Encode()
+	require.NoError(t, err)
+
+	d = &types.ConsensusDigest{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              data,
+	}
+
+	err = handler.HandleConsensusDigest(d)
+	require.NoError(t, err)
+
+	next := handler.NextGrandpaAuthorityChange()
+	require.Equal(t, uint64(earlier), next)
+}

--- a/dot/node.go
+++ b/dot/node.go
@@ -268,17 +268,24 @@ func NewNode(cfg *Config, ks *keystore.Keystore) (*Node, error) {
 		nodeSrvcs = append(nodeSrvcs, bp)
 	}
 
+	dh, err := createDigestHandler(stateSrvc, bp, fg, ver)
+	if err != nil {
+		return nil, err
+	}
+
 	if cfg.Core.GrandpaAuthority {
 		// create GRANDPA service
-		fg, err = createGRANDPAService(cfg, rt, stateSrvc, ks)
+		fg, err = createGRANDPAService(cfg, rt, stateSrvc, dh, ks)
 		if err != nil {
 			return nil, err
 		}
 		nodeSrvcs = append(nodeSrvcs, fg)
 	}
 
+	dh.SetFinalityGadget(fg)
+
 	// Syncer
-	syncer, err := createSyncService(cfg, stateSrvc, bp, fg, ver, rt)
+	syncer, err := createSyncService(cfg, stateSrvc, bp, dh, ver, rt)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/services.go
+++ b/dot/services.go
@@ -304,7 +304,7 @@ func createSystemService(cfg *types.SystemInfo) *system.Service {
 }
 
 // createGRANDPAService creates a new GRANDPA service
-func createGRANDPAService(cfg *Config, rt *runtime.Runtime, st *state.Service, ks *keystore.Keystore) (*grandpa.Service, error) {
+func createGRANDPAService(cfg *Config, rt *runtime.Runtime, st *state.Service, dh *core.DigestHandler, ks *keystore.Keystore) (*grandpa.Service, error) {
 	ad, err := rt.GrandpaAuthorities()
 	if err != nil {
 		return nil, err
@@ -323,10 +323,11 @@ func createGRANDPAService(cfg *Config, rt *runtime.Runtime, st *state.Service, k
 	}
 
 	gsCfg := &grandpa.Config{
-		LogLvl:     lvl,
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    keys[0].(*ed25519.Keypair),
+		LogLvl:        lvl,
+		BlockState:    st.Block,
+		DigestHandler: dh,
+		Voters:        voters,
+		Keypair:       keys[0].(*ed25519.Keypair),
 	}
 
 	return grandpa.NewService(gsCfg)
@@ -374,16 +375,7 @@ func createBlockVerifier(cfg *Config, st *state.Service, rt *runtime.Runtime) (*
 	return ver, nil
 }
 
-func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core.FinalityGadget, verifier *babe.VerificationManager, rt *runtime.Runtime) (*sync.Service, error) {
-	var dh *core.DigestHandler
-	var err error
-	if cfg.Core.BabeAuthority || cfg.Core.GrandpaAuthority {
-		dh, err = core.NewDigestHandler(st.Block, bp, fg, verifier)
-		if err != nil {
-			return nil, err
-		}
-	}
-
+func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, dh *core.DigestHandler, verifier *babe.VerificationManager, rt *runtime.Runtime) (*sync.Service, error) {
 	lvl, err := log.LvlFromString(cfg.Log.SyncLvl)
 	if err != nil {
 		return nil, err
@@ -400,4 +392,8 @@ func createSyncService(cfg *Config, st *state.Service, bp BlockProducer, fg core
 	}
 
 	return sync.NewService(syncCfg)
+}
+
+func createDigestHandler(st *state.Service, bp BlockProducer, fg core.FinalityGadget, verifier *babe.VerificationManager) (*core.DigestHandler, error) {
+	return core.NewDigestHandler(st.Block, bp, fg, verifier)
 }

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -262,20 +262,23 @@ func TestCreateGrandpaService(t *testing.T) {
 	cfg.Init.GenesisRaw = genFile.Name()
 
 	err := InitNode(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	stateSrvc, err := createStateService(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ks := keystore.NewKeystore()
 	kr, err := keystore.NewEd25519Keyring()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	ks.Insert(kr.Alice)
 
 	rt, err := createRuntime(cfg, stateSrvc, ks)
 	require.NoError(t, err)
 
-	gs, err := createGRANDPAService(cfg, rt, stateSrvc, ks)
+	dh, err := createDigestHandler(stateSrvc, nil, nil, nil)
+	require.NoError(t, err)
+
+	gs, err := createGRANDPAService(cfg, rt, stateSrvc, dh, ks)
 	require.NoError(t, err)
 	require.NotNil(t, gs)
 }

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -25,6 +25,9 @@ import (
 // ErrNilBlockState is returned when BlockState is nil
 var ErrNilBlockState = errors.New("cannot have nil BlockState")
 
+// ErrNilDigestHandler is returned when DigestHandler is nil
+var ErrNilDigestHandler = errors.New("cannot have nil DigestHandler")
+
 // ErrNilKeypair is returned when the keypair is nil
 var ErrNilKeypair = errors.New("cannot have nil keypair")
 

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -469,7 +469,6 @@ func (s *Service) determinePreVote() (*Vote, error) {
 	}
 
 	nextChange := s.digestHandler.NextGrandpaAuthorityChange()
-	s.logger.Info("determinePreVote", "nextChange", nextChange, "vote.number", vote.number)
 	if vote.number > nextChange {
 		header, err := s.blockState.GetHeaderByNumber(big.NewInt(int64(nextChange)))
 		if err != nil {
@@ -489,8 +488,6 @@ func (s *Service) determinePreCommit() (*Vote, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	s.logger.Info("determinePreCommit", "pvb", pvb)
 
 	nextChange := s.digestHandler.NextGrandpaAuthorityChange()
 	if pvb.number > nextChange {

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -49,7 +49,7 @@ var firstEpochInfo = &types.EpochInfo{
 type mockDigestHandler struct{}
 
 func (h *mockDigestHandler) NextGrandpaAuthorityChange() uint64 {
-	return 0
+	return 2 ^ 64 - 1
 }
 
 func newTestState(t *testing.T) *state.Service {

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -46,6 +46,12 @@ var firstEpochInfo = &types.EpochInfo{
 	FirstBlock: 0,
 }
 
+type mockDigestHandler struct{}
+
+func (h *mockDigestHandler) NextGrandpaAuthorityChange() uint64 {
+	return 0
+}
+
 func newTestState(t *testing.T) *state.Service {
 	stateSrvc := state.NewService("", log.LvlInfo)
 	stateSrvc.UseMemDB()
@@ -83,9 +89,10 @@ func TestUpdateAuthorities(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -119,9 +126,10 @@ func TestGetDirectVotes(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -160,9 +168,10 @@ func TestGetVotesForBlock_NoDescendantVotes(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -205,9 +214,10 @@ func TestGetVotesForBlock_DescendantVotes(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -262,9 +272,10 @@ func TestGetPossibleSelectedAncestors_SameAncestor(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -323,9 +334,10 @@ func TestGetPossibleSelectedAncestors_VaryingAncestor(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -389,9 +401,10 @@ func TestGetPossibleSelectedAncestors_VaryingAncestor_MoreBranches(t *testing.T)
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -461,9 +474,10 @@ func TestGetPossibleSelectedBlocks_OneBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -502,9 +516,10 @@ func TestGetPossibleSelectedBlocks_EqualVotes_SameAncestor(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -556,9 +571,10 @@ func TestGetPossibleSelectedBlocks_EqualVotes_VaryingAncestor(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -616,9 +632,10 @@ func TestGetPossibleSelectedBlocks_OneThirdEquivocating(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -659,9 +676,10 @@ func TestGetPossibleSelectedBlocks_MoreThanOneThirdEquivocating(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -711,9 +729,10 @@ func TestGetPreVotedBlock_OneBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -751,9 +770,10 @@ func TestGetPreVotedBlock_MultipleCandidates(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -805,9 +825,10 @@ func TestGetPreVotedBlock_EvenMoreCandidates(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -880,9 +901,10 @@ func TestIsCompletable(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -920,9 +942,10 @@ func TestFindParentWithNumber(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -954,9 +977,10 @@ func TestGetBestFinalCandidate_OneBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -997,9 +1021,10 @@ func TestGetBestFinalCandidate_PrecommitAncestor(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1045,9 +1070,10 @@ func TestGetBestFinalCandidate_NoPrecommit(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1088,9 +1114,10 @@ func TestGetBestFinalCandidate_PrecommitOnAnotherChain(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1133,9 +1160,10 @@ func TestDeterminePreVote_NoPrimaryPreVote(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1157,9 +1185,10 @@ func TestDeterminePreVote_WithPrimaryPreVote(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1185,9 +1214,10 @@ func TestDeterminePreVote_WithInvalidPrimaryPreVote(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1216,9 +1246,10 @@ func TestIsFinalizable_True(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1258,9 +1289,10 @@ func TestIsFinalizable_False(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1306,9 +1338,10 @@ func TestGetGrandpaGHOST_CommonAncestor(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -1349,9 +1382,10 @@ func TestGetGrandpaGHOST_MultipleCandidates(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -93,9 +93,10 @@ func TestMessageHandler_VoteMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -132,9 +133,10 @@ func TestMessageHandler_FinalizationMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -31,9 +31,10 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -82,9 +83,10 @@ func TestFinalizationMessageToConsensusMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)
@@ -117,9 +119,10 @@ func TestNewCatchUpResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Alice,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
 	}
 
 	gs, err := NewService(cfg)

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -55,10 +55,11 @@ func setupGrandpa(t *testing.T, kp *ed25519.Keypair) (*Service, chan FinalityMes
 	voters := newTestVoters(t)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kp,
-		LogLvl:     log.LvlTrace,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kp,
+		LogLvl:        log.LvlTrace,
 	}
 
 	gs, err := NewService(cfg)

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -43,3 +43,8 @@ type BlockState interface {
 	HasJustification(hash common.Hash) (bool, error)
 	GetJustification(hash common.Hash) ([]byte, error)
 }
+
+// DigestHandler is the interface required by GRANDPA for the digest handler
+type DigestHandler interface {
+	NextGrandpaAuthorityChange() uint64
+}

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -35,9 +35,10 @@ func TestCheckForEquivocation_NoEquivocation(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -68,9 +69,10 @@ func TestCheckForEquivocation_WithEquivocation(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -110,9 +112,10 @@ func TestCheckForEquivocation_WithExistingEquivocation(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -164,9 +167,10 @@ func TestValidateMessage_Valid(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -192,9 +196,10 @@ func TestValidateMessage_InvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -220,8 +225,9 @@ func TestValidateMessage_SetIDMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -248,9 +254,10 @@ func TestValidateMessage_Equivocation(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -289,9 +296,10 @@ func TestValidateMessage_BlockDoesNotExist(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)
@@ -319,9 +327,10 @@ func TestValidateMessage_IsNotDescendant(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &Config{
-		BlockState: st.Block,
-		Voters:     voters,
-		Keypair:    kr.Bob,
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Bob,
 	}
 
 	gs, err := NewService(cfg)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `DigestHandler` interface to grandpa 
- implement `NextGrandpaAuthorityChange` for `DigestHandler` which returns the block number of the next grandpa authority change
- update `determinePreVote` and `determinePreCommit` to use this

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1054