### PR TITLE
lib/runtime: fix execution of kusama block 901442

### DIFF
--- a/lib/runtime/version.go
+++ b/lib/runtime/version.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"bytes"
+	"math/big"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/scale"
@@ -32,6 +33,7 @@ type Version interface {
 	ImplVersion() uint32
 	APIItems() []*APIItem
 	TransactionVersion() uint32
+	Encode() ([]byte, error)
 }
 
 // APIItem struct to hold runtime API Name and Version
@@ -95,6 +97,47 @@ func (v *LegacyVersionData) APIItems() []*APIItem {
 // TransactionVersion returns the transaction version
 func (v *LegacyVersionData) TransactionVersion() uint32 {
 	return 0
+}
+
+func (v *LegacyVersionData) Encode() ([]byte, error) {
+	type Info struct {
+		SpecName         []byte
+		ImplName         []byte
+		AuthoringVersion uint32
+		SpecVersion      uint32
+		ImplVersion      uint32
+	}
+
+	info := &Info{
+		SpecName:         v.specName,
+		ImplName:         v.implName,
+		AuthoringVersion: v.authoringVersion,
+		SpecVersion:      v.specVersion,
+		ImplVersion:      v.implVersion,
+	}
+
+	enc, err := scale.Encode(info)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := scale.Encode(big.NewInt(int64(len(v.apiItems))))
+	if err != nil {
+		return nil, err
+	}
+	enc = append(enc, b...)
+
+	for _, apiItem := range v.apiItems {
+		enc = append(enc, apiItem.Name[:]...)
+
+		b, err = scale.Encode(apiItem.Ver)
+		if err != nil {
+			return nil, err
+		}
+		enc = append(enc, b...)
+	}
+
+	return enc, nil
 }
 
 // Decode to scale decode []byte to VersionAPI struct
@@ -209,6 +252,53 @@ func (v *VersionData) APIItems() []*APIItem {
 // TransactionVersion returns the transaction version
 func (v *VersionData) TransactionVersion() uint32 {
 	return v.transactionVersion
+}
+
+func (v *VersionData) Encode() ([]byte, error) {
+	type Info struct {
+		SpecName         []byte
+		ImplName         []byte
+		AuthoringVersion uint32
+		SpecVersion      uint32
+		ImplVersion      uint32
+	}
+
+	info := &Info{
+		SpecName:         v.specName,
+		ImplName:         v.implName,
+		AuthoringVersion: v.authoringVersion,
+		SpecVersion:      v.specVersion,
+		ImplVersion:      v.implVersion,
+	}
+
+	enc, err := scale.Encode(info)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := scale.Encode(big.NewInt(int64(len(v.apiItems))))
+	if err != nil {
+		return nil, err
+	}
+	enc = append(enc, b...)
+
+	for _, apiItem := range v.apiItems {
+		enc = append(enc, apiItem.Name[:]...)
+
+		b, err = scale.Encode(apiItem.Ver)
+		if err != nil {
+			return nil, err
+		}
+		enc = append(enc, b...)
+	}
+
+	b, err = scale.Encode(v.transactionVersion)
+	if err != nil {
+		return nil, err
+	}
+	enc = append(enc, b...)
+
+	return enc, nil
 }
 
 // Decode to scale decode []byte to VersionAPI struct

--- a/lib/runtime/version.go
+++ b/lib/runtime/version.go
@@ -99,6 +99,7 @@ func (v *LegacyVersionData) TransactionVersion() uint32 {
 	return 0
 }
 
+// Encode returns the SCALE encoding of the Version
 func (v *LegacyVersionData) Encode() ([]byte, error) {
 	type Info struct {
 		SpecName         []byte
@@ -254,6 +255,7 @@ func (v *VersionData) TransactionVersion() uint32 {
 	return v.transactionVersion
 }
 
+// Encode returns the SCALE encoding of the Version
 func (v *VersionData) Encode() ([]byte, error) {
 	type Info struct {
 		SpecName         []byte

--- a/lib/runtime/version.go
+++ b/lib/runtime/version.go
@@ -101,15 +101,13 @@ func (v *LegacyVersionData) TransactionVersion() uint32 {
 
 // Encode returns the SCALE encoding of the Version
 func (v *LegacyVersionData) Encode() ([]byte, error) {
-	type Info struct {
+	info := &struct {
 		SpecName         []byte
 		ImplName         []byte
 		AuthoringVersion uint32
 		SpecVersion      uint32
 		ImplVersion      uint32
-	}
-
-	info := &Info{
+	}{
 		SpecName:         v.specName,
 		ImplName:         v.implName,
 		AuthoringVersion: v.authoringVersion,
@@ -257,15 +255,13 @@ func (v *VersionData) TransactionVersion() uint32 {
 
 // Encode returns the SCALE encoding of the Version
 func (v *VersionData) Encode() ([]byte, error) {
-	type Info struct {
+	info := &struct {
 		SpecName         []byte
 		ImplName         []byte
 		AuthoringVersion uint32
 		SpecVersion      uint32
 		ImplVersion      uint32
-	}
-
-	info := &Info{
+	}{
 		SpecName:         v.specName,
 		ImplName:         v.implName,
 		AuthoringVersion: v.authoringVersion,

--- a/lib/runtime/version_test.go
+++ b/lib/runtime/version_test.go
@@ -1,0 +1,56 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionData(t *testing.T) {
+	testAPIItem := &APIItem{
+		Name: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Ver:  99,
+	}
+
+	version := NewVersionData(
+		[]byte("polkadot"),
+		[]byte("parity-polkadot"),
+		0,
+		25,
+		0,
+		[]*APIItem{testAPIItem},
+		5,
+	)
+
+	b, err := version.Encode()
+	require.NoError(t, err)
+
+	dec := new(VersionData)
+	err = dec.Decode(b)
+	require.NoError(t, err)
+	require.Equal(t, version, dec)
+}
+
+func TestLegacyVersionData(t *testing.T) {
+	testAPIItem := &APIItem{
+		Name: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		Ver:  99,
+	}
+
+	version := NewLegacyVersionData(
+		[]byte("polkadot"),
+		[]byte("parity-polkadot"),
+		0,
+		25,
+		0,
+		[]*APIItem{testAPIItem},
+	)
+
+	b, err := version.Encode()
+	require.NoError(t, err)
+
+	dec := new(LegacyVersionData)
+	err = dec.Decode(b)
+	require.NoError(t, err)
+	require.Equal(t, version, dec)
+}


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix `ext_misc_runtime_version_version_1` to return the correct encoding of the `runtime.Version`
- fixes execution of kusama block 901442

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/wasmer -run TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- realted to #1134
