### PR TITLE
fix: dot/network: added BestBlock bool to BlockAnnounceMessage

### DIFF
--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -57,6 +57,7 @@ func TestService_ProcessBlockAnnounceMessage(t *testing.T) {
 		StateRoot:      common.Hash{},
 		ExtrinsicsRoot: common.Hash{},
 		Digest:         nil,
+		BestBlock:      true,
 	}
 
 	// simulate block sent from BABE session

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -421,7 +421,7 @@ func (s *Service) InsertKey(kp crypto.Keypair) {
 
 // HasKey returns true if given hex encoded public key string is found in keystore, false otherwise, error if there
 //  are issues decoding string
-func (s *Service) HasKey(pubKeyStr string, keyType string) (bool, error) {
+func (s *Service) HasKey(pubKeyStr, keyType string) (bool, error) {
 	return keystore.HasKey(pubKeyStr, keyType, s.keys.Acco)
 }
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -309,6 +309,7 @@ func (s *Service) handleReceivedBlock(block *types.Block) (err error) {
 		StateRoot:      block.Header.StateRoot,
 		ExtrinsicsRoot: block.Header.ExtrinsicsRoot,
 		Digest:         block.Header.Digest,
+		BestBlock:      true,
 	}
 
 	if s.net == nil {

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -41,6 +41,7 @@ type BlockAnnounceMessage struct {
 	StateRoot      common.Hash
 	ExtrinsicsRoot common.Hash
 	Digest         types.Digest
+	BestBlock      bool
 }
 
 // SubProtocol returns the block-announces sub-protocol
@@ -86,6 +87,12 @@ func (bm *BlockAnnounceMessage) Decode(in []byte) error {
 	bm.StateRoot = h.StateRoot
 	bm.ExtrinsicsRoot = h.ExtrinsicsRoot
 	bm.Digest = h.Digest
+	bestBlock, err := common.ReadByte(r)
+	if err != nil {
+		return err
+	}
+
+	bm.BestBlock = bestBlock == 1
 	return nil
 }
 

--- a/dot/network/message_test.go
+++ b/dot/network/message_test.go
@@ -214,7 +214,7 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 	//	Digest: []byte
 
 	//                                    mtparenthash                                                      bnstateroot                                                       extrinsicsroot                                                di
-	expected, err := common.HexToBytes("0x454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400")
+	expected, err := common.HexToBytes("0x454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c1113140000")
 	require.Nil(t, err)
 
 	parentHash, err := common.HexToHash("0x4545454545454545454545454545454545454545454545454545454545454545")
@@ -241,7 +241,7 @@ func TestEncodeBlockAnnounceMessage(t *testing.T) {
 }
 
 func TestDecode_BlockAnnounceMessage(t *testing.T) {
-	announceMessage, err := common.HexToBytes("0x454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c11131400")
+	announceMessage, err := common.HexToBytes("0x454545454545454545454545454545454545454545454545454545454545454504b3266de137d20a5d0ff3a6401eb57127525fd9b2693701f0bf5a8a853fa3ebe003170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c1113140000")
 	require.Nil(t, err)
 
 	bhm := new(BlockAnnounceMessage)


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- added `BestBlock bool` to `BlockAnnounceMessage`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1401
