### PR TITLE
dot/core, lib/grandpa: refactor services to use context to stop goroutines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ build:
 	@echo "  >  \033[32mBuilding binary...\033[0m "
 	GOBIN=$(PWD)/bin go run scripts/ci.go install
 
+## debug: Builds application binary with debug flags and stores it in `./bin/gossamer`
+build-debug:
+	@echo "  >  \033[32mBuilding binary...\033[0m "
+	GOBIN=$(PWD)/bin go run scripts/ci.go install-debug
+
 ## init: Initialize gossamer using the default genesis and toml configuration files
 init:
 	./bin/gossamer --key alice init --genesis chain/gssmr/genesis.json
@@ -106,6 +111,6 @@ docker-build:
 gossamer: clean
 	GOBIN=$(PWD)/bin go run scripts/ci.go install
 
-## install: install the gossamer binary in /usr/local/bin; requires sudo
+## install: install the gossamer binary in $GOPATH/bin
 install:
-	GOBIN=/usr/local/bin go run scripts/ci.go install
+	GOBIN=$(GOPATH)/bin go run scripts/ci.go install

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"math/big"
 
@@ -29,6 +30,9 @@ var maxUint64 = uint64(2^64) - 1
 
 // DigestHandler is used to handle consensus messages and relevant authority updates to BABE and GRANDPA
 type DigestHandler struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	// interfaces
 	blockState          BlockState
 	grandpa             FinalityGadget
@@ -42,9 +46,6 @@ type DigestHandler struct {
 	importedID  byte
 	finalized   chan *types.Header
 	finalizedID byte
-
-	// state variables
-	stopped bool
 
 	// BABE changes
 	babeScheduledChange *babeChange
@@ -96,14 +97,17 @@ func NewDigestHandler(blockState BlockState, babe BlockProducer, grandpa Finalit
 	isFinalityAuthority := grandpa != nil
 	isBlockProducer := babe != nil
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	return &DigestHandler{
+		ctx:                 ctx,
+		cancel:              cancel,
 		blockState:          blockState,
 		grandpa:             grandpa,
 		babe:                babe,
 		verifier:            verifier,
 		isFinalityAuthority: isFinalityAuthority,
 		isBlockProducer:     isBlockProducer,
-		stopped:             true,
 		imported:            imported,
 		importedID:          iid,
 		finalized:           finalized,
@@ -115,12 +119,11 @@ func NewDigestHandler(blockState BlockState, babe BlockProducer, grandpa Finalit
 func (h *DigestHandler) Start() {
 	go h.handleBlockImport()
 	go h.handleBlockFinalization()
-	h.stopped = false
 }
 
 // Stop stops the DigestHandler
 func (h *DigestHandler) Stop() {
-	h.stopped = true
+	h.cancel()
 	h.blockState.UnregisterImportedChannel(h.importedID)
 	h.blockState.UnregisterFinalizedChannel(h.finalizedID)
 	close(h.imported)
@@ -177,35 +180,46 @@ func (h *DigestHandler) HandleConsensusDigest(d *types.ConsensusDigest) error {
 }
 
 func (h *DigestHandler) handleBlockImport() {
-	for block := range h.imported {
-		if h.stopped {
+	for {
+		select {
+		case block := <-h.imported:
+			if block == nil || block.Header == nil {
+				continue
+			}
+
+			if h.isFinalityAuthority {
+				h.handleGrandpaChangesOnImport(block.Header.Number)
+			}
+
+			if h.isBlockProducer {
+				h.handleBABEChangesOnImport(block.Header)
+			}
+		case <-h.ctx.Done():
 			return
-		}
-
-		if h.isFinalityAuthority {
-			h.handleGrandpaChangesOnImport(block.Header.Number)
-		}
-
-		if h.isBlockProducer {
-			h.handleBABEChangesOnImport(block.Header)
 		}
 	}
 }
 
 func (h *DigestHandler) handleBlockFinalization() {
-	for header := range h.finalized {
-		if h.stopped {
+	for {
+		select {
+		case header := <-h.finalized:
+			if header == nil {
+				continue
+			}
+
+			if h.isFinalityAuthority {
+				h.handleGrandpaChangesOnFinalization(header.Number)
+			}
+
+			if h.isBlockProducer {
+				h.handleBABEChangesOnFinalization(header)
+			}
+		case <-h.ctx.Done():
 			return
 		}
-
-		if h.isFinalityAuthority {
-			h.handleGrandpaChangesOnFinalization(header.Number)
-		}
-
-		if h.isBlockProducer {
-			h.handleBABEChangesOnFinalization(header)
-		}
 	}
+
 }
 
 func (h *DigestHandler) handleBABEChangesOnImport(header *types.Header) {

--- a/dot/core/digest.go
+++ b/dot/core/digest.go
@@ -117,9 +117,9 @@ func NewDigestHandler(blockState BlockState, babe BlockProducer, grandpa Finalit
 
 // Start starts the DigestHandler
 func (h *DigestHandler) Start() {
-	ctx, _ := context.WithCancel(h.ctx)
+	ctx, _ := context.WithCancel(h.ctx) //nolint
 	go h.handleBlockImport(ctx)
-	ctx, _ = context.WithCancel(h.ctx)
+	ctx, _ = context.WithCancel(h.ctx) //nolint
 	go h.handleBlockFinalization(ctx)
 }
 

--- a/dot/core/finality.go
+++ b/dot/core/finality.go
@@ -28,7 +28,8 @@ func (s *Service) processConsensusMessage(msg *network.ConsensusMessage) error {
 	}
 
 	if out != nil {
-		return s.safeMsgSend(out)
+		s.safeMsgSend(out)
+		return nil
 	}
 
 	return nil

--- a/dot/core/finality_test.go
+++ b/dot/core/finality_test.go
@@ -52,7 +52,6 @@ func TestSendVoteMessages(t *testing.T) {
 		MsgSend:        msgSend,
 		FinalityGadget: fg,
 	})
-	//s.started.Store(true)
 
 	go s.sendVoteMessages()
 	fg.out <- &mockFinalityMessage{}
@@ -78,7 +77,6 @@ func TestSendFinalizationMessages(t *testing.T) {
 		MsgSend:        msgSend,
 		FinalityGadget: fg,
 	})
-	//s.started.Store(true)
 
 	go s.sendFinalizationMessages()
 	fg.finalized <- &mockFinalityMessage{}

--- a/dot/core/finality_test.go
+++ b/dot/core/finality_test.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -53,7 +54,7 @@ func TestSendVoteMessages(t *testing.T) {
 		FinalityGadget: fg,
 	})
 
-	go s.sendVoteMessages()
+	go s.sendVoteMessages(context.Background())
 	fg.out <- &mockFinalityMessage{}
 
 	select {
@@ -78,7 +79,7 @@ func TestSendFinalizationMessages(t *testing.T) {
 		FinalityGadget: fg,
 	})
 
-	go s.sendFinalizationMessages()
+	go s.sendFinalizationMessages(context.Background())
 	fg.finalized <- &mockFinalityMessage{}
 
 	select {

--- a/dot/core/finality_test.go
+++ b/dot/core/finality_test.go
@@ -52,7 +52,7 @@ func TestSendVoteMessages(t *testing.T) {
 		MsgSend:        msgSend,
 		FinalityGadget: fg,
 	})
-	s.started.Store(true)
+	//s.started.Store(true)
 
 	go s.sendVoteMessages()
 	fg.out <- &mockFinalityMessage{}
@@ -78,7 +78,7 @@ func TestSendFinalizationMessages(t *testing.T) {
 		MsgSend:        msgSend,
 		FinalityGadget: fg,
 	})
-	s.started.Store(true)
+	//s.started.Store(true)
 
 	go s.sendFinalizationMessages()
 	fg.finalized <- &mockFinalityMessage{}

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -233,7 +233,7 @@ func (s *Service) safeMsgSend(msg network.Message) {
 	defer s.lock.Unlock()
 
 	if s.ctx.Err() != nil {
-		// context was cancelled
+		// context was canceled
 		return
 	}
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -17,10 +17,10 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"math/big"
 	"os"
 	"sync"
-	"sync/atomic"
 
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -40,6 +40,8 @@ var _ services.Service = &Service{}
 // and blocks by calling their respective validation functions in the runtime.
 type Service struct {
 	logger log.Logger
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	// State interfaces
 	blockState       BlockState
@@ -74,8 +76,7 @@ type Service struct {
 	blockAddChID byte
 
 	// State variables
-	lock    *sync.Mutex
-	started atomic.Value
+	lock *sync.Mutex // channel lock
 }
 
 // Config holds the configuration for the core Service.
@@ -147,8 +148,12 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	srv := &Service{
 		logger:                  logger,
+		ctx:                     ctx,
+		cancel:                  cancel,
 		rt:                      cfg.Runtime,
 		codeHash:                codeHash,
 		keys:                    cfg.Keystore,
@@ -175,14 +180,11 @@ func NewService(cfg *Config) (*Service, error) {
 		srv.blkRec = cfg.BlockProducer.GetBlockChannel()
 	}
 
-	srv.started.Store(false)
 	return srv, nil
 }
 
 // Start starts the core service
 func (s *Service) Start() error {
-	s.started.Store(true)
-
 	// start receiving blocks from BABE session
 	go s.receiveBlocks()
 
@@ -205,17 +207,14 @@ func (s *Service) Start() error {
 func (s *Service) Stop() error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	s.cancel()
+
+	s.blockState.UnregisterImportedChannel(s.blockAddChID)
+	close(s.blockAddCh)
 
 	// close channel to network service
-	if s.started.Load().(bool) {
-		s.blockState.UnregisterImportedChannel(s.blockAddChID)
-		close(s.blockAddCh)
-
-		if s.msgSend != nil {
-			close(s.msgSend)
-		}
-
-		s.started.Store(false)
+	if s.msgSend != nil {
+		close(s.msgSend)
 	}
 
 	return nil
@@ -229,54 +228,64 @@ func (s *Service) StorageRoot() (common.Hash, error) {
 	return s.storageState.StorageRoot()
 }
 
-func (s *Service) safeMsgSend(msg network.Message) error {
+func (s *Service) safeMsgSend(msg network.Message) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-
-	if !s.started.Load().(bool) {
-		return ErrServiceStopped
-	}
-
 	s.msgSend <- msg
-	return nil
 }
 
 func (s *Service) handleBlocks() {
-	for block := range s.blockAddCh {
-		err := s.handleRuntimeChanges(block.Header)
-		if err != nil {
-			log.Warn("failed to handle runtime change for block", "block", block.Header.Hash())
+	for {
+		select {
+		case block := <-s.blockAddCh:
+			if block == nil {
+				continue
+			}
+
+			err := s.handleRuntimeChanges(block.Header)
+			if err != nil {
+				log.Warn("failed to handle runtime change for block", "block", block.Header.Hash())
+			}
+		case <-s.ctx.Done():
+			return
 		}
 	}
 }
 
 // receiveBlocks starts receiving blocks from the BABE session
 func (s *Service) receiveBlocks() {
-	// receive block from BABE session
-	for block := range s.blkRec {
-		if block.Header != nil {
+	for {
+		select {
+		case block := <-s.blkRec:
+			if block.Header == nil {
+				continue
+			}
+
 			err := s.handleReceivedBlock(&block)
 			if err != nil {
-				s.logger.Error("failed to handle block from BABE session", "err", err)
+				s.logger.Warn("failed to handle block from BABE session", "err", err)
 			}
-		} else {
-			s.logger.Trace("receiveBlocks got nil Header")
+		case <-s.ctx.Done():
+			return
 		}
 	}
 }
 
 // receiveMessages starts receiving messages from the network service
 func (s *Service) receiveMessages() {
-	// receive message from network service
-	for msg := range s.msgRec {
-		if msg == nil {
-			s.logger.Error("failed to receive message from network service")
-			continue
-		}
+	for {
+		select {
+		case msg := <-s.msgRec:
+			if msg == nil {
+				continue
+			}
 
-		err := s.handleReceivedMessage(msg)
-		if err != nil {
-			s.logger.Trace("failed to handle message from network service", "err", err)
+			err := s.handleReceivedMessage(msg)
+			if err != nil {
+				s.logger.Trace("failed to handle message from network service", "err", err)
+			}
+		case <-s.ctx.Done():
+			return
 		}
 	}
 }
@@ -302,7 +311,8 @@ func (s *Service) handleReceivedBlock(block *types.Block) (err error) {
 		Digest:         block.Header.Digest,
 	}
 
-	return s.safeMsgSend(msg)
+	s.safeMsgSend(msg)
+	return nil
 }
 
 // handleReceivedMessage handles messages from the network service
@@ -414,7 +424,8 @@ func (s *Service) IsBlockProducer() bool {
 // HandleSubmittedExtrinsic is used to send a Transaction message containing a Extrinsic @ext
 func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 	msg := &network.TransactionMessage{Extrinsics: []types.Extrinsic{ext}}
-	return s.safeMsgSend(msg)
+	s.safeMsgSend(msg)
+	return nil
 }
 
 //GetMetadata calls runtime Metadata_metadata function

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -185,24 +185,27 @@ func NewService(cfg *Config) (*Service, error) {
 
 // Start starts the core service
 func (s *Service) Start() error {
+	// we can ignore the `cancel` function returned by `context.WithCancel` since Stop() cancels the parent context,
+	// so all the child contexts should also be canceled. potentially update if there is a better way to do this
+
 	// start receiving blocks from BABE session
-	ctx, _ := context.WithCancel(s.ctx)
+	ctx, _ := context.WithCancel(s.ctx) //nolint
 	go s.receiveBlocks(ctx)
 
 	// start receiving messages from network service
-	ctx, _ = context.WithCancel(s.ctx)
+	ctx, _ = context.WithCancel(s.ctx) //nolint
 	go s.receiveMessages(ctx)
 
 	// start handling imported blocks
-	ctx, _ = context.WithCancel(s.ctx)
+	ctx, _ = context.WithCancel(s.ctx) //nolint
 	go s.handleBlocks(ctx)
 
 	if s.isFinalityAuthority && s.finalityGadget != nil {
 		s.logger.Debug("routing finality gadget messages")
-		ctx, _ = context.WithCancel(s.ctx)
+		ctx, _ = context.WithCancel(s.ctx) //nolint
 		go s.sendVoteMessages(ctx)
 
-		ctx, _ = context.WithCancel(s.ctx)
+		ctx, _ = context.WithCancel(s.ctx) //nolint
 		go s.sendFinalizationMessages(ctx)
 	}
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -231,6 +231,12 @@ func (s *Service) StorageRoot() (common.Hash, error) {
 func (s *Service) safeMsgSend(msg network.Message) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	if s.ctx.Err() != nil {
+		// context was cancelled
+		return
+	}
+
 	s.msgSend <- msg
 }
 

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -129,7 +129,7 @@ func TestHandleRuntimeChanges(t *testing.T) {
 	}
 
 	s := NewTestService(t, cfg)
-	s.started.Store(true)
+	//s.started.Store(true)
 
 	_, err = runtime.GetRuntimeBlob(runtime.TESTS_FP, runtime.TEST_WASM_URL)
 	require.Nil(t, err)

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -129,7 +129,6 @@ func TestHandleRuntimeChanges(t *testing.T) {
 	}
 
 	s := NewTestService(t, cfg)
-	//s.started.Store(true)
 
 	_, err = runtime.GetRuntimeBlob(runtime.TESTS_FP, runtime.TEST_WASM_URL)
 	require.Nil(t, err)

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -74,7 +74,7 @@ type Service struct {
 
 // NewService creates a new network service from the configuration and message channels
 func NewService(cfg *Config) (*Service, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint
 
 	h := log.StreamHandler(os.Stdout, log.TerminalFormat())
 	h = log.CallerFileHandler(h)
@@ -84,7 +84,7 @@ func NewService(cfg *Config) (*Service, error) {
 	// build configuration
 	err := cfg.build()
 	if err != nil {
-		return nil, err
+		return nil, err //nolint
 	}
 
 	if cfg.MsgRec == nil {

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -131,6 +131,10 @@ func NewService(cfg *Config) (*Service, error) {
 
 // Start starts the network service
 func (s *Service) Start() error {
+	if s.IsStopped() {
+		s.ctx, s.cancel = context.WithCancel(context.Background())
+	}
+
 	// update network state
 	go s.updateNetworkState()
 

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -42,8 +42,10 @@ var logger = log.New("pkg", "network")
 
 // Service describes a network service
 type Service struct {
-	logger         log.Logger
-	ctx            context.Context
+	logger log.Logger
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	cfg            *Config
 	host           *host
 	mdns           *mdns
@@ -62,7 +64,6 @@ type Service struct {
 	msgRec  <-chan Message
 	msgSend chan<- Message
 	lock    sync.Mutex
-	closed  bool
 
 	// Configuration options
 	noBootstrap bool
@@ -73,7 +74,7 @@ type Service struct {
 
 // NewService creates a new network service from the configuration and message channels
 func NewService(cfg *Config) (*Service, error) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	h := log.StreamHandler(os.Stdout, log.TerminalFormat())
 	h = log.CallerFileHandler(h)
@@ -107,6 +108,7 @@ func NewService(cfg *Config) (*Service, error) {
 	network := &Service{
 		logger:         logger,
 		ctx:            ctx,
+		cancel:         cancel,
 		cfg:            cfg,
 		host:           host,
 		mdns:           newMDNS(host),
@@ -117,7 +119,6 @@ func NewService(cfg *Config) (*Service, error) {
 		networkState:   cfg.NetworkState,
 		msgRec:         cfg.MsgRec,
 		msgSend:        cfg.MsgSend,
-		closed:         false,
 		noBootstrap:    cfg.NoBootstrap,
 		noMDNS:         cfg.NoMDNS,
 		noStatus:       cfg.NoStatus,
@@ -156,7 +157,6 @@ func (s *Service) Start() error {
 		s.mdns.start()
 	}
 
-	s.closed = false
 	return nil
 }
 
@@ -164,6 +164,15 @@ func (s *Service) Start() error {
 // the message channel from the network service to the core service (services that
 // are dependent on the host instance should be closed first)
 func (s *Service) Stop() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// close channel to core service
+	if s.msgSend != nil && !s.IsStopped() {
+		close(s.msgSend)
+	}
+
+	s.cancel()
 
 	// close mDNS discovery service
 	err := s.mdns.close()
@@ -177,66 +186,56 @@ func (s *Service) Stop() error {
 		s.logger.Error("Failed to close host", "error", err)
 	}
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	// close channel to core service
-	if !s.closed {
-		if s.msgSend != nil {
-			close(s.msgSend)
-		}
-		s.closed = true
-	}
-
 	return nil
 }
 
 // IsStopped returns true if the service is stopped
 func (s *Service) IsStopped() bool {
-	return s.closed
+	return s.ctx.Err() != nil
 }
 
 // updateNetworkState updates the network state at the set time interval
 func (s *Service) updateNetworkState() {
 	for {
-		if s.closed {
+		select {
+		case <-s.ctx.Done():
 			return
+		case <-time.After(NetworkStateTimeout):
+			s.networkState.SetHealth(s.Health())
+			s.networkState.SetNetworkState(s.NetworkState())
+			s.networkState.SetPeers(s.Peers())
 		}
-
-		s.networkState.SetHealth(s.Health())
-		s.networkState.SetNetworkState(s.NetworkState())
-		s.networkState.SetPeers(s.Peers())
-
-		// how frequently we update network state
-		time.Sleep(NetworkStateTimeout)
 	}
 }
 
 // receiveCoreMessages broadcasts messages from the core service
 func (s *Service) receiveCoreMessages() {
 	for {
-		// receive message from core service
-		msg, ok := <-s.msgRec
-		if !ok || msg == nil {
-			s.logger.Warn("Received nil message from core service")
-			return // exit
+		select {
+		case msg, ok := <-s.msgRec:
+			if !ok || msg == nil {
+				s.logger.Debug("Received nil message from core service")
+				continue
+			}
+
+			s.logger.Debug(
+				"Broadcasting message from core service",
+				"host", s.host.id(),
+				"type", msg.Type(),
+			)
+
+			// broadcast message to connected peers
+			s.host.broadcast(msg)
+		case <-s.ctx.Done():
+			return
 		}
-
-		s.logger.Debug(
-			"Broadcasting message from core service",
-			"host", s.host.id(),
-			"type", msg.Type(),
-		)
-
-		// broadcast message to connected peers
-		s.host.broadcast(msg)
 	}
 }
 
 func (s *Service) safeMsgSend(msg Message) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	if s.closed {
+	if s.IsStopped() {
 		return errors.New("service has been stopped")
 	}
 	s.msgSend <- msg

--- a/dot/node.go
+++ b/dot/node.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"sync"
 	"syscall"
-	//"time"
 
 	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -368,9 +367,6 @@ func (n *Node) Start() error {
 	n.Services.StartAll()
 
 	go func() {
-		// time.Sleep(time.Second * 10)
-		// n.Stop()
-
 		sigc := make(chan os.Signal, 1)
 		signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigc)

--- a/dot/node.go
+++ b/dot/node.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"sync"
 	"syscall"
+	//"time"
 
 	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -367,6 +368,9 @@ func (n *Node) Start() error {
 	n.Services.StartAll()
 
 	go func() {
+		// time.Sleep(time.Second * 10)
+		// n.Stop()
+
 		sigc := make(chan os.Signal, 1)
 		signal.Notify(sigc, syscall.SIGINT, syscall.SIGTERM)
 		defer signal.Stop(sigc)

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -138,8 +138,6 @@ func NewService(cfg *Config) (*Service, error) {
 
 // Start begins the GRANDPA finality service
 func (s *Service) Start() error {
-	//s.stopped = false
-
 	go func() {
 		err := s.initiate()
 		if err != nil {

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -238,7 +238,7 @@ func (s *Service) initiate() error {
 		return err
 	}
 
-	if h == nil || h.Number.Int64() == 0 {
+	if h != nil && h.Number.Int64() == 0 {
 		err := s.waitForFirstBlock()
 		if err != nil {
 			return err
@@ -273,13 +273,19 @@ func (s *Service) waitForFirstBlock() error {
 
 	// loop until block 1
 	for {
+		done := false
+
 		select {
 		case block := <-ch:
 			if block != nil && block.Header != nil && block.Header.Number.Int64() > 0 {
-				break
+				done = true
 			}
 		case <-s.ctx.Done():
 			return nil
+		}
+
+		if done {
+			break
 		}
 	}
 

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -64,8 +64,6 @@ func setupGrandpa(t *testing.T, kp *ed25519.Keypair) (*Service, chan FinalityMes
 
 	gs, err := NewService(cfg)
 	require.NoError(t, err)
-	//gs.stopped = false
-
 	return gs, gs.in, gs.out, gs.finalized
 }
 
@@ -174,18 +172,10 @@ func broadcastVotes(from <-chan FinalityMessage, to []chan FinalityMessage, done
 func cleanup(gs *Service, in, out chan FinalityMessage, done *bool) { //nolint
 	*done = true
 	close(in)
-
-	//gs.chanLock.Lock()
-	//gs.stopped = true
-	//gs.chanLock.Unlock()
 	gs.cancel()
 }
 
 func TestPlayGrandpaRound_BaseCase(t *testing.T) {
-	// if testing.Short() {
-	// 	t.Skip()
-	// }
-
 	// this asserts that all validators finalize the same block if they all see the
 	// same pre-votes and pre-commits, even if their chains are different lengths
 	kr, err := keystore.NewEd25519Keyring()

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -64,7 +64,7 @@ func setupGrandpa(t *testing.T, kp *ed25519.Keypair) (*Service, chan FinalityMes
 
 	gs, err := NewService(cfg)
 	require.NoError(t, err)
-	gs.stopped = false
+	//gs.stopped = false
 
 	return gs, gs.in, gs.out, gs.finalized
 }
@@ -175,15 +175,16 @@ func cleanup(gs *Service, in, out chan FinalityMessage, done *bool) { //nolint
 	*done = true
 	close(in)
 
-	gs.chanLock.Lock()
-	gs.stopped = true
-	gs.chanLock.Unlock()
+	//gs.chanLock.Lock()
+	//gs.stopped = true
+	//gs.chanLock.Unlock()
+	gs.cancel()
 }
 
 func TestPlayGrandpaRound_BaseCase(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	// if testing.Short() {
+	// 	t.Skip()
+	// }
 
 	// this asserts that all validators finalize the same block if they all see the
 	// same pre-votes and pre-commits, even if their chains are different lengths

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -18,6 +18,7 @@ package grandpa
 
 import (
 	"bytes"
+	"context"
 
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
@@ -26,36 +27,37 @@ import (
 
 // receiveMessages receives messages from the in channel until the specified condition is met
 func (s *Service) receiveMessages(cond func() bool) {
-	done := false
+	ctx, cancel := context.WithCancel(s.ctx)
 
-	go func(done *bool) {
-		for msg := range s.in {
-			if *done {
+	go func() {
+		for {
+			select {
+			case msg := <-s.in:
+				s.logger.Trace("received vote message", "msg", msg)
+
+				vm, ok := msg.(*VoteMessage)
+				if !ok {
+					s.logger.Trace("failed to cast message to VoteMessage")
+					continue
+				}
+
+				v, err := s.validateMessage(vm)
+				if err != nil {
+					s.logger.Trace("failed to validate vote message", "message", vm, "error", err)
+					continue
+				}
+
+				s.logger.Debug("validated vote message", "vote", v, "subround", vm.Stage)
+			case <-ctx.Done():
 				s.logger.Trace("returning from receiveMessages")
 				return
 			}
-
-			s.logger.Trace("received vote message", "msg", msg)
-
-			vm, ok := msg.(*VoteMessage)
-			if !ok {
-				s.logger.Trace("failed to cast message to VoteMessage")
-				continue
-			}
-
-			v, err := s.validateMessage(vm)
-			if err != nil {
-				s.logger.Trace("failed to validate vote message", "message", vm, "error", err)
-				continue
-			}
-
-			s.logger.Debug("validated vote message", "vote", v, "subround", vm.Stage)
 		}
-	}(&done)
+	}()
 
 	for {
 		if cond() {
-			done = true
+			cancel()
 			return
 		}
 	}
@@ -71,7 +73,8 @@ func (s *Service) sendMessage(vote *Vote, stage subround) error {
 	s.chanLock.Lock()
 	defer s.chanLock.Unlock()
 
-	if s.stopped {
+	// context was cancelled
+	if s.ctx.Err() != nil {
 		return nil
 	}
 

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -73,7 +73,7 @@ func (s *Service) sendMessage(vote *Vote, stage subround) error {
 	s.chanLock.Lock()
 	defer s.chanLock.Unlock()
 
-	// context was cancelled
+	// context was canceled
 	if s.ctx.Err() != nil {
 		return nil
 	}

--- a/scripts/ci.go
+++ b/scripts/ci.go
@@ -45,7 +45,9 @@ func main() {
 	}
 	switch os.Args[1] {
 	case "install":
-		install()
+		install(false)
+	case "install-debug":
+		install(true)
 	case "lint":
 		lint()
 	case "test":
@@ -55,8 +57,7 @@ func main() {
 	}
 }
 
-func install() {
-
+func install(debug bool) {
 	argsList := append([]string{"list"}, []string{"./..."}...)
 
 	cmd := exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), argsList...)
@@ -74,6 +75,9 @@ func install() {
 	argsInstall := append([]string{"install"})
 	cmd = exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), argsInstall...)
 	cmd.Args = append(cmd.Args, "-v")
+	if debug {
+		cmd.Args = append(cmd.Args, "-gcflags=\"all=-N -l\"")
+	}
 	cmd.Args = append(cmd.Args, packages...)
 
 	fmt.Println("Build Gossamer", strings.Join(cmd.Args, " \\\n"))

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestStress_Grandpa_OneAuthority(t *testing.T) {
 	numNodes = 1
-	nodes, err := utils.InitializeAndStartNodes(t, numNodes, utils.GenesisOneAuth, utils.ConfigDefault)
+	nodes, err := utils.InitializeAndStartNodes(t, numNodes, utils.GenesisOneAuth, utils.ConfigBABEMaxThreshold)
 	require.NoError(t, err)
 
 	defer func() {

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -67,7 +67,7 @@ func TestRestartNode(t *testing.T) {
 	err = utils.StartNodes(t, nodes)
 	require.NoError(t, err)
 
-	errList := utils.StopNodes(t, nodes)
+	errList := utils.TearDown(t, nodes)
 	require.Len(t, errList, 0)
 
 	err = utils.StartNodes(t, nodes)

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -131,7 +131,7 @@ func StartGossamer(t *testing.T, node *Node) error {
 			"--rpcmods", "system,author,chain,state",
 			"--roles", "1", // no key provided, non-authority node
 			"--rpc",
-			"--log", "crit",
+			"--log", "info",
 		)
 	} else {
 		key = keyList[node.Idx]
@@ -146,7 +146,7 @@ func StartGossamer(t *testing.T, node *Node) error {
 			"--rpcmods", "system,author,chain,state,dev",
 			"--roles", "4", // authority node
 			"--rpc",
-			"--log", "crit",
+			"--log", "info",
 		)
 	}
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `core.Service`, `network.Service`, `grandpa.Service` to use `context.WithCancel` to stop goroutines

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./... -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #1001