### PR TITLE
fix(dot/network): check if peer supports protocol

### DIFF
--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -362,6 +362,17 @@ func (h *host) peers() []peer.ID {
 	return h.h.Network().Peers()
 }
 
+// getPeerProtocols returns all the supported protocols to one peer
+// returns an error if could not get peer protocols
+func (h *host) supportsProtocol(peerID peer.ID, protocol protocol.ID) (bool, error) {
+	peerProtocols, err := h.h.Network().Peerstore().SupportsProtocols(peerID, string(protocol))
+	if err != nil {
+		return false, err
+	}
+
+	return len(peerProtocols) > 0, nil
+}
+
 // peerCount returns the number of connected peers
 func (h *host) peerCount() int {
 	peers := h.h.Network().Peers()

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -365,7 +365,7 @@ func (h *host) peers() []peer.ID {
 // supportsProtocol checks if the protocol is supported by peerID
 // returns an error if could not get peer protocols
 func (h *host) supportsProtocol(peerID peer.ID, protocol protocol.ID) (bool, error) {
-	peerProtocols, err := h.h.Network().Peerstore().SupportsProtocols(peerID, string(protocol))
+	peerProtocols, err := h.h.Peerstore().SupportsProtocols(peerID, string(protocol))
 	if err != nil {
 		return false, err
 	}

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -362,7 +362,7 @@ func (h *host) peers() []peer.ID {
 	return h.h.Network().Peers()
 }
 
-// getPeerProtocols returns all the supported protocols to one peer
+// supportsProtocol checks if the protocol is supported by peerID
 // returns an error if could not get peer protocols
 func (h *host) supportsProtocol(peerID peer.ID, protocol protocol.ID) (bool, error) {
 	peerProtocols, err := h.h.Network().Peerstore().SupportsProtocols(peerID, string(protocol))

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -198,6 +198,12 @@ func (s *Service) createNotificationsMessageHandler(info *notificationsProtocol,
 }
 
 func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtocol, msg NotificationsMessage) {
+	support, err := s.host.supportsProtocol(peer, info.protocolID)
+	if err != nil || !support {
+		logger.Warn("the peer does not supports the protocol", "protocol", info.protocolID, "peer", peer, "err", err)
+		return
+	}
+
 	hsData, has := info.getHandshakeData(peer, false)
 	if has && !hsData.validated {
 		// peer has sent us an invalid handshake in the past, ignore
@@ -263,7 +269,7 @@ func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtoc
 	// we've completed the handshake with the peer, send message directly
 	logger.Trace("sending message", "protocol", info.protocolID, "peer", peer, "message", msg)
 
-	err := s.host.writeToStream(hsData.stream, msg)
+	err = s.host.writeToStream(hsData.stream, msg)
 	if err != nil {
 		logger.Trace("failed to send message to peer", "peer", peer, "error", err)
 	}

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -199,7 +199,7 @@ func (s *Service) createNotificationsMessageHandler(info *notificationsProtocol,
 
 func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtocol, msg NotificationsMessage) {
 	if support, err := s.host.supportsProtocol(peer, info.protocolID); err != nil || !support {
-		logger.Warn("the peer does not supports the protocol", "protocol", info.protocolID, "peer", peer, "err", err)
+		logger.Debug("the peer does not supports the protocol", "protocol", info.protocolID, "peer", peer, "err", err)
 		return
 	}
 

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -198,8 +198,7 @@ func (s *Service) createNotificationsMessageHandler(info *notificationsProtocol,
 }
 
 func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtocol, msg NotificationsMessage) {
-	support, err := s.host.supportsProtocol(peer, info.protocolID)
-	if err != nil || !support {
+	if support, err := s.host.supportsProtocol(peer, info.protocolID); err != nil || !support {
 		logger.Warn("the peer does not supports the protocol", "protocol", info.protocolID, "peer", peer, "err", err)
 		return
 	}
@@ -269,7 +268,7 @@ func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtoc
 	// we've completed the handshake with the peer, send message directly
 	logger.Trace("sending message", "protocol", info.protocolID, "peer", peer, "message", msg)
 
-	err = s.host.writeToStream(hsData.stream, msg)
+	err := s.host.writeToStream(hsData.stream, msg)
 	if err != nil {
 		logger.Trace("failed to send message to peer", "peer", peer, "error", err)
 	}


### PR DESCRIPTION
## Changes

- Encapsulate `peerstore.SupportsProtocols` function
- Check if the peer supports protocol before handshake on `sendData` function

## Tests

```
go run go test ^Test_PeerSupportsProtocol$ github.com/ChainSafe/gossamer/dot/network
```

## Issues

- closes #1571 
