### PR TITLE
fix: lib/runtime: update sign_ funcs to return fixed size byte optional

### DIFF
--- a/lib/runtime/life/instance.go
+++ b/lib/runtime/life/instance.go
@@ -110,8 +110,8 @@ func NewInstance(code []byte, cfg *Config) (runtime.Instance, error) {
 	}
 
 	ctx = runtimeCtx
-	inst.version, err = inst.Version()
-	return inst, err
+	inst.version, _ = inst.Version()
+	return inst, nil
 }
 
 // Memory is a thin wrapper around life's memory to support

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -331,7 +331,7 @@ func ext_crypto_ed25519_sign_version_1(context unsafe.Pointer, keyTypeID C.int32
 		logger.Error("[ext_crypto_ed25519_sign_version_1] could not sign message")
 	}
 
-	ret, err = toWasmMemoryOptional(instanceContext, sig)
+	ret, err = toWasmMemoryFixedSizeOptional(instanceContext, sig)
 	if err != nil {
 		logger.Error("[ext_crypto_ed25519_sign_version_1] failed to allocate memory", err)
 		return 0
@@ -494,7 +494,7 @@ func ext_crypto_sr25519_generate_version_1(context unsafe.Pointer, keyTypeID C.i
 
 	ks, err := runtimeCtx.Keystore.GetKeystore(id)
 	if err != nil {
-		logger.Warn("[ext_crypto_ed25519_sign_version_1]", "name", id, "error", err)
+		logger.Warn("[ext_crypto_sr25519_generate_version_1]", "name", id, "error", err)
 		return 0
 	}
 
@@ -593,7 +593,7 @@ func ext_crypto_sr25519_sign_version_1(context unsafe.Pointer, keyTypeID, key C.
 		return C.int64_t(emptyRet)
 	}
 
-	ret, err = toWasmMemoryOptional(instanceContext, sig)
+	ret, err = toWasmMemoryFixedSizeOptional(instanceContext, sig)
 	if err != nil {
 		logger.Error("[ext_crypto_sr25519_sign_version_1] failed to allocate memory", "error", err)
 		return C.int64_t(emptyRet)
@@ -1953,6 +1953,23 @@ func toWasmMemoryOptionalUint32(context wasm.InstanceContext, data *uint32) (int
 	}
 
 	enc := opt.Encode()
+	return toWasmMemory(context, enc)
+}
+
+// Wraps slice in optional.FixedSizeBytes and copies result to wasm memory. Returns resulting 64bit span descriptor
+func toWasmMemoryFixedSizeOptional(context wasm.InstanceContext, data []byte) (int64, error) {
+	var opt *optional.FixedSizeBytes
+	if data == nil {
+		opt = optional.NewFixedSizeBytes(false, nil)
+	} else {
+		opt = optional.NewFixedSizeBytes(true, data)
+	}
+
+	enc, err := opt.Encode()
+	if err != nil {
+		return 0, err
+	}
+
 	return toWasmMemory(context, enc)
 }
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -513,7 +513,7 @@ func Test_ext_crypto_ed25519_sign_version_1(t *testing.T) {
 	buf := &bytes.Buffer{}
 	buf.Write(out.([]byte))
 
-	value, err := new(optional.Bytes).Decode(buf)
+	value, err := new(optional.FixedSizeBytes).Decode(buf)
 	require.NoError(t, err)
 
 	ok, err := kp.Public().Verify(msgData, value.Value())
@@ -732,7 +732,7 @@ func Test_ext_crypto_sr25519_sign_version_1(t *testing.T) {
 	buf := &bytes.Buffer{}
 	buf.Write(out.([]byte))
 
-	value, err := new(optional.Bytes).Decode(buf)
+	value, err := new(optional.FixedSizeBytes).Decode(buf)
 	require.NoError(t, err)
 	require.True(t, value.Exists())
 


### PR DESCRIPTION
<!---

PLEASE READ CAREFULLY

-->

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update sign_ functs to return fixed size byte optional
- update `life` not to error if `core_version` doesn't exist (needed for host API tester)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/wasmer/ -run Test_ext_crypto_ed25519_sign_version_1
go test ./lib/runtime/wasmer/ -run Test_ext_crypto_sr25519_sign_version_1
go test ./lib/runtime/life
```

## Checklist

<!--

Each empty square brackets below is a checkbox. Replace [ ] with [x] to check
the box after completing the task.

-->

- [x] I have read [CODE_OF_CONDUCT](https://github.com/ChainSafe/gossamer/blob/development/.github/CODE_OF_CONDUCT.md) and [CONTRIBUTING](https://github.com/ChainSafe/gossamer/blob/development/.github/CONTRIBUTING.md) 
- [x] I have provided as much information as possible and necessary
- [x] I have reviewed my own pull request before requesting a review
- [ ] All integration tests and required coverage checks are passing

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

See: https://help.github.com/en/articles/closing-issues-using-keywords

-->

related to #1105 