### PR TITLE
wasmer: cleanup misc print and logging log

### DIFF
--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -113,15 +113,12 @@ import (
 )
 
 //export ext_logging_log_version_1
-func ext_logging_log_version_1(context unsafe.Pointer, level C.int32_t, targetData, msgData C.int64_t) {
+func ext_logging_log_version_1(context unsafe.Pointer, level C.int32_t, targetData C.int64_t, msgData C.int64_t) {
 	logger.Trace("[ext_logging_log_version_1] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
-	memory := instanceContext.Memory().Data()
 
-	targetPtr, targetSize := int64ToPointerAndSize(int64(targetData))
-	target := fmt.Sprintf("%s", memory[targetPtr:targetPtr+targetSize])
-	msgPtr, msgSize := int64ToPointerAndSize(int64(msgData))
-	msg := fmt.Sprintf("%s", memory[msgPtr:msgPtr+msgSize])
+	target := fmt.Sprintf("%s", asMemorySlice(instanceContext, targetData))
+	msg := fmt.Sprintf("%s", asMemorySlice(instanceContext, msgData))
 
 	switch int(level) {
 	case 0:
@@ -134,6 +131,8 @@ func ext_logging_log_version_1(context unsafe.Pointer, level C.int32_t, targetDa
 		logger.Debug("[ext_logging_log_version_1]", "target", target, "message", msg)
 	case 4:
 		logger.Trace("[ext_logging_log_version_1]", "target", target, "message", msg)
+	default:
+		logger.Error("[ext_logging_log_version_1]", "level", int(level), "target", target, "message", msg)
 	}
 }
 
@@ -378,22 +377,26 @@ func ext_trie_blake2_256_ordered_root_version_1(context unsafe.Pointer, dataSpan
 //export ext_misc_print_hex_version_1
 func ext_misc_print_hex_version_1(context unsafe.Pointer, dataSpan C.int64_t) {
 	logger.Trace("[ext_misc_print_hex_version_1] executing...")
+
 	instanceContext := wasm.IntoInstanceContext(context)
 	data := asMemorySlice(instanceContext, dataSpan)
-	logger.Info("[ext_misc_print_hex_version_1]", "data", fmt.Sprintf("0x%x", data))
+	logger.Debug("[ext_misc_print_hex_version_1]", "hex", fmt.Sprintf("0x%x", data))
 }
 
 //export ext_misc_print_num_version_1
 func ext_misc_print_num_version_1(context unsafe.Pointer, data C.int64_t) {
 	logger.Trace("[ext_misc_print_num_version_1] executing...")
-	logger.Debug("[ext_print_num]", "message", fmt.Sprintf("%d", int64(data)))
+
+	logger.Debug("[ext_misc_print_num_version_1]", "num", fmt.Sprintf("%d", int64(data)))
 }
 
 //export ext_misc_print_utf8_version_1
-func ext_misc_print_utf8_version_1(context unsafe.Pointer, data C.int64_t) {
+func ext_misc_print_utf8_version_1(context unsafe.Pointer, dataSpan C.int64_t) {
 	logger.Trace("[ext_misc_print_utf8_version_1] executing...")
-	ptr, size := int64ToPointerAndSize(int64(data))
-	ext_print_utf8(context, C.int32_t(ptr), C.int32_t(size))
+
+	instanceContext := wasm.IntoInstanceContext(context)
+	data := asMemorySlice(instanceContext, dataSpan)
+	logger.Debug("[ext_misc_print_utf8_version_1]", "utf8", fmt.Sprintf("%s", data))
 }
 
 //export ext_misc_runtime_version_version_1


### PR DESCRIPTION
## Changes

- Unify used log level (debug, like substrate) for `ext_print_..._version_1` functions
- Log unknown log level as error for `ext_logging_log_version_1`
- Cleanup code to be more DRY

## Tests

Calling host api tested with custom runtime

## Checklist

- [ ] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

No issues, just some cleanup to simplify our testsuite.