### PR TITLE
lib/blocktree: update blocktree.getNode to check leaves first

### DIFF
--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -125,6 +125,12 @@ func (bt *BlockTree) getNode(h Hash) *node {
 		return bt.head
 	}
 
+	for _, leaf := range bt.leaves.nodes() {
+		if leaf.hash == h {
+			return leaf
+		}
+	}
+
 	for _, child := range bt.head.children {
 		if n := child.getNode(h); n != nil {
 			return n


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- low hanging fruit type optimization based on some profiling, improves sync speed when blocktree is large
- when we add a block to the blocktree it's most likely adding it to a leaf of the tree, so check the leaves first in `getNode`
- previously was searching from the genesis or root node, very slow when tree is large 
- improved sync speed at block ~480k from 4blocks/s to 10blocks/s on my machine

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/blocktree
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #1134 
