### PR TITLE
fix(dot/network): split stored streams and handshakeData into inbound and outbound

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -136,6 +136,10 @@ type BlockAnnounceHandshake struct {
 	GenesisHash     common.Hash
 }
 
+func (hs *BlockAnnounceHandshake) sizeof() uint32 {
+	return 1 + 4 + 32 + 32
+}
+
 // SubProtocol returns the block-announces sub-protocol
 func (hs *BlockAnnounceHandshake) SubProtocol() string {
 	return blockAnnounceID
@@ -220,17 +224,13 @@ func (s *Service) validateBlockAnnounceHandshake(peer peer.ID, hs Handshake) err
 
 	// don't need to lock here, since function is always called inside the func returned by
 	// `createNotificationsMessageHandler` which locks the map beforehand.
-	data, ok := np.getHandshakeData(peer)
-	if !ok {
-		np.handshakeData.Store(peer, handshakeData{
-			received:  true,
-			validated: true,
-		})
-		data, _ = np.getHandshakeData(peer)
+	data, ok := np.getHandshakeData(peer, true)
+	if ok {
+		data.handshake = hs
+		// TODO: since this is used only for rpc system_peers only,
+		// we can just set the inbound handshake and use that in Peers()
+		np.inboundHandshakeData.Store(peer, data)
 	}
-
-	data.handshake = hs
-	np.handshakeData.Store(peer, data)
 
 	// if peer has higher best block than us, begin syncing
 	latestHeader, err := s.blockState.BestBlockHeader()

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -136,10 +136,6 @@ type BlockAnnounceHandshake struct {
 	GenesisHash     common.Hash
 }
 
-func (hs *BlockAnnounceHandshake) sizeof() uint32 {
-	return 1 + 4 + 32 + 32
-}
-
 // SubProtocol returns the block-announces sub-protocol
 func (hs *BlockAnnounceHandshake) SubProtocol() string {
 	return blockAnnounceID

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -117,10 +117,10 @@ func TestValidateBlockAnnounceHandshake(t *testing.T) {
 	nodeA := createTestService(t, configA)
 	nodeA.noGossip = true
 	nodeA.notificationsProtocols[BlockAnnounceMsgType] = &notificationsProtocol{
-		handshakeData: new(sync.Map),
+		inboundHandshakeData: new(sync.Map),
 	}
 	testPeerID := peer.ID("noot")
-	nodeA.notificationsProtocols[BlockAnnounceMsgType].handshakeData.Store(testPeerID, handshakeData{})
+	nodeA.notificationsProtocols[BlockAnnounceMsgType].inboundHandshakeData.Store(testPeerID, handshakeData{})
 
 	err := nodeA.validateBlockAnnounceHandshake(testPeerID, &BlockAnnounceHandshake{
 		BestBlockNumber: 100,

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -352,13 +352,13 @@ func TestStreamCloseMetadataCleanup(t *testing.T) {
 	info := nodeA.notificationsProtocols[BlockAnnounceMsgType]
 
 	// Set handshake data to received
-	info.handshakeData.Store(nodeB.host.id(), handshakeData{
+	info.inboundHandshakeData.Store(nodeB.host.id(), handshakeData{
 		received:  true,
 		validated: true,
 	})
 
 	// Verify that handshake data exists.
-	_, ok := info.getHandshakeData(nodeB.host.id())
+	_, ok := info.getHandshakeData(nodeB.host.id(), true)
 	require.True(t, ok)
 
 	time.Sleep(time.Second)
@@ -368,7 +368,7 @@ func TestStreamCloseMetadataCleanup(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// Verify that handshake data is cleared.
-	_, ok = info.getHandshakeData(nodeB.host.id())
+	_, ok = info.getHandshakeData(nodeB.host.id(), true)
 	require.False(t, ok)
 }
 

--- a/dot/network/light_test.go
+++ b/dot/network/light_test.go
@@ -22,7 +22,7 @@ func TestDecodeLightMessage(t *testing.T) {
 	reqEnc, err := testLightRequest.Encode()
 	require.NoError(t, err)
 
-	msg, err := s.decodeLightMessage(reqEnc, testPeer)
+	msg, err := s.decodeLightMessage(reqEnc, testPeer, true)
 	require.NoError(t, err)
 
 	req, ok := msg.(*LightRequest)
@@ -36,7 +36,7 @@ func TestDecodeLightMessage(t *testing.T) {
 	respEnc, err := testLightResponse.Encode()
 	require.NoError(t, err)
 
-	msg, err = s.decodeLightMessage(respEnc, testPeer)
+	msg, err = s.decodeLightMessage(respEnc, testPeer, true)
 	require.NoError(t, err)
 	resp, ok := msg.(*LightResponse)
 	require.True(t, ok)

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -85,7 +85,7 @@ type handshakeData struct {
 	validated bool
 	handshake Handshake
 	stream    libp2pnetwork.Stream
-	mu        *sync.Mutex
+	*sync.Mutex
 }
 
 func newHandshakeData(received, validated bool, stream libp2pnetwork.Stream) handshakeData {
@@ -93,7 +93,7 @@ func newHandshakeData(received, validated bool, stream libp2pnetwork.Stream) han
 		received:  received,
 		validated: validated,
 		stream:    stream,
-		mu:        new(sync.Mutex),
+		Mutex:     new(sync.Mutex),
 	}
 }
 
@@ -215,8 +215,8 @@ func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtoc
 			hsData = newHandshakeData(false, false, nil)
 		}
 
-		hsData.mu.Lock()
-		defer hsData.mu.Unlock()
+		hsData.Lock()
+		defer hsData.Unlock()
 
 		logger.Trace("sending outbound handshake", "protocol", info.protocolID, "peer", peer, "message", hs)
 		stream, err := s.host.send(peer, info.protocolID, hs)

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -50,15 +50,12 @@ type (
 
 	// NotificationsMessageHandler is called when a (non-handshake) message is received over a notifications stream.
 	NotificationsMessageHandler = func(peer peer.ID, msg NotificationsMessage) error
-
-	streamHandler = func(libp2pnetwork.Stream, peer.ID)
 )
 
 type notificationsProtocol struct {
 	protocolID         protocol.ID
 	getHandshake       HandshakeGetter
 	handshakeValidator HandshakeValidator
-	handshakeDecoder   HandshakeDecoder
 
 	inboundHandshakeData  *sync.Map //map[peer.ID]*handshakeData
 	outboundHandshakeData *sync.Map //map[peer.ID]*handshakeData

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestHandshake_SizeOf(t *testing.T) {
+	require.Equal(t, uint32(maxHandshakeSize), uint32(72))
+}
+
 func TestCreateDecoder_BlockAnnounce(t *testing.T) {
 	basePath := utils.NewTestBasePath(t, "nodeA")
 

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -145,7 +145,6 @@ func NewService(cfg *Config) (*Service, error) {
 	}
 
 	network.syncQueue = newSyncQueue(network)
-	network.noGossip = true // TODO: remove once duplicate message sending is merged
 	return network, err
 }
 

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -57,7 +57,7 @@ var (
 type (
 	// messageDecoder is passed on readStream to decode the data from the stream into a message.
 	// since messages are decoded based on context, this is different for every sub-protocol.
-	messageDecoder = func([]byte, peer.ID) (Message, error)
+	messageDecoder = func([]byte, peer.ID, bool) (Message, error)
 	// messageHandler is passed on readStream to handle the resulting message. it should return an error only if the stream is to be closed
 	messageHandler = func(stream libp2pnetwork.Stream, msg Message) error
 )
@@ -373,35 +373,39 @@ func (s *Service) RegisterNotificationsProtocol(sub protocol.ID,
 	}
 
 	np := &notificationsProtocol{
-		protocolID:    protocolID,
-		getHandshake:  handshakeGetter,
-		handshakeData: new(sync.Map),
+		protocolID:            protocolID,
+		getHandshake:          handshakeGetter,
+		handshakeValidator:    handshakeValidator,
+		inboundHandshakeData:  new(sync.Map),
+		outboundHandshakeData: new(sync.Map),
 	}
 	s.notificationsProtocols[messageID] = np
 
 	connMgr := s.host.h.ConnManager().(*ConnManager)
 	connMgr.registerCloseHandler(protocolID, func(peerID peer.ID) {
-		np.mapMu.Lock()
-		defer np.mapMu.Unlock()
-
-		if _, ok := np.getHandshakeData(peerID); ok {
+		if _, ok := np.getHandshakeData(peerID, true); ok {
 			logger.Trace(
-				"Cleaning up handshake data",
+				"Cleaning up inbound handshake data",
 				"peer", peerID,
 				"protocol", protocolID,
 			)
-			np.handshakeData.Delete(peerID)
+			np.inboundHandshakeData.Delete(peerID)
+		}
+
+		if _, ok := np.getHandshakeData(peerID, false); ok {
+			logger.Trace(
+				"Cleaning up outbound handshake data",
+				"peer", peerID,
+				"protocol", protocolID,
+			)
+			np.outboundHandshakeData.Delete(peerID)
 		}
 	})
 
 	info := s.notificationsProtocols[messageID]
 
 	decoder := createDecoder(info, handshakeDecoder, messageDecoder)
-	handlerWithValidate := s.createNotificationsMessageHandler(info, handshakeValidator, messageHandler)
-	streamHandler := func(stream libp2pnetwork.Stream, peerID peer.ID) {
-		s.readStream(stream, peerID, decoder, handlerWithValidate)
-	}
-	np.streamHandler = streamHandler
+	handlerWithValidate := s.createNotificationsMessageHandler(info, messageHandler)
 
 	s.host.registerStreamHandlerWithOverwrite(sub, overwriteProtocol, func(stream libp2pnetwork.Stream) {
 		logger.Trace("received stream", "sub-protocol", sub)
@@ -411,8 +415,7 @@ func (s *Service) RegisterNotificationsProtocol(sub protocol.ID,
 			return
 		}
 
-		p := conn.RemotePeer()
-		streamHandler(stream, p)
+		s.readStream(stream, decoder, handlerWithValidate)
 	})
 
 	logger.Info("registered notifications sub-protocol", "protocol", protocolID)
@@ -460,18 +463,10 @@ func (s *Service) SendMessage(msg NotificationsMessage) {
 
 // handleLightStream handles streams with the <protocol-id>/light/2 protocol ID
 func (s *Service) handleLightStream(stream libp2pnetwork.Stream) {
-	conn := stream.Conn()
-	if conn == nil {
-		logger.Error("Failed to get connection from stream")
-		_ = stream.Close()
-		return
-	}
-
-	peer := conn.RemotePeer()
-	s.readStream(stream, peer, s.decodeLightMessage, s.handleLightMsg)
+	s.readStream(stream, s.decodeLightMessage, s.handleLightMsg)
 }
 
-func (s *Service) decodeLightMessage(in []byte, peer peer.ID) (Message, error) {
+func (s *Service) decodeLightMessage(in []byte, peer peer.ID, _ bool) (Message, error) {
 	s.lightRequestMu.RLock()
 	defer s.lightRequestMu.RUnlock()
 
@@ -489,10 +484,15 @@ func (s *Service) decodeLightMessage(in []byte, peer peer.ID) (Message, error) {
 	return msg, err
 }
 
-func (s *Service) readStream(stream libp2pnetwork.Stream, peer peer.ID, decoder messageDecoder, handler messageHandler) {
+func isInbound(stream libp2pnetwork.Stream) bool {
+	return stream.Stat().Direction == libp2pnetwork.DirInbound
+}
+
+func (s *Service) readStream(stream libp2pnetwork.Stream, decoder messageDecoder, handler messageHandler) {
 	var (
 		maxMessageSize uint64 = maxBlockResponseSize // TODO: determine actual max message size
 		msgBytes              = make([]byte, maxMessageSize)
+		peer                  = stream.Conn().RemotePeer()
 	)
 
 	for {
@@ -506,7 +506,7 @@ func (s *Service) readStream(stream libp2pnetwork.Stream, peer peer.ID, decoder 
 		}
 
 		// decode message based on message type
-		msg, err := decoder(msgBytes[:tot], peer)
+		msg, err := decoder(msgBytes[:tot], peer, isInbound(stream))
 		if err != nil {
 			logger.Trace("failed to decode message from peer", "protocol", stream.Protocol(), "err", err)
 			continue
@@ -597,7 +597,7 @@ func (s *Service) Peers() []common.PeerInfo {
 	s.notificationsMu.RUnlock()
 
 	for _, p := range s.host.peers() {
-		data, has := np.getHandshakeData(p)
+		data, has := np.getHandshakeData(p, true)
 		if !has || data.handshake == nil {
 			peers = append(peers, common.PeerInfo{
 				PeerID: p.String(),

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -210,7 +210,7 @@ func TestBroadcastDuplicateMessage(t *testing.T) {
 	require.NotNil(t, stream)
 
 	protocol := nodeA.notificationsProtocols[BlockAnnounceMsgType]
-	protocol.handshakeData.Store(nodeB.host.id(), handshakeData{
+	protocol.outboundHandshakeData.Store(nodeB.host.id(), handshakeData{
 		received:  true,
 		validated: true,
 		stream:    stream,

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -785,7 +785,7 @@ func (q *syncQueue) handleBlockAnnounceHandshake(blockNum uint32, from peer.ID) 
 
 func (q *syncQueue) handleBlockAnnounce(msg *BlockAnnounceMessage, from peer.ID) {
 	q.updatePeerScore(from, 1)
-	logger.Debug("received BlockAnnounce", "number", msg.Number, "from", from)
+	logger.Info("received BlockAnnounce", "number", msg.Number, "from", from)
 
 	header, err := types.NewHeader(msg.ParentHash, msg.StateRoot, msg.ExtrinsicsRoot, msg.Number, msg.Digest)
 	if err != nil {

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -42,18 +42,10 @@ func (s *Service) handleSyncStream(stream libp2pnetwork.Stream) {
 		return
 	}
 
-	conn := stream.Conn()
-	if conn == nil {
-		logger.Error("Failed to get connection from stream")
-		_ = stream.Close()
-		return
-	}
-
-	peer := conn.RemotePeer()
-	s.readStream(stream, peer, s.decodeSyncMessage, s.handleSyncMessage)
+	s.readStream(stream, s.decodeSyncMessage, s.handleSyncMessage)
 }
 
-func (s *Service) decodeSyncMessage(in []byte, peer peer.ID) (Message, error) {
+func (s *Service) decodeSyncMessage(in []byte, peer peer.ID, inbound bool) (Message, error) {
 	msg := new(BlockRequestMessage)
 	err := msg.Decode(in)
 	return msg, err

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -172,6 +172,7 @@ func (q *syncQueue) syncAtHead() {
 	}
 
 	q.s.syncer.SetSyncing(true)
+	q.s.noGossip = true // don't gossip messages until we're at the head
 
 	for {
 		select {
@@ -193,6 +194,7 @@ func (q *syncQueue) syncAtHead() {
 		}
 
 		q.s.syncer.SetSyncing(false)
+		q.s.noGossip = false
 
 		// we have received new blocks since the last check, sleep
 		if prev.Number.Int64() < curr.Number.Int64() {

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -788,7 +788,7 @@ func (q *syncQueue) handleBlockAnnounceHandshake(blockNum uint32, from peer.ID) 
 
 func (q *syncQueue) handleBlockAnnounce(msg *BlockAnnounceMessage, from peer.ID) {
 	q.updatePeerScore(from, 1)
-	logger.Info("received BlockAnnounce", "number", msg.Number, "from", from)
+	logger.Debug("received BlockAnnounce", "number", msg.Number, "from", from)
 
 	header, err := types.NewHeader(msg.ParentHash, msg.StateRoot, msg.ExtrinsicsRoot, msg.Number, msg.Digest)
 	if err != nil {

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -190,6 +190,7 @@ func (q *syncQueue) syncAtHead() {
 		// we aren't at the head yet, sleep
 		if curr.Number.Int64() < q.goal && curr.Number.Cmp(prev.Number) > 0 {
 			prev = curr
+			q.s.noGossip = true
 			continue
 		}
 

--- a/dot/network/sync_test.go
+++ b/dot/network/sync_test.go
@@ -68,7 +68,7 @@ func TestDecodeSyncMessage(t *testing.T) {
 	reqEnc, err := testBlockRequestMessage.Encode()
 	require.NoError(t, err)
 
-	msg, err := s.decodeSyncMessage(reqEnc, testPeer)
+	msg, err := s.decodeSyncMessage(reqEnc, testPeer, true)
 	require.NoError(t, err)
 
 	req, ok := msg.(*BlockRequestMessage)

--- a/dot/network/test_helpers.go
+++ b/dot/network/test_helpers.go
@@ -159,7 +159,7 @@ var testBlockRequestMessage = &BlockRequestMessage{
 	Max:           optional.NewUint32(true, 1),
 }
 
-func testBlockRequestMessageDecoder(in []byte, _ peer.ID) (Message, error) {
+func testBlockRequestMessageDecoder(in []byte, _ peer.ID, _ bool) (Message, error) {
 	msg := new(BlockRequestMessage)
 	err := msg.Decode(in)
 	return msg, err
@@ -173,13 +173,13 @@ var testBlockAnnounceHandshake = &BlockAnnounceHandshake{
 	BestBlockNumber: 0,
 }
 
-func testBlockAnnounceMessageDecoder(in []byte, _ peer.ID) (Message, error) {
+func testBlockAnnounceMessageDecoder(in []byte, _ peer.ID, _ bool) (Message, error) {
 	msg := new(BlockAnnounceMessage)
 	err := msg.Decode(in)
 	return msg, err
 }
 
-func testBlockAnnounceHandshakeDecoder(in []byte, _ peer.ID) (Message, error) {
+func testBlockAnnounceHandshakeDecoder(in []byte, _ peer.ID, _ bool) (Message, error) {
 	msg := new(BlockAnnounceHandshake)
 	err := msg.Decode(in)
 	return msg, err

--- a/dot/network/test_helpers.go
+++ b/dot/network/test_helpers.go
@@ -133,7 +133,7 @@ func (s *testStreamHandler) readStream(stream libp2pnetwork.Stream, peer peer.ID
 		}
 
 		// decode message based on message type
-		msg, err := decoder(msgBytes[:tot], peer)
+		msg, err := decoder(msgBytes[:tot], peer, isInbound(stream))
 		if err != nil {
 			logger.Error("Failed to decode message from peer", "peer", peer, "err", err)
 			continue


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->
 
- split `handshakeData` into `inbound` and `outbound`, since after further research into the networking, if we receive an inbound stream, the only message we send over it is the handshake. we only send messages (that aren't a handshake) over outbound streams that we initiate
- previously the code assumed that we would need to read from the outbound stream after the handshake (this was incorrect, sorry for the fake news @arijitAD ) 
- also previously we were only storing 1 stream but we actually needed to differentiate between inbound and outbound
- remove `noGossip` so we now actually gossip messages

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network -short
```

also works w/ polkadot, kusama, if you try it (and turn on trace logs) you should be some logs like:
```
TRCE[04-30|17:28:06] sending outbound handshake               pkg=network protocol=/dot/block-announces/1 peer=12D3KooWKjHEbPLj2ak4zCqEi2rFzreT7MQp1iNRyp3aVMjrfmh5 message="BlockAnnounceHandshake Roles=1 BestBlockNumber=3604 BestBlockHash=0xe712d655470dda112152c58b7a886b2b1a21e9565bdcbfbf4043a27cece079da GenesisHash=0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3" caller=notifications.go:212
TRCE[04-30|17:28:06] sending message                          pkg=network protocol=/dot/block-announces/1 peer=12D3KooWRT7654ppFZX1mabGPNTdgDBzHY5U5ub5Xrm3eVEsntKv message="BlockAnnounceMessage ParentHash=0xb3f4bf1abcf7663ca3d7ffd3e867d05d03f2676d43a5ccf9bea61a2df309bd9b Number=4864519 StateRoot=0x02acc94df6d5a7059b14427203a0ee312f85aa9758c44a8f24e1f195290d2f41 ExtrinsicsRoot=0x1599afcabb50add4b169038f8c3a8c2ef816420a5913f373d4d9681c10bfbdf8 Digest=[PreRuntimeDigest ConsensusEngineID=BABE Data=0x03cb00000011691710000000006e1d3cc9b784f03708c7c0a10687ee45cbe27f31f1008db0d206e64466855602714bfa3ad639207f8a0623da8c37bc94830acbae0b60112cedcf71c22a2fe007591790468c29210162a5208334c638d3f06a5618ae050221260d0f17a82f1d0c SealDigest ConsensusEngineID=BABE Data=0x9c095e22771708520f72e8a4c430c1ea7291dc3ffe70b6d271871625077d8d36ba638c794d40791f786ead54e5b84a708926a387d9833de52033c89da32e478b]" caller=notifications.go:262
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- related to #1524