### PR TITLE
lib/grandpa: verify block justification when handling FinalizationMessage

### DIFF
--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -72,8 +72,8 @@ var ErrNotFinalizationMessage = errors.New("cannot get finalized hash from VoteM
 // ErrNoJustification is returned when no justification can be found for a block, ie. it has not been finalized
 var ErrNoJustification = errors.New("no justification found for block")
 
-// ErrMinVotesNotMet is returned when the number of votes is less than the required minimum
-var ErrMinVotesNotMet = errors.New("minimum number of votes not met")
+// ErrMinVotesNotMet is returned when the number of votes is less than the required minimum in a Justification
+var ErrMinVotesNotMet = errors.New("minimum number of votes not met in a Justification")
 
 // ErrInvalidCatchUpRound is returned when a catch-up message is received with an invalid round
 var ErrInvalidCatchUpRound = errors.New("catch up request is for future round")

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -71,3 +71,6 @@ var ErrNotFinalizationMessage = errors.New("cannot get finalized hash from VoteM
 
 // ErrNoJustification is returned when no justification can be found for a block, ie. it has not been finalized
 var ErrNoJustification = errors.New("no justification found for block")
+
+// ErrMinVotesNotMet is returned when the number of votes is less than the required minimum
+var ErrMinVotesNotMet = errors.New("minimum number of votes not met")

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -17,9 +17,10 @@
 package grandpa
 
 import (
+	"reflect"
+
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/scale"
-	"reflect"
 )
 
 // MessageHandler handles GRANDPA consensus messages
@@ -76,11 +77,14 @@ func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*C
 		return req.ToConsensusMessage()
 	}
 
-	// TODO: check justification here
-	h.verifyJustification(msg)
+	// check justification here
+	err := h.verifyJustification(msg)
+	if err != nil {
+		return nil, err
+	}
 
 	// set finalized head for round in db
-	err := h.blockState.SetFinalizedHash(msg.Vote.hash, msg.Round, h.grandpa.state.setID)
+	err = h.blockState.SetFinalizedHash(msg.Vote.hash, msg.Round, h.grandpa.state.setID)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +98,7 @@ func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*C
 	return nil, nil
 }
 
-func (h *MessageHandler) verifyJustification (fm *FinalizationMessage) error {
+func (h *MessageHandler) verifyJustification(fm *FinalizationMessage) error {
 	// validate justification
 	justList := fm.Justification
 	sigCount := 0

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -78,7 +78,7 @@ func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*C
 	}
 
 	// check justification here
-	err := h.verifyJustification(msg)
+	err := h.verifyFinalizationMessageJustification(msg)
 	if err != nil {
 		return nil, err
 	}
@@ -97,47 +97,13 @@ func (h *MessageHandler) handleFinalizationMessage(msg *FinalizationMessage) (*C
 
 	return nil, nil
 }
-
-func (h *MessageHandler) verifyJustification(fm *FinalizationMessage) error {
-	// validate justification
-	justList := fm.Justification
+func (h *MessageHandler) verifyFinalizationMessageJustification(fm *FinalizationMessage) error {
+	// verify justifications
 	sigCount := 0
-	for _, j := range justList {
-		// verify signature
-		msg, err := scale.Encode(&FullVote{
-			Stage: precommit,
-			Vote:  NewVote(j.Vote.hash, j.Vote.number),
-			Round: fm.Round,
-			SetID: h.grandpa.state.setID,
-		})
+	for _, just := range fm.Justification {
+		err := h.verifyJustification(just, just.Vote, fm.Round, h.grandpa.state.setID, precommit)
 		if err != nil {
 			return err
-		}
-
-		pk, err := ed25519.NewPublicKey(j.AuthorityID[:])
-		if err != nil {
-			return err
-		}
-
-		ok, err := pk.Verify(msg, j.Signature[:])
-		if err != nil {
-			return err
-		}
-
-		if !ok {
-			return ErrInvalidSignature
-		}
-
-		// verify authority in justification set
-		authFound := false
-		for _, auth := range h.grandpa.Authorities() {
-			if reflect.DeepEqual(auth.Key.AsBytes(), j.AuthorityID) {
-				authFound = true
-				break
-			}
-		}
-		if !authFound {
-			return ErrVoterNotFound
 		}
 		sigCount++
 	}
@@ -145,6 +111,45 @@ func (h *MessageHandler) verifyJustification(fm *FinalizationMessage) error {
 	// confirm total # signatures >= grandpa threshold
 	if !(uint64(sigCount) >= h.grandpa.state.threshold()) {
 		return ErrMinVotesNotMet
+	}
+	return nil
+}
+func (h *MessageHandler) verifyJustification(just *Justification, vote *Vote, round, setID uint64, stage subround) error {
+	// verify signature
+	msg, err := scale.Encode(&FullVote{
+		Stage: stage,
+		Vote:  vote,
+		Round: round,
+		SetID: setID,
+	})
+	if err != nil {
+		return err
+	}
+
+	pk, err := ed25519.NewPublicKey(just.AuthorityID[:])
+	if err != nil {
+		return err
+	}
+
+	ok, err := pk.Verify(msg, just.Signature[:])
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return ErrInvalidSignature
+	}
+
+	// verify authority in justification set
+	authFound := false
+	for _, auth := range h.grandpa.Authorities() {
+		if reflect.DeepEqual(auth.Key.AsBytes(), just.AuthorityID) {
+			authFound = true
+			break
+		}
+	}
+	if !authFound {
+		return ErrVoterNotFound
 	}
 	return nil
 }

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -142,8 +142,8 @@ func (h *MessageHandler) verifyJustification(fm *FinalizationMessage) error {
 		sigCount++
 	}
 
-	// confirm total # signatures >= 2/3 of number of voters
-	if !(sigCount >= (2/3)*len(h.grandpa.state.voters)) {
+	// confirm total # signatures >= grandpa threshold
+	if !(uint64(sigCount) >= h.grandpa.state.threshold()) {
 		return ErrMinVotesNotMet
 	}
 	return nil

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -179,7 +179,7 @@ func TestMessageHandler_FinalizationMessage_NoCatchUpRequest_InvalidSig(t *testi
 
 	h := NewMessageHandler(gs, st.Block)
 	out, err := h.HandleMessage(cm)
-	require.EqualError(t, err, "signature is not valid")
+	require.EqualError(t, err, ErrInvalidSignature.Error())
 	require.Nil(t, out)
 
 }
@@ -217,6 +217,36 @@ func TestMessageHandler_FinalizationMessage_NoCatchUpRequest_ValidSig(t *testing
 	copy(sMsgArray[:], sMsg)
 
 	gs.justification[77] = []*Justification{
+		{
+			Vote:        testVote,
+			Signature:   sMsgArray,
+			AuthorityID: gs.publicKeyBytes(),
+		},
+		{
+			Vote:        testVote,
+			Signature:   sMsgArray,
+			AuthorityID: gs.publicKeyBytes(),
+		},
+		{
+			Vote:        testVote,
+			Signature:   sMsgArray,
+			AuthorityID: gs.publicKeyBytes(),
+		},
+		{
+			Vote:        testVote,
+			Signature:   sMsgArray,
+			AuthorityID: gs.publicKeyBytes(),
+		},
+		{
+			Vote:        testVote,
+			Signature:   sMsgArray,
+			AuthorityID: gs.publicKeyBytes(),
+		},
+		{
+			Vote:        testVote,
+			Signature:   sMsgArray,
+			AuthorityID: gs.publicKeyBytes(),
+		},
 		{
 			Vote:        testVote,
 			Signature:   sMsgArray,


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- added function `verifyJustification` which check given FinalizationMessage and confirms:
  - Verifies signature is valid for singed FullVote.
  - Authority was in the set indicated by setID
  - The total number of signatures is >= 2/3 the number of voters is the list.

-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1051 
