### PR TITLE
fix(lib/babe): fix BABE state storing after building block

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
-	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd
+	golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/protobuf v1.25.0
 )

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/runtime"
+	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	log "github.com/ChainSafe/log15"
 )
 
@@ -471,8 +472,15 @@ func (b *Service) handleSlot(slotNum uint64) error {
 		return nil
 	}
 
+	old := ts.Snapshot()
+
 	// block built successfully, store resulting trie in storage state
-	err = b.storageState.StoreTrie(ts)
+	oldTs, err := rtstorage.NewTrieState(old)
+	if err != nil {
+		return err
+	}
+
+	err = b.storageState.StoreTrie(oldTs)
 	if err != nil {
 		logger.Error("failed to store trie in storage state", "error", err)
 	}

--- a/tests/polkadotjs_test/test_transaction.js
+++ b/tests/polkadotjs_test/test_transaction.js
@@ -19,11 +19,8 @@ async function main() {
     const ADDR_Bob = '0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22';
     // bob 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
 
-    const transfer = await api.tx.balances.transfer(bobKey.address, 12345)
-        .signAndSend(aliceKey,);
-
+    const transfer = await api.tx.balances.transfer(bobKey.address, 12345).signAndSend(aliceKey);
     console.log(`hxHash ${transfer}`);
-
 }
 
 main().catch(console.error);

--- a/tests/polkadotjs_test/test_transaction.js
+++ b/tests/polkadotjs_test/test_transaction.js
@@ -20,7 +20,7 @@ async function main() {
     // bob 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
 
     const transfer = await api.tx.balances.transfer(bobKey.address, 12345)
-        .signAndSend(aliceKey, {era: 0, blockHash: '0x64597c55a052d484d9ff357266be326f62573bb4fbdbb3cd49f219396fcebf78', blockNumber:0,  genesisHash: '0x64597c55a052d484d9ff357266be326f62573bb4fbdbb3cd49f219396fcebf78', nonce: 1, tip: 0, transactionVersion: 1});
+        .signAndSend(aliceKey,);
 
     console.log(`hxHash ${transfer}`);
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix BABE state storing after building block, resolves "state root mismatch" panic after submitting tx
- update polkadot.js transaction submission test

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

in chain/gssmr/config.toml, set `babe = "debug"` for logging and add
```
babe-threshold-numerator = 1
babe-threshold-denominator = 1
``` 
in the `[core]` section.
then:

```
make gossamer 
./bin/gossamer --chain gssmr init --force
./bin/gossamer --key alice --chain gssmr --rpc --ws
```

in another terminal:
```
node tests/polkadotjs_test/test_transaction.js
```

you should see gossamer build a block that includes the extrinsic w/o error
```
DBUG[04-21|15:53:26] built block                              pkg=babe header="ParentHash=0x1ea298faf569949d1220ed6a1c686231fa2fca01f9463cddccabf3d945b3ed3d Number=7 StateRoot=0x35a53727c576553b1f31319a9a1ca28d405ccdf9fa394c8fc6b27de5cbf5ed01 ExtrinsicsRoot=0x49df345eff512c90160b1ed0dbe2cc04934f2b0d9ccc2e0e942733f371035f58 Digest=[PreRuntimeDigest ConsensusEngineID=BABE Data=0x01000000003cd62a2000000000aa2e54e1b9378ef057e506b7ed5b4c497013eafd1e190d9a51e01856195b31687ab3020cc5f6ea7235690f325537ee7bfa78ebca397aca4d459f06844c5fbb0a1a6f72f00187ed8bf120d63d5b9962988eba7c334212af6d45251d1ff6e09b0d SealDigest ConsensusEngineID=BABE Data=0xfafb0297150cc538096abbf8da7054cfe144d05cb6b672b2fcc823af0385a27b73358694f370ad84748e9065c12f4735435ed39506dc8db0ad126826b40a0780] Hash=0x90ad95b1478f6b8bcf314825e1725f71020e837b45e236ab95a96676cbbcb014" body="&[8 32 4 3 0 3 204 165 128 96 57 2 49 2 132 255 212 53 147 199 21 253 211 28 97 20 26 189 4 169 159 214 130 44 133 88 133 76 205 227 154 86 132 231 165 109 162 125 1 92 205 98 213 20 68 183 202 220 30 39 91 228 158 125 67 193 63 78 93 0 249 155 94 233 251 242 90 124 244 98 92 122 224 208 81 10 104 146 233 78 23 60 163 7 169 38 190 242 106 57 214 151 39 23 87 238 236 227 174 150 123 248 132 6 0 0 0 6 0 255 142 175 4 21 22 135 115 99 38 201 254 161 126 37 252 82 135 97 54 147 201 18 144 156 178 38 170 71 148 242 106 72 229 192]" parent=0x1ea298faf569949d1220ed6a1c686231fa2fca01f9463cddccabf3d945b3ed3d caller=babe.go:490
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- related to #1400 
