### PR TITLE
dot/rpc: fix rpc subscription parameter

### DIFF
--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -106,7 +106,6 @@ func (cm *ChainModule) GetBlock(r *http.Request, req *ChainHashRequest, res *Cha
 // GetBlockHash Get hash of the 'n-th' block in the canon chain. If no parameters are provided,
 //  the latest block hash gets returned.
 func (cm *ChainModule) GetBlockHash(r *http.Request, req *ChainBlockNumberRequest, res *ChainHashResponse) error {
-	fmt.Println("RPC chain_getBlockHash", req)
 	// if request is empty, return highest hash
 	if *req == nil || reflect.ValueOf(*req).Len() == 0 {
 		*res = cm.blockAPI.BestBlockHash().String()

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -17,7 +17,6 @@
 package modules
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -100,7 +99,7 @@ func (sm *SystemModule) NetworkState(r *http.Request, req *EmptyRequest, res *Sy
 	networkState := sm.networkAPI.NetworkState()
 	res.NetworkState.PeerID = networkState.PeerID
 	for _, v := range networkState.Multiaddrs {
-		fmt.Printf("addr %v\n", v)
+		res.NetworkState.Multiaddrs = append(res.NetworkState.Multiaddrs, v.String())
 	}
 	return nil
 }


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- The `subscription` parameter in the JSON response in RPC subscription calls was in wrong place, so polkadot.js api was not responding to websocket messages.
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/rpc/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- Fixes #1137 
