### PR TITLE
lib/grandpa: return catch-up request from grandpa MessageHandler.HandleMessage if needed

### DIFF
--- a/dot/core/finality.go
+++ b/dot/core/finality.go
@@ -22,7 +22,12 @@ import (
 
 // processConsensusMessage routes a consensus message from the network to the finality gadget
 func (s *Service) processConsensusMessage(msg *network.ConsensusMessage) error {
-	return s.consensusMessageHandler.HandleMessage(msg)
+	out, err := s.consensusMessageHandler.HandleMessage(msg)
+	if err != nil {
+		return err
+	}
+
+	return s.safeMsgSend(out)
 }
 
 // sendVoteMessages routes a VoteMessage from the finality gadget to the network

--- a/dot/core/finality.go
+++ b/dot/core/finality.go
@@ -27,7 +27,11 @@ func (s *Service) processConsensusMessage(msg *network.ConsensusMessage) error {
 		return err
 	}
 
-	return s.safeMsgSend(out)
+	if out != nil {
+		return s.safeMsgSend(out)
+	}
+
+	return nil
 }
 
 // sendVoteMessages routes a VoteMessage from the finality gadget to the network

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -95,7 +95,7 @@ type FinalityMessage interface {
 
 // ConsensusMessageHandler is the interface a consensus message handler must implement
 type ConsensusMessageHandler interface {
-	HandleMessage(*network.ConsensusMessage) error
+	HandleMessage(*network.ConsensusMessage) (*network.ConsensusMessage, error)
 }
 
 // BlockProducer is the interface that a block production service must implement

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -151,8 +151,8 @@ func (fm *mockFinalityMessage) ToConsensusMessage() (*network.ConsensusMessage, 
 
 type mockConsensusMessageHandler struct{}
 
-func (h *mockConsensusMessageHandler) HandleMessage(msg *network.ConsensusMessage) error {
-	return nil
+func (h *mockConsensusMessageHandler) HandleMessage(msg *network.ConsensusMessage) (*network.ConsensusMessage, error) {
+	return nil, nil
 }
 
 // NewTestService creates a new test core service

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -37,7 +37,7 @@ var (
 	voteType            byte = 0
 	precommitType       byte = 1
 	finalizationType    byte = 2
-	catchUpRequestType  byte = 3 //nolint
+	catchUpRequestType  byte = 3
 	catchUpResponseType byte = 4 //nolint
 )
 
@@ -119,11 +119,24 @@ type catchUpRequest struct { //nolint
 	SetID uint64
 }
 
-func newCatchUpRequest(round, setID uint64) *catchUpRequest { //nolint
+func newCatchUpRequest(round, setID uint64) *catchUpRequest {
 	return &catchUpRequest{
 		Round: round,
 		SetID: setID,
 	}
+}
+
+// ToConsensusMessage converts the catchUpRequest into a network-level consensus message
+func (r *catchUpRequest) ToConsensusMessage() (*ConsensusMessage, error) {
+	enc, err := scale.Encode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              append([]byte{catchUpRequestType}, enc...),
+	}, nil
 }
 
 type catchUpResponse struct {

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -37,25 +37,15 @@ func NewMessageHandler(grandpa *Service, blockState BlockState) *MessageHandler 
 // HandleMessage handles a GRANDPA consensus message
 // if it is a FinalizationMessage, it updates the BlockState
 // if it is a VoteMessage, it sends it to the GRANDPA service
-func (h *MessageHandler) HandleMessage(msg *ConsensusMessage) error {
+func (h *MessageHandler) HandleMessage(msg *ConsensusMessage) (*ConsensusMessage, error) {
 	m, err := decodeMessage(msg)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fm, ok := m.(*FinalizationMessage)
 	if ok {
-		// set finalized head for round in db
-		err = h.blockState.SetFinalizedHash(fm.Vote.hash, fm.Round, h.grandpa.state.setID)
-		if err != nil {
-			return err
-		}
-
-		// set latest finalized head in db
-		err = h.blockState.SetFinalizedHash(fm.Vote.hash, 0, 0)
-		if err != nil {
-			return err
-		}
+		return h.handleFinalizationMessage(fm)
 	}
 
 	vm, ok := m.(*VoteMessage)
@@ -64,7 +54,27 @@ func (h *MessageHandler) HandleMessage(msg *ConsensusMessage) error {
 		h.grandpa.in <- vm
 	}
 
-	return nil
+	return nil, nil
+}
+
+func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*ConsensusMessage, error) {
+	// check if msg has same setID but higher round number, if so, return catch-up request to send
+
+	// TODO: check justification here
+
+	// set finalized head for round in db
+	err := h.blockState.SetFinalizedHash(msg.Vote.hash, msg.Round, h.grandpa.state.setID)
+	if err != nil {
+		return nil, err
+	}
+
+	// set latest finalized head in db
+	err = h.blockState.SetFinalizedHash(msg.Vote.hash, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 // decodeMessage decodes a network-level consensus message into a GRANDPA VoteMessage or FinalizationMessage

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -58,7 +58,11 @@ func (h *MessageHandler) HandleMessage(msg *ConsensusMessage) (*ConsensusMessage
 }
 
 func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*ConsensusMessage, error) {
-	// check if msg has same setID but higher round number, if so, return catch-up request to send
+	// check if msg has same setID but is 2 or more rounds ahead of us, if so, return catch-up request to send
+	if msg.Round > h.grandpa.state.round+1 { // TODO: FinalizationMessage does not have setID, confirm this is correct
+		req := newCatchUpRequest(msg.Round, h.grandpa.state.setID)
+		return req.ToConsensusMessage()
+	}
 
 	// TODO: check justification here
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `grandpa.MessageHandler.HandleMessage` to return a `*ConsensusMessage` if one needs to be sent out, currently will return a `catchUpRequest` if needed
- update `core.Service.processConsensusMessage` to send out message returned from `HandleMessage` if there is one

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1069
