### PR TITLE
Remove pruned keys from Storage state.

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -48,6 +48,8 @@ type BlockState struct {
 	finalized     map[byte]chan<- *types.Header
 	importedLock  sync.RWMutex
 	finalizedLock sync.RWMutex
+
+	pruneKeyCh chan common.Hash
 }
 
 // NewBlockState will create a new BlockState backed by the database located at basePath
@@ -57,11 +59,12 @@ func NewBlockState(db chaindb.Database, bt *blocktree.BlockTree) (*BlockState, e
 	}
 
 	bs := &BlockState{
-		bt:        bt,
-		baseDB:    db,
-		db:        chaindb.NewTable(db, blockPrefix),
-		imported:  make(map[byte]chan<- *types.Block),
-		finalized: make(map[byte]chan<- *types.Header),
+		bt:         bt,
+		baseDB:     db,
+		db:         chaindb.NewTable(db, blockPrefix),
+		imported:   make(map[byte]chan<- *types.Block),
+		finalized:  make(map[byte]chan<- *types.Header),
+		pruneKeyCh: make(chan common.Hash, 1000),
 	}
 
 	bs.genesisHash = bt.GenesisHash()
@@ -79,11 +82,12 @@ func NewBlockState(db chaindb.Database, bt *blocktree.BlockTree) (*BlockState, e
 // NewBlockStateFromGenesis initializes a BlockState from a genesis header, saving it to the database located at basePath
 func NewBlockStateFromGenesis(db chaindb.Database, header *types.Header) (*BlockState, error) {
 	bs := &BlockState{
-		bt:        blocktree.NewBlockTreeFromGenesis(header, db),
-		baseDB:    db,
-		db:        chaindb.NewTable(db, blockPrefix),
-		imported:  make(map[byte]chan<- *types.Block),
-		finalized: make(map[byte]chan<- *types.Header),
+		bt:         blocktree.NewBlockTreeFromGenesis(header, db),
+		baseDB:     db,
+		db:         chaindb.NewTable(db, blockPrefix),
+		imported:   make(map[byte]chan<- *types.Block),
+		finalized:  make(map[byte]chan<- *types.Header),
+		pruneKeyCh: make(chan common.Hash, 1000),
 	}
 
 	err := bs.setArrivalTime(header.Hash(), uint64(time.Now().Unix()))
@@ -437,6 +441,7 @@ func (bs *BlockState) SetFinalizedHash(hash common.Hash, round, setID uint64) er
 		if err != nil {
 			return err
 		}
+		bs.pruneKeyCh <- rem
 	}
 
 	return bs.db.Put(finalizedHashKey(round, setID), hash[:])

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
@@ -158,10 +159,14 @@ func (s *Service) Initialize(data *genesis.Data, header *types.Header, t *trie.T
 func (s *Service) pruneStorage() {
 	for {
 		select {
-		case keyHash := <-s.Block.pruneKeyCh:
-			s.Storage.pruneStorage(keyHash)
+		case keys := <-s.Block.pruneKeyCh:
+			for _, v := range keys {
+				s.Storage.pruneKey(v)
+			}
 		case <-s.closeCh:
 			return
+		default:
+			time.Sleep(100 * time.Millisecond)
 		}
 	}
 }

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -141,9 +141,6 @@ func (s *Service) Initialize(data *genesis.Data, header *types.Header, t *trie.T
 		s.Storage = storageState
 		s.Block = blockState
 		s.Epoch = epochState
-
-		// Start background goroutine to GC pruned keys.
-		go s.pruneStorage()
 	} else {
 
 		// close database
@@ -271,6 +268,9 @@ func (s *Service) Start() error {
 
 	// create epoch state
 	s.Epoch = NewEpochState(db)
+
+	// Start background goroutine to GC pruned keys.
+	go s.pruneStorage()
 	return nil
 }
 

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -145,6 +145,9 @@ func Test_ServicePruneStorage(t *testing.T) {
 	err = serv.Initialize(genesisData, genesisHeader, tr, firstEpochInfo)
 	require.Nil(t, err)
 
+	err = serv.Start()
+	require.Nil(t, err)
+
 	serv.Block = newTestBlockState(t, testGenesisHeader)
 	serv.Storage = newTestStorageState(t)
 	ch := make(chan *types.Header, 3)
@@ -191,4 +194,7 @@ func Test_ServicePruneStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, false, ok)
 	}
+
+	err = serv.Stop()
+	require.Nil(t, err)
 }

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -74,10 +74,17 @@ func NewStorageState(db chaindb.Database, blockState *BlockState, t *trie.Trie) 
 	}, nil
 }
 
-func (s *StorageState) pruneStorage(hash common.Hash) {
+func (s *StorageState) pruneKey(hash common.Hash) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.baseDB.Del(hash[:])
+
+	tr, ok := s.tries[hash]
+	if !ok {
+		return
+	}
+
+	dbKey, _ := tr.Hash()
+	_ = s.baseDB.Del(dbKey[:])
 	delete(s.tries, hash)
 }
 

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -74,10 +74,11 @@ func NewStorageState(db chaindb.Database, blockState *BlockState, t *trie.Trie) 
 	}, nil
 }
 
-func (s *StorageState) pruneStorage() { //nolint
-	// TODO: when a block is finalized, delete non-finalized tries from DB and mapping
-	// as well as all states before finalized block
-	// TODO: pruning options? eg archive, full, etc
+func (s *StorageState) pruneStorage(hash common.Hash) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.baseDB.Del(hash[:])
+	delete(s.tries, hash)
 }
 
 // StoreTrie stores the given trie in the StorageState and writes it to the database


### PR DESCRIPTION
## Changes
- Start a background goroutine to GC prune keys from Storage state.
- Implement prune key API in Storage state.

## Tests

## Checklist
- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues
- #1125 
