### PR TITLE
dot/network: implement block announce protocol

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -38,25 +38,20 @@ type blockAnnounceData struct {
 }
 
 func (s *Service) blockAnnounceDecoder(in []byte, peer peer.ID) (Message, error) {
-	// if we don't have handshake data on this peer, or we haven't received the handshake from them already,
-	// assume we are receiving the handshake
-	if hsData, has := s.blockAnnounceHandshakes[peer]; !has || !hsData.received {
-		r := &bytes.Buffer{}
-		_, err := r.Write(in)
-		if err != nil {
-			return nil, err
-		}
-
-		hs := new(BlockAnnounceHandshake)
-		return hs, hs.Decode(r)
-	}
-
 	r := &bytes.Buffer{}
 	_, err := r.Write(in)
 	if err != nil {
 		return nil, err
 	}
 
+	// if we don't have handshake data on this peer, or we haven't received the handshake from them already,
+	// assume we are receiving the handshake
+	if hsData, has := s.blockAnnounceHandshakes[peer]; !has || !hsData.received {
+		hs := new(BlockAnnounceHandshake)
+		return hs, hs.Decode(r)
+	}
+
+	// otherwise, assume we are receiving the BlockAnnounceMessage
 	ba := new(BlockAnnounceMessage)
 	return ba, ba.Decode(r)
 }

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -147,7 +147,6 @@ func (s *Service) handleBlockAnnounceMessage(peer peer.ID, msg Message) {
 			s.blockAnnounceHandshakes[peer] = &blockAnnounceData{
 				validated: true,
 			}
-			return
 		}
 
 		// if we are the initiator and haven't received the handshake already, validate it
@@ -156,8 +155,8 @@ func (s *Service) handleBlockAnnounceMessage(peer peer.ID, msg Message) {
 			if err != nil {
 				logger.Error("failed to validate BlockAnnounceHandshake", "peer", peer, "error", err)
 				delete(s.blockAnnounceHandshakes, peer)
+				return
 			}
-			return
 		}
 
 		// if we are the initiator, send the BlockAnnounce

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -57,8 +57,8 @@ func (s *Service) blockAnnounceDecoder(in []byte, peer peer.ID) (Message, error)
 		return nil, err
 	}
 
-	hs := new(BlockAnnounceMessage)
-	return hs, hs.Decode(r)
+	ba := new(BlockAnnounceMessage)
+	return ba, ba.Decode(r)
 }
 
 // BlockAnnounceHandshake is exchanged by nodes that are beginning the BlockAnnounce protocol

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -1,0 +1,195 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/scale"
+
+	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type blockAnnounceData struct {
+	validated bool                  // set to true if a handshake has been received and validated, false otherwise
+	msg       *BlockAnnounceMessage // if this node is the sender of the BlockAnnounce, this is set, otherwise, it's nil
+}
+
+func blockAnnounceHandshakeDecoder(in []byte) (Message, error) {
+	r := &bytes.Buffer{}
+	_, err := r.Write(in)
+	if err != nil {
+		return nil, err
+	}
+
+	hs := new(BlockAnnounceHandshake)
+	return hs, hs.Decode(r)
+}
+
+// BlockAnnounceHandshake is exchanged by nodes that are beginning the BlockAnnounce protocol
+type BlockAnnounceHandshake struct {
+	Roles           byte
+	BestBlockNumber uint64
+	BestBlockHash   common.Hash
+	GenesisHash     common.Hash
+}
+
+// String formats a BlockAnnounceHandshake as a string
+func (hs *BlockAnnounceHandshake) String() string {
+	return fmt.Sprintf("BlockAnnounceHandshake Roles=%d BestBlockNumber=%d BestBlockHash=%s GenesisHash=%s",
+		hs.Roles,
+		hs.BestBlockNumber,
+		hs.BestBlockHash,
+		hs.GenesisHash)
+}
+
+// Encode encodes a BlockAnnounceHandshake message using SCALE
+func (hs *BlockAnnounceHandshake) Encode() ([]byte, error) {
+	return scale.Encode(hs)
+}
+
+// Decode the message into a BlockAnnounceHandshake
+func (hs *BlockAnnounceHandshake) Decode(r io.Reader) error {
+	sd := scale.Decoder{Reader: r}
+	_, err := sd.Decode(hs)
+	return err
+}
+
+// Type ...
+func (hs *BlockAnnounceHandshake) Type() int {
+	return -1
+}
+
+// IDString ...
+func (hs *BlockAnnounceHandshake) IDString() string {
+	return ""
+}
+
+func (s *Service) getBlockAnnounceHandshake() (*BlockAnnounceHandshake, error) {
+	latestBlock, err := s.blockState.BestBlockHeader()
+	if err != nil {
+		return nil, err
+	}
+
+	return &BlockAnnounceHandshake{
+		Roles:           s.cfg.Roles,
+		BestBlockNumber: latestBlock.Number.Uint64(),
+		BestBlockHash:   latestBlock.Hash(),
+		GenesisHash:     s.blockState.GenesisHash(),
+	}, nil
+}
+
+func (s *Service) validateBlockAnnounceHandshake(hs *BlockAnnounceHandshake) error {
+	if hs.GenesisHash != s.blockState.GenesisHash() {
+		return errors.New("genesis hash mismatch")
+	}
+
+	return nil
+}
+
+// handleBlockAnnounceStream handles streams with the <protocol-id>/block-announces/1 protocol ID
+func (s *Service) handleBlockAnnounceStream(stream libp2pnetwork.Stream) {
+	conn := stream.Conn()
+	if conn == nil {
+		logger.Error("Failed to get connection from stream")
+		return
+	}
+
+	peer := conn.RemotePeer()
+
+	// we haven't received a handshake yet from the peer, get handshake first
+	if hsData, has := s.blockAnnounceHandshakes[peer]; !has {
+		s.readStream(stream, peer, blockAnnounceHandshakeDecoder, s.handleBlockAnnounceMessage)
+		return
+	} else if !hsData.validated {
+		// we received a handshake, but it was invalid
+		return
+	}
+
+	s.readStream(stream, peer, decodeMessageBytes, s.handleBlockAnnounceMessage)
+}
+
+// handleBlockAnnounceMessage handles BlockAnnounce messages
+// if some more blocks are required to sync the announced block, the node will open a sync stream
+// with its peer and send a BlockRequest message
+func (s *Service) handleBlockAnnounceMessage(peer peer.ID, msg Message) {
+	if hs, ok := msg.(*BlockAnnounceHandshake); ok {
+		// if we are the receiver and haven't received the handshake already, validate it
+		if _, has := s.blockAnnounceHandshakes[peer]; !has {
+			err := s.validateBlockAnnounceHandshake(hs)
+			if err != nil {
+				logger.Error("failed to validate BlockAnnounceHandshake", "peer", peer, "error", err)
+				s.blockAnnounceHandshakes[peer] = &blockAnnounceData{
+					validated: false,
+				}
+				return
+			}
+
+			s.blockAnnounceHandshakes[peer] = &blockAnnounceData{
+				validated: true,
+			}
+			return
+		}
+
+		// if we are the initiator and haven't received the handshake already, validate it
+		if hsData, has := s.blockAnnounceHandshakes[peer]; has && !hsData.validated {
+			err := s.validateBlockAnnounceHandshake(hs)
+			if err != nil {
+				logger.Error("failed to validate BlockAnnounceHandshake", "peer", peer, "error", err)
+				delete(s.blockAnnounceHandshakes, peer)
+			}
+			return
+		}
+
+		// if we are the initiator, send the BlockAnnounce
+		if hsData, has := s.blockAnnounceHandshakes[peer]; has && hsData.msg != nil {
+			err := s.host.send(peer, blockAnnounceID, s.blockAnnounceHandshakes[peer].msg)
+			if err != nil {
+				logger.Error("failed to send BlockAnnounceMessage", "peer", peer, "error", err)
+			}
+			return
+		}
+
+		// otherwise, send back a handshake
+		resp, err := s.getBlockAnnounceHandshake()
+		if err != nil {
+			logger.Error("failed to get BlockAnnounceHandshake", "error", err)
+			return
+		}
+
+		err = s.host.send(peer, blockAnnounceID, resp)
+		if err != nil {
+			logger.Error("failed to send BlockAnnounceHandshake", "peer", peer, "error", err)
+		}
+	}
+
+	if an, ok := msg.(*BlockAnnounceMessage); ok {
+		req := s.syncer.HandleBlockAnnounce(an)
+		if req != nil {
+			s.requestTracker.addRequestedBlockID(req.ID)
+			err := s.host.send(peer, syncID, req)
+			if err != nil {
+				logger.Error("failed to send BlockRequest message", "peer", peer)
+			}
+		}
+	}
+}

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -80,8 +80,7 @@ func (hs *BlockAnnounceHandshake) String() string {
 
 // Encode encodes a BlockAnnounceHandshake message using SCALE
 func (hs *BlockAnnounceHandshake) Encode() ([]byte, error) {
-	enc, err := scale.Encode(hs)
-	return append([]byte{BlockAnnounceHandshakeType}, enc...), err
+	return scale.Encode(hs)
 }
 
 // Decode the message into a BlockAnnounceHandshake
@@ -93,7 +92,7 @@ func (hs *BlockAnnounceHandshake) Decode(r io.Reader) error {
 
 // Type ...
 func (hs *BlockAnnounceHandshake) Type() int {
-	return BlockAnnounceHandshakeType
+	return -1
 }
 
 // IDString ...

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -1,0 +1,136 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package network
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/utils"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockAnnounceDecoder(t *testing.T) {
+	srv := &Service{
+		blockAnnounceHandshakes: make(map[peer.ID]*blockAnnounceData),
+	}
+
+	testPeerID := peer.ID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
+	srv.blockAnnounceHandshakes[testPeerID] = &blockAnnounceData{
+		received: false,
+	}
+
+	testHandshake := &BlockAnnounceHandshake{
+		Roles:           4,
+		BestBlockNumber: 77,
+		BestBlockHash:   common.Hash{1},
+		GenesisHash:     common.Hash{2},
+	}
+
+	enc, err := testHandshake.Encode()
+	require.NoError(t, err)
+
+	msg, err := srv.blockAnnounceDecoder(enc, testPeerID)
+	require.NoError(t, err)
+	require.Equal(t, testHandshake, msg)
+
+	testBlockAnnounce := &BlockAnnounceMessage{
+		ParentHash:     common.Hash{1},
+		Number:         big.NewInt(77),
+		StateRoot:      common.Hash{2},
+		ExtrinsicsRoot: common.Hash{3},
+		Digest:         [][]byte{},
+	}
+
+	enc, err = testBlockAnnounce.Encode()
+	require.NoError(t, err)
+
+	srv.blockAnnounceHandshakes[testPeerID].received = true
+	msg, err = srv.blockAnnounceDecoder(enc, testPeerID)
+	require.NoError(t, err)
+	require.Equal(t, testBlockAnnounce, msg)
+}
+
+func TestHandleBlockAnnounceMessage_BlockAnnounce(t *testing.T) {
+	basePath := utils.NewTestBasePath(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
+
+	config := &Config{
+		BasePath:    basePath,
+		Port:        7001,
+		RandSeed:    1,
+		NoBootstrap: true,
+		NoMDNS:      true,
+		NoStatus:    true,
+	}
+
+	s := createTestService(t, config)
+
+	peerID := peer.ID("noot")
+	msg := &BlockAnnounceMessage{
+		Number: big.NewInt(10),
+	}
+
+	s.handleBlockAnnounceMessage(peerID, msg)
+	require.True(t, s.requestTracker.hasRequestedBlockID(99))
+}
+
+func TestHandleBlockAnnounceMessage_BlockAnnounceHandshake(t *testing.T) {
+	basePath := utils.NewTestBasePath(t, "nodeA")
+
+	// removes all data directories created within test directory
+	defer utils.RemoveTestDir(t)
+
+	config := &Config{
+		BasePath:    basePath,
+		Port:        7001,
+		RandSeed:    1,
+		NoBootstrap: true,
+		NoMDNS:      true,
+		NoStatus:    true,
+	}
+
+	s := createTestService(t, config)
+
+	testPeerID := peer.ID("noot")
+	testHandshake := &BlockAnnounceHandshake{
+		Roles:           4,
+		BestBlockNumber: 77,
+		BestBlockHash:   common.Hash{1},
+		GenesisHash:     common.Hash{2},
+	}
+
+	s.handleBlockAnnounceMessage(testPeerID, testHandshake)
+	require.True(t, s.blockAnnounceHandshakes[testPeerID].received)
+	require.False(t, s.blockAnnounceHandshakes[testPeerID].validated)
+
+	testHandshake = &BlockAnnounceHandshake{
+		Roles:           4,
+		BestBlockNumber: 77,
+		BestBlockHash:   common.Hash{1},
+		GenesisHash:     s.blockState.GenesisHash(),
+	}
+
+	s.handleBlockAnnounceMessage(testPeerID, testHandshake)
+	require.True(t, s.blockAnnounceHandshakes[testPeerID].received)
+	require.True(t, s.blockAnnounceHandshakes[testPeerID].validated)
+}

--- a/dot/network/gossip.go
+++ b/dot/network/gossip.go
@@ -33,7 +33,7 @@ type gossip struct {
 // newGossip creates a new gossip instance from the host
 func newGossip(host *host) *gossip {
 	return &gossip{
-		logger:  host.logger.New("module", "gossip"),
+		logger:  logger.New("module", "gossip"),
 		host:    host,
 		hasSeen: &sync.Map{},
 	}

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -200,16 +200,6 @@ func (h *host) sendBytes(p peer.ID, sub protocol.ID, msg []byte) (err error) {
 	return err
 }
 
-// broadcastWithProtocol sends a message to each connected peer with the given sub-protocol
-func (h *host) broadcastWithProtocol(msg Message, sub protocol.ID) {
-	for _, p := range h.peers() {
-		err := h.send(p, sub, msg)
-		if err != nil {
-			logger.Error("Failed to broadcast message to peer", "peer", p, "error", err)
-		}
-	}
-}
-
 // broadcast sends a message to each connected peer
 func (h *host) broadcast(msg Message) {
 	for _, p := range h.peers() {

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -188,7 +188,7 @@ func (h *host) sendBytes(p peer.ID, sub protocol.ID, msg []byte) (err error) {
 			"Opened stream",
 			"host", h.id(),
 			"peer", p,
-			"protocol", s.Protocol(),
+			"protocol", h.protocolID+sub,
 		)
 	}
 

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/ChainSafe/log15"
 	ds "github.com/ipfs/go-datastore"
 	dsync "github.com/ipfs/go-datastore/sync"
 	"github.com/libp2p/go-libp2p"
@@ -39,7 +38,6 @@ var defaultMaxPeerCount = 5
 
 // host wraps libp2p host with network host configuration and services
 type host struct {
-	logger     log.Logger
 	ctx        context.Context
 	h          libp2phost.Host
 	dht        *kaddht.IpfsDHT
@@ -48,7 +46,7 @@ type host struct {
 }
 
 // newHost creates a host wrapper with a new libp2p host instance
-func newHost(ctx context.Context, cfg *Config, logger log.Logger) (*host, error) {
+func newHost(ctx context.Context, cfg *Config) (*host, error) {
 
 	// use "p2p" for multiaddress format
 	ma.SwapToP2pMultiaddrs()
@@ -93,10 +91,7 @@ func newHost(ctx context.Context, cfg *Config, logger log.Logger) (*host, error)
 	// format protocol id
 	pid := protocol.ID(cfg.ProtocolID)
 
-	logger = logger.New("module", "host")
-
 	return &host{
-		logger:     logger,
 		ctx:        ctx,
 		h:          h,
 		dht:        dht,
@@ -112,14 +107,14 @@ func (h *host) close() error {
 	// close DHT service
 	err := h.dht.Close()
 	if err != nil {
-		h.logger.Error("Failed to close DHT service", "error", err)
+		logger.Error("Failed to close DHT service", "error", err)
 		return err
 	}
 
 	// close libp2p host
 	err = h.h.Close()
 	if err != nil {
-		h.logger.Error("Failed to close libp2p host", "error", err)
+		logger.Error("Failed to close libp2p host", "error", err)
 		return err
 	}
 
@@ -148,7 +143,7 @@ func (h *host) bootstrap() {
 	for _, addrInfo := range h.bootnodes {
 		err := h.connect(addrInfo)
 		if err != nil {
-			h.logger.Error("Failed to bootstrap peer", "error", err)
+			logger.Error("Failed to bootstrap peer", "error", err)
 		}
 	}
 }
@@ -166,7 +161,7 @@ func (h *host) send(p peer.ID, sub protocol.ID, msg Message) (err error) {
 		return err
 	}
 
-	h.logger.Trace(
+	logger.Trace(
 		"Sent message to peer",
 		"host", h.id(),
 		"peer", p,
@@ -189,7 +184,7 @@ func (h *host) sendBytes(p peer.ID, sub protocol.ID, msg []byte) (err error) {
 			return err
 		}
 
-		h.logger.Trace(
+		logger.Trace(
 			"Opened stream",
 			"host", h.id(),
 			"peer", p,
@@ -205,12 +200,12 @@ func (h *host) sendBytes(p peer.ID, sub protocol.ID, msg []byte) (err error) {
 	return err
 }
 
-// broadcast sends a message to each connected peer with the given sub-protocol
+// broadcastWithProtocol sends a message to each connected peer with the given sub-protocol
 func (h *host) broadcastWithProtocol(msg Message, sub protocol.ID) {
 	for _, p := range h.peers() {
 		err := h.send(p, sub, msg)
 		if err != nil {
-			h.logger.Error("Failed to broadcast message to peer", "peer", p, "error", err)
+			logger.Error("Failed to broadcast message to peer", "peer", p, "error", err)
 		}
 	}
 }
@@ -220,7 +215,7 @@ func (h *host) broadcast(msg Message) {
 	for _, p := range h.peers() {
 		err := h.send(p, "", msg)
 		if err != nil {
-			h.logger.Error("Failed to broadcast message to peer", "peer", p, "error", err)
+			logger.Error("Failed to broadcast message to peer", "peer", p, "error", err)
 		}
 	}
 }
@@ -231,7 +226,7 @@ func (h *host) broadcastExcluding(msg Message, peer peer.ID) {
 		if p != peer {
 			err := h.send(p, "", msg)
 			if err != nil {
-				h.logger.Error("Failed to send message during broadcast", "peer", p, "err", err)
+				logger.Error("Failed to send message during broadcast", "peer", p, "err", err)
 			}
 		}
 	}

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -205,6 +205,16 @@ func (h *host) sendBytes(p peer.ID, sub protocol.ID, msg []byte) (err error) {
 	return err
 }
 
+// broadcast sends a message to each connected peer with the given sub-protocol
+func (h *host) broadcastWithProtocol(msg Message, sub protocol.ID) {
+	for _, p := range h.peers() {
+		err := h.send(p, sub, msg)
+		if err != nil {
+			h.logger.Error("Failed to broadcast message to peer", "peer", p, "error", err)
+		}
+	}
+}
+
 // broadcast sends a message to each connected peer
 func (h *host) broadcast(msg Message) {
 	for _, p := range h.peers() {

--- a/dot/network/mdns.go
+++ b/dot/network/mdns.go
@@ -45,7 +45,7 @@ type mdns struct {
 // newMDNS creates a new mDNS instance from the host
 func newMDNS(host *host) *mdns {
 	return &mdns{
-		logger: host.logger.New("module", "mdns"),
+		logger: logger.New("module", "mdns"),
 		host:   host,
 	}
 }

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -49,9 +49,6 @@ const (
 	RemoteChangesRequestType  = 12
 	RemoteChangesResponseType = 13
 	ChainSpecificMsgType      = 255
-
-	// TODO: do handshakes have type identifiers?
-	BlockAnnounceHandshakeType = 254
 )
 
 // Message interface

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -30,6 +30,54 @@ import (
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
+func blockAnnounceHandshakeDecoder(in []byte) (Message, error) {
+	r := &bytes.Buffer{}
+	_, err := r.Write(in)
+	if err != nil {
+		return nil, err
+	}
+
+	h := new(BlockAnnounceHandshake)
+	return h, h.Decode(r)
+}
+
+// BlockAnnounceHandshake is exchanged by nodes that are beginning the BlockAnnounce protocol
+type BlockAnnounceHandshake struct {
+	Roles           byte
+	BestBlockNumber uint64
+	BestBlockHash   common.Hash
+	GenesisHash     common.Hash
+}
+
+// String formats a BlockAnnounceHandshake as a string
+func (h *BlockAnnounceHandshake) String() string {
+	return fmt.Sprintf("BlockAnnounceHandshake Roles=%d BestBlockNumber=%d BestBlockHash=%s GenesisHash=%s",
+		h.Roles,
+		h.BestBlockNumber,
+		h.BestBlockHash,
+		h.GenesisHash)
+}
+
+// Encode encodes a BlockAnnounceHandshake message using SCALE
+func (h *BlockAnnounceHandshake) Encode() ([]byte, error) {
+	return scale.Encode(h)
+}
+
+// Decode the message into a BlockAnnounceHandshake
+func (h *BlockAnnounceHandshake) Decode(r io.Reader) error {
+	sd := scale.Decoder{Reader: r}
+	_, err := sd.Decode(h)
+	return err
+}
+
+func (h *BlockAnnounceHandshake) Type() int {
+	return -1
+}
+
+func (h *BlockAnnounceHandshake) IDString() string {
+	return ""
+}
+
 //nolint
 const (
 	StatusMsgType             = 0

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -30,54 +30,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
-func blockAnnounceHandshakeDecoder(in []byte) (Message, error) {
-	r := &bytes.Buffer{}
-	_, err := r.Write(in)
-	if err != nil {
-		return nil, err
-	}
-
-	h := new(BlockAnnounceHandshake)
-	return h, h.Decode(r)
-}
-
-// BlockAnnounceHandshake is exchanged by nodes that are beginning the BlockAnnounce protocol
-type BlockAnnounceHandshake struct {
-	Roles           byte
-	BestBlockNumber uint64
-	BestBlockHash   common.Hash
-	GenesisHash     common.Hash
-}
-
-// String formats a BlockAnnounceHandshake as a string
-func (h *BlockAnnounceHandshake) String() string {
-	return fmt.Sprintf("BlockAnnounceHandshake Roles=%d BestBlockNumber=%d BestBlockHash=%s GenesisHash=%s",
-		h.Roles,
-		h.BestBlockNumber,
-		h.BestBlockHash,
-		h.GenesisHash)
-}
-
-// Encode encodes a BlockAnnounceHandshake message using SCALE
-func (h *BlockAnnounceHandshake) Encode() ([]byte, error) {
-	return scale.Encode(h)
-}
-
-// Decode the message into a BlockAnnounceHandshake
-func (h *BlockAnnounceHandshake) Decode(r io.Reader) error {
-	sd := scale.Decoder{Reader: r}
-	_, err := sd.Decode(h)
-	return err
-}
-
-func (h *BlockAnnounceHandshake) Type() int {
-	return -1
-}
-
-func (h *BlockAnnounceHandshake) IDString() string {
-	return ""
-}
-
 //nolint
 const (
 	StatusMsgType             = 0
@@ -103,7 +55,7 @@ type Message interface {
 	Decode(io.Reader) error
 	String() string
 	Type() int
-	IDString() string
+	IDString() string // TODO: this can likely be removed
 }
 
 // decodeMessage decodes the message based on message type

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -28,6 +28,8 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common/optional"
 	"github.com/ChainSafe/gossamer/lib/common/variadic"
 	"github.com/ChainSafe/gossamer/lib/scale"
+
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 //nolint
@@ -48,7 +50,7 @@ const (
 	RemoteChangesResponseType = 13
 	ChainSpecificMsgType      = 255
 
-	// TODO: do handshake have type identifiers?
+	// TODO: do handshakes have type identifiers?
 	BlockAnnounceHandshakeType = 254
 )
 
@@ -78,18 +80,18 @@ func decodeMessage(r io.Reader) (m Message, err error) {
 	case BlockResponseMsgType:
 		m = new(BlockResponseMessage)
 		err = m.Decode(r)
-	case BlockAnnounceMsgType:
-		m = new(BlockAnnounceMessage)
-		err = m.Decode(r)
+	// case BlockAnnounceMsgType:
+	// 	m = new(BlockAnnounceMessage)
+	// 	err = m.Decode(r)
 	case TransactionMsgType:
 		m = new(TransactionMessage)
 		err = m.Decode(r)
 	case ConsensusMsgType:
 		m = new(ConsensusMessage)
 		err = m.Decode(r)
-	case BlockAnnounceHandshakeType:
-		m = new(BlockAnnounceHandshake)
-		err = m.Decode(r)
+	// case BlockAnnounceHandshakeType:
+	// 	m = new(BlockAnnounceHandshake)
+	// 	err = m.Decode(r)
 	default:
 		return nil, fmt.Errorf("unsupported message type %d", msgType)
 	}
@@ -98,7 +100,7 @@ func decodeMessage(r io.Reader) (m Message, err error) {
 }
 
 // decodeMessageBytes decodes the message based on message type
-func decodeMessageBytes(in []byte) (m Message, err error) {
+func decodeMessageBytes(in []byte, _ peer.ID) (m Message, err error) {
 	r := &bytes.Buffer{}
 	_, err = r.Write(in)
 	if err != nil {
@@ -333,7 +335,7 @@ func (bm *BlockAnnounceMessage) Encode() ([]byte, error) {
 	if err != nil {
 		return enc, err
 	}
-	return append([]byte{BlockAnnounceMsgType}, enc...), nil
+	return enc, nil //append([]byte{BlockAnnounceMsgType}, enc...), nil
 }
 
 // Decode the message into a BlockAnnounceMessage, it assumes the type byte has been removed

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -47,6 +47,9 @@ const (
 	RemoteChangesRequestType  = 12
 	RemoteChangesResponseType = 13
 	ChainSpecificMsgType      = 255
+
+	// TODO: do handshake have type identifiers?
+	BlockAnnounceHandshakeType = 254
 )
 
 // Message interface
@@ -83,6 +86,9 @@ func decodeMessage(r io.Reader) (m Message, err error) {
 		err = m.Decode(r)
 	case ConsensusMsgType:
 		m = new(ConsensusMessage)
+		err = m.Decode(r)
+	case BlockAnnounceHandshakeType:
+		m = new(BlockAnnounceHandshake)
 		err = m.Decode(r)
 	default:
 		return nil, fmt.Errorf("unsupported message type %d", msgType)

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -326,7 +326,7 @@ func (bm *BlockAnnounceMessage) Encode() ([]byte, error) {
 	if err != nil {
 		return enc, err
 	}
-	return enc, nil //append([]byte{BlockAnnounceMsgType}, enc...), nil
+	return enc, nil
 }
 
 // Decode the message into a BlockAnnounceMessage, it assumes the type byte has been removed

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -57,7 +57,7 @@ type Message interface {
 	Decode(io.Reader) error
 	String() string
 	Type() int
-	IDString() string // TODO: this can likely be removed
+	IDString() string // TODO: this can be removed
 }
 
 // decodeMessage decodes the message based on message type
@@ -77,18 +77,12 @@ func decodeMessage(r io.Reader) (m Message, err error) {
 	case BlockResponseMsgType:
 		m = new(BlockResponseMessage)
 		err = m.Decode(r)
-	// case BlockAnnounceMsgType:
-	// 	m = new(BlockAnnounceMessage)
-	// 	err = m.Decode(r)
 	case TransactionMsgType:
 		m = new(TransactionMessage)
 		err = m.Decode(r)
 	case ConsensusMsgType:
 		m = new(ConsensusMessage)
 		err = m.Decode(r)
-	// case BlockAnnounceHandshakeType:
-	// 	m = new(BlockAnnounceHandshake)
-	// 	err = m.Decode(r)
 	default:
 		return nil, fmt.Errorf("unsupported message type %d", msgType)
 	}

--- a/dot/network/message_test.go
+++ b/dot/network/message_test.go
@@ -399,15 +399,14 @@ func TestDecodeBlockResponseMessage(t *testing.T) {
 
 func TestEncodeBlockAnnounceMessage(t *testing.T) {
 	// this value is a concatenation of:
-	//  message type:  byte(3)
 	//  ParentHash: Hash: 0x4545454545454545454545454545454545454545454545454545454545454545
 	//	Number: *big.Int // block number: 1
 	//	StateRoot:  Hash: 0xb3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe0
 	//	ExtrinsicsRoot: Hash: 0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314
 	//	Digest: []byte
 
-	//                                        mtparenthash                                                      bnstateroot                                                       extrinsicsroot                                                  di
-	expected, err := common.HexToBytes("0x03454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c1113140400")
+	//                                    mtparenthash                                                      bnstateroot                                                       extrinsicsroot                                                  di
+	expected, err := common.HexToBytes("0x454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c1113140400")
 	require.Nil(t, err)
 
 	parentHash, err := common.HexToHash("0x4545454545454545454545454545454545454545454545454545454545454545")

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -236,16 +236,18 @@ func (s *Service) SendMessage(msg Message) {
 					msg:       msg.(*BlockAnnounceMessage),
 				}
 
-				logger.Info("sending BlockAnnounceHandshake", "peer", peer, "msg", hs)
-				s.host.send(peer, blockAnnounceID, hs)
+				logger.Trace("sending BlockAnnounceHandshake", "peer", peer, "message", hs)
+				err = s.host.send(peer, blockAnnounceID, hs)
 			} else {
 				// we've already completed the handshake with the peer, send BlockAnnounce directly
-				s.host.send(peer, blockAnnounceID, msg)
+				err = s.host.send(peer, blockAnnounceID, msg)
 			}
 
+			if err != nil {
+				logger.Error("failed to send message to peer", "peer", peer, "error", err)
+			}
 		}
 
-		//s.host.broadcastWithProtocol(hs, blockAnnounceID)
 		return
 	}
 

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -194,7 +194,7 @@ func TestHandleMessage_BlockAnnounce(t *testing.T) {
 		Number: big.NewInt(10),
 	}
 
-	s.handleMessage(peerID, msg)
+	s.handleBlockAnnounceMessage(peerID, msg)
 	require.True(t, s.requestTracker.hasRequestedBlockID(99))
 }
 

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -17,7 +17,6 @@
 package network
 
 import (
-	"math/big"
 	"strings"
 	"testing"
 	"time"
@@ -170,32 +169,6 @@ func TestBroadcastMessages(t *testing.T) {
 	time.Sleep(time.Second)
 
 	require.Equal(t, TestMessage, mmhB.Message)
-}
-
-func TestHandleMessage_BlockAnnounce(t *testing.T) {
-	basePath := utils.NewTestBasePath(t, "nodeA")
-
-	// removes all data directories created within test directory
-	defer utils.RemoveTestDir(t)
-
-	config := &Config{
-		BasePath:    basePath,
-		Port:        7001,
-		RandSeed:    1,
-		NoBootstrap: true,
-		NoMDNS:      true,
-		NoStatus:    true,
-	}
-
-	s := createTestService(t, config)
-
-	peerID := peer.ID("noot")
-	msg := &BlockAnnounceMessage{
-		Number: big.NewInt(10),
-	}
-
-	s.handleBlockAnnounceMessage(peerID, msg)
-	require.True(t, s.requestTracker.hasRequestedBlockID(99))
 }
 
 func TestHandleSyncMessage_BlockResponse(t *testing.T) {

--- a/dot/network/status.go
+++ b/dot/network/status.go
@@ -45,7 +45,7 @@ type status struct {
 // newStatus creates a new status instance from host
 func newStatus(host *host) *status {
 	return &status{
-		logger:        host.logger.New("module", "status"),
+		logger:        logger.New("module", "status"),
 		host:          host,
 		peerConfirmed: &sync.Map{},
 		peerMessage:   &sync.Map{},


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add support for `/<protocol-id>/block-announces/1` sub-protocol
- implement handling, creation of `BlockAnnounceHandshake`
- implement sending `BlockAnnounceMessage`s via notifications protocol (see https://crates.parity.io/sc_network/index.html#notifications-protocols)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1159