### PR TITLE
feat: add --chain dev option

### DIFF
--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -9,7 +9,7 @@ network = ""
 rpc = ""
 state = ""
 runtime = ""
-babe = ""
+babe = "debug"
 grandpa = ""
 sync = ""
 

--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -1,0 +1,38 @@
+[global]
+basepath = "~/.gossamer/dev"
+log = "info"
+metrics-port = 9876
+
+[log]
+core = ""
+network = ""
+rpc = ""
+state = ""
+runtime = ""
+babe = ""
+grandpa = ""
+sync = ""
+
+[init]
+genesis = "./chain/dev/genesis-spec.json"
+
+[account]
+key = "alice"
+unlock = ""
+
+[core]
+roles = 4
+babe-authority = true
+grandpa-authority = true
+
+[network]
+port = 7001
+nobootstrap = false
+nomdns = false
+
+[rpc]
+enabled = false
+port = 8545
+host = "localhost"
+modules = ["system", "author", "chain", "state", "rpc", "grandpa"]
+ws-port = 8546

--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -9,7 +9,7 @@ network = ""
 rpc = ""
 state = ""
 runtime = ""
-babe = "debug"
+babe = ""
 grandpa = ""
 sync = ""
 

--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -31,7 +31,8 @@ nobootstrap = false
 nomdns = false
 
 [rpc]
-enabled = false
+enabled = true
+ws = true
 port = 8545
 host = "localhost"
 modules = ["system", "author", "chain", "state", "rpc", "grandpa"]

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -24,13 +24,13 @@ import (
 var (
 	// GlobalConfig
 
-	// DefaultName Default node name
+	// DefaultName is the node name
 	DefaultName = string("Gossamer")
-	// DefaultID Default chain ID
+	// DefaultID is the chain ID
 	DefaultID = string("dev")
-	// DefaultConfig Default toml configuration path
+	// DefaultConfig is the toml configuration path
 	DefaultConfig = string("./chain/dev/config.toml")
-	// DefaultBasePath Default node base directory path
+	// DefaultBasePath is the node base directory path
 	DefaultBasePath = string("~/.gossamer/dev")
 
 	// DefaultMetricsPort is the metrics server port
@@ -46,9 +46,9 @@ var (
 
 	// AccountConfig
 
-	// DefaultKey Default account key
+	// DefaultKey is the default account key
 	DefaultKey = string("alice")
-	// DefaultUnlock Default account unlock
+	// DefaultUnlock is the account to unlock
 	DefaultUnlock = string("")
 
 	// CoreConfig
@@ -85,4 +85,8 @@ var (
 	DefaultRPCModules = []string{"system", "author", "chain", "state", "rpc", "grandpa"}
 	// DefaultRPCWSPort rpc websocket port
 	DefaultRPCWSPort = uint32(8546)
+	// DefaultRPCEnabled enables the RPC server
+	DefaultRPCEnabled = true
+	// DefaultWSEnabled enables the WS server
+	DefaultWSEnabled = true
 )

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -27,11 +27,11 @@ var (
 	// DefaultName Default node name
 	DefaultName = string("Gossamer")
 	// DefaultID Default chain ID
-	DefaultID = string("gssmr")
+	DefaultID = string("dev")
 	// DefaultConfig Default toml configuration path
-	DefaultConfig = string("./chain/gssmr/config.toml")
+	DefaultConfig = string("./chain/dev/config.toml")
 	// DefaultBasePath Default node base directory path
-	DefaultBasePath = string("~/.gossamer/gssmr")
+	DefaultBasePath = string("~/.gossamer/dev")
 
 	// DefaultMetricsPort is the metrics server port
 	DefaultMetricsPort = uint32(9876)
@@ -42,12 +42,12 @@ var (
 	// InitConfig
 
 	// DefaultGenesis is the default genesis configuration path
-	DefaultGenesis = string("./chain/gssmr/genesis.json")
+	DefaultGenesis = string("./chain/dev/genesis-spec.json")
 
 	// AccountConfig
 
 	// DefaultKey Default account key
-	DefaultKey = string("")
+	DefaultKey = string("alice")
 	// DefaultUnlock Default account unlock
 	DefaultUnlock = string("")
 

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -1,0 +1,88 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package dev
+
+import (
+	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
+	log "github.com/ChainSafe/log15"
+)
+
+var (
+	// GlobalConfig
+
+	// DefaultName Default node name
+	DefaultName = string("Gossamer")
+	// DefaultID Default chain ID
+	DefaultID = string("gssmr")
+	// DefaultConfig Default toml configuration path
+	DefaultConfig = string("./chain/gssmr/config.toml")
+	// DefaultBasePath Default node base directory path
+	DefaultBasePath = string("~/.gossamer/gssmr")
+
+	// DefaultMetricsPort is the metrics server port
+	DefaultMetricsPort = uint32(9876)
+
+	// DefaultLvl is the default log level
+	DefaultLvl = log.LvlInfo
+
+	// InitConfig
+
+	// DefaultGenesis is the default genesis configuration path
+	DefaultGenesis = string("./chain/gssmr/genesis.json")
+
+	// AccountConfig
+
+	// DefaultKey Default account key
+	DefaultKey = string("")
+	// DefaultUnlock Default account unlock
+	DefaultUnlock = string("")
+
+	// CoreConfig
+
+	// DefaultAuthority is true if the node is a block producer and a grandpa authority
+	DefaultAuthority = true
+	// DefaultRoles Default node roles
+	DefaultRoles = byte(4) // authority node (see Table D.2)
+	// DefaultBabeAuthority is true if the node is a block producer (overwrites previous settings)
+	DefaultBabeAuthority = true
+	// DefaultGrandpaAuthority is true if the node is a grandpa authority (overwrites previous settings)
+	DefaultGrandpaAuthority = true
+	// DefaultWasmInterpreter is the name of the wasm interpreter to use by default
+	DefaultWasmInterpreter = wasmer.Name
+
+	// NetworkConfig
+
+	// DefaultNetworkPort network port
+	DefaultNetworkPort = uint32(7001)
+	// DefaultNetworkBootnodes network bootnodes
+	DefaultNetworkBootnodes = []string(nil)
+	// DefaultNoBootstrap disables bootstrap
+	DefaultNoBootstrap = false
+	// DefaultNoMDNS disables mDNS discovery
+	DefaultNoMDNS = false
+
+	// RPCConfig
+
+	// DefaultRPCHTTPHost rpc host
+	DefaultRPCHTTPHost = string("localhost")
+	// DefaultRPCHTTPPort rpc port
+	DefaultRPCHTTPPort = uint32(8545)
+	// DefaultRPCModules rpc modules
+	DefaultRPCModules = []string{"system", "author", "chain", "state", "rpc", "grandpa"}
+	// DefaultRPCWSPort rpc websocket port
+	DefaultRPCWSPort = uint32(8546)
+)

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -598,8 +598,6 @@ func setDotCoreConfig(ctx *cli.Context, tomlCfg ctoml.CoreConfig, cfg *dot.CoreC
 		"babe-authority", cfg.BabeAuthority,
 		"grandpa-authority", cfg.GrandpaAuthority,
 		"epoch-length", cfg.EpochLength,
-		"babe-threshold-numerator", cfg.BabeThresholdNumerator,
-		"babe-threshold-denominator", cfg.BabeThresholdDenominator,
 		"wasm-interpreter", cfg.WasmInterpreter,
 	)
 }
@@ -674,7 +672,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 	cfg.WSExternal = tomlCfg.WSExternal
 
 	// check --rpc flag and update node configuration
-	if enabled := ctx.GlobalBool(RPCEnabledFlag.Name); enabled {
+	if enabled := ctx.GlobalBool(RPCEnabledFlag.Name); enabled || cfg.Enabled {
 		cfg.Enabled = true
 	} else if ctx.IsSet(RPCEnabledFlag.Name) && !enabled {
 		cfg.Enabled = false
@@ -708,7 +706,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 		cfg.WSPort = uint32(wsport)
 	}
 
-	if WS := ctx.GlobalBool(WSFlag.Name); WS {
+	if WS := ctx.GlobalBool(WSFlag.Name); WS || cfg.WS {
 		cfg.WS = true
 	} else if ctx.IsSet(WSFlag.Name) && !WS {
 		cfg.WS = false

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -44,10 +44,12 @@ var (
 	defaultGssmrConfigPath    = "./chain/gssmr/config.toml"
 	defaultKusamaConfigPath   = "./chain/kusama/config.toml"
 	defaultPolkadotConfigPath = "./chain/polkadot/config.toml"
+	defaultDevConfigPath      = "./chain/dev/config.toml"
 
 	gossamerName = "gssmr"
 	kusamaName   = "kusama"
 	polkadotName = "polkadot"
+	devName      = "dev"
 )
 
 // loadConfigFile loads a default config file if --chain is specified, a specific
@@ -100,6 +102,11 @@ func setupConfigFromChain(ctx *cli.Context) (*ctoml.Config, *dot.Config, error) 
 			tomlCfg = &ctoml.Config{}
 			cfg = dot.PolkadotConfig()
 			err = loadConfig(tomlCfg, defaultPolkadotConfigPath)
+		case devName:
+			logger.Info("loading toml configuration...", "config path", defaultDevConfigPath)
+			tomlCfg = &ctoml.Config{}
+			cfg = dot.DevConfig()
+			err = loadConfig(tomlCfg, defaultDevConfigPath)
 		default:
 			return nil, nil, fmt.Errorf("unknown chain id provided: %s", id)
 		}
@@ -570,11 +577,6 @@ func setDotCoreConfig(ctx *cli.Context, tomlCfg ctoml.CoreConfig, cfg *dot.CoreC
 	if cfg.Roles != types.AuthorityRole {
 		cfg.BabeAuthority = false
 		cfg.GrandpaAuthority = false
-	}
-
-	if tomlCfg.BabeThresholdDenominator != 0 {
-		cfg.BabeThresholdDenominator = tomlCfg.BabeThresholdDenominator
-		cfg.BabeThresholdNumerator = tomlCfg.BabeThresholdNumerator
 	}
 
 	switch tomlCfg.WasmInterpreter {

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -44,24 +44,24 @@ func TestConfigFromChainFlag(t *testing.T) {
 		values      []interface{}
 		expected    *dot.Config
 	}{
-		// {
-		// 	"Test gossamer --chain gssmr",
-		// 	[]string{"chain", "name"},
-		// 	[]interface{}{"gssmr", dot.GssmrConfig().Global.Name},
-		// 	dot.GssmrConfig(),
-		// },
-		// {
-		// 	"Test gossamer --chain kusama",
-		// 	[]string{"chain", "name"},
-		// 	[]interface{}{"kusama", dot.KusamaConfig().Global.Name},
-		// 	dot.KusamaConfig(),
-		// },
-		// {
-		// 	"Test gossamer --chain polkadot",
-		// 	[]string{"chain", "name"},
-		// 	[]interface{}{"polkadot", dot.PolkadotConfig().Global.Name},
-		// 	dot.PolkadotConfig(),
-		// },
+		{
+			"Test gossamer --chain gssmr",
+			[]string{"chain", "name"},
+			[]interface{}{"gssmr", dot.GssmrConfig().Global.Name},
+			dot.GssmrConfig(),
+		},
+		{
+			"Test gossamer --chain kusama",
+			[]string{"chain", "name"},
+			[]interface{}{"kusama", dot.KusamaConfig().Global.Name},
+			dot.KusamaConfig(),
+		},
+		{
+			"Test gossamer --chain polkadot",
+			[]string{"chain", "name"},
+			[]interface{}{"polkadot", dot.PolkadotConfig().Global.Name},
+			dot.PolkadotConfig(),
+		},
 		{
 			"Test gossamer --chain dev",
 			[]string{"chain", "name"},

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -751,9 +751,6 @@ func TestUpdateConfigFromGenesisJSON_Default(t *testing.T) {
 		System:  testCfg.System,
 	}
 
-	expected.Core.BabeThresholdNumerator = 0
-	expected.Core.BabeThresholdDenominator = 0
-
 	cfg, err := createDotConfig(ctx)
 	require.Nil(t, err)
 	updateDotConfigFromGenesisJSONRaw(*dotConfigToToml(testCfg), cfg)
@@ -812,8 +809,6 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg.Init.Genesis = genFile.Name()
-	expected.Core.BabeThresholdNumerator = 0
-	expected.Core.BabeThresholdDenominator = 0
 
 	db, err := chaindb.NewBadgerDB(&chaindb.Config{
 		DataDir: cfg.Global.BasePath,
@@ -851,8 +846,6 @@ func TestGlobalNodeName_WhenNodeAlreadyHasStoredName(t *testing.T) {
 	cfg.Core.Roles = types.FullNodeRole
 	cfg.Core.BabeAuthority = false
 	cfg.Core.GrandpaAuthority = false
-	cfg.Core.BabeThresholdNumerator = 0
-	cfg.Core.BabeThresholdDenominator = 0
 	cfg.Init.Genesis = genPath
 
 	err := dot.InitNode(cfg)

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -44,23 +44,29 @@ func TestConfigFromChainFlag(t *testing.T) {
 		values      []interface{}
 		expected    *dot.Config
 	}{
+		// {
+		// 	"Test gossamer --chain gssmr",
+		// 	[]string{"chain", "name"},
+		// 	[]interface{}{"gssmr", dot.GssmrConfig().Global.Name},
+		// 	dot.GssmrConfig(),
+		// },
+		// {
+		// 	"Test gossamer --chain kusama",
+		// 	[]string{"chain", "name"},
+		// 	[]interface{}{"kusama", dot.KusamaConfig().Global.Name},
+		// 	dot.KusamaConfig(),
+		// },
+		// {
+		// 	"Test gossamer --chain polkadot",
+		// 	[]string{"chain", "name"},
+		// 	[]interface{}{"polkadot", dot.PolkadotConfig().Global.Name},
+		// 	dot.PolkadotConfig(),
+		// },
 		{
-			"Test gossamer --chain gssmr",
+			"Test gossamer --chain dev",
 			[]string{"chain", "name"},
-			[]interface{}{"gssmr", dot.GssmrConfig().Global.Name},
-			dot.GssmrConfig(),
-		},
-		{
-			"Test gossamer --chain kusama",
-			[]string{"chain", "name"},
-			[]interface{}{"kusama", dot.KusamaConfig().Global.Name},
-			dot.KusamaConfig(),
-		},
-		{
-			"Test gossamer --chain polkadot",
-			[]string{"chain", "name"},
-			[]interface{}{"polkadot", dot.PolkadotConfig().Global.Name},
-			dot.PolkadotConfig(),
+			[]interface{}{"dev", dot.DevConfig().Global.Name},
+			dot.DevConfig(),
 		},
 	}
 

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -107,13 +107,11 @@ func dotConfigToToml(dcfg *dot.Config) *ctoml.Config {
 	}
 
 	cfg.Core = ctoml.CoreConfig{
-		Roles:                    dcfg.Core.Roles,
-		BabeAuthority:            dcfg.Core.BabeAuthority,
-		GrandpaAuthority:         dcfg.Core.GrandpaAuthority,
-		EpochLength:              dcfg.Core.EpochLength,
-		BabeThresholdNumerator:   dcfg.Core.BabeThresholdNumerator,
-		BabeThresholdDenominator: dcfg.Core.BabeThresholdDenominator,
-		SlotDuration:             dcfg.Core.SlotDuration,
+		Roles:            dcfg.Core.Roles,
+		BabeAuthority:    dcfg.Core.BabeAuthority,
+		GrandpaAuthority: dcfg.Core.GrandpaAuthority,
+		EpochLength:      dcfg.Core.EpochLength,
+		SlotDuration:     dcfg.Core.SlotDuration,
 	}
 
 	cfg.Network = ctoml.NetworkConfig{

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -214,6 +214,7 @@ func TestMain(m *testing.M) {
 	defaultGssmrConfigPath = "../../chain/gssmr/config.toml"
 	defaultKusamaConfigPath = "../../chain/kusama/config.toml"
 	defaultPolkadotConfigPath = "../../chain/polkadot/config.toml"
+	defaultDevConfigPath = "../../chain/dev/config.toml"
 	os.Exit(m.Run())
 }
 

--- a/dot/config.go
+++ b/dot/config.go
@@ -91,14 +91,12 @@ type NetworkConfig struct {
 
 // CoreConfig is to marshal/unmarshal toml core config vars
 type CoreConfig struct {
-	Roles                    byte
-	BabeAuthority            bool
-	GrandpaAuthority         bool
-	BabeThresholdNumerator   uint64
-	BabeThresholdDenominator uint64
-	SlotDuration             uint64
-	EpochLength              uint64
-	WasmInterpreter          string
+	Roles            byte
+	BabeAuthority    bool
+	GrandpaAuthority bool
+	SlotDuration     uint64
+	EpochLength      uint64
+	WasmInterpreter  string
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars
@@ -268,6 +266,7 @@ func PolkadotConfig() *Config {
 	}
 }
 
+// DevConfig returns the configuration for a development chain
 func DevConfig() *Config {
 	return &Config{
 		Global: GlobalConfig{
@@ -308,8 +307,8 @@ func DevConfig() *Config {
 			Host:    dev.DefaultRPCHTTPHost,
 			Modules: dev.DefaultRPCModules,
 			WSPort:  dev.DefaultRPCWSPort,
-			Enabled: true,
-			WS:      true,
+			Enabled: dev.DefaultRPCEnabled,
+			WS:      dev.DefaultWSEnabled,
 		},
 	}
 }

--- a/dot/config.go
+++ b/dot/config.go
@@ -19,6 +19,7 @@ package dot
 import (
 	"encoding/json"
 
+	"github.com/ChainSafe/gossamer/chain/dev"
 	"github.com/ChainSafe/gossamer/chain/gssmr"
 	"github.com/ChainSafe/gossamer/chain/kusama"
 	"github.com/ChainSafe/gossamer/chain/polkadot"
@@ -263,6 +264,52 @@ func PolkadotConfig() *Config {
 			Host:    polkadot.DefaultRPCHTTPHost,
 			Modules: polkadot.DefaultRPCModules,
 			WSPort:  polkadot.DefaultRPCWSPort,
+		},
+	}
+}
+
+func DevConfig() *Config {
+	return &Config{
+		Global: GlobalConfig{
+			Name:     dev.DefaultName,
+			ID:       dev.DefaultID,
+			BasePath: dev.DefaultBasePath,
+			LogLvl:   dev.DefaultLvl,
+		},
+		Log: LogConfig{
+			CoreLvl:           dev.DefaultLvl,
+			SyncLvl:           dev.DefaultLvl,
+			NetworkLvl:        dev.DefaultLvl,
+			RPCLvl:            dev.DefaultLvl,
+			StateLvl:          dev.DefaultLvl,
+			RuntimeLvl:        dev.DefaultLvl,
+			BlockProducerLvl:  dev.DefaultLvl,
+			FinalityGadgetLvl: dev.DefaultLvl,
+		},
+		Init: InitConfig{
+			Genesis: dev.DefaultGenesis,
+		},
+		Account: AccountConfig{
+			Key:    dev.DefaultKey,
+			Unlock: dev.DefaultUnlock,
+		},
+		Core: CoreConfig{
+			Roles:           dev.DefaultRoles,
+			WasmInterpreter: dev.DefaultWasmInterpreter,
+		},
+		Network: NetworkConfig{
+			Port:        dev.DefaultNetworkPort,
+			Bootnodes:   dev.DefaultNetworkBootnodes,
+			NoBootstrap: dev.DefaultNoBootstrap,
+			NoMDNS:      dev.DefaultNoMDNS,
+		},
+		RPC: RPCConfig{
+			Port:    dev.DefaultRPCHTTPPort,
+			Host:    dev.DefaultRPCHTTPHost,
+			Modules: dev.DefaultRPCModules,
+			WSPort:  dev.DefaultRPCWSPort,
+			Enabled: true,
+			WS:      true,
 		},
 	}
 }

--- a/dot/config.go
+++ b/dot/config.go
@@ -270,10 +270,11 @@ func PolkadotConfig() *Config {
 func DevConfig() *Config {
 	return &Config{
 		Global: GlobalConfig{
-			Name:     dev.DefaultName,
-			ID:       dev.DefaultID,
-			BasePath: dev.DefaultBasePath,
-			LogLvl:   dev.DefaultLvl,
+			Name:        dev.DefaultName,
+			ID:          dev.DefaultID,
+			BasePath:    dev.DefaultBasePath,
+			LogLvl:      dev.DefaultLvl,
+			MetricsPort: dev.DefaultMetricsPort,
 		},
 		Log: LogConfig{
 			CoreLvl:           dev.DefaultLvl,
@@ -293,8 +294,10 @@ func DevConfig() *Config {
 			Unlock: dev.DefaultUnlock,
 		},
 		Core: CoreConfig{
-			Roles:           dev.DefaultRoles,
-			WasmInterpreter: dev.DefaultWasmInterpreter,
+			Roles:            dev.DefaultRoles,
+			BabeAuthority:    dev.DefaultBabeAuthority,
+			GrandpaAuthority: dev.DefaultGrandpaAuthority,
+			WasmInterpreter:  dev.DefaultWasmInterpreter,
 		},
 		Network: NetworkConfig{
 			Port:        dev.DefaultNetworkPort,

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -73,14 +73,12 @@ type NetworkConfig struct {
 
 // CoreConfig is to marshal/unmarshal toml core config vars
 type CoreConfig struct {
-	Roles                    byte   `toml:"roles,omitempty"`
-	BabeAuthority            bool   `toml:"babe-authority"`
-	GrandpaAuthority         bool   `toml:"grandpa-authority"`
-	BabeThresholdNumerator   uint64 `toml:"babe-threshold-numerator,omitempty"`
-	BabeThresholdDenominator uint64 `toml:"babe-threshold-denominator,omitempty"`
-	SlotDuration             uint64 `toml:"slot-duration,omitempty"`
-	EpochLength              uint64 `toml:"epoch-length,omitempty"`
-	WasmInterpreter          string `toml:"wasm-interpreter,omitempty"`
+	Roles            byte   `toml:"roles,omitempty"`
+	BabeAuthority    bool   `toml:"babe-authority"`
+	GrandpaAuthority bool   `toml:"grandpa-authority"`
+	SlotDuration     uint64 `toml:"slot-duration,omitempty"`
+	EpochLength      uint64 `toml:"epoch-length,omitempty"`
+	WasmInterpreter  string `toml:"wasm-interpreter,omitempty"`
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars

--- a/dot/node.go
+++ b/dot/node.go
@@ -93,11 +93,6 @@ func InitNode(cfg *Config) error {
 	// create new state service
 	stateSrvc := state.NewService(cfg.Global.BasePath, cfg.Global.LogLvl)
 
-	if cfg.Core.BabeThresholdDenominator != 0 {
-		stateSrvc.BabeThresholdNumerator = cfg.Core.BabeThresholdNumerator
-		stateSrvc.BabeThresholdDenominator = cfg.Core.BabeThresholdDenominator
-	}
-
 	// initialise state service with genesis data, block, and trie
 	err = stateSrvc.Initialise(gen, header, t)
 	if err != nil {

--- a/dot/node.go
+++ b/dot/node.go
@@ -164,7 +164,7 @@ func NodeInitialized(basepath string, expected bool) bool {
 	// load genesis data from initialised node database
 	_, err = state.NewBaseState(db).LoadGenesisData()
 	if err != nil {
-		logger.Warn(
+		logger.Debug(
 			"node has not been initialised",
 			"basepath", basepath,
 			"error", err,

--- a/dot/node.go
+++ b/dot/node.go
@@ -153,6 +153,14 @@ func NodeInitialized(basepath string, expected bool) bool {
 		return false
 	}
 
+	defer func() {
+		// close database
+		err = db.Close()
+		if err != nil {
+			logger.Error("failed to close database", "error", err)
+		}
+	}()
+
 	// load genesis data from initialised node database
 	_, err = state.NewBaseState(db).LoadGenesisData()
 	if err != nil {
@@ -162,12 +170,6 @@ func NodeInitialized(basepath string, expected bool) bool {
 			"error", err,
 		)
 		return false
-	}
-
-	// close database
-	err = db.Close()
-	if err != nil {
-		logger.Error("failed to close database", "error", err)
 	}
 
 	return true

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -149,8 +149,6 @@ func TestNewNode_Authority(t *testing.T) {
 	require.Equal(t, 1, ks.Babe.Size())
 
 	cfg.Core.Roles = types.AuthorityRole
-	cfg.Core.BabeThresholdNumerator = 0
-	cfg.Core.BabeThresholdDenominator = 0
 
 	node, err := NewNode(cfg, ks, nil)
 	require.NoError(t, err)
@@ -325,8 +323,6 @@ func TestInitNode_LoadBalances(t *testing.T) {
 	cfg.Core.Roles = types.FullNodeRole
 	cfg.Core.BabeAuthority = false
 	cfg.Core.GrandpaAuthority = false
-	cfg.Core.BabeThresholdNumerator = 0
-	cfg.Core.BabeThresholdDenominator = 0
 	cfg.Init.Genesis = genPath
 
 	err := InitNode(cfg)
@@ -398,8 +394,6 @@ func TestNode_PersistGlobalName_WhenInitialize(t *testing.T) {
 	cfg.Core.Roles = types.FullNodeRole
 	cfg.Core.BabeAuthority = false
 	cfg.Core.GrandpaAuthority = false
-	cfg.Core.BabeThresholdNumerator = 0
-	cfg.Core.BabeThresholdDenominator = 0
 	cfg.Init.Genesis = genPath
 
 	err := InitNode(cfg)

--- a/dot/services.go
+++ b/dot/services.go
@@ -184,17 +184,16 @@ func createBABEService(cfg *Config, rt runtime.Instance, st *state.Service, ks k
 	}
 
 	bcfg := &babe.ServiceConfig{
-		LogLvl:               cfg.Log.BlockProducerLvl,
-		Runtime:              rt,
-		BlockState:           st.Block,
-		StorageState:         st.Storage,
-		TransactionState:     st.Transaction,
-		EpochState:           st.Epoch,
-		EpochLength:          cfg.Core.EpochLength,
-		ThresholdNumerator:   cfg.Core.BabeThresholdNumerator,
-		ThresholdDenominator: cfg.Core.BabeThresholdDenominator,
-		SlotDuration:         cfg.Core.SlotDuration,
-		Authority:            cfg.Core.BabeAuthority,
+		LogLvl:           cfg.Log.BlockProducerLvl,
+		Runtime:          rt,
+		BlockState:       st.Block,
+		StorageState:     st.Storage,
+		TransactionState: st.Transaction,
+		EpochState:       st.Epoch,
+		EpochLength:      cfg.Core.EpochLength,
+		SlotDuration:     cfg.Core.SlotDuration, // TODO: remove this, should only be modified via runtime constant
+		Authority:        cfg.Core.BabeAuthority,
+		IsDev:            cfg.Global.ID == "dev",
 	}
 
 	if cfg.Core.BabeAuthority {

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -107,8 +107,6 @@ func TestCreateBlockVerifier(t *testing.T) {
 	stateSrvc, err := createStateService(cfg)
 	require.NoError(t, err)
 
-	cfg.Core.BabeThresholdNumerator = 0
-	cfg.Core.BabeThresholdDenominator = 0
 	_, err = createBlockVerifier(stateSrvc)
 	require.NoError(t, err)
 }
@@ -135,8 +133,6 @@ func TestCreateSyncService(t *testing.T) {
 	rt, err := createRuntime(cfg, stateSrvc, ks, &network.Service{})
 	require.NoError(t, err)
 
-	cfg.Core.BabeThresholdNumerator = 0
-	cfg.Core.BabeThresholdDenominator = 0
 	ver, err := createBlockVerifier(stateSrvc)
 	require.NoError(t, err)
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/ChainSafe/chaindb v0.1.5-0.20210117220933-15e75f27268f h1:qDmWdUIE1cgG19K/eVB9nkQMkldaGwcjU9U5OyUV11k=
 github.com/ChainSafe/chaindb v0.1.5-0.20210117220933-15e75f27268f/go.mod h1:WBsCSLGM7+DvSYU6cFVUltahwU7Sw4cN3e8kiLdNFJM=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20210127175223-0f934d64ecac h1:mZyOXXu+q/op10XOYRzdpIxWWreS/zCYhl+UNpRv2O0=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20210127175223-0f934d64ecac/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782 h1:lwmjzta2Xu+3rPVY/VeNQj2xfNkyih4CwyRxYg3cpRQ=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/ChainSafe/log15 v1.0.0 h1:vRDVtWtVwIH5uSCBvgTTZh6FA58UBJ6+QiiypaZfBf8=

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -376,7 +376,11 @@ func (b *Service) invokeBlockAuthoring(epoch uint64) {
 
 	// if we're at genesis, set the first slot number for the network
 	if head.Number.Cmp(big.NewInt(0)) == 0 {
-		b.epochState.SetFirstSlot(startSlot)
+		err = b.epochState.SetFirstSlot(startSlot)
+		if err != nil {
+			logger.Error("failed to set first slot number", "error", err)
+			return
+		}
 	}
 
 	logger.Info("initiating epoch", "number", epoch, "start slot", startSlot+b.epochLength)

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -211,12 +211,6 @@ func (b *Service) Start() error {
 		return err
 	}
 
-	// err = b.initiateEpoch(epoch)
-	// if err != nil {
-	// 	logger.Error("failed to initiate epoch", "error", err)
-	// 	return err
-	// }
-
 	go b.initiate(epoch)
 	return nil
 }

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -136,6 +136,8 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		cfg.Runtime = rt
 	}
 
+	cfg.LogLvl = 4
+
 	babeService, err := NewService(cfg)
 	require.NoError(t, err)
 	return babeService

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -136,8 +136,6 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		cfg.Runtime = rt
 	}
 
-	cfg.LogLvl = 4
-
 	babeService, err := NewService(cfg)
 	require.NoError(t, err)
 	return babeService

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -31,7 +31,6 @@ func (b *Service) initiateEpoch(epoch uint64) error {
 	)
 
 	if epoch == 0 {
-		logger.Debug("at epoch 0")
 		startSlot, err = b.epochState.GetStartSlotForEpoch(epoch)
 		if err != nil {
 			return err

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -37,7 +37,7 @@ func (b *Service) initiateEpoch(epoch uint64) error {
 			return err
 		}
 	} else if epoch > 0 {
-		has, err := b.epochState.HasEpochData(epoch)
+		has, err := b.epochState.HasEpochData(epoch) //nolint
 		if err != nil {
 			return err
 		}
@@ -101,7 +101,7 @@ func (b *Service) initiateEpoch(epoch uint64) error {
 	} else if b.blockState.BestBlockHash() == b.blockState.GenesisHash() {
 		// we are at genesis, set first slot using current time
 		startSlot = getCurrentSlot(b.slotDuration)
-		err := b.epochState.SetFirstSlot(startSlot)
+		err = b.epochState.SetFirstSlot(startSlot)
 		if err != nil {
 			return err
 		}

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -31,6 +31,7 @@ func (b *Service) initiateEpoch(epoch uint64) error {
 	)
 
 	if epoch == 0 {
+		logger.Debug("at epoch 0")
 		startSlot, err = b.epochState.GetStartSlotForEpoch(epoch)
 		if err != nil {
 			return err

--- a/lib/babe/epoch_test.go
+++ b/lib/babe/epoch_test.go
@@ -27,6 +27,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInitiateEpoch_Epoch0(t *testing.T) {
+	bs := createTestService(t, nil)
+	bs.epochLength = 5
+	startSlot := uint64(1000)
+
+	err := bs.epochState.SetFirstSlot(startSlot)
+	require.NoError(t, err)
+	err = bs.initiateEpoch(0)
+	require.NoError(t, err)
+
+	for i := startSlot; i < startSlot+bs.epochLength; i++ {
+		_, has := bs.slotToProof[i]
+		require.True(t, has)
+	}
+}
+
 func TestInitiateEpoch(t *testing.T) {
 	bs := createTestService(t, nil)
 	bs.epochLength = 5

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -172,8 +172,8 @@ func (s *Service) sendNeighbourMessage() {
 			if s.neighbourMessage == nil {
 				continue
 			}
-		case info := <-s.finalisedCh:
-			if info == nil {
+		case info, ok := <-s.finalisedCh:
+			if !ok {
 				// channel was closed
 				return
 			}

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -166,11 +166,18 @@ func (s *Service) handleNetworkMessage(from peer.ID, msg NotificationsMessage) (
 func (s *Service) sendNeighbourMessage() {
 	for {
 		select {
+		case <-s.ctx.Done():
+			return
 		case <-time.After(neighbourMessageInterval):
 			if s.neighbourMessage == nil {
 				continue
 			}
 		case info := <-s.finalisedCh:
+			if info == nil {
+				// channel was closed
+				return
+			}
+
 			s.neighbourMessage = &NeighbourMessage{
 				Version: 1,
 				Round:   info.Round,

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
+var runtimes = []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, NODE_RUNTIME, DEV_RUNTIME}
+
 //nolint
 const (
 	// v0.8 substrate runtime

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -36,6 +36,11 @@ const (
 	HOST_API_TEST_RUNTIME     = "hostapi_runtime"
 	HOST_API_TEST_RUNTIME_FP  = "hostapi_runtime.compact.wasm"
 	HOST_API_TEST_RUNTIME_URL = "https://github.com/noot/polkadot-spec/blob/master/test/hostapi_runtime.compact.wasm?raw=true"
+
+	// v0.8 substrate runtime with modified name and babe C=(1, 1)
+	DEV_RUNTIME     = "dev_runtime"
+	DEV_RUNTIME_FP  = "dev_runtime.compact.wasm"
+	DEV_RUNTIME_URL = "https://github.com/noot/substrate/blob/noot/v0.8-dev-runtime/target/wasm32-unknown-unknown/release/wbuild/node-runtime/node_runtime.compact.wasm?raw=true"
 )
 
 //nolint

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -62,6 +62,8 @@ func GetRuntimeVars(targetRuntime string) (string, string) {
 		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(POLKADOT_RUNTIME_FP), POLKADOT_RUNTIME_URL
 	case HOST_API_TEST_RUNTIME:
 		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(HOST_API_TEST_RUNTIME_FP), HOST_API_TEST_RUNTIME_URL
+	case DEV_RUNTIME:
+		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(DEV_RUNTIME_FP), DEV_RUNTIME_URL
 	}
 
 	return testRuntimeFilePath, testRuntimeURL
@@ -145,7 +147,7 @@ func generateEd25519Signatures(t *testing.T, n int) []*Signature {
 // GenerateRuntimeWasmFile generates all runtime wasm files.
 func GenerateRuntimeWasmFile() ([]string, error) {
 	var wasmFilePaths []string
-	runtimes := []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, NODE_RUNTIME}
+	runtimes := []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, NODE_RUNTIME, DEV_RUNTIME}
 	for _, rt := range runtimes {
 		testRuntimeFilePath, testRuntimeURL := GetRuntimeVars(rt)
 		wasmFilePaths = append(wasmFilePaths, testRuntimeFilePath)

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -147,7 +147,6 @@ func generateEd25519Signatures(t *testing.T, n int) []*Signature {
 // GenerateRuntimeWasmFile generates all runtime wasm files.
 func GenerateRuntimeWasmFile() ([]string, error) {
 	var wasmFilePaths []string
-	runtimes := []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, NODE_RUNTIME, DEV_RUNTIME}
 	for _, rt := range runtimes {
 		testRuntimeFilePath, testRuntimeURL := GetRuntimeVars(rt)
 		wasmFilePaths = append(wasmFilePaths, testRuntimeFilePath)

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -137,7 +137,6 @@ func TestInstance_Version_NodeRuntime(t *testing.T) {
 }
 
 func TestInstance_Version_DevRuntime(t *testing.T) {
-	t.Skip()
 	expected := runtime.NewVersionData(
 		[]byte("node"),
 		[]byte("gossamer-node"),
@@ -148,23 +147,7 @@ func TestInstance_Version_DevRuntime(t *testing.T) {
 		1,
 	)
 
-	gen, err := genesis.NewGenesisFromJSON("../../../chain/dev/genesis-spec.json", 0)
-	require.NoError(t, err)
-
-	genTrie, err := genesis.NewTrieFromGenesis(gen)
-	require.NoError(t, err)
-
-	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
-
-	cfg := &Config{}
-	cfg.Storage = genState
-	cfg.LogLvl = 4
-
-	instance, err := NewRuntimeFromGenesis(gen, cfg)
-	require.NoError(t, err)
-	//instance := NewTestInstance(t, runtime.DEV_RUNTIME)
+	instance := NewTestInstance(t, runtime.DEV_RUNTIME)
 
 	version, err := instance.Version()
 	require.Nil(t, err)
@@ -298,6 +281,24 @@ func TestInstance_BabeConfiguration_NodeRuntime_NoAuthorities(t *testing.T) {
 		EpochLength:        200,
 		C1:                 1,
 		C2:                 4,
+		GenesisAuthorities: nil,
+		Randomness:         [32]byte{},
+		SecondarySlots:     1,
+	}
+
+	require.Equal(t, expected, cfg)
+}
+
+func TestInstance_BabeConfiguration_DevRuntime_NoAuthorities(t *testing.T) {
+	rt := NewTestInstance(t, runtime.DEV_RUNTIME)
+	cfg, err := rt.BabeConfiguration()
+	require.NoError(t, err)
+
+	expected := &types.BabeConfiguration{
+		SlotDuration:       3000,
+		EpochLength:        200,
+		C1:                 1,
+		C2:                 1,
 		GenesisAuthorities: nil,
 		Randomness:         [32]byte{},
 		SecondarySlots:     1,

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -136,6 +136,55 @@ func TestInstance_Version_NodeRuntime(t *testing.T) {
 	require.Equal(t, expected.TransactionVersion(), version.TransactionVersion())
 }
 
+func TestInstance_Version_DevRuntime(t *testing.T) {
+	t.Skip()
+	expected := runtime.NewVersionData(
+		[]byte("node"),
+		[]byte("gossamer-node"),
+		10,
+		260,
+		0,
+		nil,
+		1,
+	)
+
+	gen, err := genesis.NewGenesisFromJSON("../../../chain/dev/genesis-spec.json", 0)
+	require.NoError(t, err)
+
+	genTrie, err := genesis.NewTrieFromGenesis(gen)
+	require.NoError(t, err)
+
+	// set state to genesis state
+	genState, err := storage.NewTrieState(genTrie)
+	require.NoError(t, err)
+
+	cfg := &Config{}
+	cfg.Storage = genState
+	cfg.LogLvl = 4
+
+	instance, err := NewRuntimeFromGenesis(gen, cfg)
+	require.NoError(t, err)
+	//instance := NewTestInstance(t, runtime.DEV_RUNTIME)
+
+	version, err := instance.Version()
+	require.Nil(t, err)
+
+	t.Logf("SpecName: %s\n", version.SpecName())
+	t.Logf("ImplName: %s\n", version.ImplName())
+	t.Logf("AuthoringVersion: %d\n", version.AuthoringVersion())
+	t.Logf("SpecVersion: %d\n", version.SpecVersion())
+	t.Logf("ImplVersion: %d\n", version.ImplVersion())
+	t.Logf("TransactionVersion: %d\n", version.TransactionVersion())
+
+	require.Equal(t, 12, len(version.APIItems()))
+	require.Equal(t, expected.SpecName(), version.SpecName())
+	require.Equal(t, expected.ImplName(), version.ImplName())
+	require.Equal(t, expected.AuthoringVersion(), version.AuthoringVersion())
+	require.Equal(t, expected.SpecVersion(), version.SpecVersion())
+	require.Equal(t, expected.ImplVersion(), version.ImplVersion())
+	require.Equal(t, expected.TransactionVersion(), version.TransactionVersion())
+}
+
 func balanceKey(t *testing.T, pub []byte) []byte { //nolint
 	h0, err := common.Twox128Hash([]byte("System"))
 	require.NoError(t, err)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -57,6 +57,7 @@ package wasmer
 // extern int64_t ext_default_child_storage_root_version_1(void *context, int64_t a);
 // extern void ext_default_child_storage_set_version_1(void *context, int64_t a, int64_t b, int64_t c);
 // extern void ext_default_child_storage_storage_kill_version_1(void *context, int64_t a);
+// extern int32_t ext_default_child_storage_storage_kill_version_2(void *context, int64_t a, int64_t b);
 // extern void ext_default_child_storage_clear_prefix_version_1(void *context, int64_t a, int64_t b);
 // extern int32_t ext_default_child_storage_exists_version_1(void *context, int64_t a, int64_t b);
 //
@@ -1084,6 +1085,20 @@ func ext_default_child_storage_storage_kill_version_1(context unsafe.Pointer, ch
 	storage.DeleteChild(childStorageKey)
 }
 
+//export ext_default_child_storage_storage_kill_version_2
+func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer, a, b C.int64_t) C.int32_t {
+	logger.Debug("[ext_default_child_storage_storage_kill_version_2] executing...")
+	logger.Warn("[ext_default_child_storage_storage_kill_version_2] unimplemented")
+
+	// instanceContext := wasm.IntoInstanceContext(context)
+	// ctx := instanceContext.Data().(*runtime.Context)
+	// storage := ctx.Storage
+
+	// childStorageKey := asMemorySlice(instanceContext, childStorageKeySpan)
+	// storage.DeleteChild(childStorageKey)
+	return 0
+}
+
 //export ext_allocator_free_version_1
 func ext_allocator_free_version_1(context unsafe.Pointer, addr C.int32_t) {
 	logger.Trace("[ext_allocator_free_version_1] executing...")
@@ -1939,6 +1954,10 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 		return nil, err
 	}
 	_, err = imports.Append("ext_default_child_storage_storage_kill_version_1", ext_default_child_storage_storage_kill_version_1, C.ext_default_child_storage_storage_kill_version_1)
+	if err != nil {
+		return nil, err
+	}
+	_, err = imports.Append("ext_default_child_storage_storage_kill_version_2", ext_default_child_storage_storage_kill_version_2, C.ext_default_child_storage_storage_kill_version_2)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -57,7 +57,6 @@ package wasmer
 // extern int64_t ext_default_child_storage_root_version_1(void *context, int64_t a);
 // extern void ext_default_child_storage_set_version_1(void *context, int64_t a, int64_t b, int64_t c);
 // extern void ext_default_child_storage_storage_kill_version_1(void *context, int64_t a);
-// extern int32_t ext_default_child_storage_storage_kill_version_2(void *context, int64_t a, int64_t b);
 // extern void ext_default_child_storage_clear_prefix_version_1(void *context, int64_t a, int64_t b);
 // extern int32_t ext_default_child_storage_exists_version_1(void *context, int64_t a, int64_t b);
 //
@@ -1085,20 +1084,6 @@ func ext_default_child_storage_storage_kill_version_1(context unsafe.Pointer, ch
 	storage.DeleteChild(childStorageKey)
 }
 
-//export ext_default_child_storage_storage_kill_version_2
-func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer, a, b C.int64_t) C.int32_t {
-	logger.Debug("[ext_default_child_storage_storage_kill_version_2] executing...")
-	logger.Warn("[ext_default_child_storage_storage_kill_version_2] unimplemented")
-
-	// instanceContext := wasm.IntoInstanceContext(context)
-	// ctx := instanceContext.Data().(*runtime.Context)
-	// storage := ctx.Storage
-
-	// childStorageKey := asMemorySlice(instanceContext, childStorageKeySpan)
-	// storage.DeleteChild(childStorageKey)
-	return 0
-}
-
 //export ext_allocator_free_version_1
 func ext_allocator_free_version_1(context unsafe.Pointer, addr C.int32_t) {
 	logger.Trace("[ext_allocator_free_version_1] executing...")
@@ -1954,10 +1939,6 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 		return nil, err
 	}
 	_, err = imports.Append("ext_default_child_storage_storage_kill_version_1", ext_default_child_storage_storage_kill_version_1, C.ext_default_child_storage_storage_kill_version_1)
-	if err != nil {
-		return nil, err
-	}
-	_, err = imports.Append("ext_default_child_storage_storage_kill_version_2", ext_default_child_storage_storage_kill_version_2, C.ext_default_child_storage_storage_kill_version_2)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1292,7 +1292,7 @@ func ext_hashing_twox_64_version_1(context unsafe.Pointer, dataSpan C.int64_t) C
 }
 
 //export ext_offchain_index_set_version_1
-func ext_offchain_index_set_version_1(context unsafe.Pointer, a, b C.int64_t) {
+func ext_offchain_index_set_version_1(context unsafe.Pointer, keySpan, valueSpan C.int64_t) {
 	logger.Trace("[ext_offchain_index_set_version_1] executing...")
 	logger.Warn("[ext_offchain_index_set_version_1] unimplemented")
 }

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -192,3 +192,19 @@ func GetKusamaGenesisPath() string {
 
 	return fp
 }
+
+// GetDevGenesisPath gets the dev genesis path
+func GetDevGenesisPath() string {
+	path1 := "../chain/dev/genesis.json"
+	path2 := "../../chain/dev/genesis.json"
+
+	var fp string
+
+	if PathExists(path1) {
+		fp, _ = filepath.Abs(path1)
+	} else if PathExists(path2) {
+		fp, _ = filepath.Abs(path2)
+	}
+
+	return fp
+}

--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -37,12 +37,8 @@ func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 
 	utils.CreateDefaultConfig()
 	defer os.Remove(utils.ConfigDefault)
-	utils.GenerateGenesisOneAuth()
-	defer os.Remove(utils.GenesisOneAuth)
-	// utils.CreateConfigBabeMaxThreshold()
-	// defer os.Remove(utils.ConfigBABEMaxThreshold)
 
-	nodes, err := utils.InitializeAndStartNodesWebsocket(t, 1, utils.GenesisOneAuth, utils.ConfigDefault)
+	nodes, err := utils.InitializeAndStartNodesWebsocket(t, 1, utils.GenesisDev, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	command := "npx mocha ./test"

--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -39,10 +39,10 @@ func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 	defer os.Remove(utils.ConfigDefault)
 	utils.GenerateGenesisOneAuth()
 	defer os.Remove(utils.GenesisOneAuth)
-	utils.CreateConfigBabeMaxThreshold()
-	defer os.Remove(utils.ConfigBABEMaxThreshold)
+	// utils.CreateConfigBabeMaxThreshold()
+	// defer os.Remove(utils.ConfigBABEMaxThreshold)
 
-	nodes, err := utils.InitializeAndStartNodesWebsocket(t, 1, utils.GenesisOneAuth, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodesWebsocket(t, 1, utils.GenesisOneAuth, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	command := "npx mocha ./test"

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -41,13 +41,11 @@ func TestAuthorSubmitExtrinsic(t *testing.T) {
 
 	t.Log("starting gossamer...")
 
-	utils.CreateConfigBabeMaxThreshold()
-	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDev, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	defer func() {
 		t.Log("going to tear down gossamer...")
-		os.Remove(utils.ConfigBABEMaxThreshold)
 		errList := utils.TearDown(t, nodes)
 		require.Len(t, errList, 0)
 	}()

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -71,11 +71,8 @@ func TestChainRPC(t *testing.T) {
 		},
 	}
 
-	utils.CreateConfigBabeMaxThreshold()
-	defer os.Remove(utils.ConfigBABEMaxThreshold)
-
 	t.Log("starting gossamer...")
-	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDev, utils.ConfigDefault)
 	require.Nil(t, err)
 
 	time.Sleep(time.Second) // give server a second to start
@@ -188,13 +185,8 @@ func TestChainSubscriptionRPC(t *testing.T) {
 		},
 	}
 
-	utils.GenerateGenesisOneAuth()
-	defer os.Remove(utils.GenesisOneAuth)
-	utils.CreateConfigBabeMaxThreshold()
-	defer os.Remove(utils.ConfigBABEMaxThreshold)
-
 	t.Log("starting gossamer...")
-	nodes, err := utils.InitializeAndStartNodesWebsocket(t, 1, utils.GenesisOneAuth, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodesWebsocket(t, 1, utils.GenesisDev, utils.ConfigDefault)
 	require.Nil(t, err)
 
 	time.Sleep(time.Second) // give server a second to start

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -162,11 +162,7 @@ func TestStateRPCAPI(t *testing.T) {
 	}
 
 	t.Log("starting gossamer...")
-
-	utils.CreateConfigBabeMaxThreshold()
-	defer os.Remove(utils.ConfigBABEMaxThreshold)
-
-	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDev, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	defer func() {
@@ -367,11 +363,7 @@ func TestRPCStructParamUnmarshal(t *testing.T) {
 	}
 
 	t.Log("starting gossamer...")
-
-	utils.CreateConfigBabeMaxThreshold()
-	defer os.Remove(utils.ConfigBABEMaxThreshold)
-
-	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDev, utils.ConfigDefault)
 	require.Nil(t, err)
 
 	defer func() {

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -162,7 +162,7 @@ func TestStateRPCAPI(t *testing.T) {
 	}
 
 	t.Log("starting gossamer...")
-	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDev, utils.ConfigDefault)
+	nodes, err := utils.InitializeAndStartNodes(t, 1, utils.GenesisDefault, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	defer func() {

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -27,11 +27,8 @@ import (
 )
 
 func TestStress_Grandpa_OneAuthority(t *testing.T) {
-	utils.GenerateGenesisOneAuth()
-	defer os.Remove(utils.GenesisOneAuth)
-
 	numNodes := 1
-	nodes, err := utils.InitializeAndStartNodes(t, numNodes, utils.GenesisOneAuth, utils.ConfigDefault)
+	nodes, err := utils.InitializeAndStartNodes(t, numNodes, utils.GenesisDev, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	defer func() {

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -31,7 +31,7 @@ func TestStress_Grandpa_OneAuthority(t *testing.T) {
 	defer os.Remove(utils.GenesisOneAuth)
 
 	numNodes := 1
-	nodes, err := utils.InitializeAndStartNodes(t, numNodes, utils.GenesisOneAuth, utils.ConfigBABEMaxThreshold)
+	nodes, err := utils.InitializeAndStartNodes(t, numNodes, utils.GenesisOneAuth, utils.ConfigDefault)
 	require.NoError(t, err)
 
 	defer func() {

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -358,7 +358,7 @@ func TestSync_Restart(t *testing.T) {
 	close(done)
 }
 
-func TestStress_SubmitExtrinsic(t *testing.T) {
+func TestSync_SubmitExtrinsic(t *testing.T) {
 	t.Log("starting gossamer...")
 
 	//utils.CreateConfigBabeMaxThreshold()

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -99,13 +99,13 @@ func TestSync_SingleBlockProducer(t *testing.T) {
 
 	// start block producing node first
 	//nolint
-	node, err := utils.RunGossamer(t, numNodes-1, utils.TestDir(t, utils.KeyList[numNodes-1]), utils.GenesisDefault, utils.ConfigBABEMaxThreshold, false)
+	node, err := utils.RunGossamer(t, numNodes-1, utils.TestDir(t, utils.KeyList[numNodes-1]), utils.GenesisDev, utils.ConfigDefault, false)
 	require.NoError(t, err)
 
 	// wait and start rest of nodes - if they all start at the same time the first round usually doesn't complete since
 	// all nodes vote for different blocks.
 	time.Sleep(time.Second * 15)
-	nodes, err := utils.InitializeAndStartNodes(t, numNodes-1, utils.GenesisDefault, utils.ConfigNoBABE)
+	nodes, err := utils.InitializeAndStartNodes(t, numNodes-1, utils.GenesisDev, utils.ConfigNoBABE)
 	require.NoError(t, err)
 	nodes = append(nodes, node)
 
@@ -185,12 +185,12 @@ func TestSync_SingleSyncingNode(t *testing.T) {
 	utils.SetLogLevel(log.LvlInfo)
 
 	// start block producing node
-	alice, err := utils.RunGossamer(t, 0, utils.TestDir(t, utils.KeyList[0]), utils.GenesisDefault, utils.ConfigBABEMaxThreshold, false)
+	alice, err := utils.RunGossamer(t, 0, utils.TestDir(t, utils.KeyList[0]), utils.GenesisDev, utils.ConfigDefault, false)
 	require.NoError(t, err)
 	time.Sleep(time.Second * 15)
 
 	// start syncing node
-	bob, err := utils.RunGossamer(t, 1, utils.TestDir(t, utils.KeyList[1]), utils.GenesisDefault, utils.ConfigNoBABE, false)
+	bob, err := utils.RunGossamer(t, 1, utils.TestDir(t, utils.KeyList[1]), utils.GenesisDev, utils.ConfigNoBABE, false)
 	require.NoError(t, err)
 
 	nodes := []*utils.Node{alice, bob}
@@ -237,7 +237,7 @@ func TestSync_Bench(t *testing.T) {
 	numBlocks := 64
 
 	// start block producing node
-	alice, err := utils.RunGossamer(t, 0, utils.TestDir(t, utils.KeyList[1]), utils.GenesisDefault, utils.ConfigBABEMaxThreshold, false)
+	alice, err := utils.RunGossamer(t, 0, utils.TestDir(t, utils.KeyList[1]), utils.GenesisDev, utils.ConfigDefault, false)
 	require.NoError(t, err)
 
 	for {
@@ -258,7 +258,7 @@ func TestSync_Bench(t *testing.T) {
 	t.Log("BABE paused")
 
 	// start syncing node
-	bob, err := utils.RunGossamer(t, 1, utils.TestDir(t, utils.KeyList[0]), utils.GenesisDefault, utils.ConfigNoBABE, false)
+	bob, err := utils.RunGossamer(t, 1, utils.TestDir(t, utils.KeyList[0]), utils.GenesisDev, utils.ConfigNoBABE, false)
 	require.NoError(t, err)
 
 	nodes := []*utils.Node{alice, bob}
@@ -312,7 +312,7 @@ func TestSync_Restart(t *testing.T) {
 
 	// start block producing node first
 	//nolint
-	node, err := utils.RunGossamer(t, numNodes-1, utils.TestDir(t, utils.KeyList[numNodes-1]), utils.GenesisDefault, utils.ConfigBABEMaxThreshold, false)
+	node, err := utils.RunGossamer(t, numNodes-1, utils.TestDir(t, utils.KeyList[numNodes-1]), utils.GenesisDefault, utils.ConfigDefault, false)
 	require.NoError(t, err)
 
 	// wait and start rest of nodes
@@ -358,27 +358,27 @@ func TestSync_Restart(t *testing.T) {
 	close(done)
 }
 
-func TestPendingExtrinsic(t *testing.T) {
+func TestStress_SubmitExtrinsic(t *testing.T) {
 	t.Log("starting gossamer...")
 
-	utils.CreateConfigBabeMaxThreshold()
+	//utils.CreateConfigBabeMaxThreshold()
 
 	numNodes := 3
 	// index of node to submit tx to
 	idx := numNodes - 1 // TODO: randomise this
 
 	// start block producing node first
-	node, err := utils.RunGossamer(t, numNodes-1, utils.TestDir(t, utils.KeyList[numNodes-1]), utils.GenesisDefault, utils.ConfigBABEMaxThreshold, false)
+	node, err := utils.RunGossamer(t, numNodes-1, utils.TestDir(t, utils.KeyList[numNodes-1]), utils.GenesisDev, utils.ConfigDefault, false)
 	require.NoError(t, err)
 
 	// Start rest of nodes
-	nodes, err := utils.InitializeAndStartNodes(t, numNodes-1, utils.GenesisDefault, utils.ConfigNoBABE)
+	nodes, err := utils.InitializeAndStartNodes(t, numNodes-1, utils.GenesisDev, utils.ConfigNoBABE)
 	require.NoError(t, err)
 	nodes = append(nodes, node)
 
 	defer func() {
 		t.Log("going to tear down gossamer...")
-		os.Remove(utils.ConfigBABEMaxThreshold)
+		//os.Remove(utils.ConfigBABEMaxThreshold)
 		errList := utils.StopNodes(t, nodes)
 		require.Len(t, errList, 0)
 	}()

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -48,7 +48,6 @@ func TestMain(m *testing.M) {
 	}
 
 	utils.CreateConfigNoBabe()
-	//utils.CreateConfigBabeMaxThreshold()
 	utils.CreateDefaultConfig()
 
 	logLvl := log.LvlInfo
@@ -70,7 +69,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	os.Remove(utils.ConfigNoBABE)
-	//os.Remove(utils.ConfigBABEMaxThreshold)
 	os.Remove(utils.ConfigDefault)
 	os.Exit(code)
 }
@@ -232,7 +230,6 @@ func TestSync_ManyProducers(t *testing.T) {
 }
 
 func TestSync_Bench(t *testing.T) {
-	//t.Skip() // TODO: fix this test
 	utils.SetLogLevel(log.LvlInfo)
 	numBlocks := 64
 
@@ -361,8 +358,6 @@ func TestSync_Restart(t *testing.T) {
 func TestSync_SubmitExtrinsic(t *testing.T) {
 	t.Log("starting gossamer...")
 
-	//utils.CreateConfigBabeMaxThreshold()
-
 	numNodes := 3
 	// index of node to submit tx to
 	idx := numNodes - 1 // TODO: randomise this
@@ -378,7 +373,6 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 
 	defer func() {
 		t.Log("going to tear down gossamer...")
-		//os.Remove(utils.ConfigBABEMaxThreshold)
 		errList := utils.StopNodes(t, nodes)
 		require.Len(t, errList, 0)
 	}()

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 	}
 
 	utils.CreateConfigNoBabe()
-	utils.CreateConfigBabeMaxThreshold()
+	//utils.CreateConfigBabeMaxThreshold()
 	utils.CreateDefaultConfig()
 
 	logLvl := log.LvlInfo
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	os.Remove(utils.ConfigNoBABE)
-	os.Remove(utils.ConfigBABEMaxThreshold)
+	//os.Remove(utils.ConfigBABEMaxThreshold)
 	os.Remove(utils.ConfigDefault)
 	os.Exit(code)
 }

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -76,6 +76,10 @@ var (
 	ConfigLogGrandpa string = filepath.Join(currentDir, "../utils/config_log_grandpa.toml")
 	// ConfigNoBABE is a config file with BABE disabled
 	ConfigNoBABE string = filepath.Join(currentDir, "../utils/config_nobabe.toml")
+	// ConfigNoGrandpa is a config file with grandpa disabled
+	ConfigNoGrandpa string = filepath.Join(currentDir, "../utils/config_nograndpa.toml")
+	// ConfigNotAuthority is a config file with no authority functionality
+	ConfigNotAuthority string = filepath.Join(currentDir, "../utils/config_notauthority.toml")
 )
 
 // Node represents a gossamer process
@@ -501,4 +505,30 @@ func generateConfigNoBabe() *ctoml.Config {
 func CreateConfigNoBabe() {
 	cfg := generateConfigNoBabe()
 	_ = dot.ExportTomlConfig(cfg, ConfigNoBABE)
+}
+
+func generateConfigNoGrandpa() *ctoml.Config {
+	cfg := generateDefaultConfig()
+	cfg.Core.GrandpaAuthority = false
+	return cfg
+}
+
+// CreateConfigNoGrandpa generates and creates no grandpa config file.
+func CreateConfigNoGrandpa() {
+	cfg := generateConfigNoGrandpa()
+	_ = dot.ExportTomlConfig(cfg, ConfigNoGrandpa)
+}
+
+func generateConfigNotAuthority() *ctoml.Config {
+	cfg := generateDefaultConfig()
+	cfg.Core.Roles = 1
+	cfg.Core.BabeAuthority = false
+	cfg.Core.GrandpaAuthority = false
+	return cfg
+}
+
+// CreateConfigNotAuthority generates and creates non-authority config file.
+func CreateConfigNotAuthority() {
+	cfg := generateConfigNotAuthority()
+	_ = dot.ExportTomlConfig(cfg, ConfigNotAuthority)
 }

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -76,8 +76,6 @@ var (
 	ConfigLogGrandpa string = filepath.Join(currentDir, "../utils/config_log_grandpa.toml")
 	// ConfigNoBABE is a config file with BABE disabled
 	ConfigNoBABE string = filepath.Join(currentDir, "../utils/config_nobabe.toml")
-	// ConfigBABEMaxThreshold is a config file with BABE threshold set to maximum (node can produce block every slot)
-	//ConfigBABEMaxThreshold string = filepath.Join(currentDir, "../utils/config_babe_max_threshold.toml")
 )
 
 // Node represents a gossamer process
@@ -469,31 +467,6 @@ func CreateDefaultConfig() {
 	_ = dot.ExportTomlConfig(cfg, ConfigDefault)
 }
 
-// func generateConfigBabeMaxThreshold() *ctoml.Config {
-// 	cfg := generateDefaultConfig()
-// 	cfg.Log = ctoml.LogConfig{
-// 		SyncLvl:          "debug",
-// 		NetworkLvl:       "debug",
-// 		BlockProducerLvl: "info",
-// 	}
-// 	cfg.Core = ctoml.CoreConfig{
-// 		Roles:                    4,
-// 		BabeAuthority:            true,
-// 		GrandpaAuthority:         true,
-// 		BabeThresholdNumerator:   1,
-// 		BabeThresholdDenominator: 1,
-// 		SlotDuration:             3000,
-// 	}
-// 	cfg.RPC.Modules = []string{"system", "author", "chain", "state", "dev", "rpc"}
-// 	return cfg
-// }
-
-// // CreateConfigBabeMaxThreshold generates and creates babe max threshold config file.
-// func CreateConfigBabeMaxThreshold() {
-// 	cfg := generateConfigBabeMaxThreshold()
-// 	_ = dot.ExportTomlConfig(cfg, ConfigBABEMaxThreshold)
-// }
-
 func generateConfigLogGrandpa() *ctoml.Config {
 	cfg := generateDefaultConfig()
 	cfg.Log = ctoml.LogConfig{
@@ -519,8 +492,7 @@ func generateConfigNoBabe() *ctoml.Config {
 		SyncLvl:    "debug",
 		NetworkLvl: "debug",
 	}
-	// cfg.Core.BabeThresholdNumerator = 1
-	// cfg.Core.BabeThresholdDenominator = 1
+
 	cfg.Core.BabeAuthority = false
 	return cfg
 }

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -67,6 +67,8 @@ var (
 	GenesisSixAuths string = filepath.Join(currentDir, "../utils/genesis_sixauths.json")
 	// GenesisDefault is the default gssmr genesis file
 	GenesisDefault string = filepath.Join(currentDir, "../..", "chain/gssmr/genesis.json")
+	// GenesisDev is the default dev genesis file
+	GenesisDev string = filepath.Join(currentDir, "../..", "chain/dev/genesis.json")
 
 	// ConfigDefault is the default config file
 	ConfigDefault string = filepath.Join(currentDir, "../utils/config_default.toml")
@@ -75,7 +77,7 @@ var (
 	// ConfigNoBABE is a config file with BABE disabled
 	ConfigNoBABE string = filepath.Join(currentDir, "../utils/config_nobabe.toml")
 	// ConfigBABEMaxThreshold is a config file with BABE threshold set to maximum (node can produce block every slot)
-	ConfigBABEMaxThreshold string = filepath.Join(currentDir, "../utils/config_babe_max_threshold.toml")
+	//ConfigBABEMaxThreshold string = filepath.Join(currentDir, "../utils/config_babe_max_threshold.toml")
 )
 
 // Node represents a gossamer process
@@ -392,7 +394,7 @@ func TestDir(t *testing.T, name string) string {
 
 // GenerateGenesisOneAuth generates Genesis file with one authority.
 func GenerateGenesisOneAuth() {
-	bs, err := dot.BuildFromGenesis(utils.GetGssmrGenesisPath(), 1)
+	bs, err := dot.BuildFromGenesis(utils.GetDevGenesisPath(), 1)
 	if err != nil {
 		logger.Error("genesis file not found", "error", err)
 		os.Exit(1)
@@ -467,30 +469,30 @@ func CreateDefaultConfig() {
 	_ = dot.ExportTomlConfig(cfg, ConfigDefault)
 }
 
-func generateConfigBabeMaxThreshold() *ctoml.Config {
-	cfg := generateDefaultConfig()
-	cfg.Log = ctoml.LogConfig{
-		SyncLvl:          "debug",
-		NetworkLvl:       "debug",
-		BlockProducerLvl: "info",
-	}
-	cfg.Core = ctoml.CoreConfig{
-		Roles:                    4,
-		BabeAuthority:            true,
-		GrandpaAuthority:         true,
-		BabeThresholdNumerator:   1,
-		BabeThresholdDenominator: 1,
-		SlotDuration:             3000,
-	}
-	cfg.RPC.Modules = []string{"system", "author", "chain", "state", "dev", "rpc"}
-	return cfg
-}
+// func generateConfigBabeMaxThreshold() *ctoml.Config {
+// 	cfg := generateDefaultConfig()
+// 	cfg.Log = ctoml.LogConfig{
+// 		SyncLvl:          "debug",
+// 		NetworkLvl:       "debug",
+// 		BlockProducerLvl: "info",
+// 	}
+// 	cfg.Core = ctoml.CoreConfig{
+// 		Roles:                    4,
+// 		BabeAuthority:            true,
+// 		GrandpaAuthority:         true,
+// 		BabeThresholdNumerator:   1,
+// 		BabeThresholdDenominator: 1,
+// 		SlotDuration:             3000,
+// 	}
+// 	cfg.RPC.Modules = []string{"system", "author", "chain", "state", "dev", "rpc"}
+// 	return cfg
+// }
 
-// CreateConfigBabeMaxThreshold generates and creates babe max threshold config file.
-func CreateConfigBabeMaxThreshold() {
-	cfg := generateConfigBabeMaxThreshold()
-	_ = dot.ExportTomlConfig(cfg, ConfigBABEMaxThreshold)
-}
+// // CreateConfigBabeMaxThreshold generates and creates babe max threshold config file.
+// func CreateConfigBabeMaxThreshold() {
+// 	cfg := generateConfigBabeMaxThreshold()
+// 	_ = dot.ExportTomlConfig(cfg, ConfigBABEMaxThreshold)
+// }
 
 func generateConfigLogGrandpa() *ctoml.Config {
 	cfg := generateDefaultConfig()
@@ -517,8 +519,8 @@ func generateConfigNoBabe() *ctoml.Config {
 		SyncLvl:    "debug",
 		NetworkLvl: "debug",
 	}
-	cfg.Core.BabeThresholdNumerator = 1
-	cfg.Core.BabeThresholdDenominator = 1
+	// cfg.Core.BabeThresholdNumerator = 1
+	// cfg.Core.BabeThresholdDenominator = 1
 	cfg.Core.BabeAuthority = false
 	return cfg
 }

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -68,7 +68,7 @@ var (
 	// GenesisDefault is the default gssmr genesis file
 	GenesisDefault string = filepath.Join(currentDir, "../..", "chain/gssmr/genesis.json")
 	// GenesisDev is the default dev genesis file
-	GenesisDev string = filepath.Join(currentDir, "../..", "chain/dev/genesis.json")
+	GenesisDev string = filepath.Join(currentDir, "../..", "chain/dev/genesis-spec.json")
 
 	// ConfigDefault is the default config file
 	ConfigDefault string = filepath.Join(currentDir, "../utils/config_default.toml")

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -390,15 +390,15 @@ func TestDir(t *testing.T, name string) string {
 	return filepath.Join("/tmp/", t.Name(), name)
 }
 
-// GenerateGenesisOneAuth generates Genesis file with one authority.
-func GenerateGenesisOneAuth() {
-	bs, err := dot.BuildFromGenesis(utils.GetDevGenesisPath(), 1)
-	if err != nil {
-		logger.Error("genesis file not found", "error", err)
-		os.Exit(1)
-	}
-	_ = dot.CreateJSONRawFile(bs, GenesisOneAuth)
-}
+// // GenerateGenesisOneAuth generates Genesis file with one authority.
+// func GenerateGenesisOneAuth() {
+// 	bs, err := dot.BuildFromGenesis(utils.GetDevGenesisPath(), 1)
+// 	if err != nil {
+// 		logger.Error("genesis file not found", "error", err)
+// 		os.Exit(1)
+// 	}
+// 	_ = dot.CreateJSONRawFile(bs, GenesisOneAuth)
+// }
 
 // GenerateGenesisThreeAuth generates Genesis file with three authority.
 func GenerateGenesisThreeAuth() {

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -394,16 +394,6 @@ func TestDir(t *testing.T, name string) string {
 	return filepath.Join("/tmp/", t.Name(), name)
 }
 
-// // GenerateGenesisOneAuth generates Genesis file with one authority.
-// func GenerateGenesisOneAuth() {
-// 	bs, err := dot.BuildFromGenesis(utils.GetDevGenesisPath(), 1)
-// 	if err != nil {
-// 		logger.Error("genesis file not found", "error", err)
-// 		os.Exit(1)
-// 	}
-// 	_ = dot.CreateJSONRawFile(bs, GenesisOneAuth)
-// }
-
 // GenerateGenesisThreeAuth generates Genesis file with three authority.
 func GenerateGenesisThreeAuth() {
 	bs, err := dot.BuildFromGenesis(utils.GetGssmrGenesisPath(), 3)


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add --chain dev option which creates a development chain that has 1 authority and authors a block every slot (babe threshold c parameter was configured to be (1, 1) in the runtime)
- turn on RPC and WS servers by default for dev chain
- fix issues with BABE slot calculation that was causing the node not to author due to incorrect slot number/epoch calculations
- remove babe threshold numerator and denominator from configuration as now the dev runtime can be used to "force" block authoring
- update integration tests to use dev genesis file


see modified runtime here:
https://github.com/noot/substrate/blob/noot/v0.8-dev-runtime/bin/node/runtime/src/lib.rs#L107
https://github.com/noot/substrate/blob/noot/v0.8-dev-runtime/bin/node/runtime/src/lib.rs#L1071

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
./bin/gossamer --chain dev init 
./bin/gossamer --chain dev
```

blocks should be authored every slot, if you stop and restart the node it should still continue to do that on restart

```
make it-rpc
make it-stress
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1408 closes #1409
