### PR TITLE
feat(dot/sync): implement CodeSubstitutes

### DIFF
--- a/dot/services.go
+++ b/dot/services.go
@@ -387,6 +387,7 @@ func createSyncService(cfg *Config, st *state.Service, bp sync.BlockProducer, fg
 		Verifier:         verifier,
 		Runtime:          rt,
 		DigestHandler:    dh,
+		BaseState:        st.Base,
 	}
 
 	return sync.NewService(syncCfg)

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 )
@@ -54,6 +55,11 @@ type StorageState interface {
 	StoreTrie(ts *rtstorage.TrieState) error
 	LoadCodeHash(*common.Hash) (common.Hash, error)
 	SetSyncing(bool)
+}
+
+// BaseState is the interface for the base (genesis) state
+type BaseState interface {
+	LoadGenesisData() (*genesis.Data, error)
 }
 
 // TransactionState is the interface for transaction queue methods

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -33,6 +33,7 @@ type Genesis struct {
 	ForkBlocks         []string               `json:"forkBlocks"`
 	BadBlocks          []string               `json:"badBlocks"`
 	ConsensusEngine    string                 `json:"consensusEngine"`
+	CodeSubstitutes    map[string]string      `json:"codeSubstitutes"`
 }
 
 // Data defines the genesis file data formatted for trie storage

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -48,6 +48,7 @@ type Data struct {
 	ForkBlocks         []string
 	BadBlocks          []string
 	ConsensusEngine    string
+	CodeSubstitutes    map[string]string
 }
 
 // TelemetryEndpoint struct to hold telemetry endpoint information
@@ -75,6 +76,7 @@ func (g *Genesis) GenesisData() *Data {
 		ForkBlocks:         g.ForkBlocks,
 		BadBlocks:          g.BadBlocks,
 		ConsensusEngine:    g.ConsensusEngine,
+		CodeSubstitutes:    g.CodeSubstitutes,
 	}
 }
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implement code to handle code substitutes defined in genesis.json.  wasm code is replaced with code contained in codeSubstitutes map when block is imported with same hash as key in codeSubstitutes map.
-
-

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->
TODO:
```

```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #1619
