### PR TITLE
lib/runtime: implement ext_hashing_sha2_256_version_1

### DIFF
--- a/lib/common/hasher.go
+++ b/lib/common/hasher.go
@@ -17,6 +17,7 @@
 package common
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
 
 	"github.com/OneOfOne/xxhash"
@@ -125,4 +126,10 @@ func Twox256(in []byte) (Hash, error) {
 	binary.LittleEndian.PutUint64(hash3, res3)
 
 	return NewHash(append(append(append(hash0, hash1...), hash2...), hash3...)), nil
+}
+
+// Sha256 returns the SHA2-256 hash of the input data
+func Sha256(in []byte) Hash {
+	hash := sha256.Sum256(in)
+	return Hash(hash)
 }

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -743,10 +743,20 @@ func ext_hashing_keccak_256_version_1(context unsafe.Pointer, dataSpan C.int64_t
 }
 
 //export ext_hashing_sha2_256_version_1
-func ext_hashing_sha2_256_version_1(context unsafe.Pointer, z C.int64_t) C.int32_t {
+func ext_hashing_sha2_256_version_1(context unsafe.Pointer, dataSpan C.int64_t) C.int32_t {
 	logger.Trace("[ext_hashing_sha2_256_version_1] executing...")
-	logger.Warn("[ext_hashing_sha2_256_version_1] unimplemented")
-	return 0
+	instanceContext := wasm.IntoInstanceContext(context)
+
+	data := asMemorySlice(instanceContext, dataSpan)
+	hash := common.Sha256(data)
+
+	out, err := toWasmMemorySized(instanceContext, hash[:], 32)
+	if err != nil {
+		logger.Error("[ext_hashing_sha2_256_version_1] failed to allocate", "error", err)
+		return 0
+	}
+
+	return C.int32_t(out)
 }
 
 //export ext_hashing_twox_256_version_1

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -138,6 +138,23 @@ func Test_ext_hashing_twox_64_version_1(t *testing.T) {
 	require.Equal(t, expected[:], hash)
 }
 
+func Test_ext_hashing_sha2_256_version_1(t *testing.T) {
+	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
+
+	data := []byte("helloworld")
+	enc, err := scale.Encode(data)
+	require.NoError(t, err)
+
+	ret, err := inst.Exec("rtm_ext_hashing_sha2_256_version_1", enc)
+	require.NoError(t, err)
+
+	hash, err := scale.Decode(ret, []byte{})
+	require.NoError(t, err)
+
+	expected := common.Sha256(data)
+	require.Equal(t, expected[:], hash)
+}
+
 func Test_ext_storage_clear_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- implement ext_hashing_sha2_256_version_1

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/wasmer -run Test_ext_hashing_sha2_256_version_1
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- #1105
