### PR TITLE
Added protected peers functionality

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -235,9 +235,10 @@ func (s *Service) handleBlockAnnounceMessage(peer peer.ID, msg NotificationsMess
 	if an, ok := msg.(*BlockAnnounceMessage); ok {
 		req := s.syncer.HandleBlockAnnounce(an)
 		if req != nil {
-			s.syncing[peer] = struct{}{}
-			err := s.host.send(peer, syncID, req)
-			if err != nil {
+			if err := s.setSyncingPeer(peer); err != nil {
+				return err
+			}
+			if err := s.host.send(peer, syncID, req); err != nil {
 				logger.Error("failed to send BlockRequest message", "peer", peer)
 			}
 		}

--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -141,6 +141,7 @@ func (cm *ConnManager) unprotectedPeers(peers []peer.ID) []peer.ID {
 			unprot = append(unprot, id)
 		}
 	}
+
 	return unprot
 }
 
@@ -156,11 +157,13 @@ func (cm *ConnManager) Connected(n network.Network, c network.Conn) {
 	defer cm.Unlock()
 
 	if len(n.Peers()) > cm.max {
-		var (
-			unprotPeers = cm.unprotectedPeers(n.Peers())
-			// TODO: change to crypto/rand
-			i = rand.Intn(len(unprotPeers)) //nolint
-		)
+		unprotPeers := cm.unprotectedPeers(n.Peers())
+		if len(unprotPeers) == 0 {
+			return
+		}
+
+		// TODO: change to crypto/rand
+		i := rand.Intn(len(unprotPeers)) //nolint
 
 		logger.Trace("Over max peer count, disconnecting from random unprotected peer", "peer", unprotPeers[i])
 		err := n.ClosePeer(unprotPeers[i])

--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -79,7 +79,7 @@ func (*ConnManager) GetTagInfo(peer.ID) *connmgr.TagInfo { return &connmgr.TagIn
 // TrimOpenConns peer
 func (*ConnManager) TrimOpenConns(ctx context.Context) {}
 
-// Protect peer will add the given peer to the protectedPeerMap wich will
+// Protect peer will add the given peer to the protectedPeerMap which will
 // protect the peer from pruning.
 func (cm *ConnManager) Protect(id peer.ID, tag string) {
 	cm.protectedPeerMapMu.Lock()

--- a/dot/network/connmgr_test.go
+++ b/dot/network/connmgr_test.go
@@ -55,3 +55,28 @@ func TestMaxPeers(t *testing.T) {
 	p := nodes[0].host.h.Peerstore().Peers()
 	require.LessOrEqual(t, defaultMaxPeerCount, len(p))
 }
+
+func TestProtectUnprotectPeer(t *testing.T) {
+	cm := newConnManager(4)
+	require.Zero(t, len(cm.protectedPeerMap))
+
+	p1 := peer.ID("a")
+	p2 := peer.ID("b")
+	p3 := peer.ID("c")
+	p4 := peer.ID("d")
+
+	cm.Protect(p1, "")
+	cm.Protect(p2, "")
+
+	require.True(t, cm.IsProtected(p1, ""))
+	require.True(t, cm.IsProtected(p2, ""))
+
+	unprot := cm.unprotectedPeers([]peer.ID{p1, p2, p3, p4})
+	require.Equal(t, unprot, []peer.ID{p3, p4})
+
+	cm.Unprotect(p1, "")
+	cm.Unprotect(p2, "")
+
+	unprot = cm.unprotectedPeers([]peer.ID{p1, p2, p3, p4})
+	require.Equal(t, unprot, []peer.ID{p1, p2, p3, p4})
+}

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -560,9 +560,13 @@ func (s *Service) handleSyncMessage(peer peer.ID, msg Message) error {
 			if err != nil {
 				logger.Error("failed to send BlockRequest message", "peer", peer)
 			}
+			// protect this peer cause we are syncing with it.
+			s.host.h.ConnManager().Protect(peer, "")
 		} else {
 			// we are done syncing
 			delete(s.syncing, peer)
+			// peer can be unprotected cause syncing is done.
+			s.host.h.ConnManager().Unprotect(peer, "")
 			// TODO: close stream
 		}
 	}

--- a/go.sum
+++ b/go.sum
@@ -629,6 +629,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
Added protected peers functionality and prevent syncing peers from pruning when the maximum amount of connecting peers is exceeded.

<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Updated `ConnManager` so it can protect and unprotect peers
- Updated `ConnManager` so it will not prune protected peers
- Updated `Service` so it will use the `ConnManager` to flag and unflag syncing peers.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing


## TODO
- Add test that checks if peers are flagged protected from the `Service`

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1275
