### PR TITLE
[dot/config] add chainType to gssmr default SystemInfo

### DIFF
--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -86,4 +86,9 @@ var (
 	DefaultRPCModules = []string{"system", "author", "chain", "state", "rpc"}
 	// DefaultRPCWSPort rpc websocket port
 	DefaultRPCWSPort = uint32(8546)
+
+	// SystemConfig
+
+	//DefaultChainType chain type
+	DefaultChainType = string("development")
 )

--- a/dot/config.go
+++ b/dot/config.go
@@ -163,6 +163,7 @@ func GssmrConfig() *Config {
 		},
 		System: types.SystemInfo{
 			NodeName:         gssmr.DefaultName,
+			ChainType:        gssmr.DefaultChainType,
 			SystemProperties: make(map[string]interface{}),
 		},
 	}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Added DefaultChainType value to dot/config.go for rpc system_ChainType to use.  Polkadot.js calls system_chainType when connecting and throws error if null, so this now set to development.
- Not sure if this should be stored as System config value, or stored in chain data?  Open to suggestions since this seems like a temporary fix to get polkadot.js to stop complaining.
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
