### PR TITLE
config: always parse init section

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -108,6 +108,7 @@ func createDotConfig(ctx *cli.Context) (cfg *dot.Config, err error) {
 	setDotGlobalConfig(ctx, tomlCfg, &cfg.Global)
 
 	// set remaining cli configuration values
+	setDotInitConfig(ctx, tomlCfg.Init, &cfg.Init)
 	setDotAccountConfig(ctx, tomlCfg.Account, &cfg.Account)
 	setDotCoreConfig(ctx, tomlCfg.Core, &cfg.Core)
 	setDotNetworkConfig(ctx, tomlCfg.Network, &cfg.Network)


### PR DESCRIPTION
## Changes

This patch parses the `[init]` section of the supplied config when the node is started normally, so it is no longer overridden by the default.

## Tests

Test scenario is running the node with a config that sets a custom genesis file (without calling `gossamer init...` with it first).

Before the patch:
```
INFO[01-05|22:36:26] loading default configuration...         pkg=cmd id=gssmr caller=config.go:88
INFO[01-05|22:36:26] loading toml configuration...            pkg=cmd config path=/home/florian/Projects/Web3/polkadot-spec-tests/test/helpers/../runtimes/tester/gossamer.config.toml caller=config.go:48
WARN[01-05|22:36:26] overwriting default configuration with toml configuration values pkg=cmd id=gssmr config path=/home/florian/Projects/Web3/polkadot-spec-tests/test/helpers/../runtimes/tester/gossamer.config.toml caller=config.go:52
DBUG[01-05|22:36:26] set log configuration                    pkg=cmd --log=debug global=dbug caller=config.go:320
INFO[01-05|22:36:26] loaded package log configuration         pkg=cmd cfg="{CoreLvl:info SyncLvl:info NetworkLvl:info RPCLvl:info StateLvl:info RuntimeLvl:info BlockProducerLvl:info FinalityGadgetLvl:info}" caller=config.go:106
DBUG[01-05|22:36:26] global configuration                     pkg=cmd name="Specification Conformance Test Runtime" id=spectest basepath=/tmp/tmpj5Z8yF/ caller=config.go:385
DBUG[01-05|22:36:26] account configuration                    pkg=cmd key=alice unlock= caller=config.go:413
DBUG[01-05|22:36:26] core configuration                       pkg=cmd babe-authority=false grandpa-authority=false babe-threshold=<nil> wasm-interpreter=wasmer caller=config.go:483
DBUG[01-05|22:36:26] network configuration                    pkg=cmd port=7001 bootnodes=[] protocol= nobootstrap=true nomdns=true caller=config.go:530
DBUG[01-05|22:36:26] rpc configuration                        pkg=cmd enabled=false port=8545 host=localhost modules="[system author chain]" ws=false wsport=8546 caller=config.go:586
WARN[01-05|22:36:26] node has not been initialized            pkg=dot basepath=/tmp/tmpj5Z8yF error="failed to locate KEYREGISTRY file in data directory" caller=node.go:157
INFO[01-05|22:36:26] initializing node...                     pkg=dot name="Specification Conformance Test Runtime" id=spectest basepath=/tmp/tmpj5Z8yF genesis-raw=./chain/gssmr/genesis-raw.json caller=node.go:53
EROR[01-05|22:36:26] failed to initialize node                pkg=cmd error="failed to load genesis from file: open /home/florian/Projects/Web3/polkadot-spec-tests/test/chain/gssmr/genesis-raw.json: no such file or directory" caller=main.go:153
failed to load genesis from file: open /home/florian/Projects/Web3/polkadot-spec-tests/test/chain/gssmr/genesis-raw.json: no such file or directory
```

With the patch:
```
INFO[01-05|23:06:30] loading default configuration...         pkg=cmd id=gssmr caller=config.go:88
INFO[01-05|23:06:30] loading toml configuration...            pkg=cmd config path=/home/florian/Projects/Web3/polkadot-spec-tests/test/helpers/../runtimes/tester/gossamer.config.toml caller=config.go:48
WARN[01-05|23:06:30] overwriting default configuration with toml configuration values pkg=cmd id=gssmr config path=/home/florian/Projects/Web3/polkadot-spec-tests/test/helpers/../runtimes/tester/gossamer.config.toml caller=config.go:52
DBUG[01-05|23:06:30] set log configuration                    pkg=cmd --log=debug global=dbug caller=config.go:321
INFO[01-05|23:06:30] loaded package log configuration         pkg=cmd cfg="{CoreLvl:info SyncLvl:info NetworkLvl:info RPCLvl:info StateLvl:info RuntimeLvl:info BlockProducerLvl:info FinalityGadgetLvl:info}" caller=config.go:106
DBUG[01-05|23:06:30] global configuration                     pkg=cmd name="Specification Conformance Test Runtime" id=spectest basepath=/tmp/tmp73lFCO/ caller=config.go:386
DBUG[01-05|23:06:30] init configuration                       pkg=cmd genesis-raw=./runtimes/tester/genesis.gossamer.json caller=config.go:334
DBUG[01-05|23:06:30] account configuration                    pkg=cmd key=alice unlock= caller=config.go:414
DBUG[01-05|23:06:30] core configuration                       pkg=cmd babe-authority=true grandpa-authority=true babe-threshold=<nil> wasm-interpreter=wasmer caller=config.go:484
DBUG[01-05|23:06:30] network configuration                    pkg=cmd port=7001 bootnodes=[] protocol= nobootstrap=true nomdns=true caller=config.go:531
DBUG[01-05|23:06:30] rpc configuration                        pkg=cmd enabled=false port=8545 host=localhost modules="[system author chain]" ws=false wsport=8546 caller=config.go:587
WARN[01-05|23:06:30] node has not been initialized            pkg=dot basepath=/tmp/tmp73lFCO error="failed to locate KEYREGISTRY file in data directory" caller=node.go:157
INFO[01-05|23:06:30] initializing node...                     pkg=dot name="Specification Conformance Test Runtime" id=spectest basepath=/tmp/tmp73lFCO genesis-raw=./runtimes/tester/genesis.gossamer.json caller=node.go:53
```

## Checklist

- [ ] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

- None