### PR TITLE
lib/grandpa: implement catch up response handling

### DIFF
--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -80,3 +80,6 @@ var ErrInvalidCatchUpRound = errors.New("catch up request is for future round")
 
 // ErrGHOSTlessCatchUp is returned when a catch up response does not contain a valid grandpa-GHOST (ie. finalized block)
 var ErrGHOSTlessCatchUp = errors.New("catch up response does not contain grandpa-GHOST")
+
+// ErrCatchUpResponseNotCompletable is returned when the round represented by the catch up response is not completable
+var ErrCatchUpResponseNotCompletable = errors.New("catch up response is not completable")

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -37,7 +37,7 @@ var ErrBlockDoesNotExist = errors.New("block does not exist")
 // ErrInvalidSignature is returned when trying to validate a vote message with an invalid signature
 var ErrInvalidSignature = errors.New("signature is not valid")
 
-// ErrSetIDMismatch is returned when trying to validate a vote message with an invalid voter set ID
+// ErrSetIDMismatch is returned when trying to validate a vote message with an invalid voter set ID, or when receiving a catch up message with a different set ID
 var ErrSetIDMismatch = errors.New("set IDs do not match")
 
 // ErrRoundMismatch is returned when trying to validate a vote message that isn't for the current round
@@ -77,3 +77,6 @@ var ErrMinVotesNotMet = errors.New("minimum number of votes not met in a Justifi
 
 // ErrInvalidCatchUpRound is returned when a catch-up message is received with an invalid round
 var ErrInvalidCatchUpRound = errors.New("catch up request is for future round")
+
+// ErrGHOSTlessCatchUp is returned when a catch up response does not contain a valid grandpa-GHOST (ie. finalized block)
+var ErrGHOSTlessCatchUp = errors.New("catch up response does not contain grandpa-GHOST")

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -78,6 +78,9 @@ var ErrMinVotesNotMet = errors.New("minimum number of votes not met in a Justifi
 // ErrInvalidCatchUpRound is returned when a catch-up message is received with an invalid round
 var ErrInvalidCatchUpRound = errors.New("catch up request is for future round")
 
+// ErrInvalidCatchUpResponseRound is returned when a catch-up response is received with an invalid round
+var ErrInvalidCatchUpResponseRound = errors.New("catch up response is not for previous round")
+
 // ErrGHOSTlessCatchUp is returned when a catch up response does not contain a valid grandpa-GHOST (ie. finalized block)
 var ErrGHOSTlessCatchUp = errors.New("catch up response does not contain grandpa-GHOST")
 

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -114,7 +114,7 @@ func NewService(cfg *Config) (*Service, error) {
 		logger:             logger,
 		ctx:                ctx,
 		cancel:             cancel,
-		state:              NewState(cfg.Voters, cfg.SetID, 0),
+		state:              NewState(cfg.Voters, cfg.SetID, 0), // TODO: determine current round
 		blockState:         cfg.BlockState,
 		digestHandler:      cfg.DigestHandler,
 		keypair:            cfg.Keypair,
@@ -138,6 +138,8 @@ func NewService(cfg *Config) (*Service, error) {
 
 // Start begins the GRANDPA finality service
 func (s *Service) Start() error {
+	// TODO: determine if we need to send a catch-up request
+
 	go func() {
 		err := s.initiate()
 		if err != nil {

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -216,5 +216,13 @@ func (r *catchUpResponse) Type() byte {
 
 // ToConsensusMessage converts the catchUpResponse into a network-level consensus message
 func (r *catchUpResponse) ToConsensusMessage() (*ConsensusMessage, error) {
-	return nil, nil
+	enc, err := scale.Encode(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConsensusMessage{
+		ConsensusEngineID: types.GrandpaEngineID,
+		Data:              append([]byte{catchUpResponseType}, enc...),
+	}, nil
 }

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -132,7 +132,7 @@ func (h *MessageHandler) handleCatchUpResponse(msg *catchUpResponse) error {
 		return err
 	}
 
-	if err := h.verifyPreCommitJustification(msg); err != nil {
+	if err = h.verifyPreCommitJustification(msg); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (h *MessageHandler) handleCatchUpResponse(msg *catchUpResponse) error {
 		return ErrGHOSTlessCatchUp
 	}
 
-	if err := h.verifyCatchUpResponseCompletability(prevote, msg.Hash); err != nil {
+	if err = h.verifyCatchUpResponseCompletability(prevote, msg.Hash); err != nil {
 		return err
 	}
 

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -31,7 +31,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testHash = common.Hash{0xa, 0xb, 0xc, 0xd}
+var testHeader = &types.Header{
+	ParentHash: testGenesisHeader.Hash(),
+	Number:     big.NewInt(1),
+}
+
+var testHash = testHeader.Hash()
+
+func buildTestJustifications(t *testing.T, qty int, round, setID uint64, kr *keystore.Ed25519Keyring, subround subround) []*Justification {
+	just := []*Justification{}
+	for i := 0; i < qty; i++ {
+		j := &Justification{
+			Vote:        NewVote(testHash, round),
+			Signature:   createSignedVoteMsg(t, round, round, setID, kr.Keys[i%len(kr.Keys)], subround),
+			AuthorityID: kr.Keys[i%len(kr.Keys)].Public().(*ed25519.PublicKey).AsBytes(),
+		}
+		just = append(just, j)
+	}
+	return just
+
+}
+
+func createSignedVoteMsg(t *testing.T, number, round, setID uint64, pk *ed25519.Keypair, subround subround) [64]byte {
+	// create vote message
+	msg, err := scale.Encode(&FullVote{
+		Stage: subround,
+		Vote:  NewVote(testHash, number),
+		Round: round,
+		SetID: setID,
+	})
+	require.NoError(t, err)
+
+	var sMsgArray [64]byte
+	sMsg, err := pk.Sign(msg)
+	require.NoError(t, err)
+	copy(sMsgArray[:], sMsg)
+	return sMsgArray
+}
 
 func TestDecodeMessage_VoteMessage(t *testing.T) {
 	cm := &ConsensusMessage{
@@ -196,7 +232,7 @@ func TestMessageHandler_FinalizationMessage_NoCatchUpRequest_ValidSig(t *testing
 
 	round := uint64(77)
 	gs.state.round = round
-	gs.justification[round] = buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr)
+	gs.justification[round] = buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
 
 	fm := gs.newFinalizationMessage(gs.head, round)
 	fm.Vote = NewVote(testHash, round)
@@ -236,7 +272,7 @@ func TestMessageHandler_FinalizationMessage_NoCatchUpRequest_MinVoteError(t *tes
 	round := uint64(77)
 	gs.state.round = round
 
-	gs.justification[round] = buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr)
+	gs.justification[round] = buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
 
 	fm := gs.newFinalizationMessage(gs.head, round)
 	cm, err := fm.ToConsensusMessage()
@@ -435,7 +471,7 @@ func TestVerifyJustification(t *testing.T) {
 	vote := NewVote(testHash, 123)
 	just := &Justification{
 		Vote:        vote,
-		Signature:   createSignedVoteMsg(t, vote.number, 77, gs.state.setID, kr.Alice),
+		Signature:   createSignedVoteMsg(t, vote.number, 77, gs.state.setID, kr.Alice, precommit),
 		AuthorityID: kr.Alice.Public().(*ed25519.PublicKey).AsBytes(),
 	}
 
@@ -465,7 +501,7 @@ func TestVerifyJustification_InvalidSignature(t *testing.T) {
 	just := &Justification{
 		Vote: vote,
 		// create signed vote with mismatched vote number
-		Signature:   createSignedVoteMsg(t, vote.number+1, 77, gs.state.setID, kr.Alice),
+		Signature:   createSignedVoteMsg(t, vote.number+1, 77, gs.state.setID, kr.Alice, precommit),
 		AuthorityID: kr.Alice.Public().(*ed25519.PublicKey).AsBytes(),
 	}
 
@@ -497,7 +533,7 @@ func TestVerifyJustification_InvalidAuthority(t *testing.T) {
 	vote := NewVote(testHash, 123)
 	just := &Justification{
 		Vote:        vote,
-		Signature:   createSignedVoteMsg(t, vote.number, 77, gs.state.setID, fakeKey),
+		Signature:   createSignedVoteMsg(t, vote.number, 77, gs.state.setID, fakeKey, precommit),
 		AuthorityID: fakeKey.Public().(*ed25519.PublicKey).AsBytes(),
 	}
 
@@ -505,33 +541,107 @@ func TestVerifyJustification_InvalidAuthority(t *testing.T) {
 	require.EqualError(t, err, ErrVoterNotFound.Error())
 }
 
-func buildTestJustifications(t *testing.T, qty int, round, setID uint64, kr *keystore.Ed25519Keyring) []*Justification {
-	just := []*Justification{}
-	for i := 0; i < qty; i++ {
-		j := &Justification{
-			Vote:        NewVote(testHash, round),
-			Signature:   createSignedVoteMsg(t, round, round, setID, kr.Keys[i%len(kr.Keys)]),
-			AuthorityID: kr.Keys[i%len(kr.Keys)].Public().(*ed25519.PublicKey).AsBytes(),
-		}
-		just = append(just, j)
-	}
-	return just
+func TestMessageHandler_VerifyPreVoteJustification(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
 
+	cfg := &Config{
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	h := NewMessageHandler(gs, st.Block)
+
+	just := buildTestJustifications(t, int(gs.state.threshold()), 1, gs.state.setID, kr, prevote)
+	msg := &catchUpResponse{
+		Round:                1,
+		SetID:                gs.state.setID,
+		PreVoteJustification: just,
+	}
+
+	prevote, err := h.verifyPreVoteJustification(msg)
+	require.NoError(t, err)
+	require.Equal(t, testHash, prevote)
 }
 
-func createSignedVoteMsg(t *testing.T, number, round, setID uint64, pk *ed25519.Keypair) [64]byte {
-	// create vote message
-	msg, err := scale.Encode(&FullVote{
-		Stage: precommit,
-		Vote:  NewVote(testHash, number),
-		Round: round,
-		SetID: setID,
-	})
+func TestMessageHandler_VerifyPreCommitJustification(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)
 
-	var sMsgArray [64]byte
-	sMsg, err := pk.Sign(msg)
+	cfg := &Config{
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
 	require.NoError(t, err)
-	copy(sMsgArray[:], sMsg)
-	return sMsgArray
+
+	h := NewMessageHandler(gs, st.Block)
+
+	round := uint64(1)
+	just := buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
+	msg := &catchUpResponse{
+		Round:                  round,
+		SetID:                  gs.state.setID,
+		PreCommitJustification: just,
+		Hash:                   testHash,
+		Number:                 round,
+	}
+
+	err = h.verifyPreCommitJustification(msg)
+	require.NoError(t, err)
+}
+
+func TestMessageHandler_HandleCatchUpResponse(t *testing.T) {
+	st := newTestState(t)
+	voters := newTestVoters(t)
+	kr, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+
+	cfg := &Config{
+		BlockState:    st.Block,
+		DigestHandler: &mockDigestHandler{},
+		Voters:        voters,
+		Keypair:       kr.Alice,
+	}
+
+	gs, err := NewService(cfg)
+	require.NoError(t, err)
+
+	err = st.Block.SetHeader(testHeader)
+	require.NoError(t, err)
+
+	h := NewMessageHandler(gs, st.Block)
+
+	round := uint64(1)
+	gs.state.round = round + 1
+
+	pvJust := buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr, prevote)
+	pcJust := buildTestJustifications(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
+	msg := &catchUpResponse{
+		Round:                  round,
+		SetID:                  gs.state.setID,
+		PreVoteJustification:   pvJust,
+		PreCommitJustification: pcJust,
+		Hash:                   testHash,
+		Number:                 round,
+	}
+
+	cm, err := msg.ToConsensusMessage()
+	require.NoError(t, err)
+
+	out, err := h.HandleMessage(cm)
+	require.NoError(t, err)
+	require.Nil(t, out)
 }

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -394,10 +394,6 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 	setID := uint64(0)
 	gs.state.round = round + 1
 
-	testHeader := &types.Header{
-		Number: big.NewInt(1),
-	}
-
 	v := &Vote{
 		hash:   testHeader.Hash(),
 		number: 1,


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement `handleCatchUpResponse` for grandpa message handler which checks pre-vote and pre-commit justifications

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1071