### PR TITLE
chore(lib/runtime): update SignatureVerifier to use batch verifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ChainSafe/gossamer
 
 require (
 	github.com/ChainSafe/chaindb v0.1.5-0.20210117220933-15e75f27268f
-	github.com/ChainSafe/go-schnorrkel v0.0.0-20210127175223-0f934d64ecac
+	github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/OneOfOne/xxhash v1.2.5
 	github.com/btcsuite/btcutil v1.0.2
@@ -25,6 +25,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/gtank/merlin v0.1.1
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
+	github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87
 	github.com/huin/goupnp v1.0.1-0.20200620063722-49508fba0031 // indirect
 	github.com/ipfs/go-ds-badger2 v0.1.0
 	github.com/jcelliott/lumber v0.0.0-20160324203708-dd349441af25 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+filippo.io/edwards25519 v1.0.0-beta.2 h1:/BZRNzm8N4K4eWfK28dL4yescorxtO7YG1yun8fy+pI=
+filippo.io/edwards25519 v1.0.0-beta.2/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
@@ -6,8 +8,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/chaindb v0.1.5-0.20210117220933-15e75f27268f h1:qDmWdUIE1cgG19K/eVB9nkQMkldaGwcjU9U5OyUV11k=
 github.com/ChainSafe/chaindb v0.1.5-0.20210117220933-15e75f27268f/go.mod h1:WBsCSLGM7+DvSYU6cFVUltahwU7Sw4cN3e8kiLdNFJM=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20210127175223-0f934d64ecac h1:mZyOXXu+q/op10XOYRzdpIxWWreS/zCYhl+UNpRv2O0=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20210127175223-0f934d64ecac/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
+github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782 h1:lwmjzta2Xu+3rPVY/VeNQj2xfNkyih4CwyRxYg3cpRQ=
+github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=
 github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
@@ -184,6 +186,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87 h1:uUjLpLt6bVvZ72SQc/B4dXcPBw4Vgd7soowdRl52qEM=
+github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87/go.mod h1:XGsKKeXxeRr95aEOgipvluMPlgjr7dGlk9ZTWOjcUcg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=

--- a/lib/crypto/sr25519/sr25519.go
+++ b/lib/crypto/sr25519/sr25519.go
@@ -378,6 +378,7 @@ func (k *PublicKey) Hex() string {
 	return "0x" + h
 }
 
+// Key returns the underlying schnorrkel key
 func (k *PublicKey) Key() *sr25519.PublicKey {
 	return k.key
 }

--- a/lib/crypto/sr25519/sr25519.go
+++ b/lib/crypto/sr25519/sr25519.go
@@ -378,6 +378,10 @@ func (k *PublicKey) Hex() string {
 	return "0x" + h
 }
 
+func (k *PublicKey) Key() *sr25519.PublicKey {
+	return k.key
+}
+
 // AsBytes returns the key as a [PublicKeyLength]byte
 func (k *PublicKey) AsBytes() [PublicKeyLength]byte {
 	return k.key.Encode()

--- a/lib/runtime/sig_verifier.go
+++ b/lib/runtime/sig_verifier.go
@@ -1,15 +1,16 @@
 package runtime
 
 import (
+	ced25519 "crypto/ed25519"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
-	log "github.com/ChainSafe/log15"
-	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+
+	"github.com/ChainSafe/go-schnorrkel"
+	"github.com/hdevalence/ed25519consensus"
 )
 
 // Signature ...
@@ -22,13 +23,10 @@ type Signature struct {
 
 // SignatureVerifier ...
 type SignatureVerifier struct {
-	batch   []*Signature
-	init    bool // Indicates whether the batch processing is started.
-	invalid bool // Set to true if any signature verification fails.
-	closeCh chan struct{}
+	ed25519Batch *ed25519consensus.BatchVerifier
+	sr25519Batch *schnorrkel.BatchVerifier
+	init         bool // Indicates whether the batch processing is started.
 	sync.RWMutex
-	sync.Once
-	sync.WaitGroup
 }
 
 // NewSignatureVerifier initializes SignatureVerifier which does background verification of signatures.
@@ -36,13 +34,7 @@ type SignatureVerifier struct {
 // Finish() is called to stop the verification process.
 // Signatures can be added to the batch using Add().
 func NewSignatureVerifier() *SignatureVerifier {
-	return &SignatureVerifier{
-		batch:   make([]*Signature, 0),
-		init:    false,
-		invalid: false,
-		RWMutex: sync.RWMutex{},
-		closeCh: make(chan struct{}),
-	}
+	return &SignatureVerifier{}
 }
 
 // Start signature verification in batch.
@@ -52,28 +44,8 @@ func (sv *SignatureVerifier) Start() {
 	sv.init = true
 	sv.Unlock()
 
-	sv.WaitGroup.Add(1)
-
-	go func() {
-		defer sv.Done()
-		for {
-			select {
-			case <-sv.closeCh:
-				return
-			default:
-				sign := sv.Remove()
-				if sign == nil {
-					continue
-				}
-				err := sign.verify()
-				if err != nil {
-					log.Error("[ext_crypto_start_batch_verify_version_1]", "error", err)
-					sv.Invalid()
-					return
-				}
-			}
-		}
-	}()
+	*sv.ed25519Batch = ed25519consensus.NewBatchVerifier()
+	sv.sr25519Batch = schnorrkel.NewBatchVerifier()
 }
 
 // IsStarted ...
@@ -83,97 +55,58 @@ func (sv *SignatureVerifier) IsStarted() bool {
 	return sv.init
 }
 
-// IsInvalid ...
-func (sv *SignatureVerifier) IsInvalid() bool {
-	sv.RLock()
-	defer sv.RUnlock()
-	return sv.invalid
-}
-
-// Invalid ...
-func (sv *SignatureVerifier) Invalid() {
-	sv.RLock()
-	defer sv.RUnlock()
-	sv.invalid = true
-}
-
 // Add ...
-func (sv *SignatureVerifier) Add(s *Signature) {
-	if sv.IsInvalid() {
-		return
+func (sv *SignatureVerifier) Add(s *Signature) error {
+	if !sv.IsStarted() {
+		return fmt.Errorf("verifier has not yet been started")
 	}
 
 	sv.Lock()
 	defer sv.Unlock()
-	sv.batch = append(sv.batch, s)
-}
 
-// Remove returns the first signature from the batch. Returns nil if batch is empty.
-func (sv *SignatureVerifier) Remove() *Signature {
-	sv.Lock()
-	defer sv.Unlock()
-	if len(sv.batch) == 0 {
-		return nil
+	switch s.KeyTypeID {
+	case crypto.Ed25519Type:
+		pubKey, err := ed25519.NewPublicKey(s.PubKey)
+		if err != nil {
+			return fmt.Errorf("invalid ed25519 public key: %w", err)
+		}
+
+		sv.ed25519Batch.Add(ced25519.PublicKey(*pubKey), s.Msg, s.Sign)
+	case crypto.Sr25519Type:
+		pubKey, err := sr25519.NewPublicKey(s.PubKey)
+		if err != nil {
+			return fmt.Errorf("invalid sr25519 public key: %w", err)
+		}
+
+		b := [sr25519.SignatureLength]byte{}
+		copy(b[:], s.Sign)
+
+		sig := &schnorrkel.Signature{}
+		err = sig.Decode(b)
+		if err != nil {
+			return fmt.Errorf("invalid sr25519 signature: %w", err)
+		}
+
+		t := schnorrkel.NewSigningContext(sr25519.SigningContext, s.Msg)
+		return sv.sr25519Batch.Add(t, sig, pubKey.Key())
+	default:
+		return fmt.Errorf("invalid signature type added to batch verifier: type=%s", s.KeyTypeID)
 	}
-	sign := sv.batch[0]
-	sv.batch = sv.batch[1:len(sv.batch)]
-	return sign
+
+	return nil
 }
 
 // Reset reset the signature verifier for reuse.
-func (sv *SignatureVerifier) Reset() {
+func (sv *SignatureVerifier) reset() {
 	sv.Lock()
 	defer sv.Unlock()
-	sv.init = false
-	sv.batch = make([]*Signature, 0)
-	sv.invalid = false
-	sv.closeCh = make(chan struct{})
+
+	sv.ed25519Batch = nil
+	sv.sr25519Batch = nil
 }
 
 // Finish waits till batch is finished. Returns true if all the signatures are valid, Otherwise returns false.
 func (sv *SignatureVerifier) Finish() bool {
-	for {
-		time.Sleep(100 * time.Millisecond)
-		sv.Lock()
-		if sv.invalid || len(sv.batch) == 0 {
-			close(sv.closeCh)
-			sv.Unlock()
-			break
-		}
-		sv.RUnlock()
-	}
-	// Wait till start function to finish and then reset it.
-	sv.Wait()
-	isInvalid := sv.IsInvalid()
-	sv.Reset()
-	return !isInvalid
-}
-
-func (sig *Signature) verify() error {
-	switch sig.KeyTypeID {
-	case crypto.Ed25519Type:
-		pubKey, err := ed25519.NewPublicKey(sig.PubKey)
-		if err != nil {
-			return fmt.Errorf("failed to fetch ed25519 public key: %s", err)
-		}
-		ok, err := pubKey.Verify(sig.Msg, sig.Sign)
-		if err != nil || !ok {
-			return fmt.Errorf("failed to verify ed25519 signature: %s", err)
-		}
-	case crypto.Sr25519Type:
-		pubKey, err := sr25519.NewPublicKey(sig.PubKey)
-		if err != nil {
-			return fmt.Errorf("failed to fetch sr25519 public key: %s", err)
-		}
-		ok, err := pubKey.Verify(sig.Msg, sig.Sign)
-		if err != nil || !ok {
-			return fmt.Errorf("failed to verify sr25519 signature: %s", err)
-		}
-	case crypto.Secp256k1Type:
-		ok := secp256k1.VerifySignature(sig.PubKey, sig.Msg, sig.Sign)
-		if !ok {
-			return fmt.Errorf("failed to verify secp256k1 signature")
-		}
-	}
-	return nil
+	defer sv.reset()
+	return sv.ed25519Batch.Verify() && sv.sr25519Batch.Verify()
 }

--- a/lib/runtime/sig_verifier.go
+++ b/lib/runtime/sig_verifier.go
@@ -44,7 +44,8 @@ func (sv *SignatureVerifier) Start() {
 	sv.init = true
 	sv.Unlock()
 
-	*sv.ed25519Batch = ed25519consensus.NewBatchVerifier()
+	ed25519Batch := ed25519consensus.NewBatchVerifier()
+	sv.ed25519Batch = &ed25519Batch
 	sv.sr25519Batch = schnorrkel.NewBatchVerifier()
 }
 
@@ -103,6 +104,7 @@ func (sv *SignatureVerifier) reset() {
 
 	sv.ed25519Batch = nil
 	sv.sr25519Batch = nil
+	sv.init = false
 }
 
 // Finish waits till batch is finished. Returns true if all the signatures are valid, Otherwise returns false.

--- a/lib/runtime/sig_verifier.go
+++ b/lib/runtime/sig_verifier.go
@@ -97,7 +97,7 @@ func (sv *SignatureVerifier) Add(s *Signature) error {
 	return nil
 }
 
-// Reset reset the signature verifier for reuse.
+// reset resets the signature verifier for reuse.
 func (sv *SignatureVerifier) reset() {
 	sv.Lock()
 	defer sv.Unlock()

--- a/lib/runtime/sig_verifier_test.go
+++ b/lib/runtime/sig_verifier_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/crypto/secp256k1"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +23,7 @@ func TestBackgroundSignVerification(t *testing.T) {
 
 	// Wait for background go routine to verify signature.
 	time.Sleep(1 * time.Second)
-	require.False(t, signVerify.IsInvalid())
+	require.True(t, signVerify.IsStarted())
 }
 
 func TestBackgroundSignVerificationMultipleStart(t *testing.T) {
@@ -103,30 +102,9 @@ func TestAllCryptoTypeSignature(t *testing.T) {
 		KeyTypeID: crypto.Sr25519Type,
 	}
 
-	blakeHash, err := common.Blake2bHash([]byte("secp256k1"))
-	require.NoError(t, err)
-
-	kp, err := secp256k1.GenerateKeypair()
-	require.NoError(t, err)
-
-	secpSigData, err := kp.Sign(blakeHash.ToBytes())
-	require.NoError(t, err)
-
-	secpSigData = secpSigData[:len(secpSigData)-1] // remove recovery id
-	secpSignature := &Signature{
-		PubKey:    kp.Public().Encode(),
-		Sign:      secpSigData,
-		Msg:       blakeHash.ToBytes(),
-		KeyTypeID: crypto.Secp256k1Type,
-	}
-
 	signVerify := NewSignatureVerifier()
-
 	signVerify.Start()
-
 	signVerify.Add(edSignatures[0])
 	signVerify.Add(srSignature)
-	signVerify.Add(secpSignature)
-
 	require.True(t, signVerify.Finish())
 }

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -352,21 +352,27 @@ func ext_crypto_ed25519_verify_version_1(context unsafe.Pointer, sig C.int32_t, 
 	message := asMemorySlice(instanceContext, msg)
 	pubKeyData := memory[key : key+32]
 
-	pubKey, err := ed25519.NewPublicKey(pubKeyData)
-	if err != nil {
-		logger.Error("[ext_crypto_ed25519_verify_version_1] failed to create public key")
-		return 0
-	}
-
 	if sigVerifier.IsStarted() {
 		signature := runtime.Signature{
-			PubKey:    pubKey.Encode(),
+			PubKey:    pubKeyData,
 			Sign:      signature,
 			Msg:       message,
 			KeyTypeID: crypto.Ed25519Type,
 		}
-		sigVerifier.Add(&signature)
+
+		err := sigVerifier.Add(&signature)
+		if err != nil {
+			logger.Error("[ext_crypto_ed25519_verify_version_1] failed to add to batch verifier", "error", err)
+			return 0
+		}
+
 		return 1
+	}
+
+	pubKey, err := ed25519.NewPublicKey(pubKeyData)
+	if err != nil {
+		logger.Error("[ext_crypto_ed25519_verify_version_1] failed to create public key")
+		return 0
 	}
 
 	if ok, err := pubKey.Verify(message, signature); err != nil || !ok {
@@ -611,27 +617,33 @@ func ext_crypto_sr25519_verify_version_1(context unsafe.Pointer, sig C.int32_t, 
 
 	message := asMemorySlice(instanceContext, msg)
 	signature := memory[sig : sig+64]
+	pubkey := memory[key : key+32]
 
-	pub, err := sr25519.NewPublicKey(memory[key : key+32])
-	if err != nil {
-		logger.Error("[ext_crypto_sr25519_verify_version_1] invalid sr25519 public key")
-		return 0
-	}
-
-	logger.Debug("[ext_crypto_sr25519_verify_version_1]", "pub", pub.Hex(),
+	logger.Debug("[ext_crypto_sr25519_verify_version_1]", "pub", fmt.Sprintf("0x%x", pubkey),
 		"message", fmt.Sprintf("0x%x", message),
 		"signature", fmt.Sprintf("0x%x", signature),
 	)
 
 	if sigVerifier.IsStarted() {
 		signature := runtime.Signature{
-			PubKey:    pub.Encode(),
+			PubKey:    pubkey,
 			Sign:      signature,
 			Msg:       message,
 			KeyTypeID: crypto.Sr25519Type,
 		}
-		sigVerifier.Add(&signature)
+
+		err := sigVerifier.Add(&signature)
+		if err != nil {
+			logger.Error("[ext_crypto_ed25519_verify_version_1] failed to add to batch verifier", "error", err)
+			return 0
+		}
 		return 1
+	}
+
+	pub, err := sr25519.NewPublicKey(pubkey)
+	if err != nil {
+		logger.Error("[ext_crypto_sr25519_verify_version_1] invalid sr25519 public key")
+		return 0
 	}
 
 	if ok, err := pub.VerifyDeprecated(message, signature); err != nil || !ok {
@@ -654,27 +666,33 @@ func ext_crypto_sr25519_verify_version_2(context unsafe.Pointer, sig C.int32_t, 
 
 	message := asMemorySlice(instanceContext, msg)
 	signature := memory[sig : sig+64]
+	pubkey := memory[key : key+32]
 
-	pub, err := sr25519.NewPublicKey(memory[key : key+32])
-	if err != nil {
-		logger.Error("[ext_crypto_sr25519_verify_version_2] invalid sr25519 public key")
-		return 0
-	}
-
-	logger.Debug("[ext_crypto_sr25519_verify_version_2]", "pub", pub.Hex(),
+	logger.Debug("[ext_crypto_sr25519_verify_version_2]", "pub", fmt.Sprintf("0x%x", pubkey),
 		"message", fmt.Sprintf("0x%x", message),
 		"signature", fmt.Sprintf("0x%x", signature),
 	)
 
 	if sigVerifier.IsStarted() {
 		signature := runtime.Signature{
-			PubKey:    pub.Encode(),
+			PubKey:    pubkey,
 			Sign:      signature,
 			Msg:       message,
 			KeyTypeID: crypto.Sr25519Type,
 		}
-		sigVerifier.Add(&signature)
+
+		err := sigVerifier.Add(&signature)
+		if err != nil {
+			logger.Error("[ext_crypto_ed25519_verify_version_1] failed to add to batch verifier", "error", err)
+			return 0
+		}
 		return 1
+	}
+
+	pub, err := sr25519.NewPublicKey(pubkey)
+	if err != nil {
+		logger.Error("[ext_crypto_sr25519_verify_version_2] invalid sr25519 public key")
+		return 0
 	}
 
 	if ok, err := pub.Verify(message, signature); err != nil || !ok {

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -689,9 +689,7 @@ func ext_crypto_sr25519_verify_version_2(context unsafe.Pointer, sig C.int32_t, 
 //export ext_crypto_start_batch_verify_version_1
 func ext_crypto_start_batch_verify_version_1(context unsafe.Pointer) {
 	logger.Debug("[ext_crypto_start_batch_verify_version_1] executing...")
-
-	// TODO: fix and re-enable signature verification
-	// beginBatchVerify(context)
+	beginBatchVerify(context)
 }
 
 func beginBatchVerify(context unsafe.Pointer) { //nolint
@@ -709,10 +707,7 @@ func beginBatchVerify(context unsafe.Pointer) { //nolint
 //export ext_crypto_finish_batch_verify_version_1
 func ext_crypto_finish_batch_verify_version_1(context unsafe.Pointer) C.int32_t {
 	logger.Debug("[ext_crypto_finish_batch_verify_version_1] executing...")
-
-	// TODO: fix and re-enable signature verification
-	// return finishBatchVerify(context)
-	return 1
+	return finishBatchVerify(context)
 }
 
 func finishBatchVerify(context unsafe.Pointer) C.int32_t { //nolint


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update SignatureVerifier to use batch verifiers for sr25519, ed25519 signatures
- TODO: this causes block executions to fail, since batch verification was previously disabled

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/... -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1405
