### PR TITLE
chore: remove finalnum inherent, clear babe `slotToProof` map

### DIFF
--- a/dot/sync/test_helpers.go
+++ b/dot/sync/test_helpers.go
@@ -163,9 +163,6 @@ func BuildBlock(t *testing.T, instance runtime.Instance, parent *types.Header, e
 	err = idata.SetInt64Inherent(types.Babeslot, 1)
 	require.NoError(t, err)
 
-	err = idata.SetBigIntInherent(types.Finalnum, big.NewInt(0))
-	require.NoError(t, err)
-
 	ienc, err := idata.Encode()
 	require.NoError(t, err)
 

--- a/dot/types/babe.go
+++ b/dot/types/babe.go
@@ -31,7 +31,7 @@ type BabeConfiguration struct {
 	C1                 uint64 // (1-(c1/c2)) is the probability of a slot being empty
 	C2                 uint64
 	GenesisAuthorities []*AuthorityRaw
-	Randomness         [32]byte
+	Randomness         [RandomnessLength]byte
 	SecondarySlots     byte
 }
 

--- a/dot/types/inherents.go
+++ b/dot/types/inherents.go
@@ -30,7 +30,6 @@ import (
 var (
 	Timstap0 = []byte("timstap0")
 	Babeslot = []byte("babeslot")
-	Finalnum = []byte("finalnum")
 	Uncles00 = []byte("uncles00")
 )
 

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -134,8 +134,8 @@ func (b *BlockBuilder) buildBlock(parent *types.Header, slot Slot) (*types.Block
 
 	logger.Trace("finalised block")
 
-	header.ParentHash = parent.Hash()
-	header.Number.Add(parent.Number, big.NewInt(1))
+	// header.ParentHash = parent.Hash()
+	// header.Number.Add(parent.Number, big.NewInt(1))
 
 	// create seal and add to digest
 	seal, err := b.buildBlockSeal(header)

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -134,9 +134,6 @@ func (b *BlockBuilder) buildBlock(parent *types.Header, slot Slot) (*types.Block
 
 	logger.Trace("finalised block")
 
-	// header.ParentHash = parent.Hash()
-	// header.Number.Add(parent.Number, big.NewInt(1))
-
 	// create seal and add to digest
 	seal, err := b.buildBlockSeal(header)
 	if err != nil {

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -275,17 +275,6 @@ func (b *BlockBuilder) buildBlockInherents(slot Slot) ([][]byte, error) {
 		return nil, err
 	}
 
-	// add finalnum
-	fin, err := b.blockState.GetFinalizedHeader(0, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	err = idata.SetBigIntInherent(types.Finalnum, fin.Number)
-	if err != nil {
-		return nil, err
-	}
-
 	ienc, err := idata.Encode()
 	if err != nil {
 		return nil, err

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -113,7 +113,10 @@ func (b *Service) initiateEpoch(epoch uint64) error {
 	logger.Debug("initiating epoch", "epoch", epoch, "start slot", startSlot)
 
 	for i := startSlot; i < startSlot+b.epochLength; i++ {
-		delete(b.slotToProof, i-b.epochLength) // clear data from previous epoch
+		if epoch > 0 {
+			delete(b.slotToProof, i-b.epochLength) // clear data from previous epoch
+		}
+
 		b.slotToProof[i], err = b.runLottery(i, epoch)
 		if err != nil {
 			return fmt.Errorf("error running slot lottery at slot %d: error %s", i, err)

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -113,6 +113,7 @@ func (b *Service) initiateEpoch(epoch uint64) error {
 	logger.Debug("initiating epoch", "epoch", epoch, "start slot", startSlot)
 
 	for i := startSlot; i < startSlot+b.epochLength; i++ {
+		delete(b.slotToProof, i-b.epochLength) // clear data from previous epoch
 		b.slotToProof[i], err = b.runLottery(i, epoch)
 		if err != nil {
 			return fmt.Errorf("error running slot lottery at slot %d: error %s", i, err)

--- a/lib/runtime/life/exports_test.go
+++ b/lib/runtime/life/exports_test.go
@@ -137,9 +137,6 @@ func buildBlock(t *testing.T, instance runtime.Instance) *types.Block {
 	err = idata.SetInt64Inherent(types.Babeslot, 1)
 	require.NoError(t, err)
 
-	err = idata.SetBigIntInherent(types.Finalnum, big.NewInt(0))
-	require.NoError(t, err)
-
 	ienc, err := idata.Encode()
 	require.NoError(t, err)
 

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -386,9 +386,6 @@ func buildBlock(t *testing.T, instance runtime.Instance) *types.Block {
 	err = idata.SetInt64Inherent(types.Babeslot, 1)
 	require.NoError(t, err)
 
-	err = idata.SetBigIntInherent(types.Finalnum, big.NewInt(0))
-	require.NoError(t, err)
-
 	ienc, err := idata.Encode()
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- remove finalnum inherent (no longer used)
- clear babe `slotToProof` map data from previous epoch as it's no longer needed

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/babe -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- n/a
