### PR TITLE
chore: update dev, gssmr to use genesis-spec by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ build-debug: clean
 
 ## init: Initialise gossamer using the default genesis and toml configuration files
 init:
-	./bin/gossamer --key alice init --genesis chain/gssmr/genesis.json --force
+	./bin/gossamer init --force
 
 ## init-repo: Set initial configuration for the repo
 init-repo:

--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -14,7 +14,7 @@ grandpa = ""
 sync = ""
 
 [init]
-genesis = "./chain/dev/genesis.json"
+genesis = "./chain/dev/genesis-spec.json"
 
 [account]
 key = "alice"

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -47,7 +47,7 @@ var (
 	// InitConfig
 
 	// DefaultGenesis is the default genesis configuration path
-	DefaultGenesis = string("./chain/dev/genesis.json")
+	DefaultGenesis = string("./chain/dev/genesis-spec.json")
 
 	// AccountConfig
 

--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -10,7 +10,7 @@ rpc = ""
 state = ""
 runtime = ""
 babe = ""
-grandpa = "debug"
+grandpa = ""
 sync = ""
 
 [init]

--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -10,11 +10,11 @@ rpc = ""
 state = ""
 runtime = ""
 babe = ""
-grandpa = ""
+grandpa = "debug"
 sync = ""
 
 [init]
-genesis = "./chain/gssmr/genesis.json"
+genesis = "./chain/gssmr/genesis-spec.json"
 
 [account]
 key = ""

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -47,7 +47,7 @@ var (
 	// InitConfig
 
 	// DefaultGenesis is the default genesis configuration path
-	DefaultGenesis = string("./chain/gssmr/genesis.json")
+	DefaultGenesis = string("./chain/gssmr/genesis-spec.json")
 
 	// AccountConfig
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update dev, gssmr to use `genesis-spec.json` by default, it's nicer this way for testing since the spec file can easily be read/modified/# of authorities changed, without needing to change it then do `build-spec` etc

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
./bin/gossamer --chain gssmr init --force
./bin/gossamer --chain gssmr --key alice
./bin/gossamer --chain dev init --force
./bin/gossamer --chain dev
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- n/a
