### PR TITLE
maintainence: attempt to fix network tests on CI 

### DIFF
--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -168,7 +168,6 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 		config := &network.Config{
 			BasePath:           testDatadirPath,
 			Port:               7001,
-			RandSeed:           1,
 			NoBootstrap:        true,
 			NoMDNS:             true,
 			BlockState:         stateSrvc.Block,

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -89,7 +89,6 @@ func TestHandleBlockAnnounceMessage(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -110,7 +109,6 @@ func TestValidateBlockAnnounceHandshake(t *testing.T) {
 	configA := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -104,7 +104,6 @@ type Config struct {
 // build checks the configuration, sets up the private key for the network service,
 // and applies default values where appropriate
 func (c *Config) build() error {
-
 	// check state configuration
 	err := c.checkState()
 	if err != nil {

--- a/dot/network/connmgr_test.go
+++ b/dot/network/connmgr_test.go
@@ -33,7 +33,6 @@ func TestMaxPeers(t *testing.T) {
 		config := &Config{
 			BasePath:    utils.NewTestBasePath(t, fmt.Sprintf("node%d", i)),
 			Port:        7000 + uint32(i),
-			RandSeed:    1 + int64(i),
 			NoBootstrap: true,
 			NoMDNS:      true,
 			MaxPeers:    max,
@@ -91,7 +90,6 @@ func TestPersistentPeers(t *testing.T) {
 	configA := &Config{
 		BasePath:    utils.NewTestBasePath(t, "node-a"),
 		Port:        7000,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -101,7 +99,6 @@ func TestPersistentPeers(t *testing.T) {
 	configB := &Config{
 		BasePath:        utils.NewTestBasePath(t, "node-b"),
 		Port:            7001,
-		RandSeed:        2,
 		NoMDNS:          true,
 		PersistentPeers: []string{addrs[0].String()},
 	}

--- a/dot/network/discovery_test.go
+++ b/dot/network/discovery_test.go
@@ -135,13 +135,11 @@ func TestBeginDiscovery(t *testing.T) {
 	nodeB := createTestService(t, configB)
 	nodeB.noGossip = true
 
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
@@ -184,24 +182,20 @@ func TestBeginDiscovery_ThreeNodes(t *testing.T) {
 	nodeC.noGossip = true
 
 	// connect A and B
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
 	// connect A and C
-	addrInfosC, err := nodeC.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosC[0])
+	addrInfoC := nodeC.host.addrInfo()
+	err = nodeA.host.connect(addrInfoC)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosC[0])
+		err = nodeA.host.connect(addrInfoC)
 	}
 	require.NoError(t, err)
 

--- a/dot/network/discovery_test.go
+++ b/dot/network/discovery_test.go
@@ -37,7 +37,6 @@ func newTestDiscovery(t *testing.T, num int) []*discovery {
 		config := &Config{
 			BasePath:    utils.NewTestBasePath(t, fmt.Sprintf("node%d", i)),
 			Port:        uint32(7001 + i),
-			RandSeed:    int64(1 + i),
 			NoBootstrap: true,
 			NoMDNS:      true,
 		}
@@ -119,7 +118,6 @@ func TestBeginDiscovery(t *testing.T) {
 	configA := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -130,7 +128,6 @@ func TestBeginDiscovery(t *testing.T) {
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -159,7 +156,6 @@ func TestBeginDiscovery_ThreeNodes(t *testing.T) {
 	configA := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -170,7 +166,6 @@ func TestBeginDiscovery_ThreeNodes(t *testing.T) {
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -181,7 +176,6 @@ func TestBeginDiscovery_ThreeNodes(t *testing.T) {
 	configC := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeC"),
 		Port:        7003,
-		RandSeed:    3,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -36,7 +36,6 @@ func TestGossip(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -49,7 +48,6 @@ func TestGossip(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -73,7 +71,6 @@ func TestGossip(t *testing.T) {
 	configC := &Config{
 		BasePath:    basePathC,
 		Port:        7003,
-		RandSeed:    3,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -56,14 +56,12 @@ func TestGossip(t *testing.T) {
 	handlerB := newTestStreamHandler(testBlockAnnounceMessageDecoder)
 	nodeB.host.registerStreamHandler("", handlerB.handleStream)
 
-	addrInfosA, err := nodeA.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeB.host.connect(*addrInfosA[0])
+	addrInfoA := nodeA.host.addrInfo()
+	err := nodeB.host.connect(addrInfoA)
 	// retry connect if "failed to dial" error
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeB.host.connect(*addrInfosA[0])
+		err = nodeB.host.connect(addrInfoA)
 	}
 	require.NoError(t, err)
 
@@ -79,26 +77,24 @@ func TestGossip(t *testing.T) {
 	handlerC := newTestStreamHandler(testBlockAnnounceMessageDecoder)
 	nodeC.host.registerStreamHandler("", handlerC.handleStream)
 
-	err = nodeC.host.connect(*addrInfosA[0])
+	err = nodeC.host.connect(addrInfoA)
 	// retry connect if "failed to dial" error
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeC.host.connect(*addrInfosA[0])
+		err = nodeC.host.connect(addrInfoA)
 	}
 	require.NoError(t, err)
 
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeC.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err = nodeC.host.connect(addrInfoB)
 	// retry connect if "failed to dial" error
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeC.host.connect(*addrInfosB[0])
+		err = nodeC.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
-	_, err = nodeA.host.send(addrInfosB[0].ID, "", testBlockAnnounceMessage)
+	_, err = nodeA.host.send(addrInfoB.ID, "", testBlockAnnounceMessage)
 	require.NoError(t, err)
 
 	time.Sleep(TestMessageTimeout)

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -48,6 +48,8 @@ var privateCIDRs = []string{
 	"169.254.0.0/16",
 }
 
+var connectTimeout = time.Second * 5
+
 // host wraps libp2p host with network host configuration and services
 type host struct {
 	ctx             context.Context
@@ -241,7 +243,7 @@ func (h *host) registerStreamHandlerWithOverwrite(pid protocol.ID, overwrite boo
 // connect connects the host to a specific peer address
 func (h *host) connect(p peer.AddrInfo) (err error) {
 	h.h.Peerstore().AddAddrs(p.ID, p.Addrs, peerstore.PermanentAddrTTL)
-	ctx, cancel := context.WithTimeout(h.ctx, time.Second*2)
+	ctx, cancel := context.WithTimeout(h.ctx, connectTimeout)
 	defer cancel()
 	err = h.h.Connect(ctx, p)
 	return err

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -379,16 +379,12 @@ func (h *host) peerCount() int {
 	return len(peers)
 }
 
-// addrInfos returns the libp2p AddrInfos of the host
-func (h *host) addrInfos() (addrInfos []*peer.AddrInfo, err error) {
-	for _, multiaddr := range h.multiaddrs() {
-		addrInfo, err := peer.AddrInfoFromP2pAddr(multiaddr)
-		if err != nil {
-			return nil, err
-		}
-		addrInfos = append(addrInfos, addrInfo)
+// addrInfo returns the libp2p peer.AddrInfo of the host
+func (h *host) addrInfo() peer.AddrInfo {
+	return peer.AddrInfo{
+		ID:    h.h.ID(),
+		Addrs: h.h.Addrs(),
 	}
-	return addrInfos, nil
 }
 
 // multiaddrs returns the multiaddresses of the host

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -33,7 +33,6 @@ func TestExternalAddrs(t *testing.T) {
 	config := &Config{
 		BasePath:    utils.NewTestBasePath(t, "node"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -64,7 +63,6 @@ func TestConnect(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -77,7 +75,6 @@ func TestConnect(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -123,7 +120,6 @@ func TestBootstrap(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -138,7 +134,6 @@ func TestBootstrap(t *testing.T) {
 	configB := &Config{
 		BasePath:  basePathB,
 		Port:      7002,
-		RandSeed:  2,
 		Bootnodes: []string{addrA.String()},
 		NoMDNS:    true,
 	}
@@ -180,7 +175,6 @@ func TestSend(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -193,7 +187,6 @@ func TestSend(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -231,7 +224,6 @@ func TestExistingStream(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -248,7 +240,6 @@ func TestExistingStream(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -299,7 +290,6 @@ func TestStreamCloseMetadataCleanup(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -313,7 +303,6 @@ func TestStreamCloseMetadataCleanup(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -373,7 +362,6 @@ func Test_PeerSupportsProtocol(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -384,7 +372,6 @@ func Test_PeerSupportsProtocol(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/light_test.go
+++ b/dot/network/light_test.go
@@ -62,14 +62,12 @@ func TestHandleLightMessage_Response(t *testing.T) {
 	}
 	b := createTestService(t, configB)
 
-	addrInfosB, err := b.host.addrInfos()
-	require.NoError(t, err)
-
-	err = s.host.connect(*addrInfosB[0])
+	addrInfoB := b.host.addrInfo()
+	err := s.host.connect(addrInfoB)
 	// retry connect if "failed to dial" error
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = s.host.connect(*addrInfosB[0])
+		err = s.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 

--- a/dot/network/light_test.go
+++ b/dot/network/light_test.go
@@ -49,7 +49,6 @@ func TestHandleLightMessage_Response(t *testing.T) {
 	config := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -58,7 +57,6 @@ func TestHandleLightMessage_Response(t *testing.T) {
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/mdns_test.go
+++ b/dot/network/mdns_test.go
@@ -33,7 +33,6 @@ func TestMDNS(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 	}
 
@@ -46,7 +45,6 @@ func TestMDNS(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 	}
 

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -248,7 +248,6 @@ func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtoc
 			_ = stream.Close()
 			info.outboundHandshakeData.Delete(peer)
 			return
-
 		case hsResponse := <-s.readHandshake(stream, decodeBlockAnnounceHandshake):
 			hsTimer.Stop()
 			if hsResponse.err != nil {

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -126,13 +126,11 @@ func TestCreateNotificationsMessageHandler_BlockAnnounce(t *testing.T) {
 	testPeerID := b.host.id()
 
 	// connect nodes
-	addrInfosB, err := b.host.addrInfos()
-	require.NoError(t, err)
-
-	err = s.host.connect(*addrInfosB[0])
+	addrInfoB := b.host.addrInfo()
+	err := s.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = s.host.connect(*addrInfosB[0])
+		err = s.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
@@ -195,13 +193,11 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 	testPeerID := b.host.id()
 
 	// connect nodes
-	addrInfosB, err := b.host.addrInfos()
-	require.NoError(t, err)
-
-	err = s.host.connect(*addrInfosB[0])
+	addrInfoB := b.host.addrInfo()
+	err := s.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = s.host.connect(*addrInfosB[0])
+		err = s.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -17,7 +17,6 @@
 package network
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"sync"
@@ -27,9 +26,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/utils"
-	ma "github.com/multiformats/go-multiaddr"
-
-	"github.com/libp2p/go-libp2p"
 	libp2pnetwork "github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
@@ -238,31 +234,50 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 }
 
 func Test_HandshakeTimeout(t *testing.T) {
-	// create service A
-	config := &Config{
-		BasePath:    utils.NewTestBasePath(t, "nodeA"),
+	basePathA := utils.NewTestBasePath(t, "nodeA")
+	configA := &Config{
+		BasePath:    basePathA,
 		Port:        7001,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
-	ha := createTestService(t, config)
+
+	nodeA := createTestService(t, configA)
+	nodeA.noGossip = true
+
+	basePathB := utils.NewTestBasePath(t, "nodeB")
+	configB := &Config{
+		BasePath:    basePathB,
+		Port:        7002,
+		RandSeed:    2,
+		NoBootstrap: true,
+		NoMDNS:      true,
+	}
+
+	nodeB := createTestService(t, configB)
+	nodeB.noGossip = true
 
 	// create info and handler
 	info := &notificationsProtocol{
-		protocolID:            ha.host.protocolID + blockAnnounceID,
-		getHandshake:          ha.getBlockAnnounceHandshake,
-		handshakeValidator:    ha.validateBlockAnnounceHandshake,
+		protocolID:            nodeA.host.protocolID + blockAnnounceID,
+		getHandshake:          nodeA.getBlockAnnounceHandshake,
+		handshakeValidator:    nodeA.validateBlockAnnounceHandshake,
 		inboundHandshakeData:  new(sync.Map),
 		outboundHandshakeData: new(sync.Map),
 	}
 
-	// creating host b with will never respond to a handshake
-	addrB, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", 7002))
-	require.NoError(t, err)
+	nodeB.host.h.SetStreamHandler(info.protocolID, func(stream libp2pnetwork.Stream) {
+		fmt.Println("never respond a handshake message")
+	})
 
-	hb, err := libp2p.New(
-		context.Background(), libp2p.ListenAddrs(addrB),
-	)
+	addrInfosB := nodeB.host.addrInfo()
+
+	err := nodeA.host.connect(addrInfosB)
+	// retry connect if "failed to dial" error
+	if failedToDial(err) {
+		time.Sleep(TestBackoffTimeout)
+		err = nodeA.host.connect(addrInfosB)
+	}
 	require.NoError(t, err)
 
 	testHandshakeMsg := &BlockAnnounceHandshake{
@@ -271,32 +286,18 @@ func Test_HandshakeTimeout(t *testing.T) {
 		BestBlockHash:   common.Hash{1},
 		GenesisHash:     common.Hash{2},
 	}
+	nodeA.SendMessage(testHandshakeMsg)
 
-	hb.SetStreamHandler(info.protocolID, func(stream libp2pnetwork.Stream) {
-		fmt.Println("never respond a handshake message")
-	})
+	go nodeA.sendData(nodeB.host.id(), testHandshakeMsg, info, nil)
 
-	addrBInfo := peer.AddrInfo{
-		ID:    hb.ID(),
-		Addrs: hb.Addrs(),
-	}
+	time.Sleep(time.Second)
 
-	err = ha.host.connect(addrBInfo)
-	if failedToDial(err) {
-		time.Sleep(TestBackoffTimeout)
-		err = ha.host.connect(addrBInfo)
-	}
-	require.NoError(t, err)
-
-	go ha.sendData(hb.ID(), testHandshakeMsg, info, nil)
-
-	time.Sleep(handshakeTimeout / 2)
-	// peer should be stored in handshake data until timeout
-	_, ok := info.outboundHandshakeData.Load(hb.ID())
+	// Verify that handshake data exists.
+	_, ok := info.getHandshakeData(nodeB.host.id(), false)
 	require.True(t, ok)
 
 	// a stream should be open until timeout
-	connAToB := ha.host.h.Network().ConnsToPeer(hb.ID())
+	connAToB := nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
 	require.Len(t, connAToB, 1)
 	require.Len(t, connAToB[0].GetStreams(), 1)
 
@@ -304,11 +305,11 @@ func Test_HandshakeTimeout(t *testing.T) {
 	time.Sleep(handshakeTimeout)
 
 	// handshake data should be removed
-	_, ok = info.outboundHandshakeData.Load(hb.ID())
+	_, ok = info.getHandshakeData(nodeB.host.id(), false)
 	require.False(t, ok)
 
 	// stream should be closed
-	connAToB = ha.host.h.Network().ConnsToPeer(hb.ID())
+	connAToB = nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
 	require.Len(t, connAToB, 1)
 	require.Len(t, connAToB[0].GetStreams(), 0)
 }

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -45,7 +45,6 @@ func TestCreateDecoder_BlockAnnounce(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -108,7 +107,6 @@ func TestCreateNotificationsMessageHandler_BlockAnnounce(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -118,7 +116,6 @@ func TestCreateNotificationsMessageHandler_BlockAnnounce(t *testing.T) {
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -169,7 +166,6 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 	config := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -189,7 +185,6 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -251,7 +246,6 @@ func Test_HandshakeTimeout(t *testing.T) {
 	config := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -166,14 +166,12 @@ func TestBroadcastMessages(t *testing.T) {
 	handler := newTestStreamHandler(testBlockAnnounceHandshakeDecoder)
 	nodeB.host.registerStreamHandler(blockAnnounceID, handler.handleStream)
 
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	// retry connect if "failed to dial" error
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
@@ -213,14 +211,12 @@ func TestBroadcastDuplicateMessage(t *testing.T) {
 	handler := newTestStreamHandler(testBlockAnnounceHandshakeDecoder)
 	nodeB.host.registerStreamHandler(blockAnnounceID, handler.handleStream)
 
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	// retry connect if "failed to dial" error
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
@@ -288,13 +284,11 @@ func TestPersistPeerStore(t *testing.T) {
 	nodeA := nodes[0]
 	nodeB := nodes[1]
 
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
@@ -328,13 +322,11 @@ func TestHandleConn(t *testing.T) {
 
 	nodeB := createTestService(t, configB)
 
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -70,7 +70,6 @@ func createTestService(t *testing.T, cfg *Config) (srvc *Service) {
 		cfg = &Config{
 			BasePath:    basePath,
 			Port:        7001,
-			RandSeed:    1,
 			NoBootstrap: true,
 			NoMDNS:      true,
 			LogLvl:      4,
@@ -272,7 +271,6 @@ func TestService_Health(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -113,6 +113,7 @@ func createTestService(t *testing.T, cfg *Config) (srvc *Service) {
 
 	t.Cleanup(func() {
 		srvc.Stop()
+		time.Sleep(time.Second)
 		err = os.RemoveAll(cfg.BasePath)
 		if err != nil {
 			fmt.Printf("failed to remove path %s : %s\n", cfg.BasePath, err)

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -48,7 +48,6 @@ func createServiceHelper(t *testing.T, num int) []*Service {
 		config := &Config{
 			BasePath:    utils.NewTestBasePath(t, fmt.Sprintf("node%d", i)),
 			Port:        uint32(7001 + i),
-			RandSeed:    int64(1 + i),
 			NoBootstrap: true,
 			NoMDNS:      true,
 		}
@@ -146,7 +145,6 @@ func TestBroadcastMessages(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -159,7 +157,6 @@ func TestBroadcastMessages(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -194,7 +191,6 @@ func TestBroadcastDuplicateMessage(t *testing.T) {
 	configA := &Config{
 		BasePath:    basePathA,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -207,7 +203,6 @@ func TestBroadcastDuplicateMessage(t *testing.T) {
 	configB := &Config{
 		BasePath:    basePathB,
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -320,7 +315,6 @@ func TestHandleConn(t *testing.T) {
 	configA := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -330,7 +324,6 @@ func TestHandleConn(t *testing.T) {
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/sync_justification_test.go
+++ b/dot/network/sync_justification_test.go
@@ -35,7 +35,6 @@ func TestSyncQueue_PushResponse_Justification(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -74,7 +73,6 @@ func TestSyncQueue_PushResponse_EmptyJustification(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/sync_test.go
+++ b/dot/network/sync_test.go
@@ -82,7 +82,6 @@ func TestSyncQueue_PushResponse(t *testing.T) {
 	config := &Config{
 		BasePath:    basePath,
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}
@@ -285,7 +284,6 @@ func TestSyncQueue_ProcessBlockRequests(t *testing.T) {
 	configA := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeA"),
 		Port:        7001,
-		RandSeed:    1,
 		NoBootstrap: true,
 		NoMDNS:      true,
 		LogLvl:      4,
@@ -297,7 +295,6 @@ func TestSyncQueue_ProcessBlockRequests(t *testing.T) {
 	configB := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeB"),
 		Port:        7002,
-		RandSeed:    2,
 		NoBootstrap: true,
 		NoMDNS:      true,
 		LogLvl:      4,
@@ -309,7 +306,6 @@ func TestSyncQueue_ProcessBlockRequests(t *testing.T) {
 	configC := &Config{
 		BasePath:    utils.NewTestBasePath(t, "nodeC"),
 		Port:        7003,
-		RandSeed:    3,
 		NoBootstrap: true,
 		NoMDNS:      true,
 	}

--- a/dot/network/sync_test.go
+++ b/dot/network/sync_test.go
@@ -314,24 +314,20 @@ func TestSyncQueue_ProcessBlockRequests(t *testing.T) {
 	nodeC.noGossip = true
 
 	// connect A and B
-	addrInfosB, err := nodeB.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosB[0])
+	addrInfoB := nodeB.host.addrInfo()
+	err := nodeA.host.connect(addrInfoB)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosB[0])
+		err = nodeA.host.connect(addrInfoB)
 	}
 	require.NoError(t, err)
 
 	// connect A and C
-	addrInfosC, err := nodeC.host.addrInfos()
-	require.NoError(t, err)
-
-	err = nodeA.host.connect(*addrInfosC[0])
+	addrInfoC := nodeC.host.addrInfo()
+	err = nodeA.host.connect(addrInfoC)
 	if failedToDial(err) {
 		time.Sleep(TestBackoffTimeout)
-		err = nodeA.host.connect(*addrInfosC[0])
+		err = nodeA.host.connect(addrInfoC)
 	}
 	require.NoError(t, err)
 

--- a/dot/network/transaction_test.go
+++ b/dot/network/transaction_test.go
@@ -78,7 +78,6 @@ func TestHandleTransactionMessage(t *testing.T) {
 	config := &Config{
 		BasePath:           basePath,
 		Port:               7001,
-		RandSeed:           1,
 		NoBootstrap:        true,
 		NoMDNS:             true,
 		TransactionHandler: handler,

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -17,10 +17,12 @@
 package modules
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
@@ -121,6 +123,11 @@ func newNetworkService(t *testing.T) *network.Service {
 
 	t.Cleanup(func() {
 		_ = srv.Stop()
+		time.Sleep(time.Second)
+		err = os.RemoveAll(cfg.BasePath)
+		if err != nil {
+			fmt.Printf("failed to remove path %s : %s\n", cfg.BasePath, err)
+		}
 	})
 
 	return srv


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- sleep after stopping network service so give it time to shut down, increase `host.connect` timeout
- remove `RandSeed` usage in tests

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-
