### PR TITLE
lib/runtime: fix Blake2b128 and Keccak256

### DIFF
--- a/lib/common/hasher.go
+++ b/lib/common/hasher.go
@@ -26,12 +26,17 @@ import (
 
 // Blake2b128 returns the 128-bit blake2b hash of the input data
 func Blake2b128(in []byte) ([]byte, error) {
-	hasher, err := blake2b.New(16, []byte{})
+	h, err := blake2b.New(16, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return hasher.Sum([]byte{}), nil
+	_, err = h.Write(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.Sum(nil), nil
 }
 
 // Blake2bHash returns the 256-bit blake2b hash of the input data
@@ -41,25 +46,30 @@ func Blake2bHash(in []byte) (Hash, error) {
 		return [32]byte{}, err
 	}
 
-	var res []byte
 	_, err = h.Write(in)
 	if err != nil {
 		return [32]byte{}, err
 	}
 
-	res = h.Sum(nil)
+	hash := h.Sum(nil)
 	var buf = [32]byte{}
-	copy(buf[:], res)
-	return buf, err
+	copy(buf[:], hash)
+	return buf, nil
 }
 
 // Keccak256 returns the keccak256 hash of the input data
-func Keccak256(in []byte) Hash {
+func Keccak256(in []byte) (Hash, error) {
 	h := sha3.NewLegacyKeccak256()
-	hash := h.Sum([]byte{})
+
+	_, err := h.Write(in)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	hash := h.Sum(nil)
 	var buf = [32]byte{}
 	copy(buf[:], hash)
-	return buf
+	return buf, nil
 }
 
 // Twox256 returns the twox256 hash of the input data

--- a/lib/common/hasher_test.go
+++ b/lib/common/hasher_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/scale"
 
 	"github.com/stretchr/testify/require"
 )
@@ -38,11 +37,10 @@ func TestBlake2b218_EmptyHash(t *testing.T) {
 }
 
 func TestBlake128(t *testing.T) {
-	t.Skip()
-	in, err := scale.Encode([]byte("static"))
-	require.NoError(t, err)
+	in := []byte("static")
 	h, err := common.Blake2b128(in)
 	require.NoError(t, err)
+
 	expected, err := common.HexToBytes("0x440973e4e50902f1d0ec97de357eb2fd")
 	require.NoError(t, err)
 	require.Equal(t, expected, h)
@@ -63,17 +61,19 @@ func TestBlake2bHash_EmptyHash(t *testing.T) {
 func TestKeccak256_EmptyHash(t *testing.T) {
 	// test case from https://github.com/debris/tiny-keccak/blob/master/tests/keccak.rs#L4
 	in := []byte{}
-	h := common.Keccak256(in)
+	h, err := common.Keccak256(in)
+	require.NoError(t, err)
+
 	expected, err := common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 	require.NoError(t, err)
 	require.Equal(t, expected, h)
 }
 
 func TestKeccak256(t *testing.T) {
-	t.Skip()
-	in, err := scale.Encode([]byte("static"))
+	in := []byte("static")
+	h, err := common.Keccak256(in)
 	require.NoError(t, err)
-	h := common.Keccak256(in)
+
 	expected, err := common.HexToHash("0xd517392f8119f79c1623774b9346e00104a1d193f1fa641e6e659bf323c37967")
 	require.NoError(t, err)
 	require.Equal(t, expected, h)

--- a/lib/runtime/wasmer/imports_old.go
+++ b/lib/runtime/wasmer/imports_old.go
@@ -426,7 +426,12 @@ func ext_keccak_256(context unsafe.Pointer, data, length, out int32) {
 	logger.Trace("[ext_keccak_256] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
 	memory := instanceContext.Memory().Data()
-	hash := common.Keccak256(memory[data : data+length])
+	hash, err := common.Keccak256(memory[data : data+length])
+	if err != nil {
+		logger.Error("[ext_keccak_256]", "error", err)
+		return
+	}
+
 	logger.Trace("[ext_keccak_256]", "hash", hash)
 	copy(memory[out:out+32], hash[:])
 }

--- a/lib/runtime/wasmtime/imports.go
+++ b/lib/runtime/wasmtime/imports.go
@@ -440,7 +440,13 @@ func ext_keccak_256(c *wasmtime.Caller, data, length, out int32) {
 	logger.Trace("[ext_keccak_256] executing...")
 	m := c.GetExport("memory").Memory()
 	memory := m.UnsafeData()
-	hash := common.Keccak256(memory[data : data+length])
+
+	hash, err := common.Keccak256(memory[data : data+length])
+	if err != nil {
+		logger.Error("[ext_keccak_256]", "error", err)
+		return
+	}
+
 	logger.Trace("[ext_keccak_256]", "hash", hash)
 	copy(memory[out:out+32], hash[:])
 	runtime.KeepAlive(m)


### PR DESCRIPTION
## Changes

- Fixes `Blake2b128` by passing input to the hasher
- Fixes `Keccak256` by passing input to the hasher 
- Enables all `Blake2b128` and `Keccak256` test again
- Clean up `Blake2b256` to go with other code

## Tests

Now passes previously failing tests in w3f/polkadot-spec/pull/295.

## Checklist

- [ ] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

- Bug was introduced in #291, 
- Part of it was fixed in #1127
- w3f/polkadot-spec#295
- closes #989