### PR TITLE
cmd/gossamer: add check for cfg.BasePath

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -273,6 +273,10 @@ func setDotGlobalConfig(ctx *cli.Context, cfg *dot.GlobalConfig) {
 		cfg.BasePath = basepath
 	}
 
+	// check if cfg.BasePath his been set, if not set to default
+	if cfg.BasePath == "" {
+		cfg.BasePath = dot.GssmrConfig().Global.BasePath
+	}
 	// check --log flag
 	if lvlToInt, err := strconv.Atoi(ctx.String(LogFlag.Name)); err == nil {
 		lvl := log.Lvl(lvlToInt)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- added check in `setDotGlabalConfig` to confirm cfg.BasePath has been set, if not it sets it to default gossamer basepath (~/.gossamer/gssmr)
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1037 
