### PR TITLE
feat(dot/network): add propagate return bool to messageHandler func type to determine whether to propagate message or not

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -255,14 +255,14 @@ func (s *Service) validateBlockAnnounceHandshake(peer peer.ID, hs Handshake) err
 // handleBlockAnnounceMessage handles BlockAnnounce messages
 // if some more blocks are required to sync the announced block, the node will open a sync stream
 // with its peer and send a BlockRequest message
-func (s *Service) handleBlockAnnounceMessage(peer peer.ID, msg NotificationsMessage) error {
+func (s *Service) handleBlockAnnounceMessage(peer peer.ID, msg NotificationsMessage) (bool, error) {
 	if an, ok := msg.(*BlockAnnounceMessage); ok {
 		s.syncQueue.handleBlockAnnounce(an, peer)
 		err := s.syncer.HandleBlockAnnounce(an)
 		if err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	return nil
+	return true, nil
 }

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -101,8 +101,9 @@ func TestHandleBlockAnnounceMessage(t *testing.T) {
 		Number: big.NewInt(10),
 	}
 
-	err := s.handleBlockAnnounceMessage(peerID, msg)
+	propagate, err := s.handleBlockAnnounceMessage(peerID, msg)
 	require.NoError(t, err)
+	require.True(t, propagate)
 }
 
 func TestValidateBlockAnnounceHandshake(t *testing.T) {

--- a/dot/network/transaction.go
+++ b/dot/network/transaction.go
@@ -156,11 +156,11 @@ func decodeTransactionMessage(in []byte) (NotificationsMessage, error) {
 	return msg, err
 }
 
-func (s *Service) handleTransactionMessage(_ peer.ID, msg NotificationsMessage) error {
+func (s *Service) handleTransactionMessage(_ peer.ID, msg NotificationsMessage) (bool, error) {
 	txMsg, ok := msg.(*TransactionMessage)
 	if !ok {
-		return errors.New("invalid transaction type")
+		return false, errors.New("invalid transaction type")
 	}
 
-	return s.transactionHandler.HandleTransactionMessage(txMsg)
+	return true, s.transactionHandler.HandleTransactionMessage(txMsg)
 }

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -49,16 +49,6 @@ func NewMessageHandler(grandpa *Service, blockState BlockState) *MessageHandler 
 // if it is a CommitMessage, it updates the BlockState
 // if it is a VoteMessage, it sends it to the GRANDPA service
 func (h *MessageHandler) handleMessage(from peer.ID, m GrandpaMessage) (network.NotificationsMessage, error) {
-	// if msg == nil || len(msg.Data) == 0 {
-	// 	logger.Trace("received nil message or message with nil data")
-	// 	return nil, nil
-	// }
-
-	// m, err := decodeMessage(msg)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	logger.Trace("handling grandpa message", "msg", m)
 
 	switch m.Type() {

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -48,16 +48,16 @@ func NewMessageHandler(grandpa *Service, blockState BlockState) *MessageHandler 
 // HandleMessage handles a GRANDPA consensus message
 // if it is a CommitMessage, it updates the BlockState
 // if it is a VoteMessage, it sends it to the GRANDPA service
-func (h *MessageHandler) handleMessage(from peer.ID, msg *ConsensusMessage) (network.NotificationsMessage, error) {
-	if msg == nil || len(msg.Data) == 0 {
-		logger.Trace("received nil message or message with nil data")
-		return nil, nil
-	}
+func (h *MessageHandler) handleMessage(from peer.ID, m GrandpaMessage) (network.NotificationsMessage, error) {
+	// if msg == nil || len(msg.Data) == 0 {
+	// 	logger.Trace("received nil message or message with nil data")
+	// 	return nil, nil
+	// }
 
-	m, err := decodeMessage(msg)
-	if err != nil {
-		return nil, err
-	}
+	// m, err := decodeMessage(msg)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	logger.Trace("handling grandpa message", "msg", m)
 

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -62,12 +62,21 @@ func TestHandleNetworkMessage(t *testing.T) {
 	h := NewMessageHandler(gs, st.Block)
 	gs.messageHandler = h
 
-	err = gs.handleNetworkMessage(peer.ID(""), cm)
+	propagate, err := gs.handleNetworkMessage(peer.ID(""), cm)
 	require.NoError(t, err)
+	require.True(t, propagate)
 
 	select {
 	case <-gs.network.(*testNetwork).out:
 	case <-time.After(testTimeout):
 		t.Fatal("expected to send message")
 	}
+
+	neighbourMsg := &NeighbourMessage{}
+	cm, err = neighbourMsg.ToConsensusMessage()
+	require.NoError(t, err)
+
+	propagate, err = gs.handleNetworkMessage(peer.ID(""), cm)
+	require.NoError(t, err)
+	require.False(t, propagate)
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add `propagate` return bool to `messageHandler` func type to determine whether to propagate message or not
- update `messageHandler` funcs and test accordingly
- update grandpa `messageHandler` to return `propagate=false` for `NeighbourMessage` and `catchUpResponse` types

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network -short
go test ./lib/grandpa -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1532
