### PR TITLE
add decodeRPC to SlotDuration and EpochLength

### DIFF
--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"encoding/binary"
-	"fmt"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -33,24 +32,32 @@ func PauseBABE(t *testing.T, node *Node) error {
 
 // SlotDuration Calls dev endpoint for slot duration
 func SlotDuration(t *testing.T, node *Node) uint64 {
-	slotDuration, err := PostRPC("dev_slotDuration", NewEndpoint(node.RPCPort), "")
+	slotDuration, err := PostRPC("dev_slotDuration", NewEndpoint(node.RPCPort), "[]")
 
 	if err != nil {
 		require.NoError(t, err)
 	}
 
-	slotDurationParsed := binary.LittleEndian.Uint64(common.MustHexToBytes(fmt.Sprintf("%s", slotDuration)))
+	slotDurationDecoded := new(string)
+	err = DecodeRPC(t, slotDuration, slotDurationDecoded)
+	require.NoError(t, err)
+
+	slotDurationParsed := binary.LittleEndian.Uint64(common.MustHexToBytes(*slotDurationDecoded))
 	return slotDurationParsed
 }
 
 // EpochLength Calls dev endpoint for epoch length
 func EpochLength(t *testing.T, node *Node) uint64 {
-	epochLength, err := PostRPC("dev_epochLength", NewEndpoint(node.RPCPort), "")
+	epochLength, err := PostRPC("dev_epochLength", NewEndpoint(node.RPCPort), "[]")
 
 	if err != nil {
 		require.NoError(t, err)
 	}
 
-	epochLengthParsed := binary.LittleEndian.Uint64(common.MustHexToBytes(fmt.Sprintf("%s", epochLength)))
+	epochLengthDecoded := new(string)
+	err = DecodeRPC(t, epochLength, epochLengthDecoded)
+	require.NoError(t, err)
+
+	epochLengthParsed := binary.LittleEndian.Uint64(common.MustHexToBytes(*epochLengthDecoded))
 	return epochLengthParsed
 }


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- This fixes issue that caused TestSync_MultipleEpoch to fail.
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make it-stress
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

-
