### PR TITLE
lib/runtime: update allocator to take []byte instead of *wasm.Memory

### DIFF
--- a/lib/runtime/runtime.go
+++ b/lib/runtime/runtime.go
@@ -108,7 +108,7 @@ func NewRuntime(code []byte, cfg *Config) (*Runtime, error) {
 		instance.Memory = memory
 	}
 
-	memAllocator := NewAllocator(instance.Memory, 0)
+	memAllocator := NewAllocator(instance.Memory.Data(), 0)
 
 	validator := false
 	if cfg.Role == byte(4) {


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

-  update allocator to take []byte instead of *wasm.Memory, allows for more generic usage

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
