### PR TITLE
lib/runtime: fix ext_storage_read

### DIFF
--- a/lib/common/optional/types.go
+++ b/lib/common/optional/types.go
@@ -17,6 +17,7 @@
 package optional
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math/big"
@@ -66,6 +67,17 @@ func (x *Uint32) String() string {
 func (x *Uint32) Set(exists bool, value uint32) {
 	x.exists = exists
 	x.value = value
+}
+
+// Encode returns the SCALE encoding of the optional.Uint32
+func (x *Uint32) Encode() []byte {
+	if !x.exists {
+		return []byte{0}
+	}
+
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, x.value)
+	return append([]byte{1}, buf...)
 }
 
 // Bytes represents an optional Bytes type.

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1219,13 +1219,13 @@ func ext_storage_read_version_1(context unsafe.Pointer, keySpan, valueOut C.int6
 	value, err := storage.Get(key)
 	if err != nil {
 		logger.Error("[ext_storage_read_version_1]", "error", err)
-		ret, _ := toWasmMemoryOptional(instanceContext, []byte{})
+		ret, _ := toWasmMemoryOptional(instanceContext, nil)
 		return C.int64_t(ret)
 	}
 
 	logger.Trace("[ext_storage_read_version_1]", "value", value)
 	if value == nil {
-		ret, _ := toWasmMemoryOptional(instanceContext, []byte{})
+		ret, _ := toWasmMemoryOptional(instanceContext, nil)
 		return C.int64_t(ret)
 	}
 
@@ -1429,7 +1429,7 @@ func toWasmMemorySized(context wasm.InstanceContext, data []byte, size uint32) (
 // Wraps slice in optional and copies result to wasm memory. Returns resulting 64bit span descriptor
 func toWasmMemoryOptional(context wasm.InstanceContext, data []byte) (int64, error) {
 	var opt *optional.Bytes
-	if len(data) == 0 {
+	if data == nil {
 		opt = optional.NewBytes(false, nil)
 	} else {
 		opt = optional.NewBytes(true, data)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1239,10 +1239,7 @@ func ext_storage_read_version_1(context unsafe.Pointer, keySpan, valueOut C.int6
 		copy(memory[valueBuf:valueBuf+valueLen], value[offset:])
 	}
 
-	sizeBuf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(sizeBuf, size)
-
-	sizeSpan, err := toWasmMemoryOptional(instanceContext, sizeBuf)
+	sizeSpan, err := toWasmMemoryOptionalUint32(instanceContext, &size)
 	if err != nil {
 		logger.Error("[ext_storage_read_version_1] failed to allocate", "error", err)
 		return 0
@@ -1440,6 +1437,19 @@ func toWasmMemoryOptional(context wasm.InstanceContext, data []byte) (int64, err
 		return 0, err
 	}
 
+	return toWasmMemory(context, enc)
+}
+
+// Wraps slice in optional and copies result to wasm memory. Returns resulting 64bit span descriptor
+func toWasmMemoryOptionalUint32(context wasm.InstanceContext, data *uint32) (int64, error) {
+	var opt *optional.Uint32
+	if data == nil {
+		opt = optional.NewUint32(false, 0)
+	} else {
+		opt = optional.NewUint32(true, *data)
+	}
+
+	enc := opt.Encode()
 	return toWasmMemory(context, enc)
 }
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -352,7 +352,7 @@ func Test_ext_storage_read_version_1_again(t *testing.T) {
 	read, err := new(optional.Bytes).Decode(buf)
 	require.NoError(t, err)
 	val := read.Value()
-	//require.Equal(t, len(testvalue) - int(testoffset), len(val)) // TODO: fix
+	require.Equal(t, len(testvalue)-int(testoffset), len(val)) // TODO: fix
 	require.Equal(t, testvalue[testoffset:], val[:len(testvalue)-int(testoffset)])
 }
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -325,6 +325,37 @@ func Test_ext_storage_read_version_1(t *testing.T) {
 	require.Equal(t, testvalue[testoffset:], val[:len(testvalue)-int(testoffset)])
 }
 
+func Test_ext_storage_read_version_1_again(t *testing.T) {
+	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
+
+	testkey := []byte("noot")
+	testvalue := []byte("_was_here_")
+	err := inst.inst.ctx.Storage.Set(testkey, testvalue)
+	require.NoError(t, err)
+
+	testoffset := uint32(8)
+	testBufferSize := uint32(5)
+
+	encKey, err := scale.Encode(testkey)
+	require.NoError(t, err)
+	encOffset, err := scale.Encode(testoffset)
+	require.NoError(t, err)
+	encBufferSize, err := scale.Encode(testBufferSize)
+	require.NoError(t, err)
+
+	ret, err := inst.Exec("rtm_ext_storage_read_version_1", append(append(encKey, encOffset...), encBufferSize...))
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	buf.Write(ret)
+
+	read, err := new(optional.Bytes).Decode(buf)
+	require.NoError(t, err)
+	val := read.Value()
+	//require.Equal(t, len(testvalue) - int(testoffset), len(val)) // TODO: fix
+	require.Equal(t, testvalue[testoffset:], val[:len(testvalue)-int(testoffset)])
+}
+
 func Test_ext_storage_read_version_1_OffsetLargerThanValue(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -383,7 +383,7 @@ func Test_ext_storage_read_version_1_OffsetLargerThanValue(t *testing.T) {
 	read, err := new(optional.Bytes).Decode(buf)
 	require.NoError(t, err)
 	val := read.Value()
-	require.Equal(t, make([]byte, int(testBufferSize)), val)
+	require.Equal(t, []byte{}, val)
 }
 
 func Test_ext_storage_root_version_1(t *testing.T) {


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `ext_storage_read` to return correct optional

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/wasmer
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1105 