### PR TITLE
fix(cmd): update deprecated package

### DIFF
--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -31,7 +31,7 @@ import (
 	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
-	"golang.org/x/crypto/ssh/terminal" //nolint
+	terminal "golang.org/x/term"
 )
 
 const confirmCharacter = "Y"

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
+	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/protobuf v1.25.0
 )


### PR DESCRIPTION
## Changes
- use `golang.org/x/term` package instead of `golang.org/x/crypto/ssh/terminal`

## Tests

```
make gossamer
./bin/gossamer account --generate
```
This command should shows up a password promp

## Issues
- Closes #1599
