### PR TITLE
lib/grandpa: handle catch up requests

### DIFF
--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -91,6 +91,7 @@ type FinalityGadget interface {
 // FinalityMessage is the interface a finality message must implement
 type FinalityMessage interface {
 	ToConsensusMessage() (*network.ConsensusMessage, error)
+	Type() byte
 }
 
 // ConsensusMessageHandler is the interface a consensus message handler must implement

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -149,6 +149,10 @@ func (fm *mockFinalityMessage) ToConsensusMessage() (*network.ConsensusMessage, 
 	return testConsensusMessage, nil
 }
 
+func (fm *mockFinalityMessage) Type() byte {
+	return 0
+}
+
 type mockConsensusMessageHandler struct{}
 
 func (h *mockConsensusMessageHandler) HandleMessage(msg *network.ConsensusMessage) (*network.ConsensusMessage, error) {

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -71,3 +71,6 @@ var ErrNotFinalizationMessage = errors.New("cannot get finalized hash from VoteM
 
 // ErrNoJustification is returned when no justification can be found for a block, ie. it has not been finalized
 var ErrNoJustification = errors.New("no justification found for block")
+
+// ErrInvalidCatchUpRound is returned when a catch-up message is received with an invalid round
+var ErrInvalidCatchUpRound = errors.New("catch up request is for future round")

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -11,11 +12,8 @@ import (
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
-// FinalityMessage is the interface a finality message must implement
-type FinalityMessage interface {
-	ToConsensusMessage() (*network.ConsensusMessage, error)
-	Type() byte
-}
+// FinalityMessage is an alias for the core.FinalityMessage interface
+type FinalityMessage = core.FinalityMessage
 
 // ConsensusMessage is an alias for network.ConsensusMessage
 type ConsensusMessage = network.ConsensusMessage

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -12,8 +11,11 @@ import (
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
-// FinalityMessage is an alias for the core.FinalityMessage interface
-type FinalityMessage = core.FinalityMessage
+// FinalityMessage is the interface a finality message must implement
+type FinalityMessage interface {
+	ToConsensusMessage() (*network.ConsensusMessage, error)
+	Type() byte
+}
 
 // ConsensusMessage is an alias for network.ConsensusMessage
 type ConsensusMessage = network.ConsensusMessage
@@ -38,7 +40,7 @@ var (
 	precommitType       byte = 1
 	finalizationType    byte = 2
 	catchUpRequestType  byte = 3
-	catchUpResponseType byte = 4 //nolint
+	catchUpResponseType byte = 4
 )
 
 // FullVote represents a vote with additional information about the state
@@ -72,6 +74,11 @@ type VoteMessage struct {
 	Message *SignedMessage
 }
 
+// Type returns voteType or precommitType
+func (v *VoteMessage) Type() byte {
+	return byte(v.Stage)
+}
+
 // ToConsensusMessage converts the VoteMessage into a network-level consensus message
 func (v *VoteMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 	enc, err := scale.Encode(v)
@@ -91,6 +98,11 @@ type FinalizationMessage struct {
 	Round         uint64
 	Vote          *Vote
 	Justification []*Justification
+}
+
+// Type returns finalizationType
+func (f *FinalizationMessage) Type() byte {
+	return finalizationType
 }
 
 // ToConsensusMessage converts the FinalizationMessage into a network-level consensus message
@@ -114,7 +126,7 @@ func (s *Service) newFinalizationMessage(header *types.Header, round uint64) *Fi
 	}
 }
 
-type catchUpRequest struct { //nolint
+type catchUpRequest struct {
 	Round uint64
 	SetID uint64
 }
@@ -124,6 +136,11 @@ func newCatchUpRequest(round, setID uint64) *catchUpRequest {
 		Round: round,
 		SetID: setID,
 	}
+}
+
+// Type returns catchUpRequestType
+func (r *catchUpRequest) Type() byte {
+	return catchUpRequestType
 }
 
 // ToConsensusMessage converts the catchUpRequest into a network-level consensus message
@@ -192,4 +209,14 @@ func (s *Service) newCatchUpResponse(round, setID uint64) (*catchUpResponse, err
 		Hash:                   header.Hash(),
 		Number:                 header.Number.Uint64(),
 	}, nil
+}
+
+// Type returns catchUpResponseType
+func (r *catchUpResponse) Type() byte {
+	return catchUpResponseType
+}
+
+// ToConsensusMessage converts the catchUpResponse into a network-level consensus message
+func (r *catchUpResponse) ToConsensusMessage() (*ConsensusMessage, error) {
+	return nil, nil
 }

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -43,15 +43,25 @@ func (h *MessageHandler) HandleMessage(msg *ConsensusMessage) (*ConsensusMessage
 		return nil, err
 	}
 
-	fm, ok := m.(*FinalizationMessage)
-	if ok {
-		return h.handleFinalizationMessage(fm)
-	}
-
-	vm, ok := m.(*VoteMessage)
-	if h.grandpa != nil && ok {
-		// send vote message to grandpa service
-		h.grandpa.in <- vm
+	switch m.Type() {
+	case voteType, precommitType:
+		vm, ok := m.(*VoteMessage)
+		if h.grandpa != nil && ok {
+			// send vote message to grandpa service
+			h.grandpa.in <- vm
+		}
+	case finalizationType:
+		if fm, ok := m.(*FinalizationMessage); ok {
+			return h.handleFinalizationMessage(fm)
+		}
+	case catchUpRequestType:
+		if r, ok := m.(*catchUpRequest); ok {
+			return h.handleCatchUpRequest(r)
+		}
+	case catchUpResponseType:
+		return nil, nil
+	default:
+		return nil, ErrInvalidMessageType
 	}
 
 	return nil, nil
@@ -81,17 +91,51 @@ func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*C
 	return nil, nil
 }
 
+func (h *MessageHandler) handleCatchUpRequest(msg *catchUpRequest) (*ConsensusMessage, error) {
+	if msg.SetID != h.grandpa.state.setID {
+		return nil, ErrSetIDMismatch
+	}
+
+	if msg.Round >= h.grandpa.state.round {
+		return nil, ErrInvalidCatchUpRound
+	}
+
+	resp, err := h.grandpa.newCatchUpResponse(msg.Round, msg.SetID)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.ToConsensusMessage()
+}
+
 // decodeMessage decodes a network-level consensus message into a GRANDPA VoteMessage or FinalizationMessage
 func decodeMessage(msg *ConsensusMessage) (m FinalityMessage, err error) {
-	var mi interface{}
+	var (
+		mi interface{}
+		ok bool
+	)
 
 	switch msg.Data[0] {
 	case voteType, precommitType:
 		mi, err = scale.Decode(msg.Data[1:], &VoteMessage{Message: new(SignedMessage)})
-		m = mi.(*VoteMessage)
+		if m, ok = mi.(*VoteMessage); !ok {
+			return nil, ErrInvalidMessageType
+		}
 	case finalizationType:
 		mi, err = scale.Decode(msg.Data[1:], &FinalizationMessage{})
-		m = mi.(*FinalizationMessage)
+		if m, ok = mi.(*FinalizationMessage); !ok {
+			return nil, ErrInvalidMessageType
+		}
+	case catchUpRequestType:
+		mi, err = scale.Decode(msg.Data[1:], &catchUpRequest{})
+		if m, ok = mi.(*catchUpRequest); !ok {
+			return nil, ErrInvalidMessageType
+		}
+	case catchUpResponseType:
+		mi, err = scale.Decode(msg.Data[1:], &catchUpResponse{})
+		if m, ok = mi.(*catchUpResponse); !ok {
+			return nil, ErrInvalidMessageType
+		}
 	default:
 		return nil, ErrInvalidMessageType
 	}

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -17,13 +17,16 @@
 package grandpa
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
+	"github.com/ChainSafe/gossamer/lib/scale"
 
 	"github.com/stretchr/testify/require"
 )
@@ -81,6 +84,23 @@ func TestDecodeMessage_FinalizationMessage(t *testing.T) {
 				AuthorityID: kr.Alice.Public().(*ed25519.PublicKey).AsBytes(),
 			},
 		},
+	}
+
+	require.Equal(t, expected, msg)
+}
+
+func TestDecodeMessage_CatchUpRequest(t *testing.T) {
+	cm := &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              common.MustHexToBytes("0x0311000000000000002200000000000000"),
+	}
+
+	msg, err := decodeMessage(cm)
+	require.NoError(t, err)
+
+	expected := &catchUpRequest{
+		Round: 0x11,
+		SetID: 0x22,
 	}
 
 	require.Equal(t, expected, msg)
@@ -206,6 +226,133 @@ func TestMessageHandler_FinalizationMessage_WithCatchUpRequest(t *testing.T) {
 
 	req := newCatchUpRequest(77, gs.state.setID)
 	expected, err := req.ToConsensusMessage()
+	require.NoError(t, err)
+	require.Equal(t, expected, out)
+}
+
+func TestMessageHandler_CatchUpRequest_InvalidRound(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	req := newCatchUpRequest(77, 0)
+	cm, err := req.ToConsensusMessage()
+	require.NoError(t, err)
+
+	h := NewMessageHandler(gs, st.Block)
+	_, err = h.HandleMessage(cm)
+	require.Equal(t, ErrInvalidCatchUpRound, err)
+}
+
+func TestMessageHandler_CatchUpRequest_InvalidSetID(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	req := newCatchUpRequest(1, 77)
+	cm, err := req.ToConsensusMessage()
+	require.NoError(t, err)
+
+	h := NewMessageHandler(gs, st.Block)
+	_, err = h.HandleMessage(cm)
+	require.Equal(t, ErrSetIDMismatch, err)
+}
+
+func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	// set up needed info for response
+	round := uint64(1)
+	setID := uint64(0)
+	gs.state.round = round + 1
+
+	testHeader := &types.Header{
+		Number: big.NewInt(1),
+	}
+
+	v := &Vote{
+		hash:   testHeader.Hash(),
+		number: 1,
+	}
+
+	err = gs.blockState.SetFinalizedHash(testHeader.Hash(), round, setID)
+	require.NoError(t, err)
+	err = gs.blockState.(*state.BlockState).SetHeader(testHeader)
+	require.NoError(t, err)
+
+	pvj := []*Justification{
+		{
+			Vote:        testVote,
+			Signature:   testSignature,
+			AuthorityID: testAuthorityID,
+		},
+	}
+
+	pvjEnc, err := scale.Encode(pvj)
+	require.NoError(t, err)
+
+	pcj := []*Justification{
+		{
+			Vote:        testVote2,
+			Signature:   testSignature,
+			AuthorityID: testAuthorityID,
+		},
+	}
+
+	pcjEnc, err := scale.Encode(pcj)
+	require.NoError(t, err)
+
+	err = gs.blockState.SetJustification(v.hash, append(pvjEnc, pcjEnc...))
+	require.NoError(t, err)
+
+	resp, err := gs.newCatchUpResponse(round, setID)
+	require.NoError(t, err)
+
+	expected, err := resp.ToConsensusMessage()
+	require.NoError(t, err)
+
+	// create and handle request
+	req := newCatchUpRequest(round, setID)
+	cm, err := req.ToConsensusMessage()
+	require.NoError(t, err)
+
+	h := NewMessageHandler(gs, st.Block)
+	out, err := h.HandleMessage(cm)
 	require.NoError(t, err)
 	require.Equal(t, expected, out)
 }


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement `handleCatchUpRequest` which validates the request and returns a response if valid
- update `decodeMessage` to handle all grandpa msg types

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1070
