### PR TITLE
dot/core: handle chain re-orgs by re-adding transactions into pool

### DIFF
--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -51,6 +51,9 @@ type BlockState interface {
 	UnregisterImportedChannel(id byte)
 	RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error)
 	UnregisterFinalizedChannel(id byte)
+	HighestCommonAncestor(a, b common.Hash) (common.Hash, error)
+	SubChain(start, end common.Hash) ([]common.Hash, error)
+	GetBlockBody(hash common.Hash) (*types.Body, error)
 }
 
 // StorageState interface for storage state methods

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -256,7 +256,7 @@ func (s *Service) handleBlocks(ctx context.Context) {
 
 			err = s.handleChainReorg(prev, block.Header.Hash())
 			if err != nil {
-				log.Warn("failed to readd transactions to chain upon re-org", "error", err)
+				log.Warn("failed to re-add transactions to chain upon re-org", "error", err)
 			}
 
 			err = s.handleRuntimeChanges(block.Header)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/services"
+	"github.com/ChainSafe/gossamer/lib/transaction"
 
 	log "github.com/ChainSafe/log15"
 )
@@ -240,6 +241,8 @@ func (s *Service) StorageRoot() (common.Hash, error) {
 
 func (s *Service) handleBlocks(ctx context.Context) {
 	for {
+		prev := s.blockState.BestBlockHash()
+
 		select {
 		case block := <-s.blockAddCh:
 			if block == nil {
@@ -249,6 +252,11 @@ func (s *Service) handleBlocks(ctx context.Context) {
 			err := s.storageState.StoreInDB(block.Header.StateRoot)
 			if err != nil {
 				log.Warn("failed to store storage trie in database", "error", err)
+			}
+
+			err = s.handleChainReorg(prev, block.Header.Hash())
+			if err != nil {
+				log.Warn("failed to readd transactions to chain upon re-org", "error", err)
 			}
 
 			err = s.handleRuntimeChanges(block.Header)
@@ -397,6 +405,52 @@ func (s *Service) handleRuntimeChanges(header *types.Header) error {
 		err = s.verifier.SetRuntimeChangeAtBlock(header, s.rt)
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// handleChainReorg checks if there is a chain re-org (ie. new chain head is on a different chain than the
+// previous chain head). If there is a re-org, it moves the transactions that were included on the previous
+// chain back into the transaction pool.
+func (s *Service) handleChainReorg(prev, curr common.Hash) error {
+	ancestor, err := s.blockState.HighestCommonAncestor(prev, curr)
+	if err != nil {
+		return err
+	}
+
+	// if the highest common ancestor of the previous chain head and current chain head is the previous chain head,
+	// then the current chain head is the descendant of the previous and thus are on the same chain
+	if ancestor == prev {
+		return nil
+	}
+
+	subchain, err := s.blockState.SubChain(ancestor, prev)
+	if err != nil {
+		return nil
+	}
+
+	for _, hash := range subchain {
+		body, err := s.blockState.GetBlockBody(hash)
+		if err != nil {
+			continue
+		}
+
+		exts, err := body.AsExtrinsics()
+		if err != nil {
+			continue
+		}
+
+		for _, ext := range exts {
+			// validate the transaction
+			txv, err := s.rt.ValidateTransaction(ext)
+			if err != nil {
+				return err
+			}
+
+			vtx := transaction.NewValidTransaction(ext, txv)
+			s.transactionState.AddToPool(vtx)
 		}
 	}
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -444,11 +444,11 @@ func (s *Service) handleChainReorg(prev, curr common.Hash) error {
 		}
 
 		for _, ext := range exts {
-			s.logger.Crit("validating transaction on re-org chain", "extrinsic", ext)
+			s.logger.Trace("validating transaction on re-org chain", "extrinsic", ext)
 
 			txv, err := s.rt.ValidateTransaction(ext)
 			if err != nil {
-				s.logger.Crit("failed to validate")
+				s.logger.Trace("failed to validate transaction", "extrinsic", ext)
 				continue
 			}
 

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -219,6 +219,10 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 		cfg.StorageState = stateSrvc.Storage
 	}
 
+	if cfg.TransactionState == nil {
+		cfg.TransactionState = stateSrvc.Transaction
+	}
+
 	if cfg.ConsensusMessageHandler == nil {
 		cfg.ConsensusMessageHandler = &mockConsensusMessageHandler{}
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement `handleChainReorg` function which is called upon a block import
- it checks if there is a chain re-org and if so, validates then readds the transactions included on that chain back into the pool

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/core
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #764
