### PR TITLE
lib/trie: fix ClearPrefix again

### DIFF
--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -39,8 +39,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var maxRetries = 8 //nolint
-
 func newTestGenesisWithTrieAndHeader(t *testing.T) (*genesis.Genesis, *trie.Trie, *types.Header) {
 	gen, err := genesis.NewGenesisFromJSONRaw("../../chain/gssmr/genesis-raw.json")
 	require.NoError(t, err)
@@ -302,12 +300,6 @@ func TestHandleBlockResponse_BlockData(t *testing.T) {
 
 	parent, err := syncer.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
-
-	parentState, err := syncer.storageState.TrieState(&parent.StateRoot)
-	require.NoError(t, err)
-	ts, err := parentState.Copy()
-	require.NoError(t, err)
-	syncer.runtime.SetContextStorage(ts)
 	block := buildBlock(t, syncer.runtime, parent)
 
 	bd := []*types.BlockData{{
@@ -384,18 +376,12 @@ func TestSyncer_ExecuteBlock(t *testing.T) {
 
 	parent, err := syncer.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
-
-	parentState, err := syncer.storageState.TrieState(&parent.StateRoot)
-	require.NoError(t, err)
-	ts, err := parentState.Copy()
-	require.NoError(t, err)
-	syncer.runtime.SetContextStorage(ts)
 	block := buildBlock(t, syncer.runtime, parent)
 
 	// reset parentState
-	parentState, err = syncer.storageState.TrieState(&parent.StateRoot)
+	parentState, err := syncer.storageState.TrieState(&parent.StateRoot)
 	require.NoError(t, err)
-	ts, err = parentState.Copy()
+	ts, err := parentState.Copy()
 	require.NoError(t, err)
 	syncer.runtime.SetContextStorage(ts)
 

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -51,10 +51,7 @@ func (s *TrieState) Trie() *trie.Trie {
 
 // Copy performs a deep copy of the TrieState
 func (s *TrieState) Copy() (*TrieState, error) {
-	trieCopy, err := s.t.DeepCopy()
-	if err != nil {
-		return nil, err
-	}
+	trieCopy := s.t.Snapshot()
 
 	return &TrieState{
 		t: trieCopy,

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -547,7 +547,8 @@ func (t *Trie) clearPrefix(curr node, prefix []byte) (node, bool) {
 			// found prefix at child index, delete child
 			c.children[len(c.key)+int(prefix[0])] = nil
 			c.setDirty(true)
-			return c, true
+			curr = handleDeletion(c, prefix)
+			return curr, true
 		}
 
 		if len(prefix) <= len(c.key) {

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -561,15 +561,14 @@ func (t *Trie) clearPrefix(curr node, prefix []byte) (node, bool) {
 		}
 
 		var wasUpdated bool
-		//for i, child := range c.children {
 		i := prefix[len(c.key)]
+
 		c.children[i], wasUpdated = t.clearPrefix(c.children[i], prefix[len(c.key)+1:])
 		if wasUpdated {
 			c.setDirty(true)
 			curr = handleDeletion(c, prefix)
-			//break
 		}
-		//}
+
 		return curr, curr.isDirty()
 	case *leaf:
 		length := lenCommonPrefix(c.key, prefix)

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -764,6 +764,9 @@ func TestClearPrefix(t *testing.T) {
 
 		trie.ClearPrefix(prefix)
 		prefixNibbles := keyToNibbles(prefix)
+		if len(prefixNibbles) > 0 && prefixNibbles[len(prefixNibbles)-1] == 0 {
+			prefixNibbles = prefixNibbles[:len(prefixNibbles)-1]
+		}
 
 		for _, test := range tests {
 			var res []byte
@@ -771,7 +774,6 @@ func TestClearPrefix(t *testing.T) {
 			require.NoError(t, err)
 
 			keyNibbles := keyToNibbles(test.key)
-
 			length := lenCommonPrefix(keyNibbles, prefixNibbles)
 			if length == len(prefixNibbles) {
 				require.Nil(t, res)
@@ -848,4 +850,88 @@ func TestClearPrefix_Small(t *testing.T) {
 	require.NotEqual(t, tHash, dcTrieHash)
 	require.NotEqual(t, tHash, ssTrieHash)
 	require.Equal(t, dcTrieHash, ssTrieHash)
+}
+
+func TestTrie_ClearPrefixVsDelete(t *testing.T) {
+	prefixes := [][]byte{
+		{},
+		{0x0},
+		{0x01},
+		{0x01, 0x35},
+		{0xf},
+		{0xf2},
+		{0x01, 0x30},
+		{0x01, 0x35, 0x70},
+		{0x01, 0x35, 0x77},
+		{0xf2, 0x0},
+		{0x07},
+		{0x09},
+		[]byte("a"),
+	}
+
+	cases := [][]Test{
+		{
+			{key: []byte{0x01, 0x35}, value: []byte("pen")},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
+			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g")},
+			{key: []byte{0x01, 0x35, 0x99}, value: []byte("g")},
+			{key: []byte{0xf2}, value: []byte("feather")},
+			{key: []byte{0xf2, 0x3}, value: []byte("f")},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
+			{key: []byte{0x07}, value: []byte("ramen")},
+			{key: []byte{0}, value: nil},
+		},
+		// {
+		// 	{key: []byte{0x01, 0x35}, value: []byte("pen")},
+		// 	{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
+		// 	{key: []byte{0x01, 0x35, 0x70}, value: []byte("g")},
+		// 	{key: []byte{0xf2}, value: []byte("feather")},
+		// 	{key: []byte{0xf2, 0x30}, value: []byte("f")},
+		// 	{key: []byte{0x09, 0xd3}, value: []byte("noot")},
+		// 	{key: []byte{0x07}, value: []byte("ramen")},
+		// },
+		{
+			{key: []byte("asdf"), value: []byte("asdf")},
+			{key: []byte("ghjk"), value: []byte("ghjk")},
+			{key: []byte("qwerty"), value: []byte("qwerty")},
+			{key: []byte("uiopl"), value: []byte("uiopl")},
+			{key: []byte("zxcv"), value: []byte("zxcv")},
+			{key: []byte("bnm"), value: []byte("bnm")},
+		},
+	}
+
+	for _, testCase := range cases {
+		for _, prefix := range prefixes {
+			trieDelete := NewEmptyTrie()
+			trieClearPrefix := NewEmptyTrie()
+
+			for _, test := range testCase {
+				trieDelete.Put(test.key, test.value)
+				trieClearPrefix.Put(test.key, test.value)
+			}
+
+			prefixedKeys := trieDelete.GetKeysWithPrefix(prefix)
+			for _, key := range prefixedKeys {
+				trieDelete.Delete(key)
+			}
+
+			trieClearPrefix.ClearPrefix(prefix)
+
+			require.Equal(t, trieClearPrefix.MustHash(), trieDelete.MustHash(),
+				fmt.Sprintf("tries not equal! prefix=0x%x\n, %s, %s", prefix, trieClearPrefix, trieDelete),
+			)
+
+			// 	for _, kv := range testCase {
+			// 		val, err := GetFromDB(db, trie.MustHash(), kv.key)
+			// 		require.NoError(t, err)
+
+			// 		if bytes.Equal(kv.key, curr.key) {
+			// 			require.Nil(t, val, fmt.Sprintf("key=%x", kv.key))
+			// 			continue
+			// 		}
+
+			// 		require.Equal(t, kv.value, val)
+			// 	}
+		}
+	}
 }

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -854,13 +854,13 @@ func TestClearPrefix_Small(t *testing.T) {
 
 func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 	prefixes := [][]byte{
-		//{},
-		// {0x0},
-		// {0x01},
-		// {0x01, 0x35},
-		// {0xf},
-		// {0xf2},
-		// {0x01, 0x30},
+		{},
+		{0x0},
+		{0x01},
+		{0x01, 0x35},
+		{0xf},
+		{0xf2},
+		{0x01, 0x30},
 		{0x01, 0x35, 0x70},
 		{0x01, 0x35, 0x77},
 		{0xf2, 0x0},
@@ -874,22 +874,22 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 			{key: []byte{0x01, 0x35}, value: []byte("pen")},
 			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
 			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g")},
-			{key: []byte{0x01, 0x35, 0x99}, value: []byte("g")},
+			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h")},
 			{key: []byte{0xf2}, value: []byte("feather")},
 			{key: []byte{0xf2, 0x3}, value: []byte("f")},
 			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
 			{key: []byte{0x07}, value: []byte("ramen")},
 			{key: []byte{0}, value: nil},
 		},
-		// {
-		// 	{key: []byte{0x01, 0x35}, value: []byte("pen")},
-		// 	{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-		// 	{key: []byte{0x01, 0x35, 0x70}, value: []byte("g")},
-		// 	{key: []byte{0xf2}, value: []byte("feather")},
-		// 	{key: []byte{0xf2, 0x30}, value: []byte("f")},
-		// 	{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-		// 	{key: []byte{0x07}, value: []byte("ramen")},
-		// },
+		{
+			{key: []byte{0x01, 0x35}, value: []byte("pen")},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
+			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g")},
+			{key: []byte{0xf2}, value: []byte("feather")},
+			{key: []byte{0xf2, 0x30}, value: []byte("f")},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
+			{key: []byte{0x07}, value: []byte("ramen")},
+		},
 		{
 			{key: []byte("asdf"), value: []byte("asdf")},
 			{key: []byte("ghjk"), value: []byte("ghjk")},
@@ -910,9 +910,6 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 				trieClearPrefix.Put(test.key, test.value)
 			}
 
-			t.Log(trieClearPrefix)
-			t.Log(trieDelete)
-
 			prefixedKeys := trieDelete.GetKeysWithPrefix(prefix)
 			for _, key := range prefixedKeys {
 				trieDelete.Delete(key)
@@ -923,18 +920,6 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 			require.Equal(t, trieClearPrefix.MustHash(), trieDelete.MustHash(),
 				fmt.Sprintf("tries not equal! prefix=0x%x\n, %s, %s", prefix, trieClearPrefix, trieDelete),
 			)
-
-			// 	for _, kv := range testCase {
-			// 		val, err := GetFromDB(db, trie.MustHash(), kv.key)
-			// 		require.NoError(t, err)
-
-			// 		if bytes.Equal(kv.key, curr.key) {
-			// 			require.Nil(t, val, fmt.Sprintf("key=%x", kv.key))
-			// 			continue
-			// 		}
-
-			// 		require.Equal(t, kv.value, val)
-			// 	}
 		}
 	}
 }

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -854,13 +854,13 @@ func TestClearPrefix_Small(t *testing.T) {
 
 func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 	prefixes := [][]byte{
-		{},
-		{0x0},
-		{0x01},
-		{0x01, 0x35},
-		{0xf},
-		{0xf2},
-		{0x01, 0x30},
+		//{},
+		// {0x0},
+		// {0x01},
+		// {0x01, 0x35},
+		// {0xf},
+		// {0xf2},
+		// {0x01, 0x30},
 		{0x01, 0x35, 0x70},
 		{0x01, 0x35, 0x77},
 		{0xf2, 0x0},
@@ -909,6 +909,9 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 				trieDelete.Put(test.key, test.value)
 				trieClearPrefix.Put(test.key, test.value)
 			}
+
+			t.Log(trieClearPrefix)
+			t.Log(trieDelete)
 
 			prefixedKeys := trieDelete.GetKeysWithPrefix(prefix)
 			for _, key := range prefixedKeys {


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix `ClearPrefix` and `GetKeysWithPrefix`, now `ClearPrefix` creates a correctly structured trie after clearing

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

kusama block 595 can sync now :)

```
go test ./lib/trie
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #1134 