### PR TITLE
lib/runtime: implement ext_clear_child_storage and tests

### DIFF
--- a/dot/state/trie.go
+++ b/dot/state/trie.go
@@ -144,3 +144,10 @@ func (s *TrieState) DeleteChildStorage(key []byte) error {
 	defer s.lock.Unlock()
 	return s.t.DeleteFromChild(key)
 }
+
+// ClearChildStorage removes the child storage entry from the trie
+func (s *TrieState) ClearChildStorage(keyToChild, key []byte) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.t.ClearFromChild(keyToChild, key)
+}

--- a/lib/runtime/imports.go
+++ b/lib/runtime/imports.go
@@ -176,9 +176,20 @@ func ext_child_storage_root(context unsafe.Pointer, a, b, c C.int32_t) C.int32_t
 }
 
 //export ext_clear_child_storage
-func ext_clear_child_storage(context unsafe.Pointer, a, b, c, d C.int32_t) {
+func ext_clear_child_storage(context unsafe.Pointer, storageKeyData, storageKeyLen, keyData, keyLen C.int32_t) {
 	logger.Trace("[ext_clear_child_storage] executing...")
-	logger.Warn("[ext_clear_child_storage] not yet implemented")
+	instanceContext := wasm.IntoInstanceContext(context)
+	memory := instanceContext.Memory().Data()
+
+	runtimeCtx := instanceContext.Data().(*Ctx)
+	s := runtimeCtx.storage
+
+	keyToChild := memory[storageKeyData : storageKeyData+storageKeyLen]
+	key := memory[keyData : keyData+keyLen]
+	err := s.ClearChildStorage(keyToChild, key)
+	if err != nil {
+		logger.Error("[ext_clear_child_storage]", "error", err)
+	}
 }
 
 //export ext_secp256k1_ecdsa_recover_compressed

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -34,6 +34,7 @@ type Storage interface {
 	SetBalance(key [32]byte, balance uint64) error
 	GetBalance(key [32]byte) (uint64, error)
 	DeleteChildStorage(key []byte) error
+	ClearChildStorage(keyToChild, key []byte) error
 }
 
 // BasicNetwork interface for functions used by runtime network state function

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -287,6 +287,10 @@ func (trs testRuntimeStorage) DeleteChildStorage(key []byte) error {
 	return trs.trie.DeleteFromChild(key)
 }
 
+func (trs testRuntimeStorage) ClearChildStorage(keyToChild, key []byte) error {
+	return trs.trie.ClearFromChild(keyToChild, key)
+}
+
 type testRuntimeNetwork struct {
 }
 

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -104,3 +104,15 @@ func (t *Trie) DeleteFromChild(keyToChild []byte) error {
 	key := append(ChildStorageKeyPrefix, keyToChild...)
 	return t.Delete(key)
 }
+
+// ClearFromChild removes the child storage entry
+func (t *Trie) ClearFromChild(keyToChild, key []byte) error {
+	child, err := t.GetChild(keyToChild)
+	if err != nil {
+		return err
+	}
+	if child == nil {
+		return fmt.Errorf("child trie does not exist at key %s%s", ChildStorageKeyPrefix, keyToChild)
+	}
+	return child.Delete(key)
+}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement `ext_clear_child_storage` and tests
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
