### PR TITLE
fix(lib/crypto/ed25519): update ed25519 to use go-schnorrkel bip39 derivation

### DIFF
--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto"
 
-	bip39 "github.com/cosmos/go-bip39"
+	"github.com/ChainSafe/go-schnorrkel"
 )
 
 // PublicKeyLength is the fixed Public Key Length
@@ -120,7 +120,10 @@ func NewKeypairFromPrivateKeyString(in string) (*Keypair, error) {
 
 // NewKeypairFromMnenomic returns a new Keypair using the given mnemonic and password.
 func NewKeypairFromMnenomic(mnemonic, password string) (*Keypair, error) {
-	seed := bip39.NewSeed(mnemonic, password)
+	seed, err := schnorrkel.SeedFromMnemonic(mnemonic, password)
+	if err != nil {
+		return nil, err
+	}
 	return NewKeypairFromSeed(seed[:32])
 }
 

--- a/lib/crypto/ed25519/ed25519_test.go
+++ b/lib/crypto/ed25519/ed25519_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/lib/common"
+
 	bip39 "github.com/cosmos/go-bip39"
 	"github.com/stretchr/testify/require"
 )
@@ -100,4 +102,13 @@ func TestNewKeypairFromMnenomic(t *testing.T) {
 
 	_, err = NewKeypairFromMnenomic(mnemonic, "")
 	require.NoError(t, err)
+}
+
+func TestNewKeypairFromMnenomic_Again(t *testing.T) {
+	mnemonic := "twist sausage october vivid neglect swear crumble hawk beauty fabric egg fragile"
+	kp, err := NewKeypairFromMnenomic(mnemonic, "")
+	require.NoError(t, err)
+
+	expectedPubkey := common.MustHexToBytes("0xf56d9231e7b7badd3f1e10ad15ef8aa08b70839723d0a2d10d7329f0ea2b8c61")
+	require.Equal(t, expectedPubkey, kp.Public().Encode())
 }

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -127,8 +127,8 @@ func ext_logging_log_version_1(context unsafe.Pointer, level C.int32_t, targetDa
 	logger.Trace("[ext_logging_log_version_1] executing...")
 	instanceContext := wasm.IntoInstanceContext(context)
 
-	target := fmt.Sprintf("%s", asMemorySlice(instanceContext, targetData))
-	msg := fmt.Sprintf("%s", asMemorySlice(instanceContext, msgData))
+	target := string(asMemorySlice(instanceContext, targetData))
+	msg := string(asMemorySlice(instanceContext, msgData))
 
 	switch int(level) {
 	case 0:
@@ -849,7 +849,7 @@ func ext_misc_print_utf8_version_1(context unsafe.Pointer, dataSpan C.int64_t) {
 
 	instanceContext := wasm.IntoInstanceContext(context)
 	data := asMemorySlice(instanceContext, dataSpan)
-	logger.Debug("[ext_misc_print_utf8_version_1]", "utf8", fmt.Sprintf("%s", data))
+	logger.Debug("[ext_misc_print_utf8_version_1]", "utf8", string(data))
 }
 
 //export ext_misc_runtime_version_version_1
@@ -1241,7 +1241,7 @@ func ext_hashing_twox_128_version_1(context unsafe.Pointer, dataSpan C.int64_t) 
 		return 0
 	}
 
-	logger.Debug("[ext_hashing_twox_128_version_1]", "data", fmt.Sprintf("%s", data), "hash", fmt.Sprintf("0x%x", hash))
+	logger.Debug("[ext_hashing_twox_128_version_1]", "data", string(data), "hash", fmt.Sprintf("0x%x", hash))
 
 	out, err := toWasmMemorySized(instanceContext, hash, 16)
 	if err != nil {

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -215,7 +215,7 @@ func ext_crypto_ed25519_generate_version_1(context unsafe.Pointer, keyTypeID C.i
 	var kp crypto.Keypair
 
 	if seed.Exists() {
-		kp, err = ed25519.NewKeypairFromMnenomic(string(seedBytes), "")
+		kp, err = ed25519.NewKeypairFromMnenomic(string(seed.Value()), "")
 	} else {
 		kp, err = ed25519.GenerateKeypair()
 	}

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -419,8 +419,6 @@ func Test_ext_crypto_ed25519_generate_version_1(t *testing.T) {
 	mnemonic, err := crypto.NewBIP39Mnemonic()
 	require.NoError(t, err)
 
-	// TODO: we currently don't provide a seed since the spec says the seed is an optional BIP-39 seed
-	// clarify whether this is a mnemonic or not
 	data := optional.NewBytes(true, []byte(mnemonic))
 	seedData, err := data.Encode()
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update ed25519 to use go-schnorrkel bip39 derivation, should fix `ext_crypto_ed25519_generate_version_1`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/crypto/ed25519 -run TestNewKeypairFromMnenomic
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1418