### PR TITLE
fix: docker-script: Add non-authority role arg to entrypoint

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -23,6 +23,7 @@ set -euxo pipefail
 
 if [ ! -f $BASE_PATH/genesis_created ]; then
 	/usr/local/gossamer init --genesis-raw=/gocode/src/github.com/ChainSafe/gossamer/chain/gssmr/genesis-raw.json
+	/usr/local/gossamer --chain gssmr --roles 1
 	touch $BASE_PATH/genesis_created;
 fi;
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Currently when you run `make docker` the node starts and then shuts down as it runs as an authority node by default and has not been passed a `--key` 
- The proposed change would start the docker instance as a non-authority node, I am unsure if that is preferred I can also just provide  the `--key alice` arg to the entrypoint. Please advise @noot  
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-
