### PR TITLE
dot/network: start syncQueue after bootstrapping, don't run syncQueue during tests

### DIFF
--- a/dot/network/connmgr_test.go
+++ b/dot/network/connmgr_test.go
@@ -30,7 +30,7 @@ func TestMaxPeers(t *testing.T) {
 	nodes := make([]*Service, max+2)
 	for i := range nodes {
 		config := &Config{
-			BasePath:    utils.NewTestBasePath(t, fmt.Sprintf("node%d", i)),
+			BasePath:    utils.NewTestBasePath(t, fmt.Sprintf("node%d-x", i)),
 			Port:        7000 + uint32(i),
 			RandSeed:    1 + int64(i),
 			NoBootstrap: true,

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -84,6 +84,7 @@ func createTestService(t *testing.T, cfg *Config) (srvc *Service) {
 
 	err = srvc.Start()
 	require.NoError(t, err)
+	srvc.syncQueue.stop()
 
 	t.Cleanup(func() {
 		srvc.Stop()

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -394,13 +394,14 @@ func (q *syncQueue) pushResponse(resp *BlockResponseMessage, pid peer.ID) {
 	q.responseLock.Lock()
 	defer q.responseLock.Unlock()
 
-	for _, bd := range resp.BlockData {
-		if bd.Number() == nil || bd.Number().Int64() < head.Int64() {
-			continue
-		}
+	// for _, bd := range resp.BlockData {
+	// 	if bd.Number() == nil || bd.Number().Int64() < head.Int64() {
+	// 		continue
+	// 	}
 
-		q.responses = append(q.responses, bd)
-	}
+	// 	q.responses = append(q.responses, bd)
+	// }
+	q.responses = append(q.responses, resp.BlockData...)
 
 	q.responses = sortResponses(q.responses)
 	logger.Debug("pushed block data to queue", "start", start, "end", end, "queue", q.stringifyResponseQueue())


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- start syncQueue after bootstrapping (i noticed it would start before the node was done setting up the networking, causing weird behaviour)
- don't run syncQueue during tests (network tests have been having issues lately, this hopefully will help)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network -short
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [ ] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [ ] I have provided as much information as possible and necessary
- [ ] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

- realted to #1134
