### PR TITLE
 Disable docker for external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,29 +71,29 @@ jobs:
     script:
       - make VERSION=$VERSION docker-build
       - make VERSION=$VERSION docker-version
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker push chainsafe/gossamer:$VERSION
   - stage: Integration Tests
     name: Stable
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-stable; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-stable; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stable
   - name: RPC
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-rpc; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-rpc; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-rpc
   - name: Stress
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-stress; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-stress; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stress
   - name: GRANDPA
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-grandpa; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-grandpa; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-grandpa
   allow_failures:
     - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,17 +71,30 @@ jobs:
     script:
       - make VERSION=$VERSION docker-build
       - make VERSION=$VERSION docker-version
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker push chainsafe/gossamer:$VERSION
   - stage: Integration Tests
     name: Stable
-    script: docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stable
+    script:
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-stable; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stable
   - name: RPC
-    script: docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-rpc
+    script:
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-rpc; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-rpc
   - name: Stress
-    script: docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stress
+    script:
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-stress; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stress
   - name: GRANDPA
-    script: docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-grandpa
+    script:
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-grandpa; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
+      - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-grandpa
   allow_failures:
     - stage: build
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,29 +71,29 @@ jobs:
     script:
       - make VERSION=$VERSION docker-build
       - make VERSION=$VERSION docker-version
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
       - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - docker push chainsafe/gossamer:$VERSION
   - stage: Integration Tests
     name: Stable
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-stable; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-stable; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stable
   - name: RPC
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-rpc; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-rpc; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-rpc
   - name: Stress
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-stress; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-stress; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-stress
   - name: GRANDPA
     script:
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then make it-grandpa; fi'
-      - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then travis_terminate 0; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then make it-grandpa; fi'
+      - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then travis_terminate 0; fi'
       - docker run --rm -it --entrypoint="make" chainsafe/gossamer:$VERSION it-grandpa
   allow_failures:
     - stage: build


### PR DESCRIPTION
Travis doesn't expose environment data to PRs sent from a forked repo.
https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions
## Changes
- Disable docker for PRs sent from a forked repo.

## Checklist

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
