### PR TITLE
chore(lib/grandpa): update grandpa message types to match substrate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
-	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd
+	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/protobuf v1.25.0
 )

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -69,8 +69,8 @@ var ErrCannotDecodeSubround = errors.New("cannot decode invalid subround value")
 // ErrInvalidMessageType is returned when a network.Message cannot be decoded
 var ErrInvalidMessageType = errors.New("cannot decode invalid message type")
 
-// ErrNotFinalizationMessage is returned when calling GetFinalizedHash on a message that isn't a FinalizationMessage
-var ErrNotFinalizationMessage = errors.New("cannot get finalized hash from VoteMessage")
+// ErrNotCommitMessage is returned when calling GetFinalizedHash on a message that isn't a CommitMessage
+var ErrNotCommitMessage = errors.New("cannot get finalized hash from VoteMessage")
 
 // ErrNoJustification is returned when no justification can be found for a block, ie. it has not been finalized
 var ErrNoJustification = errors.New("no justification found for block")
@@ -92,3 +92,6 @@ var ErrCatchUpResponseNotCompletable = errors.New("catch up response is not comp
 
 // ErrServicePaused is returned if the service is paused and waiting for catch up messages
 var ErrServicePaused = errors.New("service is paused")
+
+// ErrPrecommitSignatureMismatch is returned when the number of precommits and signatures in a CommitMessage do not match
+var ErrPrecommitSignatureMismatch = errors.New("number of precommits does not match number of signatures")

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -394,20 +394,20 @@ func (s *Service) playGrandpaRound() error {
 			s.network.SendMessage(msg)
 		}
 
-		// primProposal, err := s.createVoteMessage(&Vote{
-		// 	hash:   s.head.Hash(),
-		// 	number: uint32(s.head.Number.Int64()),
-		// }, primaryProposal, s.keypair)
-		// if err != nil {
-		// 	logger.Error("failed to create primary proposal message", "error", err)
-		// } else {
-		// 	msg, err = primProposal.ToConsensusMessage()
-		// 	if err != nil {
-		// 		logger.Error("failed to encode finalization message", "error", err)
-		// 	} else {
-		// 		s.network.SendMessage(msg)
-		// 	}
-		// }
+		primProposal, err := s.createVoteMessage(&Vote{
+			hash:   s.head.Hash(),
+			number: uint32(s.head.Number.Int64()),
+		}, primaryProposal, s.keypair)
+		if err != nil {
+			logger.Error("failed to create primary proposal message", "error", err)
+		} else {
+			msg, err = primProposal.ToConsensusMessage()
+			if err != nil {
+				logger.Error("failed to encode finalization message", "error", err)
+			} else {
+				s.network.SendMessage(msg)
+			}
+		}
 	}
 
 	logger.Debug("receiving pre-vote messages...")

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -394,20 +394,20 @@ func (s *Service) playGrandpaRound() error {
 			s.network.SendMessage(msg)
 		}
 
-		primProposal, err := s.createVoteMessage(&Vote{
-			hash:   s.head.Hash(),
-			number: uint32(s.head.Number.Int64()),
-		}, primaryProposal, s.keypair)
-		if err != nil {
-			logger.Error("failed to create primary proposal message", "error", err)
-		} else {
-			msg, err = primProposal.ToConsensusMessage()
-			if err != nil {
-				logger.Error("failed to encode finalization message", "error", err)
-			} else {
-				s.network.SendMessage(msg)
-			}
-		}
+		// primProposal, err := s.createVoteMessage(&Vote{
+		// 	hash:   s.head.Hash(),
+		// 	number: uint32(s.head.Number.Int64()),
+		// }, primaryProposal, s.keypair)
+		// if err != nil {
+		// 	logger.Error("failed to create primary proposal message", "error", err)
+		// } else {
+		// 	msg, err = primProposal.ToConsensusMessage()
+		// 	if err != nil {
+		// 		logger.Error("failed to encode finalization message", "error", err)
+		// 	} else {
+		// 		s.network.SendMessage(msg)
+		// 	}
+		// }
 	}
 
 	logger.Debug("receiving pre-vote messages...")

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -387,7 +387,7 @@ func (s *Service) playGrandpaRound() error {
 
 	// if primary, broadcast the best final candidate from the previous round
 	if bytes.Equal(primary.key.Encode(), s.keypair.Public().Encode()) {
-		msg, err := s.newFinalizationMessage(s.head, s.state.round-1).ToConsensusMessage()
+		msg, err := s.newCommitMessage(s.head, s.state.round-1).ToConsensusMessage()
 		if err != nil {
 			logger.Error("failed to encode finalization message", "error", err)
 		} else {
@@ -584,7 +584,7 @@ func (s *Service) attemptToFinalize() error {
 		votes := s.getDirectVotes(precommit)
 		logger.Debug("finalized block!!!", "setID", s.state.setID, "round", s.state.round, "hash", s.head.Hash(),
 			"precommits #", pc, "votes for bfc #", votes[*bfc], "total votes for bfc", pc, "precommits", s.precommits)
-		msg, err := s.newFinalizationMessage(s.head, s.state.round).ToConsensusMessage()
+		msg, err := s.newCommitMessage(s.head, s.state.round).ToConsensusMessage()
 		if err != nil {
 			return err
 		}

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -393,6 +393,21 @@ func (s *Service) playGrandpaRound() error {
 		} else {
 			s.network.SendMessage(msg)
 		}
+
+		primProposal, err := s.createVoteMessage(&Vote{
+			hash:   s.head.Hash(),
+			number: uint32(s.head.Number.Int64()),
+		}, primaryProposal, s.keypair)
+		if err != nil {
+			logger.Error("failed to create primary proposal message", "error", err)
+		} else {
+			msg, err = primProposal.ToConsensusMessage()
+			if err != nil {
+				logger.Error("failed to encode finalization message", "error", err)
+			} else {
+				s.network.SendMessage(msg)
+			}
+		}
 	}
 
 	logger.Debug("receiving pre-vote messages...")

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -67,6 +67,7 @@ func (m *SignedMessage) String() string {
 	return fmt.Sprintf("hash=%s number=%d authorityID=0x%x", m.Hash, m.Number, m.AuthorityID)
 }
 
+// Decode SCALE decodes the data into a SignedMessage
 func (m *SignedMessage) Decode(r io.Reader) (err error) {
 	m.Stage, err = subround(0).Decode(r)
 	if err != nil {
@@ -105,6 +106,7 @@ type VoteMessage struct {
 	Message *SignedMessage
 }
 
+// Decode SCALE decodes the data into a VoteMessage
 func (v *VoteMessage) Decode(r io.Reader) (err error) {
 	v.Round, err = common.ReadUint64(r)
 	if err != nil {

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -19,6 +19,8 @@ package grandpa
 import (
 	"bytes"
 	"fmt"
+	"io"
+	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -36,11 +38,10 @@ type GrandpaMessage interface { //nolint
 
 var (
 	voteType            byte = 0
-	precommitType       byte = 1 // TODO: precommitType is now part of voteType
+	commitType          byte = 1
 	neighbourType       byte = 2
 	catchUpRequestType  byte = 3
 	catchUpResponseType byte = 4
-	finalizationType    byte = 5 // TODO: this is actually 1
 )
 
 // FullVote represents a vote with additional information about the state
@@ -54,6 +55,7 @@ type FullVote struct {
 
 // SignedMessage represents a block hash and number signed by an authority
 type SignedMessage struct {
+	Stage       subround // // 0 for pre-vote, 1 for pre-commit, 2 for primary proposal
 	Hash        common.Hash
 	Number      uint32
 	Signature   [64]byte // ed25519.SignatureLength
@@ -70,13 +72,12 @@ func (m *SignedMessage) String() string {
 type VoteMessage struct {
 	Round   uint64
 	SetID   uint64
-	Stage   subround // 0 for pre-vote, 1 for pre-commit
 	Message *SignedMessage
 }
 
-// Type returns voteType or precommitType
+// Type returns voteType
 func (v *VoteMessage) Type() byte {
-	return byte(v.Stage)
+	return voteType
 }
 
 // ToConsensusMessage converts the VoteMessage into a network-level consensus message
@@ -86,9 +87,8 @@ func (v *VoteMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 		return nil, err
 	}
 
-	typ := byte(v.Stage)
 	return &ConsensusMessage{
-		Data: append([]byte{typ}, enc...),
+		Data: append([]byte{voteType}, enc...),
 	}, nil
 }
 
@@ -117,36 +117,139 @@ func (m *NeighbourMessage) Type() byte {
 	return neighbourType
 }
 
-// FinalizationMessage represents a network finalization message
-type FinalizationMessage struct {
-	Round         uint64
-	Vote          *Vote
-	Justification []*SignedPrecommit
+// AuthData represents signature data within a CommitMessage to be paired with a Precommit
+type AuthData struct {
+	Signature   [64]byte
+	AuthorityID ed25519.PublicKeyBytes
 }
 
-// Type returns finalizationType
-func (f *FinalizationMessage) Type() byte {
-	return finalizationType
+// Encode SCALE encodes the AuthData
+func (d *AuthData) Encode() ([]byte, error) {
+	return append(d.Signature[:], d.AuthorityID[:]...), nil
 }
 
-// ToConsensusMessage converts the FinalizationMessage into a network-level consensus message
-func (f *FinalizationMessage) ToConsensusMessage() (*ConsensusMessage, error) {
+// Decode SCALE decodes the data into an AuthData
+func (d *AuthData) Decode(r io.Reader) error {
+	sig, err := common.Read64Bytes(r)
+	if err != nil {
+		return err
+	}
+
+	copy(d.Signature[:], sig[:])
+
+	id, err := common.Read32Bytes(r)
+	if err != nil {
+		return err
+	}
+
+	copy(d.AuthorityID[:], id[:])
+	return nil
+}
+
+// CommitMessage represents a network finalization message
+type CommitMessage struct {
+	Round      uint64
+	SetID      uint64
+	Vote       *Vote
+	Precommits []*Vote
+	AuthData   []*AuthData
+}
+
+// Decode SCALE decodes the data into a CommitMessage
+func (f *CommitMessage) Decode(r io.Reader) (err error) {
+	f.Round, err = common.ReadUint64(r)
+	if err != nil {
+		return err
+	}
+
+	f.SetID, err = common.ReadUint64(r)
+	if err != nil {
+		return err
+	}
+
+	f.Vote, err = new(Vote).Decode(r)
+	if err != nil {
+		return err
+	}
+
+	sd := &scale.Decoder{Reader: r}
+	numPrecommits, err := sd.Decode(new(big.Int))
+	if err != nil {
+		return err
+	}
+
+	f.Precommits = make([]*Vote, numPrecommits.(*big.Int).Int64())
+	for i := range f.Precommits {
+		f.Precommits[i], err = new(Vote).Decode(r)
+		if err != nil {
+			return err
+		}
+	}
+
+	numAuthData, err := sd.Decode(new(big.Int))
+	if err != nil {
+		return err
+	}
+	fmt.Println(numAuthData)
+
+	if numAuthData.(*big.Int).Cmp(numPrecommits.(*big.Int)) != 0 {
+		return ErrPrecommitSignatureMismatch
+	}
+
+	f.AuthData = make([]*AuthData, numAuthData.(*big.Int).Int64())
+	fmt.Println(f.AuthData)
+	for i := range f.AuthData {
+		f.AuthData[i] = new(AuthData)
+		err = f.AuthData[i].Decode(r)
+		if err != nil {
+			return err
+		}
+		fmt.Println(f.AuthData[i])
+	}
+	return nil
+}
+
+// Type returns commitType
+func (f *CommitMessage) Type() byte {
+	return commitType
+}
+
+// ToConsensusMessage converts the CommitMessage into a network-level consensus message
+func (f *CommitMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 	enc, err := scale.Encode(f)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ConsensusMessage{
-		Data: append([]byte{finalizationType}, enc...),
+		Data: append([]byte{commitType}, enc...),
 	}, nil
 }
 
-func (s *Service) newFinalizationMessage(header *types.Header, round uint64) *FinalizationMessage {
-	return &FinalizationMessage{
-		Round:         round,
-		Vote:          NewVoteFromHeader(header),
-		Justification: s.justification[round],
+func (s *Service) newCommitMessage(header *types.Header, round uint64) *CommitMessage {
+	just := s.justification[round]
+	precommits, authData := justificationToCompact(just)
+	return &CommitMessage{
+		Round:      round,
+		Vote:       NewVoteFromHeader(header),
+		Precommits: precommits,
+		AuthData:   authData,
 	}
+}
+
+func justificationToCompact(just []*SignedPrecommit) ([]*Vote, []*AuthData) {
+	precommits := make([]*Vote, len(just))
+	authData := make([]*AuthData, len(just))
+
+	for i, j := range just {
+		precommits[i] = j.Vote
+		authData[i] = &AuthData{
+			Signature:   j.Signature,
+			AuthorityID: j.AuthorityID,
+		}
+	}
+
+	return precommits, authData
 }
 
 type catchUpRequest struct {
@@ -179,8 +282,8 @@ func (r *catchUpRequest) ToConsensusMessage() (*ConsensusMessage, error) {
 }
 
 type catchUpResponse struct {
-	Round                  uint64
 	SetID                  uint64
+	Round                  uint64
 	PreVoteJustification   []*SignedPrecommit
 	PreCommitJustification []*SignedPrecommit
 	Hash                   common.Hash
@@ -227,8 +330,8 @@ func (s *Service) newCatchUpResponse(round, setID uint64) (*catchUpResponse, err
 	pcj := d.([]*SignedPrecommit)
 
 	return &catchUpResponse{
-		Round:                  round,
 		SetID:                  setID,
+		Round:                  round,
 		PreVoteJustification:   pvj,
 		PreCommitJustification: pcj,
 		Hash:                   header.Hash(),

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -278,8 +278,11 @@ func decodeMessage(msg *ConsensusMessage) (m GrandpaMessage, err error) {
 		m = &VoteMessage{}
 		_, err = scale.Decode(msg.Data[1:], m)
 	case commitType:
-		m = &CommitMessage{}
-		_, err = scale.Decode(msg.Data[1:], m)
+		r := &bytes.Buffer{}
+		_, _ = r.Write(msg.Data[1:])
+		cm := &CommitMessage{}
+		err = cm.Decode(r)
+		m = cm
 	case neighbourType:
 		mi, err = scale.Decode(msg.Data[1:], &NeighbourMessage{})
 		if m, ok = mi.(*NeighbourMessage); !ok {

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -18,7 +18,6 @@ package grandpa
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"reflect"
 	"sync"
@@ -276,12 +275,9 @@ func decodeMessage(msg *ConsensusMessage) (m GrandpaMessage, err error) {
 
 	switch msg.Data[0] {
 	case voteType:
-		mi, err = scale.Decode(msg.Data[1:], &VoteMessage{Message: new(SignedMessage)})
-		if m, ok = mi.(*VoteMessage); !ok {
-			return nil, ErrInvalidMessageType
-		}
+		m = &VoteMessage{}
+		_, err = scale.Decode(msg.Data[1:], m)
 	case commitType:
-		fmt.Println("decoding commitType")
 		m = &CommitMessage{}
 		_, err = scale.Decode(msg.Data[1:], m)
 	case neighbourType:

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -44,8 +44,8 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 	expected := &VoteMessage{
 		Round: gs.state.round,
 		SetID: gs.state.setID,
-		Stage: precommit,
 		Message: &SignedMessage{
+			Stage:       precommit,
 			Hash:        v.hash,
 			Number:      v.number,
 			AuthorityID: gs.keypair.Public().(*ed25519.PublicKey).AsBytes(),
@@ -62,8 +62,8 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 	expected = &VoteMessage{
 		Round: gs.state.round,
 		SetID: gs.state.setID,
-		Stage: prevote,
 		Message: &SignedMessage{
+			Stage:       prevote,
 			Hash:        v.hash,
 			Number:      v.number,
 			AuthorityID: gs.keypair.Public().(*ed25519.PublicKey).AsBytes(),
@@ -73,7 +73,7 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 	require.Equal(t, expected, vm)
 }
 
-func TestFinalizationMessageToConsensusMessage(t *testing.T) {
+func TestCommitMessageToConsensusMessage(t *testing.T) {
 	gs, _ := newTestService(t)
 	gs.justification[77] = []*SignedPrecommit{
 		{
@@ -83,12 +83,14 @@ func TestFinalizationMessageToConsensusMessage(t *testing.T) {
 		},
 	}
 
-	fm := gs.newFinalizationMessage(gs.head, 77)
+	fm := gs.newCommitMessage(gs.head, 77)
+	precommits, authData := justificationToCompact(gs.justification[77])
 
-	expected := &FinalizationMessage{
-		Round:         77,
-		Vote:          NewVoteFromHeader(gs.head),
-		Justification: gs.justification[77],
+	expected := &CommitMessage{
+		Round:      77,
+		Vote:       NewVoteFromHeader(gs.head),
+		Precommits: precommits,
+		AuthData:   authData,
 	}
 
 	require.Equal(t, expected, fm)

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -54,7 +54,7 @@ func TestHandleNetworkMessage(t *testing.T) {
 		},
 	}
 
-	fm := gs.newFinalizationMessage(gs.head, 77)
+	fm := gs.newCommitMessage(gs.head, 77)
 	cm, err := fm.ToConsensusMessage()
 	require.NoError(t, err)
 	gs.state.voters = gs.state.voters[:1]

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -58,7 +58,7 @@ func (n *testNetwork) SendMessage(msg NotificationsMessage) {
 	gmsg, err := decodeMessage(cm)
 	require.NoError(n.t, err)
 
-	if gmsg.Type() == finalizationType {
+	if gmsg.Type() == commitType {
 		n.finalized <- gmsg
 	} else {
 		n.out <- gmsg
@@ -259,7 +259,7 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(kr.Keys))
 
-	finalized := make([]*FinalizationMessage, len(kr.Keys))
+	finalized := make([]*CommitMessage, len(kr.Keys))
 
 	for i, fin := range fins {
 		go func(i int, fin <-chan GrandpaMessage) {
@@ -267,7 +267,7 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 			case f := <-fin:
 
 				// receive first message, which is finalized block from previous round
-				if f.(*FinalizationMessage).Round == 0 {
+				if f.(*CommitMessage).Round == 0 {
 					select {
 					case f = <-fin:
 					case <-time.After(testTimeout):
@@ -275,7 +275,7 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 					}
 				}
 
-				finalized[i] = f.(*FinalizationMessage)
+				finalized[i] = f.(*CommitMessage)
 
 			case <-time.After(testTimeout):
 				t.Errorf("did not receive finalized block from %d", i)
@@ -289,9 +289,11 @@ func TestPlayGrandpaRound_BaseCase(t *testing.T) {
 
 	for _, fb := range finalized {
 		require.NotNil(t, fb)
-		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
-		finalized[0].Justification = []*SignedPrecommit{}
-		fb.Justification = []*SignedPrecommit{}
+		require.GreaterOrEqual(t, len(fb.Precommits), len(kr.Keys)/2)
+		finalized[0].Precommits = []*Vote{}
+		finalized[0].AuthData = []*AuthData{}
+		fb.Precommits = []*Vote{}
+		fb.AuthData = []*AuthData{}
 		require.Equal(t, finalized[0], fb)
 	}
 }
@@ -357,7 +359,7 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(kr.Keys))
 
-	finalized := make([]*FinalizationMessage, len(kr.Keys))
+	finalized := make([]*CommitMessage, len(kr.Keys))
 
 	for i, fin := range fins {
 
@@ -366,7 +368,7 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 			case f := <-fin:
 
 				// receive first message, which is finalized block from previous round
-				if f.(*FinalizationMessage).Round == 0 {
+				if f.(*CommitMessage).Round == 0 {
 					select {
 					case f = <-fin:
 					case <-time.After(testTimeout):
@@ -374,7 +376,7 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 					}
 				}
 
-				finalized[i] = f.(*FinalizationMessage)
+				finalized[i] = f.(*CommitMessage)
 			case <-time.After(testTimeout):
 				t.Errorf("did not receive finalized block from %d", i)
 			}
@@ -387,9 +389,12 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 
 	for _, fb := range finalized {
 		require.NotNil(t, fb)
-		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
-		finalized[0].Justification = []*SignedPrecommit{}
-		fb.Justification = []*SignedPrecommit{}
+		require.GreaterOrEqual(t, len(fb.Precommits), len(kr.Keys)/2)
+		require.GreaterOrEqual(t, len(fb.AuthData), len(kr.Keys)/2)
+		finalized[0].Precommits = []*Vote{}
+		finalized[0].AuthData = []*AuthData{}
+		fb.Precommits = []*Vote{}
+		fb.AuthData = []*AuthData{}
 		require.Equal(t, finalized[0], fb)
 	}
 }
@@ -454,7 +459,7 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(len(kr.Keys))
 
-	finalized := make([]*FinalizationMessage, len(kr.Keys))
+	finalized := make([]*CommitMessage, len(kr.Keys))
 
 	for i, fin := range fins {
 
@@ -463,7 +468,7 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 			case f := <-fin:
 
 				// receive first message, which is finalized block from previous round
-				if f.(*FinalizationMessage).Round == 0 {
+				if f.(*CommitMessage).Round == 0 {
 					select {
 					case f = <-fin:
 					case <-time.After(testTimeout):
@@ -471,7 +476,7 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 					}
 				}
 
-				finalized[i] = f.(*FinalizationMessage)
+				finalized[i] = f.(*CommitMessage)
 			case <-time.After(testTimeout):
 				t.Errorf("did not receive finalized block from %d", i)
 			}
@@ -484,9 +489,12 @@ func TestPlayGrandpaRound_OneThirdEquivocating(t *testing.T) {
 
 	for _, fb := range finalized {
 		require.NotNil(t, fb)
-		require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
-		finalized[0].Justification = []*SignedPrecommit{}
-		fb.Justification = []*SignedPrecommit{}
+		require.GreaterOrEqual(t, len(fb.Precommits), len(kr.Keys)/2)
+		require.GreaterOrEqual(t, len(fb.AuthData), len(kr.Keys)/2)
+		finalized[0].Precommits = []*Vote{}
+		finalized[0].AuthData = []*AuthData{}
+		fb.Precommits = []*Vote{}
+		fb.AuthData = []*AuthData{}
 		require.Equal(t, finalized[0], fb)
 	}
 }
@@ -535,7 +543,7 @@ func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(len(kr.Keys))
 
-		finalized := make([]*FinalizationMessage, len(kr.Keys))
+		finalized := make([]*CommitMessage, len(kr.Keys))
 
 		for i, fin := range fins {
 
@@ -544,7 +552,7 @@ func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
 				case f := <-fin:
 
 					// receive first message, which is finalized block from previous round
-					if f.(*FinalizationMessage).Round == uint64(j) {
+					if f.(*CommitMessage).Round == uint64(j) {
 						select {
 						case f = <-fin:
 						case <-time.After(testTimeout):
@@ -552,7 +560,7 @@ func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
 						}
 					}
 
-					finalized[i] = f.(*FinalizationMessage)
+					finalized[i] = f.(*CommitMessage)
 				case <-time.After(testTimeout):
 					t.Errorf("did not receive finalized block from %d", i)
 				}
@@ -567,9 +575,12 @@ func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
 		for _, fb := range finalized {
 			require.NotNil(t, fb)
 			require.Equal(t, head, fb.Vote.hash)
-			require.GreaterOrEqual(t, len(fb.Justification), len(kr.Keys)/2)
-			finalized[0].Justification = []*SignedPrecommit{}
-			fb.Justification = []*SignedPrecommit{}
+			require.GreaterOrEqual(t, len(fb.Precommits), len(kr.Keys)/2)
+			require.GreaterOrEqual(t, len(fb.AuthData), len(kr.Keys)/2)
+			finalized[0].Precommits = []*Vote{}
+			finalized[0].AuthData = []*AuthData{}
+			fb.Precommits = []*Vote{}
+			fb.AuthData = []*AuthData{}
 			require.Equal(t, finalized[0], fb)
 		}
 

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -33,7 +33,7 @@ type subround byte
 var (
 	prevote         subround = 0
 	precommit       subround = 1
-	primaryProposal subround = 2 //nolint // TODO: this isn't a subround, maybe rename type, and figure out when it's used
+	primaryProposal subround = 2
 )
 
 func (s subround) Encode() ([]byte, error) {

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -30,8 +30,11 @@ import (
 
 type subround byte
 
-var prevote subround = 0
-var precommit subround = 1
+var (
+	prevote         subround = 0
+	precommit       subround = 1
+	primaryProposal subround = 2 //nolint // TODO: this isn't a subround, maybe rename type, and figure out when it's used
+)
 
 func (s subround) Encode() ([]byte, error) {
 	return []byte{byte(s)}, nil


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- rename `FinalizationMessage` -> `CommitMessage`, update format to match spec/substrate
- update message type IDs
- update `VoteMessage` to have `Stage` in `SignedMessage`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1521
