### PR TITLE
fix(dot/network): Check for size when decoding leb128.

### DIFF
--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -157,6 +157,8 @@ func readLEB128ToUint64(r io.Reader, buf []byte) (uint64, error) {
 
 	var out uint64
 	var shift uint
+
+	maxSize := 10 // Max bytes in LEB128 encoding of uint64 is 10.
 	for {
 		_, err := r.Read(buf)
 		if err != nil {
@@ -168,6 +170,12 @@ func readLEB128ToUint64(r io.Reader, buf []byte) (uint64, error) {
 		if b&0x80 == 0 {
 			break
 		}
+
+		maxSize--
+		if maxSize == 0 {
+			return 0, fmt.Errorf("invalid LEB128 encoded data")
+		}
+
 		shift += 7
 	}
 	return out, nil

--- a/dot/network/utils_test.go
+++ b/dot/network/utils_test.go
@@ -102,6 +102,11 @@ func TestReadLEB128ToUint64(t *testing.T) {
 			input:  []byte("\xB9\x64"),
 			output: 12857,
 		},
+		{
+			input: []byte{'\xFF', '\xFF', '\xFF', '\xFF', '\xFF',
+				'\xFF', '\xFF', '\xFF', '\xFF', '\x01'},
+			output: 18446744073709551615,
+		},
 	}
 
 	for _, tc := range tests {
@@ -114,4 +119,16 @@ func TestReadLEB128ToUint64(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tc.output, ret)
 	}
+}
+
+func TestInvalidLeb128(t *testing.T) {
+	input := []byte{'\xFF', '\xFF', '\xFF', '\xFF', '\xFF',
+		'\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\x01'}
+	b := make([]byte, 2)
+	buf := new(bytes.Buffer)
+	_, err := buf.Write(input)
+	require.NoError(t, err)
+
+	_, err = readLEB128ToUint64(buf, b[:1])
+	require.Error(t, err)
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Check for size when decoding leb128

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
TestInvalidLeb128
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-
