### PR TITLE
dot/state: replace blockDB, storageDB, epochDB with chaindb.table

### DIFF
--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -30,13 +30,10 @@ import (
 )
 
 func TestConcurrencySetHeader(t *testing.T) {
-	db := chaindb.NewMemDatabase()
-
 	threads := runtime.NumCPU()
 	dbs := make([]chaindb.Database, threads)
 	for i := 0; i < threads; i++ {
-		cpy := *db
-		dbs[i] = &cpy
+		dbs[i] = chaindb.NewMemDatabase()
 	}
 
 	pend := new(sync.WaitGroup)

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -31,12 +31,11 @@ import (
 
 func TestConcurrencySetHeader(t *testing.T) {
 	db := chaindb.NewMemDatabase()
-	blockDB := NewBlockDB(db)
 
 	threads := runtime.NumCPU()
-	dbs := make([]*BlockDB, threads)
+	dbs := make([]chaindb.Database, threads)
 	for i := 0; i < threads; i++ {
-		cpy := *blockDB
+		cpy := *db
 		dbs[i] = &cpy
 	}
 

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -35,11 +35,9 @@ var testGenesisHeader = &types.Header{
 
 func newTestBlockState(t *testing.T, header *types.Header) *BlockState {
 	db := chaindb.NewMemDatabase()
-	blockDb := NewBlockDB(db)
-
 	if header == nil {
 		return &BlockState{
-			db: blockDb,
+			db: chaindb.NewTable(db, blockPrefix),
 		}
 	}
 

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -28,7 +28,7 @@ import (
 	"github.com/ChainSafe/chaindb"
 )
 
-var storagePrefix = []byte("storage")
+var storagePrefix = "storage"
 var codeKey = common.CodeKey
 
 // ErrTrieDoesNotExist is returned when attempting to interact with a trie that is not stored in the StorageState
@@ -38,41 +38,18 @@ func errTrieDoesNotExist(hash common.Hash) error {
 	return fmt.Errorf("%w: %s", ErrTrieDoesNotExist, hash)
 }
 
-// StorageDB stores trie structure in an underlying database
-type StorageDB struct {
-	db chaindb.Database
-}
-
-// Put appends `storage` to the key and sets the key-value pair in the db
-func (storageDB *StorageDB) Put(key, value []byte) error {
-	key = append(storagePrefix, key...)
-	return storageDB.db.Put(key, value)
-}
-
-// Get appends `storage` to the key and retrieves the value from the db
-func (storageDB *StorageDB) Get(key []byte) ([]byte, error) {
-	key = append(storagePrefix, key...)
-	return storageDB.db.Get(key)
-}
-
 // StorageState is the struct that holds the trie, db and lock
 type StorageState struct {
 	blockState *BlockState
 	tries      map[common.Hash]*trie.Trie
 
-	db   *StorageDB
-	lock sync.RWMutex
+	baseDB chaindb.Database
+	db     chaindb.Database
+	lock   sync.RWMutex
 
 	// change notifiers
 	changed     map[byte]chan<- *KeyValue
 	changedLock sync.RWMutex
-}
-
-// NewStorageDB instantiates badgerDB instance for storing trie structure
-func NewStorageDB(db chaindb.Database) *StorageDB {
-	return &StorageDB{
-		db,
-	}
 }
 
 // NewStorageState creates a new StorageState backed by the given trie and database located at basePath.
@@ -93,7 +70,8 @@ func NewStorageState(db chaindb.Database, blockState *BlockState, t *trie.Trie) 
 		//trie:    t,
 		blockState: blockState,
 		tries:      tries,
-		db:         NewStorageDB(db),
+		baseDB:     db,
+		db:         chaindb.NewTable(db, storagePrefix),
 		changed:    make(map[byte]chan<- *KeyValue),
 	}, nil
 }
@@ -145,13 +123,13 @@ func (s *StorageState) StoreInDB(root common.Hash) error {
 		return errTrieDoesNotExist(root)
 	}
 
-	return StoreTrie(s.db.db, s.tries[root])
+	return StoreTrie(s.baseDB, s.tries[root])
 }
 
 // LoadFromDB loads an encoded trie from the DB where the key is `root`
 func (s *StorageState) LoadFromDB(root common.Hash) (*trie.Trie, error) {
 	t := trie.NewEmptyTrie()
-	err := LoadTrie(s.db.db, t, root)
+	err := LoadTrie(s.baseDB, t, root)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- replace blockDB, storageDB, epochDB with chaindb.table which adds a prefix
- update block notify tests to not stall

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/state
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1091