### PR TITLE
dot/sync: handle block response justification 

### DIFF
--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -170,7 +170,7 @@ func (cm *ConnManager) Connected(n network.Network, c network.Conn) {
 		logger.Trace("Over max peer count, disconnecting from random unprotected peer", "peer", unprotPeers[i])
 		err := n.ClosePeer(unprotPeers[i])
 		if err != nil {
-			logger.Debug("failed to close connection to peer", "peer", unprotPeers[i], "num peers", len(n.Peers()))
+			logger.Trace("failed to close connection to peer", "peer", unprotPeers[i], "num peers", len(n.Peers()))
 		}
 	}
 }

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -206,12 +206,10 @@ func (h *host) send(p peer.ID, sub protocol.ID, msg Message) (err error) {
 
 	// check if stream needs to be opened
 	if s == nil {
-		logger.Debug("opening new stream with peer", "peer", p, "sub-protocol", sub)
-
 		// open outbound stream with host protocol id
 		s, err = h.h.NewStream(h.ctx, p, h.protocolID+sub)
 		if err != nil {
-			logger.Debug("failed to open new stream with peer", "peer", p, "sub-protocol", sub, "error", err)
+			logger.Trace("failed to open new stream with peer", "peer", p, "sub-protocol", sub, "error", err)
 			return err
 		}
 

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -457,7 +457,7 @@ func (s *Service) readStream(stream libp2pnetwork.Stream, peer peer.ID, decoder 
 		if err == io.EOF {
 			continue
 		} else if err != nil {
-			logger.Debug("failed to read from stream", "protocol", stream.Protocol(), "error", err)
+			logger.Trace("failed to read from stream", "protocol", stream.Protocol(), "error", err)
 			_ = stream.Close()
 			return
 		}
@@ -465,7 +465,7 @@ func (s *Service) readStream(stream libp2pnetwork.Stream, peer peer.ID, decoder 
 		// decode message based on message type
 		msg, err := decoder(msgBytes[:tot], peer)
 		if err != nil {
-			logger.Debug("Failed to decode message from peer", "peer", peer, "err", err)
+			logger.Trace("Failed to decode message from peer", "peer", peer, "err", err)
 			continue
 		}
 

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -253,7 +253,7 @@ func (q *syncQueue) benchmark() {
 
 		before, err := q.s.blockState.BestBlockHeader()
 		if err != nil {
-			logger.Error("failed to get best block haeder", "error", err)
+			logger.Error("failed to get best block header", "error", err)
 			continue
 		}
 
@@ -266,7 +266,7 @@ func (q *syncQueue) benchmark() {
 
 		after, err := q.s.blockState.BestBlockHeader()
 		if err != nil {
-			logger.Error("failed to get best block haeder", "error", err)
+			logger.Error("failed to get best block header", "error", err)
 			continue
 		}
 

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -89,7 +89,7 @@ var (
 	blockRequestSize       uint32 = 128
 	blockRequestQueueSize  int64  = 8
 	maxBlockResponseSize   uint64 = 1024 * 1024 * 4 // 4mb
-	badPeerThreshold       int    = -2
+	badPeerThreshold       int    = -3
 	protectedPeerThreshold int    = 4
 )
 

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -492,13 +492,13 @@ func (bs *BlockState) CompareAndSetBlockData(bd *types.BlockData) error {
 		}
 	}
 
-	hasJustification, _ := bs.HasJustification(bd.Hash)
-	if bd.Justification != nil && bd.Justification.Exists() && !hasJustification {
-		err := bs.SetJustification(bd.Hash, bd.Justification.Value())
-		if err != nil {
-			return err
-		}
-	}
+	// hasJustification, _ := bs.HasJustification(bd.Hash)
+	// if bd.Justification != nil && bd.Justification.Exists() && !hasJustification {
+	// 	err := bs.SetJustification(bd.Hash, bd.Justification.Value())
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -69,8 +69,12 @@ func NewBlockState(db chaindb.Database, bt *blocktree.BlockTree) (*BlockState, e
 		pruneKeyCh: make(chan *types.Header, pruneKeyBufferSize),
 	}
 
-	bs.genesisHash = bt.GenesisHash()
-	var err error
+	genesisBlock, err := bs.GetBlockByNumber(big.NewInt(0))
+	if err != nil {
+		return nil, err
+	}
+
+	bs.genesisHash = genesisBlock.Header.Hash()
 
 	// set the current highest block
 	bs.highestBlockHeader, err = bs.BestBlockHeader()
@@ -84,7 +88,7 @@ func NewBlockState(db chaindb.Database, bt *blocktree.BlockTree) (*BlockState, e
 // NewBlockStateFromGenesis initializes a BlockState from a genesis header, saving it to the database located at basePath
 func NewBlockStateFromGenesis(db chaindb.Database, header *types.Header) (*BlockState, error) {
 	bs := &BlockState{
-		bt:         blocktree.NewBlockTreeFromGenesis(header, db),
+		bt:         blocktree.NewBlockTreeFromRoot(header, db),
 		baseDB:     db,
 		db:         chaindb.NewTable(db, blockPrefix),
 		imported:   make(map[byte]chan<- *types.Block),

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -496,14 +496,6 @@ func (bs *BlockState) CompareAndSetBlockData(bd *types.BlockData) error {
 		}
 	}
 
-	// hasJustification, _ := bs.HasJustification(bd.Hash)
-	// if bd.Justification != nil && bd.Justification.Exists() && !hasJustification {
-	// 	err := bs.SetJustification(bd.Hash, bd.Justification.Value())
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// }
-
 	return nil
 }
 

--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -90,12 +90,5 @@ func TestGetSet_ReceiptMessageQueue_Justification(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, blockdata.MessageQueue.Value(), messageQueue)
 		}
-
-		// test Justification
-		if blockdata.Justification.Exists() {
-			justification, err := s.GetJustification(blockdata.Hash)
-			require.Nil(t, err)
-			require.Equal(t, blockdata.Justification.Value(), justification)
-		}
 	}
 }

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -278,7 +278,7 @@ func (s *Service) Start() error {
 	if !bytes.Equal(btHead[:], bestHash[:]) {
 		logger.Info("detected abnormal node shutdown, restoring from last finalized block")
 
-		lastFinalized, err := s.Block.GetFinalizedHeader(0, 0)
+		lastFinalized, err := s.Block.GetFinalizedHeader(0, 0) //nolint
 		if err != nil {
 			return fmt.Errorf("failed to get latest finalized block: %w", err)
 		}

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -17,6 +17,7 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -124,7 +125,7 @@ func (s *Service) Initialize(gen *genesis.Genesis, header *types.Header, t *trie
 	}
 
 	// create and store blockree from genesis block
-	bt := blocktree.NewBlockTreeFromGenesis(header, db)
+	bt := blocktree.NewBlockTreeFromRoot(header, db)
 	err = bt.Store()
 	if err != nil {
 		return fmt.Errorf("failed to write blocktree to database: %s", err)
@@ -269,6 +270,21 @@ func (s *Service) Start() error {
 	s.Block, err = NewBlockState(db, bt)
 	if err != nil {
 		return fmt.Errorf("failed to create block state: %w", err)
+	}
+
+	// TODO: if blocktree head isn't "best hash", then the node shutdown abnormally.
+	// restore state from last finalized hash.
+	btHead := bt.DeepestBlockHash()
+
+	if !bytes.Equal(btHead[:], bestHash[:]) {
+		logger.Info("detected abnormal node shutdown, restoring from last finalized block")
+
+		lastFinalized, err := s.Block.GetFinalizedHeader(0, 0)
+		if err != nil {
+			return fmt.Errorf("failed to get latest finalized block: %w", err)
+		}
+
+		s.Block.bt = blocktree.NewBlockTreeFromRoot(lastFinalized, db)
 	}
 
 	// create storage state

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -272,10 +272,9 @@ func (s *Service) Start() error {
 		return fmt.Errorf("failed to create block state: %w", err)
 	}
 
-	// TODO: if blocktree head isn't "best hash", then the node shutdown abnormally.
+	// if blocktree head isn't "best hash", then the node shutdown abnormally.
 	// restore state from last finalized hash.
 	btHead := bt.DeepestBlockHash()
-
 	if !bytes.Equal(btHead[:], bestHash[:]) {
 		logger.Info("detected abnormal node shutdown, restoring from last finalized block")
 

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -42,6 +42,8 @@ type BlockState interface {
 	GetReceipt(common.Hash) ([]byte, error)
 	GetMessageQueue(common.Hash) ([]byte, error)
 	GetJustification(common.Hash) ([]byte, error)
+	SetJustification(hash common.Hash, data []byte) error
+	SetFinalizedHash(hash common.Hash, round, setID uint64) error
 }
 
 // StorageState is the interface for the storage state

--- a/dot/sync/message_test.go
+++ b/dot/sync/message_test.go
@@ -170,26 +170,6 @@ func TestService_CreateBlockResponse(t *testing.T) {
 				},
 			},
 		},
-		{
-			description: "test get Justification",
-			value: &network.BlockRequestMessage{
-				RequestedData: 16,
-				StartingBlock: start,
-				EndBlockHash:  optional.NewHash(true, endHash),
-				Direction:     1,
-				Max:           optional.NewUint32(false, 0),
-			},
-			expectedMsgValue: &network.BlockResponseMessage{
-				BlockData: []*types.BlockData{
-					{
-						Hash:          optional.NewHash(true, bestHash).Value(),
-						Header:        optional.NewHeader(false, nil),
-						Body:          optional.NewBody(false, nil),
-						Justification: bds.Justification,
-					},
-				},
-			},
-		},
 	}
 
 	for _, test := range testCases {

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -219,11 +219,6 @@ func (s *Service) ProcessBlockData(data []*types.BlockData) error {
 		}
 
 		if bd.Header.Exists() && bd.Body.Exists() {
-			header, err := types.NewHeaderFromOptional(bd.Header)
-			if err != nil {
-				return err
-			}
-
 			body, err := types.NewBodyFromOptional(bd.Body)
 			if err != nil {
 				return err

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -203,7 +203,7 @@ func (s *Service) ProcessBlockData(data []*types.BlockData) error {
 		}
 
 		if bd.Body.Exists() && !hasBody {
-			body, err := types.NewBodyFromOptional(bd.Body)
+			body, err := types.NewBodyFromOptional(bd.Body) //nolint
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ func (s *Service) ProcessBlockData(data []*types.BlockData) error {
 				return err
 			}
 
-			body, err := types.NewBodyFromOptional(bd.Body) //nolint
+			body, err := types.NewBodyFromOptional(bd.Body)
 			if err != nil {
 				return err
 			}

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -219,7 +219,12 @@ func (s *Service) ProcessBlockData(data []*types.BlockData) error {
 		}
 
 		if bd.Header.Exists() && bd.Body.Exists() {
-			body, err := types.NewBodyFromOptional(bd.Body)
+			header, err = types.NewHeaderFromOptional(bd.Header)
+			if err != nil {
+				return err
+			}
+
+			body, err := types.NewBodyFromOptional(bd.Body) //nolint
 			if err != nil {
 				return err
 			}
@@ -334,7 +339,7 @@ func (s *Service) handleBlock(block *types.Block) error {
 }
 
 func (s *Service) handleJustification(header *types.Header, justification []byte) {
-	if len(justification) == 0 {
+	if len(justification) == 0 || header == nil {
 		return
 	}
 

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -335,3 +335,19 @@ func TestSyncer_HandleRuntimeChanges(t *testing.T) {
 	err = syncer.handleRuntimeChanges(ts)
 	require.NoError(t, err)
 }
+
+func TestSyncer_HandleJustification(t *testing.T) {
+	syncer := newTestSyncer(t)
+
+	header := &types.Header{
+		Number: big.NewInt(1),
+	}
+
+	just := []byte("testjustification")
+
+	syncer.handleJustification(header, just)
+
+	res, err := syncer.blockState.GetJustification(header.Hash())
+	require.NoError(t, err)
+	require.Equal(t, just, res)
+}

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -33,7 +33,7 @@ type Hash = common.Hash
 
 // BlockTree represents the current state with all possible blocks
 type BlockTree struct {
-	head   *node // genesis node
+	head   *node // root node TODO: rename this!!
 	leaves *leafMap
 	db     database.Database
 }
@@ -47,11 +47,11 @@ func NewEmptyBlockTree(db database.Database) *BlockTree {
 	}
 }
 
-// NewBlockTreeFromGenesis initializes a blocktree with a genesis block.
-// Currently passes in arrival time as a parameter instead of setting it as time of instantiation
-func NewBlockTreeFromGenesis(genesis *types.Header, db database.Database) *BlockTree {
+// NewBlockTreeFromRoot initializes a blocktree with a root block. The root block is always the most recently
+// finalized block (ie the genesis block if the node is just starting.)
+func NewBlockTreeFromRoot(root *types.Header, db database.Database) *BlockTree {
 	head := &node{
-		hash:        genesis.Hash(),
+		hash:        root.Hash(),
 		parent:      nil,
 		children:    []*node{},
 		depth:       big.NewInt(0),

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -71,7 +71,7 @@ func newBlockTreeFromNode(head *node, db database.Database) *BlockTree {
 }
 
 func createFlatTree(t *testing.T, depth int) (*BlockTree, []common.Hash) {
-	bt := NewBlockTreeFromGenesis(testHeader, nil)
+	bt := NewBlockTreeFromRoot(testHeader, nil)
 	require.NotNil(t, bt)
 
 	previousHash := bt.head.hash

--- a/lib/blocktree/database_test.go
+++ b/lib/blocktree/database_test.go
@@ -19,7 +19,7 @@ type testBranch struct {
 }
 
 func createTestBlockTree(header *types.Header, depth int, db chaindb.Database) (*BlockTree, []testBranch) {
-	bt := NewBlockTreeFromGenesis(header, db)
+	bt := NewBlockTreeFromRoot(header, db)
 	previousHash := header.Hash()
 
 	// branch tree randomly
@@ -77,15 +77,11 @@ func TestStoreBlockTree(t *testing.T) {
 	bt, _ := createTestBlockTree(testHeader, 10, db)
 
 	err := bt.Store()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	resBt := NewBlockTreeFromGenesis(testHeader, db)
+	resBt := NewBlockTreeFromRoot(testHeader, db)
 	err = resBt.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if !reflect.DeepEqual(bt.head, resBt.head) {
 		t.Fatalf("Fail: got %v expected %v", resBt, bt)


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- handle justifications provided in block responses by setting latest finalized hash (will use grandpa to verify justification in a follow-up PR, wanted to get this in first since it allows the blocktree to be pruned, improving sync times)
- on node restart, if there was an "abnormal shutdown" ie the blocktree wasn't stored properly because the node panicked or was killed forcefully, then restore the state from the latest finalized hash
- update logging to log blocks imported every 5s (if you liked the previous logs, you can turn on `sync` package debug logs):
```
INFO[03-02|03:10:06] 🔨 finalized block                     pkg=sync number=1094832 hash=0xb7d4a3c8a51dd5e189c2aec82dffec97f91f2f09ce1736878aa985ec108eb41f caller=syncer.go:353
INFO[03-02|03:10:11] 🔗 imported blocks                     pkg=network from=1094832 to=1094918 hashes="[0xb7d4a3c8a51dd5e189c2aec82dffec97f91f2f09ce1736878aa985ec108eb41f ... 0xd7fd20dbe3646d2a52e3e82963ac00462cb6bfd95627a4f667903628f79000df]" caller=sync.go:275
INFO[03-02|03:10:11] 🚣 currently syncing                   pkg=network goal=6426917 average blocks/second=17.199 overall average=10.906 caller=sync.go:279
INFO[03-02|03:10:16] 🔗 imported blocks                     pkg=network from=1094918 to=1095008 hashes="[0xd7fd20dbe3646d2a52e3e82963ac00462cb6bfd95627a4f667903628f79000df ... 0x71192a673ef180eabf2df8c4baf8d0335e32cfbeda8f1bddaf6221aea0dc7774]" caller=sync.go:275
INFO[03-02|03:10:16] 🚣 currently syncing                   pkg=network goal=6426917 average blocks/second=17.988 overall average=11.087 caller=sync.go:279
```

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/state
go test ./dot/sync -short
```

as usual please try to run a kusama node and see that blocks are being marked as finalized

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [x] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- related to #1363