### PR TITLE
lib/runtime: use GlobalKeystore

### DIFF
--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -192,7 +192,7 @@ func (q *syncQueue) start() {
 			logger.Debug("sync response queue", "queue", q.stringifyResponseQueue())
 			q.responseLock.Unlock()
 			q.responseCh <- q.responses
-			q.responses = q.responses[len(q.responses)-1:]
+			q.responses = []*types.BlockData{}
 		}
 	}()
 

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -192,7 +192,7 @@ func (q *syncQueue) start() {
 			logger.Debug("sync response queue", "queue", q.stringifyResponseQueue())
 			q.responseLock.Unlock()
 			q.responseCh <- q.responses
-			q.responses = []*types.BlockData{}
+			q.responses = q.responses[len(q.responses)-1:]
 		}
 	}()
 

--- a/dot/node.go
+++ b/dot/node.go
@@ -197,7 +197,7 @@ func NewNode(cfg *Config, ks *keystore.GlobalKeystore, stopFunc func()) (*Node, 
 	}
 
 	// create runtime
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), networkSrvc)
+	rt, err := createRuntime(cfg, stateSrvc, ks, networkSrvc)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/services.go
+++ b/dot/services.go
@@ -78,7 +78,7 @@ func createStateService(cfg *Config) (*state.Service, error) {
 	return stateSrvc, nil
 }
 
-func createRuntime(cfg *Config, st *state.Service, ks *keystore.GenericKeystore, net *network.Service) (runtime.Instance, error) {
+func createRuntime(cfg *Config, st *state.Service, ks *keystore.GlobalKeystore, net *network.Service) (runtime.Instance, error) {
 	logger.Info(
 		"creating runtime...",
 		"interpreter", cfg.Core.WasmInterpreter,

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -82,7 +82,7 @@ func TestCreateCoreService(t *testing.T) {
 
 	networkSrvc := &network.Service{}
 
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), networkSrvc)
+	rt, err := createRuntime(cfg, stateSrvc, ks, networkSrvc)
 	require.NoError(t, err)
 
 	dh, err := createDigestHandler(stateSrvc, nil, nil)
@@ -140,7 +140,7 @@ func TestCreateSyncService(t *testing.T) {
 
 	ks := keystore.NewGlobalKeystore()
 	require.NotNil(t, ks)
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), &network.Service{})
+	rt, err := createRuntime(cfg, stateSrvc, ks, &network.Service{})
 	require.NoError(t, err)
 
 	cfg.Core.BabeThresholdNumerator = 0
@@ -205,7 +205,7 @@ func TestCreateRPCService(t *testing.T) {
 	ed25519Keyring, _ := keystore.NewEd25519Keyring()
 	ks.Gran.Insert(ed25519Keyring.Alice())
 
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), networkSrvc)
+	rt, err := createRuntime(cfg, stateSrvc, ks, networkSrvc)
 	require.NoError(t, err)
 
 	dh, err := createDigestHandler(stateSrvc, nil, nil)
@@ -248,7 +248,7 @@ func TestCreateBABEService(t *testing.T) {
 	require.Nil(t, err)
 	ks.Babe.Insert(kr.Alice())
 
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), &network.Service{})
+	rt, err := createRuntime(cfg, stateSrvc, ks, &network.Service{})
 	require.NoError(t, err)
 
 	bs, err := createBABEService(cfg, rt, stateSrvc, ks.Babe)
@@ -280,7 +280,7 @@ func TestCreateGrandpaService(t *testing.T) {
 	require.NoError(t, err)
 	ks.Gran.Insert(kr.Alice())
 
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), &network.Service{})
+	rt, err := createRuntime(cfg, stateSrvc, ks, &network.Service{})
 	require.NoError(t, err)
 
 	dh, err := createDigestHandler(stateSrvc, nil, nil)
@@ -332,7 +332,7 @@ func TestNewWebSocketServer(t *testing.T) {
 	ks := keystore.NewGlobalKeystore()
 	ed25519Keyring, _ := keystore.NewEd25519Keyring()
 	ks.Gran.Insert(ed25519Keyring.Alice())
-	rt, err := createRuntime(cfg, stateSrvc, ks.Acco.(*keystore.GenericKeystore), networkSrvc)
+	rt, err := createRuntime(cfg, stateSrvc, ks, networkSrvc)
 	require.NoError(t, err)
 
 	dh, err := createDigestHandler(stateSrvc, nil, nil)

--- a/lib/keystore/keystore.go
+++ b/lib/keystore/keystore.go
@@ -17,6 +17,8 @@
 package keystore
 
 import (
+	"errors"
+
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto"
 )
@@ -68,5 +70,28 @@ func NewGlobalKeystore() *GlobalKeystore {
 		Imon: NewBasicKeystore(ImonName, crypto.Sr25519Type),
 		Audi: NewBasicKeystore(AudiName, crypto.Sr25519Type),
 		Dumy: NewGenericKeystore(DumyName),
+	}
+}
+
+// GetKeystore returns a keystore given its name
+func (k *GlobalKeystore) GetKeystore(name []byte) (Keystore, error) {
+	nameStr := Name(name[:])
+	switch nameStr {
+	case BabeName:
+		return k.Babe, nil
+	case GranName:
+		return k.Gran, nil
+	case AccoName:
+		return k.Acco, nil
+	case AuraName:
+		return k.Aura, nil
+	case ImonName:
+		return k.Imon, nil
+	case AudiName:
+		return k.Audi, nil
+	case DumyName:
+		return k.Dumy, nil
+	default:
+		return nil, errors.New("invalid keystore name")
 	}
 }

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -39,7 +39,7 @@ type NodeStorage struct {
 // InstanceConfig represents a runtime instance configuration
 type InstanceConfig struct {
 	Storage     Storage
-	Keystore    *keystore.GenericKeystore
+	Keystore    *keystore.GlobalKeystore
 	LogLvl      log.Lvl
 	Role        byte
 	NodeStorage NodeStorage
@@ -72,7 +72,7 @@ type TransactionStorageChange struct {
 type Context struct {
 	Storage     Storage
 	Allocator   *FreeingBumpHeapAllocator
-	Keystore    *keystore.GenericKeystore
+	Keystore    *keystore.GlobalKeystore
 	Validator   bool
 	NodeStorage NodeStorage
 	Network     BasicNetwork

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/crypto/secp256k1"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/scale"
@@ -425,9 +426,10 @@ func Test_ext_storage_set_version_1(t *testing.T) {
 
 func Test_ext_crypto_ed25519_generate_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
-	require.Equal(t, 0, inst.inst.ctx.Keystore.Size())
 
-	idData := []byte{2, 2, 2, 2}
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks)
 
 	// TODO: we currently don't provide a seed since the spec says the seed is an optional BIP-39 seed
 	// clarify whether this is a mnemonic or not
@@ -458,8 +460,8 @@ func Test_ext_crypto_ed25519_generate_version_1(t *testing.T) {
 	pubKey, err := ed25519.NewPublicKey(pubKeyBytes)
 	require.NoError(t, err)
 
-	require.Equal(t, 1, inst.inst.ctx.Keystore.Size())
-	kp := inst.inst.ctx.Keystore.GetKeypair(pubKey)
+	require.Equal(t, 1, ks.Size())
+	kp := ks.GetKeypair(pubKey)
 	require.NotNil(t, kp)
 }
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -451,7 +451,10 @@ func Test_ext_crypto_ed25519_generate_version_1(t *testing.T) {
 
 func Test_ext_crypto_ed25519_public_keys_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
-	require.Equal(t, 0, inst.inst.ctx.Keystore.Size())
+
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
 
 	var pubKeys [][]byte
 	for i := 0; i < 5; i++ {
@@ -459,7 +462,7 @@ func Test_ext_crypto_ed25519_public_keys_version_1(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		inst.inst.ctx.Keystore.Insert(kp)
+		ks.Insert(kp)
 		pubKeys = append(pubKeys, kp.Public().Encode())
 	}
 
@@ -469,8 +472,6 @@ func Test_ext_crypto_ed25519_public_keys_version_1(t *testing.T) {
 	for _, key := range pubKeys {
 		expectedPubKeys = append(expectedPubKeys, key...)
 	}
-
-	idData := []byte{2, 2, 2, 2}
 
 	res, err := inst.Exec("rtm_ext_crypto_ed25519_public_keys_version_1", idData)
 	require.NoError(t, err)
@@ -483,7 +484,6 @@ func Test_ext_crypto_ed25519_public_keys_version_1(t *testing.T) {
 
 	value, err := new(optional.Bytes).Decode(buf)
 	require.NoError(t, err)
-
 	require.Equal(t, expectedPubKeys, value.Value())
 }
 
@@ -493,9 +493,9 @@ func Test_ext_crypto_ed25519_sign_version_1(t *testing.T) {
 	kp, err := ed25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	inst.inst.ctx.Keystore.Insert(kp)
-
-	idData := []byte{2, 2, 2, 2}
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	ks.Insert(kp)
 
 	pubKeyData := kp.Public().Encode()
 	encPubKey, err := scale.Encode(pubKeyData)
@@ -519,7 +519,6 @@ func Test_ext_crypto_ed25519_sign_version_1(t *testing.T) {
 
 	ok, err := kp.Public().Verify(msgData, value.Value())
 	require.NoError(t, err)
-
 	require.True(t, ok)
 }
 
@@ -529,7 +528,9 @@ func Test_ext_crypto_ed25519_verify_version_1(t *testing.T) {
 	kp, err := ed25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	inst.inst.ctx.Keystore.Insert(kp)
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	ks.Insert(kp)
 
 	pubKeyData := kp.Public().Encode()
 	encPubKey, err := scale.Encode(pubKeyData)
@@ -558,9 +559,10 @@ func Test_ext_crypto_ed25519_verify_version_1(t *testing.T) {
 
 func Test_ext_crypto_sr25519_generate_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
-	require.Equal(t, 0, inst.inst.ctx.Keystore.Size())
 
-	idData := []byte{2, 2, 2, 2}
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
 
 	data := optional.NewBytes(false, nil)
 	seedData, err := data.Encode()
@@ -576,9 +578,9 @@ func Test_ext_crypto_sr25519_generate_version_1(t *testing.T) {
 
 	pubKey, err := ed25519.NewPublicKey(out.([]byte))
 	require.NoError(t, err)
-	require.Equal(t, 1, inst.inst.ctx.Keystore.Size())
+	require.Equal(t, 1, ks.Size())
 
-	kp := inst.inst.ctx.Keystore.GetKeypair(pubKey)
+	kp := ks.GetKeypair(pubKey)
 	require.NotNil(t, kp)
 }
 
@@ -592,7 +594,6 @@ func Test_ext_crypto_secp256k1_ecdsa_recover_version_1(t *testing.T) {
 	kp, err := secp256k1.GenerateKeypair()
 	require.NoError(t, err)
 
-	inst.inst.ctx.Keystore.Insert(kp)
 	sigData, err := kp.Private().Sign(blakeHash.ToBytes())
 	require.NoError(t, err)
 
@@ -627,7 +628,10 @@ func Test_ext_crypto_secp256k1_ecdsa_recover_version_1(t *testing.T) {
 
 func Test_ext_crypto_sr25519_public_keys_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
-	require.Equal(t, 0, inst.inst.ctx.Keystore.Size())
+
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
 
 	var pubKeys [][]byte
 	for i := 0; i < 5; i++ {
@@ -635,7 +639,7 @@ func Test_ext_crypto_sr25519_public_keys_version_1(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		inst.inst.ctx.Keystore.Insert(kp)
+		ks.Insert(kp)
 		pubKeys = append(pubKeys, kp.Public().Encode())
 	}
 
@@ -667,7 +671,9 @@ func Test_ext_crypto_sr25519_sign_version_1(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	inst.inst.ctx.Keystore.Insert(kp)
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
 
 	pubKeyData := kp.Public().Encode()
 	encPubKey, err := scale.Encode(pubKeyData)
@@ -676,8 +682,6 @@ func Test_ext_crypto_sr25519_sign_version_1(t *testing.T) {
 	msgData := []byte("Hello world!")
 	encMsg, err := scale.Encode(msgData)
 	require.NoError(t, err)
-
-	idData := []byte{2, 2, 2, 2}
 
 	res, err := inst.Exec("rtm_ext_crypto_sr25519_sign_version_1", append(append(idData, encPubKey...), encMsg...))
 	require.NoError(t, err)
@@ -703,7 +707,9 @@ func Test_ext_crypto_sr25519_verify_version_1(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	inst.inst.ctx.Keystore.Insert(kp)
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
 
 	pubKeyData := kp.Public().Encode()
 	encPubKey, err := scale.Encode(pubKeyData)

--- a/lib/runtime/wasmer/legacy_imports_test.go
+++ b/lib/runtime/wasmer/legacy_imports_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/scale"
 	"github.com/ChainSafe/gossamer/lib/trie"
@@ -760,11 +761,14 @@ func TestExt_secp256k1_ecdsa_recover(t *testing.T) {
 
 // test that TestExt_sr25519_generate generates and saves a keypair in the keystore
 func TestExt_sr25519_generate(t *testing.T) {
-	runtime := NewTestLegacyInstance(t, runtime.TEST_RUNTIME)
+	inst := NewTestLegacyInstance(t, runtime.TEST_RUNTIME)
 
-	mem := runtime.vm.Memory.Data()
+	mem := inst.vm.Memory.Data()
 
-	idData := []byte{1, 0, 0, 0}
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
+
 	seedLen := 32
 
 	seedData := make([]byte, seedLen)
@@ -778,7 +782,7 @@ func TestExt_sr25519_generate(t *testing.T) {
 	copy(mem[idLoc:idLoc+len(idData)], idData)
 
 	// call wasm function
-	testFunc, ok := runtime.vm.Exports["test_ext_sr25519_generate"]
+	testFunc, ok := inst.vm.Exports["test_ext_sr25519_generate"]
 	if !ok {
 		t.Fatal("could not find exported function")
 	}
@@ -790,7 +794,7 @@ func TestExt_sr25519_generate(t *testing.T) {
 	pubkey, err := sr25519.NewPublicKey(pubkeyData)
 	require.Nil(t, err)
 
-	kp := runtime.ctx.Keystore.GetKeypair(pubkey)
+	kp := ks.GetKeypair(pubkey)
 	if kp == nil {
 		t.Fatal("Fail: keypair was not saved in keystore")
 	}
@@ -798,11 +802,14 @@ func TestExt_sr25519_generate(t *testing.T) {
 
 // test that TestExt_ed25519_generate generates and saves a keypair in the keystore
 func TestExt_ed25519_generate(t *testing.T) {
-	runtime := NewTestLegacyInstance(t, runtime.TEST_RUNTIME)
+	inst := NewTestLegacyInstance(t, runtime.TEST_RUNTIME)
 
-	mem := runtime.vm.Memory.Data()
+	mem := inst.vm.Memory.Data()
 
-	idData := []byte{1, 0, 0, 0}
+	idData := []byte(keystore.AccoName)
+	ks, _ := inst.ctx.Keystore.GetKeystore(idData)
+	require.Equal(t, 0, ks.Size())
+
 	seedLen := 32
 
 	seedData := make([]byte, seedLen)
@@ -816,7 +823,7 @@ func TestExt_ed25519_generate(t *testing.T) {
 	copy(mem[idLoc:idLoc+len(idData)], idData)
 
 	// call wasm function
-	testFunc, ok := runtime.vm.Exports["test_ext_ed25519_generate"]
+	testFunc, ok := inst.vm.Exports["test_ext_ed25519_generate"]
 	if !ok {
 		t.Fatal("could not find exported function")
 	}
@@ -828,7 +835,7 @@ func TestExt_ed25519_generate(t *testing.T) {
 	pubkey, err := ed25519.NewPublicKey(pubkeyData)
 	require.Nil(t, err)
 
-	kp := runtime.ctx.Keystore.GetKeypair(pubkey)
+	kp := ks.GetKeypair(pubkey)
 	if kp == nil {
 		t.Fatal("Fail: keypair was not saved in keystore")
 	}

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -125,7 +125,7 @@ func setupConfig(t *testing.T, targetRuntime string, tt *trie.Trie, lvl log.Lvl,
 		Imports: importsFunc,
 	}
 	cfg.Storage = s
-	cfg.Keystore = keystore.NewGenericKeystore("test")
+	cfg.Keystore = keystore.NewGlobalKeystore()
 	cfg.LogLvl = lvl
 	cfg.NodeStorage = ns
 	cfg.Network = new(runtime.TestRuntimeNetwork)

--- a/lib/runtime/wasmtime/test_helpers.go
+++ b/lib/runtime/wasmtime/test_helpers.go
@@ -55,7 +55,7 @@ func NewTestInstanceWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie, 
 	}
 	cfg.Storage, err = storage.NewTrieState(tt)
 	require.NoError(t, err)
-	cfg.Keystore = keystore.NewGenericKeystore("test")
+	cfg.Keystore = keystore.NewGlobalKeystore()
 	cfg.LogLvl = lvl
 	cfg.NodeStorage = ns
 	cfg.Network = new(runtime.TestRuntimeNetwork)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update runtime to use `GlobalKeystore`
- update ext_crypto funcs accordingly to use `id` parameter

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/...
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- closes #1279