### PR TITLE
[dot/rpc] use encoded extrinsics in RPC getBlock

### DIFF
--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -97,7 +97,7 @@ func (cm *ChainModule) GetBlock(r *http.Request, req *ChainHashRequest, res *Cha
 	}
 
 	if *block.Body != nil {
-		ext, err := block.Body.AsExtrinsics()
+		ext, err := block.Body.AsEncodedExtrinsics()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Update RPC chain_getBlock to return encoded extrinsics (was previously sending raw extrinsics). Polkadot.js expects extrinsics to be scale encoded, which is why it was complaining.
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/rpc/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- fixes #1315 
