### PR TITLE
fix(dot): Closes db if node initialized check fails

### DIFF
--- a/dot/node.go
+++ b/dot/node.go
@@ -147,6 +147,14 @@ func NodeInitialized(basepath string, expected bool) bool {
 		return false
 	}
 
+	defer func() {
+		// close database
+		err = db.Close()
+		if err != nil {
+			logger.Error("failed to close database", "error", err)
+		}
+	}()
+
 	// load genesis data from initialised node database
 	_, err = state.NewBaseState(db).LoadGenesisData()
 	if err != nil {
@@ -156,12 +164,6 @@ func NodeInitialized(basepath string, expected bool) bool {
 			"error", err,
 		)
 		return false
-	}
-
-	// close database
-	err = db.Close()
-	if err != nil {
-		logger.Error("failed to close database", "error", err)
 	}
 
 	return true


### PR DESCRIPTION
## Changes

I have found if the func `dot.NodeInitialized` fails when trying to execute the func `LoadGenesisData` then the database was not closed, so I've added a `defer` to closes de database when the function is exited.

## Tests

I have not implemented unit tests but I collect some evidences:

1. When a execute the init for the first time the process will be successful, then I went to the `gssmr` (basepath) dir and remove all the stuff except the `KEYREGISTRY` file and when I try to reinitialize the node I got the error:
![node_without_db_closes](https://user-images.githubusercontent.com/17255488/116644285-efbbde80-a940-11eb-9cb8-b5e7eb1f06a8.png)


2. After the inclusion of `defer` to close database anyways, then the node was capable to reinitialize without troubles:
![after_defer_with_closes_db](https://user-images.githubusercontent.com/17255488/116644354-2265d700-a941-11eb-8b22-76654c3b9d81.png)


## Issues

- no issues open
