### PR TITLE
feat(lib/grandpa): send NeighbourMessage to peers

### DIFF
--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -44,7 +44,7 @@ type BlockState interface {
 	SetFinalizedHash(common.Hash, uint64, uint64) error
 	RegisterImportedChannel(ch chan<- *types.Block) (byte, error)
 	UnregisterImportedChannel(id byte)
-	RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error)
+	RegisterFinalizedChannel(ch chan<- *types.FinalisationInfo) (byte, error)
 	UnregisterFinalizedChannel(id byte)
 	HighestCommonAncestor(a, b common.Hash) (common.Hash, error)
 	SubChain(start, end common.Hash) ([]common.Hash, error)

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -33,7 +33,7 @@ type BlockAPI interface {
 	GetJustification(hash common.Hash) ([]byte, error)
 	RegisterImportedChannel(ch chan<- *types.Block) (byte, error)
 	UnregisterImportedChannel(id byte)
-	RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error)
+	RegisterFinalizedChannel(ch chan<- *types.FinalisationInfo) (byte, error)
 	UnregisterFinalizedChannel(id byte)
 	SubChain(start, end common.Hash) ([]common.Hash, error)
 }

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -95,7 +95,7 @@ func TestBlockListener_Listen(t *testing.T) {
 }
 
 func TestBlockFinalizedListener_Listen(t *testing.T) {
-	notifyChan := make(chan *types.Header)
+	notifyChan := make(chan *types.FinalisationInfo)
 	mockConnection := &MockWSConnAPI{}
 	bfl := BlockFinalizedListener{
 		channel: notifyChan,
@@ -113,14 +113,16 @@ func TestBlockFinalizedListener_Listen(t *testing.T) {
 
 	go bfl.Listen()
 
-	notifyChan <- header
+	notifyChan <- &types.FinalisationInfo{
+		Header: header,
+	}
 	time.Sleep(time.Millisecond * 10)
 	require.Equal(t, expectedResponse, mockConnection.lastMessage)
 }
 
 func TestExtrinsicSubmitListener_Listen(t *testing.T) {
 	notifyImportedChan := make(chan *types.Block)
-	notifyFinalizedChan := make(chan *types.Header)
+	notifyFinalizedChan := make(chan *types.FinalisationInfo)
 
 	mockConnection := &MockWSConnAPI{}
 	esl := ExtrinsicSubmitListener{
@@ -149,7 +151,9 @@ func TestExtrinsicSubmitListener_Listen(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 	require.Equal(t, expectedImportedRespones, mockConnection.lastMessage)
 
-	notifyFinalizedChan <- header
+	notifyFinalizedChan <- &types.FinalisationInfo{
+		Header: header,
+	}
 	time.Sleep(time.Millisecond * 10)
 	resFinalised := map[string]interface{}{"finalised": block.Header.Hash().String()}
 	expectedFinalizedRespones := newSubscriptionResponse(AuthorExtrinsicUpdates, esl.subID, resFinalised)

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -236,7 +236,7 @@ func (c *WSConn) initBlockListener(reqID float64) (uint, error) {
 
 func (c *WSConn) initBlockFinalizedListener(reqID float64) (uint, error) {
 	bfl := &BlockFinalizedListener{
-		channel: make(chan *types.Header),
+		channel: make(chan *types.FinalisationInfo),
 		wsconn:  c,
 	}
 
@@ -271,7 +271,7 @@ func (c *WSConn) initExtrinsicWatch(reqID float64, params interface{}) (uint, er
 		importedChan:  make(chan *types.Block),
 		wsconn:        c,
 		extrinsic:     types.Extrinsic(extBytes),
-		finalisedChan: make(chan *types.Header),
+		finalisedChan: make(chan *types.FinalisationInfo),
 	}
 
 	if c.BlockAPI == nil {

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -223,7 +223,7 @@ func (m *MockBlockAPI) RegisterImportedChannel(ch chan<- *types.Block) (byte, er
 }
 func (m *MockBlockAPI) UnregisterImportedChannel(id byte) {
 }
-func (m *MockBlockAPI) RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error) {
+func (m *MockBlockAPI) RegisterFinalizedChannel(ch chan<- *types.FinalisationInfo) (byte, error) {
 	return 0, nil
 }
 func (m *MockBlockAPI) UnregisterFinalizedChannel(id byte) {}

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -120,7 +120,7 @@ func (m *MockBlockAPI) RegisterImportedChannel(ch chan<- *types.Block) (byte, er
 }
 func (m *MockBlockAPI) UnregisterImportedChannel(id byte) {
 }
-func (m *MockBlockAPI) RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error) {
+func (m *MockBlockAPI) RegisterFinalizedChannel(ch chan<- *types.FinalisationInfo) (byte, error) {
 	return 0, nil
 }
 func (m *MockBlockAPI) UnregisterFinalizedChannel(id byte) {}

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -52,7 +52,7 @@ func TestImportChannel(t *testing.T) {
 func TestFinalizedChannel(t *testing.T) {
 	bs := newTestBlockState(t, testGenesisHeader)
 
-	ch := make(chan *types.Header, 3)
+	ch := make(chan *types.FinalisationInfo, 3)
 	id, err := bs.RegisterFinalizedChannel(ch)
 	require.NoError(t, err)
 
@@ -117,12 +117,12 @@ func TestFinalizedChannel_Multi(t *testing.T) {
 	bs := newTestBlockState(t, testGenesisHeader)
 
 	num := 5
-	chs := make([]chan *types.Header, num)
+	chs := make([]chan *types.FinalisationInfo, num)
 	ids := make([]byte, num)
 
 	var err error
 	for i := 0; i < num; i++ {
-		chs[i] = make(chan *types.Header)
+		chs[i] = make(chan *types.FinalisationInfo)
 		ids[i], err = bs.RegisterFinalizedChannel(chs[i])
 		require.NoError(t, err)
 	}
@@ -134,7 +134,7 @@ func TestFinalizedChannel_Multi(t *testing.T) {
 
 	for i, ch := range chs {
 
-		go func(i int, ch chan *types.Header) {
+		go func(i int, ch chan *types.FinalisationInfo) {
 			select {
 			case <-ch:
 			case <-time.After(testMessageTimeout):

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -165,3 +165,10 @@ func DecodeGrandpaVoters(r io.Reader) (GrandpaVoters, error) {
 
 	return voters, nil
 }
+
+// FinalisationInfo represents information about what block was finalized in what round and setID
+type FinalisationInfo struct {
+	Header *Header
+	Round  uint64
+	SetID  uint64
+}

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -166,7 +166,7 @@ func DecodeGrandpaVoters(r io.Reader) (GrandpaVoters, error) {
 	return voters, nil
 }
 
-// FinalisationInfo represents information about what block was finalized in what round and setID
+// FinalisationInfo represents information about what block was finalised in what round and setID
 type FinalisationInfo struct {
 	Header *Header
 	Round  uint64

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -74,7 +74,9 @@ type Service struct {
 	justification      map[uint64][]*SignedPrecommit // map of round number -> precommit round justification
 
 	// channels for communication with other services
-	in chan GrandpaMessage // only used to receive *VoteMessage
+	in            chan GrandpaMessage // only used to receive *VoteMessage
+	finalisedCh   chan *types.FinalisationInfo
+	finalisedChID byte
 }
 
 // Config represents a GRANDPA service configuration
@@ -133,6 +135,12 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, err
 	}
 
+	finalisedCh := make(chan *types.FinalisationInfo, 16)
+	fid, err := cfg.BlockState.RegisterFinalizedChannel(finalisedCh)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Service{
 		ctx:                ctx,
@@ -156,6 +164,8 @@ func NewService(cfg *Config) (*Service, error) {
 		in:                 make(chan GrandpaMessage, 128),
 		resumed:            make(chan struct{}),
 		network:            cfg.Network,
+		finalisedCh:        finalisedCh,
+		finalisedChID:      fid,
 	}
 
 	s.messageHandler = NewMessageHandler(s, s.blockState)
@@ -194,6 +204,9 @@ func (s *Service) Stop() error {
 	defer s.chanLock.Unlock()
 
 	s.cancel()
+
+	s.blockState.UnregisterFinalizedChannel(s.finalisedChID)
+	close(s.finalisedCh)
 
 	if !s.authority {
 		return nil

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -74,9 +74,10 @@ type Service struct {
 	justification      map[uint64][]*SignedPrecommit // map of round number -> precommit round justification
 
 	// channels for communication with other services
-	in            chan GrandpaMessage // only used to receive *VoteMessage
-	finalisedCh   chan *types.FinalisationInfo
-	finalisedChID byte
+	in               chan GrandpaMessage // only used to receive *VoteMessage
+	finalisedCh      chan *types.FinalisationInfo
+	finalisedChID    byte
+	neighbourMessage *NeighbourMessage // cached neighbour message
 }
 
 // Config represents a GRANDPA service configuration
@@ -195,6 +196,7 @@ func (s *Service) Start() error {
 		}
 	}()
 
+	go s.sendNeighbourMessage()
 	return nil
 }
 

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -29,8 +29,9 @@ import (
 )
 
 var (
-	grandpaID protocol.ID = "/paritytech/grandpa/1"
-	messageID             = network.ConsensusMsgType
+	grandpaID                protocol.ID = "/paritytech/grandpa/1"
+	messageID                            = network.ConsensusMsgType
+	neighbourMessageInterval             = time.Minute * 5
 )
 
 // Handshake is an alias for network.Handshake
@@ -146,7 +147,7 @@ func (s *Service) handleNetworkMessage(from peer.ID, msg NotificationsMessage) e
 func (s *Service) sendNeighbourMessage() {
 	for {
 		select {
-		case <-time.After(time.Minute * 5):
+		case <-time.After(neighbourMessageInterval):
 			if s.neighbourMessage == nil {
 				continue
 			}

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -145,19 +145,13 @@ func (s *Service) handleNetworkMessage(from peer.ID, msg NotificationsMessage) e
 
 func (s *Service) sendNeighbourMessage() {
 	for {
-		var msg *NeighbourMessage
-
 		select {
 		case <-time.After(time.Minute * 5):
-			// TODO: fill out?? cache neighbour msg?
-			msg = &NeighbourMessage{
-				Version: 1,
-				// Round: info.Round,
-				// SetID: info.SetID,
-				// Number: uint32(info.Header.Number.Int64()),
+			if s.neighbourMessage == nil {
+				continue
 			}
 		case info := <-s.finalisedCh:
-			msg = &NeighbourMessage{
+			s.neighbourMessage = &NeighbourMessage{
 				Version: 1,
 				Round:   info.Round,
 				SetID:   info.SetID,
@@ -165,7 +159,7 @@ func (s *Service) sendNeighbourMessage() {
 			}
 		}
 
-		cm, err := msg.ToConsensusMessage()
+		cm, err := s.neighbourMessage.ToConsensusMessage()
 		if err != nil {
 			logger.Warn("failed to convert NeighbourMessage to network message", "error", err)
 			continue

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -17,8 +17,11 @@
 package grandpa
 
 import (
+	"math/big"
 	"testing"
 	"time"
+
+	"github.com/ChainSafe/gossamer/dot/types"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
@@ -69,5 +72,58 @@ func TestHandleNetworkMessage(t *testing.T) {
 	case <-gs.network.(*testNetwork).out:
 	case <-time.After(testTimeout):
 		t.Fatal("expected to send message")
+	}
+}
+
+func TestSendNeighbourMessage(t *testing.T) {
+	gs, st := newTestService(t)
+	neighbourMessageInterval = time.Second
+	defer func() {
+		neighbourMessageInterval = time.Minute * 5
+	}()
+	go gs.sendNeighbourMessage()
+
+	block := &types.Block{
+		Header: &types.Header{
+			ParentHash: testGenesisHeader.Hash(),
+			Number:     big.NewInt(1),
+		},
+		Body: &types.Body{},
+	}
+
+	err := st.Block.AddBlock(block)
+	require.NoError(t, err)
+
+	hash := block.Header.Hash()
+	round := uint64(7)
+	setID := uint64(33)
+	err = st.Block.SetFinalizedHash(hash, round, setID)
+	require.NoError(t, err)
+
+	expected := &NeighbourMessage{
+		Version: 1,
+		SetID:   setID,
+		Round:   round,
+		Number:  1,
+	}
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("did not send message")
+	case msg := <-gs.network.(*testNetwork).out:
+		nm, ok := msg.(*NeighbourMessage)
+		require.True(t, ok)
+		require.Equal(t, expected, nm)
+	}
+
+	require.Equal(t, expected, gs.neighbourMessage)
+
+	select {
+	case <-time.After(time.Second * 2):
+		t.Fatal("did not send message")
+	case msg := <-gs.network.(*testNetwork).out:
+		nm, ok := msg.(*NeighbourMessage)
+		require.True(t, ok)
+		require.Equal(t, expected, nm)
 	}
 }

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -44,7 +44,7 @@ type BlockState interface {
 	BlocktreeAsString() string
 	RegisterImportedChannel(ch chan<- *types.Block) (byte, error)
 	UnregisterImportedChannel(id byte)
-	RegisterFinalizedChannel(ch chan<- *types.Header) (byte, error)
+	RegisterFinalizedChannel(ch chan<- *types.FinalisationInfo) (byte, error)
 	UnregisterFinalizedChannel(id byte)
 	SetJustification(hash common.Hash, data []byte) error
 	HasJustification(hash common.Hash) (bool, error)


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `grandpa.Service` to send neighbour message to peers either every 5 minutes or whenever a new block is finalized
- update `blockState` finalized chans to have type `types.FinalisationInfo` which contains the round and set ID as well as the block number, needed for neighbour message

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa -short
go test ./dot/core
go test ./dot/rpc/...
go test ./dot/state
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1525
