### PR TITLE
fix(dot/state, lib/grandpa): 

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -122,11 +122,6 @@ func NewBlockStateFromGenesis(db chaindb.Database, header *types.Header) (*Block
 		return nil, err
 	}
 
-	err = bs.SetRound(0)
-	if err != nil {
-		return nil, err
-	}
-
 	return bs, nil
 }
 
@@ -166,16 +161,6 @@ func blockBodyKey(hash common.Hash) []byte {
 // arrivalTimeKey = arrivalTimePrefix + hash
 func arrivalTimeKey(hash common.Hash) []byte {
 	return append(arrivalTimePrefix, hash.ToBytes()...)
-}
-
-// finalizedHashKey = hashkey + round + setID (LE encoded)
-func finalizedHashKey(round, setID uint64) []byte {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, round)
-	key := append(common.FinalizedBlockHashKey, buf...)
-	buf2 := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf2, setID)
-	return append(key, buf2...)
 }
 
 // GenesisHash returns the hash of the genesis block
@@ -371,127 +356,6 @@ func (bs *BlockState) GetBlockBody(hash common.Hash) (*types.Body, error) {
 // SetBlockBody will add a block body to the db
 func (bs *BlockState) SetBlockBody(hash common.Hash, body *types.Body) error {
 	return bs.db.Put(blockBodyKey(hash), body.AsOptional().Value())
-}
-
-// HasFinalizedBlock returns true if there is a finalised block for a given round and setID, false otherwise
-func (bs *BlockState) HasFinalizedBlock(round, setID uint64) (bool, error) {
-	return bs.db.Has(finalizedHashKey(round, setID))
-}
-
-// NumberIsFinalised checks if a block number is finalised or not
-func (bs *BlockState) NumberIsFinalised(num *big.Int) (bool, error) {
-	header, err := bs.GetFinalizedHeader(0, 0)
-	if err != nil {
-		return false, err
-	}
-
-	return num.Cmp(header.Number) <= 0, nil
-}
-
-// GetFinalizedHeader returns the latest finalised block header
-func (bs *BlockState) GetFinalizedHeader(round, setID uint64) (*types.Header, error) {
-	h, err := bs.GetFinalizedHash(round, setID)
-	if err != nil {
-		return nil, err
-	}
-
-	header, err := bs.GetHeader(h)
-	if err != nil {
-		return nil, err
-	}
-
-	return header, nil
-}
-
-// GetFinalizedHash gets the latest finalised block header
-func (bs *BlockState) GetFinalizedHash(round, setID uint64) (common.Hash, error) {
-	h, err := bs.db.Get(finalizedHashKey(round, setID))
-	if err != nil {
-		return common.Hash{}, err
-	}
-
-	return common.NewHash(h), nil
-}
-
-// SetFinalizedHash sets the latest finalised block header
-func (bs *BlockState) SetFinalizedHash(hash common.Hash, round, setID uint64) error {
-	bs.Lock()
-	defer bs.Unlock()
-
-	has, _ := bs.HasHeader(hash)
-	if !has {
-		return fmt.Errorf("cannot finalise unknown block %s", hash)
-	}
-
-	// if nothing was previously finalised, set the first slot of the network to the
-	// slot number of block 1, which is now being set as final
-	if bs.lastFinalised.Equal(bs.genesisHash) && !hash.Equal(bs.genesisHash) {
-		err := bs.setFirstSlotOnFinalisation()
-		if err != nil {
-			return err
-		}
-	}
-
-	if round > 0 {
-		go bs.notifyFinalized(hash, round, setID)
-
-		err := bs.SetRound(round)
-		if err != nil {
-			return err
-		}
-	}
-
-	pruned := bs.bt.Prune(hash)
-	for _, rem := range pruned {
-		header, err := bs.GetHeader(rem)
-		if err != nil {
-			return err
-		}
-
-		err = bs.DeleteBlock(rem)
-		if err != nil {
-			return err
-		}
-
-		logger.Trace("pruned block", "hash", rem, "number", header.Number)
-		bs.pruneKeyCh <- header
-	}
-
-	bs.lastFinalised = hash
-	return bs.db.Put(finalizedHashKey(round, setID), hash[:])
-}
-
-func (bs *BlockState) setFirstSlotOnFinalisation() error {
-	header, err := bs.GetHeaderByNumber(big.NewInt(1))
-	if err != nil {
-		return err
-	}
-
-	slot, err := types.GetSlotFromHeader(header)
-	if err != nil {
-		return err
-	}
-
-	return bs.baseState.storeFirstSlot(slot)
-}
-
-// SetRound sets the latest finalised GRANDPA round in the db
-// TODO: this needs to use both setID and round
-func (bs *BlockState) SetRound(round uint64) error {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, round)
-	return bs.db.Put(common.LatestFinalizedRoundKey, buf)
-}
-
-// GetRound gets the latest finalised GRANDPA round from the db
-func (bs *BlockState) GetRound() (uint64, error) {
-	r, err := bs.db.Get(common.LatestFinalizedRoundKey)
-	if err != nil {
-		return 0, err
-	}
-
-	round := binary.LittleEndian.Uint64(r)
-	return round, nil
 }
 
 // CompareAndSetBlockData will compare empty fields and set all elements in a block data to db

--- a/dot/state/block_data.go
+++ b/dot/state/block_data.go
@@ -32,9 +32,6 @@ func (bs *BlockState) HasReceipt(hash common.Hash) (bool, error) {
 
 // SetReceipt sets a Receipt in the database
 func (bs *BlockState) SetReceipt(hash common.Hash, data []byte) error {
-	bs.Lock()
-	defer bs.Unlock()
-
 	err := bs.db.Put(prefixKey(hash, receiptPrefix), data)
 	if err != nil {
 		return err
@@ -60,9 +57,6 @@ func (bs *BlockState) HasMessageQueue(hash common.Hash) (bool, error) {
 
 // SetMessageQueue sets a MessageQueue in the database
 func (bs *BlockState) SetMessageQueue(hash common.Hash, data []byte) error {
-	bs.Lock()
-	defer bs.Unlock()
-
 	err := bs.db.Put(prefixKey(hash, messageQueuePrefix), data)
 	if err != nil {
 		return err
@@ -88,9 +82,6 @@ func (bs *BlockState) HasJustification(hash common.Hash) (bool, error) {
 
 // SetJustification sets a Justification in the database
 func (bs *BlockState) SetJustification(hash common.Hash, data []byte) error {
-	bs.Lock()
-	defer bs.Unlock()
-
 	err := bs.db.Put(prefixKey(hash, justificationPrefix), data)
 	if err != nil {
 		return err

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -1,0 +1,166 @@
+package state
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/big"
+
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+)
+
+var (
+	prevotesPrefix   = []byte("pv")
+	precommitsPrefix = []byte("pc")
+)
+
+func prevotesKey(round, setID uint64) []byte {
+	k := roundSetIDKey(round, setID)
+	return append(prevotesPrefix, k...)
+}
+
+func precommitsKey(round, setID uint64) []byte {
+	k := roundSetIDKey(round, setID)
+	return append(precommitsPrefix, k...)
+}
+
+// finalizedHashKey = FinalizedBlockHashKey + round + setID (LE encoded)
+func finalizedHashKey(round, setID uint64) []byte {
+	return append(common.FinalizedBlockHashKey, roundSetIDKey(round, setID)...)
+}
+
+func roundSetIDKey(round, setID uint64) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, round)
+	buf2 := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf2, setID)
+	return append(buf, buf2...)
+}
+
+// HasPrevotes returns if the db contains prevotes for the given round and set ID
+func (bs *BlockState) HasPrevotes(round, setID uint64) (bool, error) {
+	return bs.db.Has(prevotesKey(round, setID))
+}
+
+// SetPrevotes sets the prevotes for a specific round and set ID in the database
+func (bs *BlockState) SetPrevotes(round, setID uint64, data []byte) error {
+	return bs.db.Put(prevotesKey(round, setID), data)
+}
+
+// GetPrevotes retrieves the prevotes for a specific round and set ID from the database
+func (bs *BlockState) GetPrevotes(round, setID uint64) ([]byte, error) {
+	return bs.db.Get(prevotesKey(round, setID))
+}
+
+// HasPrecommits returns if the db contains precommits for the given round and set ID
+func (bs *BlockState) HasPrecommits(round, setID uint64) (bool, error) {
+	return bs.db.Has(precommitsKey(round, setID))
+}
+
+// SetPrecommits sets the precommits for a specific round and set ID in the database
+func (bs *BlockState) SetPrecommits(round, setID uint64, data []byte) error {
+	return bs.db.Put(precommitsKey(round, setID), data)
+}
+
+// GetPrecommits retrieves the precommits for a specific round and set ID from the database
+func (bs *BlockState) GetPrecommits(round, setID uint64) ([]byte, error) {
+	return bs.db.Get(precommitsKey(round, setID))
+}
+
+// HasFinalizedBlock returns true if there is a finalised block for a given round and setID, false otherwise
+func (bs *BlockState) HasFinalizedBlock(round, setID uint64) (bool, error) {
+	return bs.db.Has(finalizedHashKey(round, setID))
+}
+
+// NumberIsFinalised checks if a block number is finalised or not
+func (bs *BlockState) NumberIsFinalised(num *big.Int) (bool, error) {
+	header, err := bs.GetFinalizedHeader(0, 0)
+	if err != nil {
+		return false, err
+	}
+
+	return num.Cmp(header.Number) <= 0, nil
+}
+
+// GetFinalizedHeader returns the finalised block header by round and setID
+func (bs *BlockState) GetFinalizedHeader(round, setID uint64) (*types.Header, error) {
+	h, err := bs.GetFinalizedHash(round, setID)
+	if err != nil {
+		return nil, err
+	}
+
+	header, err := bs.GetHeader(h)
+	if err != nil {
+		return nil, err
+	}
+
+	return header, nil
+}
+
+// GetFinalizedHash gets the finalised block header by round and setID
+func (bs *BlockState) GetFinalizedHash(round, setID uint64) (common.Hash, error) {
+	h, err := bs.db.Get(finalizedHashKey(round, setID))
+	if err != nil {
+		return common.Hash{}, err
+	}
+
+	return common.NewHash(h), nil
+}
+
+// SetFinalizedHash sets the latest finalised block header
+// Note that using round=0 and setID=0 would refer to the latest finalized hash
+func (bs *BlockState) SetFinalizedHash(hash common.Hash, round, setID uint64) error {
+	bs.Lock()
+	defer bs.Unlock()
+
+	has, _ := bs.HasHeader(hash)
+	if !has {
+		return fmt.Errorf("cannot finalise unknown block %s", hash)
+	}
+
+	// if nothing was previously finalised, set the first slot of the network to the
+	// slot number of block 1, which is now being set as final
+	if bs.lastFinalised.Equal(bs.genesisHash) && !hash.Equal(bs.genesisHash) {
+		err := bs.setFirstSlotOnFinalisation()
+		if err != nil {
+			return err
+		}
+	}
+
+	if round > 0 {
+		go bs.notifyFinalized(hash, round, setID)
+	}
+
+	pruned := bs.bt.Prune(hash)
+	for _, rem := range pruned {
+		header, err := bs.GetHeader(rem)
+		if err != nil {
+			return err
+		}
+
+		err = bs.DeleteBlock(rem)
+		if err != nil {
+			return err
+		}
+
+		logger.Trace("pruned block", "hash", rem, "number", header.Number)
+		bs.pruneKeyCh <- header
+	}
+
+	bs.lastFinalised = hash
+	return bs.db.Put(finalizedHashKey(round, setID), hash[:])
+}
+
+func (bs *BlockState) setFirstSlotOnFinalisation() error {
+	header, err := bs.GetHeaderByNumber(big.NewInt(1))
+	if err != nil {
+		return err
+	}
+
+	slot, err := types.GetSlotFromHeader(header)
+	if err != nil {
+		return err
+	}
+
+	return bs.baseState.storeFirstSlot(slot)
+}

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -13,44 +13,6 @@ func finalizedHashKey(round, setID uint64) []byte {
 	return append(common.FinalizedBlockHashKey, roundSetIDKey(round, setID)...)
 }
 
-// func roundSetIDKey(round, setID uint64) []byte {
-// 	buf := make([]byte, 8)
-// 	binary.LittleEndian.PutUint64(buf, round)
-// 	buf2 := make([]byte, 8)
-// 	binary.LittleEndian.PutUint64(buf2, setID)
-// 	return append(buf, buf2...)
-// }
-
-// // HasPrevotes returns if the db contains prevotes for the given round and set ID
-// func (bs *BlockState) HasPrevotes(round, setID uint64) (bool, error) {
-// 	return bs.db.Has(prevotesKey(round, setID))
-// }
-
-// // SetPrevotes sets the prevotes for a specific round and set ID in the database
-// func (bs *BlockState) SetPrevotes(round, setID uint64, data []byte) error {
-// 	return bs.db.Put(prevotesKey(round, setID), data)
-// }
-
-// // GetPrevotes retrieves the prevotes for a specific round and set ID from the database
-// func (bs *BlockState) GetPrevotes(round, setID uint64) ([]byte, error) {
-// 	return bs.db.Get(prevotesKey(round, setID))
-// }
-
-// // HasPrecommits returns if the db contains precommits for the given round and set ID
-// func (bs *BlockState) HasPrecommits(round, setID uint64) (bool, error) {
-// 	return bs.db.Has(precommitsKey(round, setID))
-// }
-
-// // SetPrecommits sets the precommits for a specific round and set ID in the database
-// func (bs *BlockState) SetPrecommits(round, setID uint64, data []byte) error {
-// 	return bs.db.Put(precommitsKey(round, setID), data)
-// }
-
-// // GetPrecommits retrieves the precommits for a specific round and set ID from the database
-// func (bs *BlockState) GetPrecommits(round, setID uint64) ([]byte, error) {
-// 	return bs.db.Get(precommitsKey(round, setID))
-// }
-
 // HasFinalizedBlock returns true if there is a finalised block for a given round and setID, false otherwise
 func (bs *BlockState) HasFinalizedBlock(round, setID uint64) (bool, error) {
 	return bs.db.Has(finalizedHashKey(round, setID))
@@ -92,7 +54,7 @@ func (bs *BlockState) GetFinalizedHash(round, setID uint64) (common.Hash, error)
 }
 
 // SetFinalizedHash sets the latest finalised block header
-// Note that using round=0 and setID=0 would refer to the latest finalized hash
+// Note that using round=0 and setID=0 would refer to the latest finalised hash
 func (bs *BlockState) SetFinalizedHash(hash common.Hash, round, setID uint64) error {
 	bs.Lock()
 	defer bs.Unlock()

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math/big"
 
@@ -9,63 +8,48 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
-var (
-	prevotesPrefix   = []byte("pv")
-	precommitsPrefix = []byte("pc")
-)
-
-func prevotesKey(round, setID uint64) []byte {
-	k := roundSetIDKey(round, setID)
-	return append(prevotesPrefix, k...)
-}
-
-func precommitsKey(round, setID uint64) []byte {
-	k := roundSetIDKey(round, setID)
-	return append(precommitsPrefix, k...)
-}
-
 // finalizedHashKey = FinalizedBlockHashKey + round + setID (LE encoded)
 func finalizedHashKey(round, setID uint64) []byte {
 	return append(common.FinalizedBlockHashKey, roundSetIDKey(round, setID)...)
 }
 
-func roundSetIDKey(round, setID uint64) []byte {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, round)
-	buf2 := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf2, setID)
-	return append(buf, buf2...)
-}
+// func roundSetIDKey(round, setID uint64) []byte {
+// 	buf := make([]byte, 8)
+// 	binary.LittleEndian.PutUint64(buf, round)
+// 	buf2 := make([]byte, 8)
+// 	binary.LittleEndian.PutUint64(buf2, setID)
+// 	return append(buf, buf2...)
+// }
 
-// HasPrevotes returns if the db contains prevotes for the given round and set ID
-func (bs *BlockState) HasPrevotes(round, setID uint64) (bool, error) {
-	return bs.db.Has(prevotesKey(round, setID))
-}
+// // HasPrevotes returns if the db contains prevotes for the given round and set ID
+// func (bs *BlockState) HasPrevotes(round, setID uint64) (bool, error) {
+// 	return bs.db.Has(prevotesKey(round, setID))
+// }
 
-// SetPrevotes sets the prevotes for a specific round and set ID in the database
-func (bs *BlockState) SetPrevotes(round, setID uint64, data []byte) error {
-	return bs.db.Put(prevotesKey(round, setID), data)
-}
+// // SetPrevotes sets the prevotes for a specific round and set ID in the database
+// func (bs *BlockState) SetPrevotes(round, setID uint64, data []byte) error {
+// 	return bs.db.Put(prevotesKey(round, setID), data)
+// }
 
-// GetPrevotes retrieves the prevotes for a specific round and set ID from the database
-func (bs *BlockState) GetPrevotes(round, setID uint64) ([]byte, error) {
-	return bs.db.Get(prevotesKey(round, setID))
-}
+// // GetPrevotes retrieves the prevotes for a specific round and set ID from the database
+// func (bs *BlockState) GetPrevotes(round, setID uint64) ([]byte, error) {
+// 	return bs.db.Get(prevotesKey(round, setID))
+// }
 
-// HasPrecommits returns if the db contains precommits for the given round and set ID
-func (bs *BlockState) HasPrecommits(round, setID uint64) (bool, error) {
-	return bs.db.Has(precommitsKey(round, setID))
-}
+// // HasPrecommits returns if the db contains precommits for the given round and set ID
+// func (bs *BlockState) HasPrecommits(round, setID uint64) (bool, error) {
+// 	return bs.db.Has(precommitsKey(round, setID))
+// }
 
-// SetPrecommits sets the precommits for a specific round and set ID in the database
-func (bs *BlockState) SetPrecommits(round, setID uint64, data []byte) error {
-	return bs.db.Put(precommitsKey(round, setID), data)
-}
+// // SetPrecommits sets the precommits for a specific round and set ID in the database
+// func (bs *BlockState) SetPrecommits(round, setID uint64, data []byte) error {
+// 	return bs.db.Put(precommitsKey(round, setID), data)
+// }
 
-// GetPrecommits retrieves the precommits for a specific round and set ID from the database
-func (bs *BlockState) GetPrecommits(round, setID uint64) ([]byte, error) {
-	return bs.db.Get(precommitsKey(round, setID))
-}
+// // GetPrecommits retrieves the precommits for a specific round and set ID from the database
+// func (bs *BlockState) GetPrecommits(round, setID uint64) ([]byte, error) {
+// 	return bs.db.Get(precommitsKey(round, setID))
+// }
 
 // HasFinalizedBlock returns true if there is a finalised block for a given round and setID, false otherwise
 func (bs *BlockState) HasFinalizedBlock(round, setID uint64) (bool, error) {

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -299,19 +299,6 @@ func TestFinalizedHash(t *testing.T) {
 	require.Equal(t, testhash, h)
 }
 
-func TestLatestFinalizedRound(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
-	r, err := bs.GetRound()
-	require.NoError(t, err)
-	require.Equal(t, uint64(0), r)
-
-	err = bs.SetRound(99)
-	require.NoError(t, err)
-	r, err = bs.GetRound()
-	require.NoError(t, err)
-	require.Equal(t, uint64(99), r)
-}
-
 func TestFinalization_DeleteBlock(t *testing.T) {
 	bs := newTestBlockState(t, testGenesisHeader)
 	AddBlocksToState(t, bs, 5)

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
 	"github.com/ChainSafe/gossamer/lib/scale"
 )
 
@@ -310,7 +309,7 @@ func roundSetIDKey(round, setID uint64) []byte {
 }
 
 // SetPrevotes sets the prevotes for a specific round and set ID in the database
-func (s *GrandpaState) SetPrevotes(round, setID uint64, pvs []*grandpa.SignedVote) error {
+func (s *GrandpaState) SetPrevotes(round, setID uint64, pvs []*types.GrandpaSignedVote) error {
 	data, err := scale.Encode(pvs)
 	if err != nil {
 		return err
@@ -320,22 +319,22 @@ func (s *GrandpaState) SetPrevotes(round, setID uint64, pvs []*grandpa.SignedVot
 }
 
 // GetPrevotes retrieves the prevotes for a specific round and set ID from the database
-func (s *GrandpaState) GetPrevotes(round, setID uint64) ([]*grandpa.SignedVote, error) {
+func (s *GrandpaState) GetPrevotes(round, setID uint64) ([]*types.GrandpaSignedVote, error) {
 	data, err := s.db.Get(prevotesKey(round, setID))
 	if err != nil {
 		return nil, err
 	}
 
-	pvs, err := scale.Decode(data, []*grandpa.SignedVote{})
+	pvs, err := scale.Decode(data, []*types.GrandpaSignedVote{})
 	if err != nil {
 		return nil, err
 	}
 
-	return pvs.([]*grandpa.SignedVote), nil
+	return pvs.([]*types.GrandpaSignedVote), nil
 }
 
 // SetPrecommits sets the precommits for a specific round and set ID in the database
-func (s *GrandpaState) SetPrecommits(round, setID uint64, pcs []*grandpa.SignedVote) error {
+func (s *GrandpaState) SetPrecommits(round, setID uint64, pcs []*types.GrandpaSignedVote) error {
 	data, err := scale.Encode(pcs)
 	if err != nil {
 		return err
@@ -345,16 +344,16 @@ func (s *GrandpaState) SetPrecommits(round, setID uint64, pcs []*grandpa.SignedV
 }
 
 // GetPrecommits retrieves the precommits for a specific round and set ID from the database
-func (s *GrandpaState) GetPrecommits(round, setID uint64) ([]*grandpa.SignedVote, error) {
+func (s *GrandpaState) GetPrecommits(round, setID uint64) ([]*types.GrandpaSignedVote, error) {
 	data, err := s.db.Get(precommitsKey(round, setID))
 	if err != nil {
 		return nil, err
 	}
 
-	pcs, err := scale.Decode(data, []*grandpa.SignedVote{})
+	pcs, err := scale.Decode(data, []*types.GrandpaSignedVote{})
 	if err != nil {
 		return nil, err
 	}
 
-	return pcs.([]*grandpa.SignedVote), nil
+	return pcs.([]*types.GrandpaSignedVote), nil
 }

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -125,6 +125,7 @@ func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
 func TestGrandpaState_LatestRound(t *testing.T) {
 	db := NewInMemoryDB(t)
 	gs, err := NewGrandpaStateFromGenesis(db, testAuths)
+	require.NoError(t, err)
 
 	r, err := gs.GetLatestRound()
 	require.NoError(t, err)
@@ -132,6 +133,7 @@ func TestGrandpaState_LatestRound(t *testing.T) {
 
 	err = gs.SetLatestRound(99)
 	require.NoError(t, err)
+
 	r, err = gs.GetLatestRound()
 	require.NoError(t, err)
 	require.Equal(t, uint64(99), r)

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -120,5 +120,19 @@ func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
 	setID, err = gs.GetSetIDByBlockNumber(big.NewInt(101))
 	require.NoError(t, err)
 	require.Equal(t, genesisSetID+1, setID)
+}
 
+func TestGrandpaState_LatestRound(t *testing.T) {
+	db := NewInMemoryDB(t)
+	gs, err := NewGrandpaStateFromGenesis(db, testAuths)
+
+	r, err := gs.GetLatestRound()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), r)
+
+	err = gs.SetLatestRound(99)
+	require.NoError(t, err)
+	r, err = gs.GetLatestRound()
+	require.NoError(t, err)
+	require.Equal(t, uint64(99), r)
 }

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 
@@ -171,4 +172,84 @@ type FinalisationInfo struct {
 	Header *Header
 	Round  uint64
 	SetID  uint64
+}
+
+// GrandpaSignedVote represents a signed precommit message for a finalised block
+type GrandpaSignedVote struct {
+	Vote        *GrandpaVote
+	Signature   [64]byte
+	AuthorityID ed25519.PublicKeyBytes
+}
+
+func (s *GrandpaSignedVote) String() string {
+	return fmt.Sprintf("SignedVote hash=%s number=%d authority=%s",
+		s.Vote.Hash,
+		s.Vote.Number,
+		s.AuthorityID,
+	)
+}
+
+// Encode returns the SCALE encoded Justification
+func (s *GrandpaSignedVote) Encode() ([]byte, error) {
+	enc, err := s.Vote.Encode()
+	if err != nil {
+		return nil, err
+	}
+
+	enc = append(enc, s.Signature[:]...)
+	enc = append(enc, s.AuthorityID[:]...)
+	return enc, nil
+}
+
+// Decode returns the SCALE decoded Justification
+func (s *GrandpaSignedVote) Decode(r io.Reader) (*GrandpaSignedVote, error) {
+	sd := &scale.Decoder{Reader: r}
+	i, err := sd.Decode(s)
+	if err != nil {
+		return nil, err
+	}
+
+	d := i.(*GrandpaSignedVote)
+	s.Vote = d.Vote
+	s.Signature = d.Signature
+	s.AuthorityID = d.AuthorityID
+	return s, nil
+}
+
+// GrandpaVote represents a vote for a block with the given hash and number
+type GrandpaVote struct {
+	Hash   common.Hash
+	Number uint32
+}
+
+// String returns the Vote as a string
+func (v *GrandpaVote) String() string {
+	return fmt.Sprintf("hash=%s number=%d", v.Hash, v.Number)
+}
+
+// Encode returns the SCALE encoding of a Vote
+func (v *GrandpaVote) Encode() ([]byte, error) {
+	buf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(buf, v.Number)
+	return append(v.Hash[:], buf...), nil
+}
+
+// Decode returns the SCALE decoded Vote
+func (v *GrandpaVote) Decode(r io.Reader) (*GrandpaVote, error) {
+	if v == nil {
+		v = new(GrandpaVote)
+	}
+
+	var err error
+	v.Hash, err = common.ReadHash(r)
+	if err != nil {
+		return nil, err
+	}
+
+	v.Number, err = common.ReadUint32(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
 }

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -417,7 +417,7 @@ func (b *Service) invokeBlockAuthoring() error {
 				return nil
 			case <-slotDone[i]:
 				slotNum := startSlot + uint64(i)
-				err = b.handleSlot(slotNum)
+				err = b.handleSlot(epoch, slotNum)
 				if err == ErrNotAuthorized {
 					logger.Debug("not authorized to produce a block in this slot",
 						"epoch", epoch,
@@ -479,7 +479,7 @@ func (b *Service) waitForEpochStart(epoch uint64) (uint64, error) {
 	return epochStart, nil
 }
 
-func (b *Service) handleSlot(slotNum uint64) error {
+func (b *Service) handleSlot(epoch, slotNum uint64) error {
 	if _, has := b.slotToProof[slotNum]; !has {
 		return ErrNotAuthorized
 	}
@@ -523,6 +523,7 @@ func (b *Service) handleSlot(slotNum uint64) error {
 	logger.Info("built block", "hash", block.Header.Hash().String(),
 		"number", block.Header.Number,
 		"state root", block.Header.StateRoot,
+		"epoch", epoch,
 		"slot", slotNum,
 	)
 	logger.Debug("built block",

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -101,5 +101,6 @@ var (
 	// ErrAuthorityNotInSet is returned when a precommit within a justification is signed by a key not in the authority set
 	ErrAuthorityNotInSet = errors.New("authority is not in set")
 
-	errVoteExists = errors.New("already have vote")
+	errVoteExists              = errors.New("already have vote")
+	errVoteToSignatureMismatch = errors.New("votes and authority count mismatch")
 )

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -301,7 +301,6 @@ func (s *Service) initiateRound() error {
 	s.precommits = new(sync.Map)
 	s.pvEquivocations = make(map[ed25519.PublicKeyBytes][]*SignedVote)
 	s.pcEquivocations = make(map[ed25519.PublicKeyBytes][]*SignedVote)
-	s.justification = make(map[uint64][]*SignedVote)
 	s.tracker, err = newTracker(s.blockState, s.in)
 	if err != nil {
 		return err

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -196,7 +196,7 @@ func (s *Service) Start() error {
 	go func() {
 		err := s.initiate()
 		if err != nil {
-			logger.Error("failed to initiate", "error", err)
+			logger.Crit("failed to initiate", "error", err)
 		}
 	}()
 
@@ -648,10 +648,8 @@ func (s *Service) attemptToFinalize() error {
 			"setID", s.state.setID,
 			"round", s.state.round,
 			"hash", s.head.Hash(),
-			"precommits #", pc,
-			"direct votes for bfc #", votes[*bfc],
+			"direct votes for bfc", votes[*bfc],
 			"total votes for bfc", pc,
-			"precommits", s.precommits,
 		)
 
 		cm, err := s.newCommitMessage(s.head, s.state.round)

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -153,7 +153,7 @@ func NewService(cfg *Config) (*Service, error) {
 	s := &Service{
 		ctx:                ctx,
 		cancel:             cancel,
-		state:              NewState(cfg.Voters, setID, round),
+		state:              NewState(cfg.Voters, setID, round+1),
 		blockState:         cfg.BlockState,
 		grandpaState:       cfg.GrandpaState,
 		digestHandler:      cfg.DigestHandler,
@@ -283,7 +283,8 @@ func (s *Service) initiateRound() error {
 		return err
 	}
 
-	if s.state.round == 0 {
+	// there was a setID change, or the node was started from genesis
+	if s.state.round == 1 {
 		s.chanLock.Lock()
 		s.mapLock.Lock()
 		s.preVotedBlock[0] = NewVoteFromHeader(s.head)

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -813,11 +813,11 @@ func (s *Service) finalise() error {
 	// set best final candidate
 	s.bestFinalCandidate[s.state.round] = bfc
 
-	// create prevote justification ie. list of all signed prevotes for the bfc
-	pvs, err := s.createJustification(bfc.hash, prevote)
-	if err != nil {
-		return err
-	}
+	// // create prevote justification ie. list of all signed prevotes for the bfc
+	// pvs, err := s.createJustification(bfc.hash, prevote)
+	// if err != nil {
+	// 	return err
+	// }
 
 	// create precommit justification ie. list of all signed precommits for the bfc
 	pcs, err := s.createJustification(bfc.hash, precommit)
@@ -825,10 +825,10 @@ func (s *Service) finalise() error {
 		return err
 	}
 
-	pvj, err := newJustification(s.state.round, bfc.hash, bfc.number, pvs).Encode()
-	if err != nil {
-		return err
-	}
+	// pvj, err := newJustification(s.state.round, bfc.hash, bfc.number, pvs).Encode()
+	// if err != nil {
+	// 	return err
+	// }
 
 	pcj, err := newJustification(s.state.round, bfc.hash, bfc.number, pcs).Encode()
 	if err != nil {
@@ -838,7 +838,8 @@ func (s *Service) finalise() error {
 	// cache justification
 	s.justification[s.state.round] = pcs
 
-	err = s.blockState.SetJustification(bfc.hash, append(pvj, pcj...))
+	// TODO: store prevotes in database, needed for catch-up
+	err = s.blockState.SetJustification(bfc.hash, pcj)
 	if err != nil {
 		return err
 	}

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -135,13 +135,13 @@ func TestGetDirectVotes(t *testing.T) {
 	gs, _ := newTestService(t)
 
 	voteA := &Vote{
-		hash:   common.Hash{0xa},
-		number: 1,
+		Hash:   common.Hash{0xa},
+		Number: 1,
 	}
 
 	voteB := &Vote{
-		hash:   common.Hash{0xb},
-		number: 1,
+		Hash:   common.Hash{0xb},
+		Number: 1,
 	}
 
 	for i, k := range kr.Keys {
@@ -192,11 +192,11 @@ func TestGetVotesForBlock_NoDescendantVotes(t *testing.T) {
 		}
 	}
 
-	votesForA, err := gs.getVotesForBlock(voteA.hash, prevote)
+	votesForA, err := gs.getVotesForBlock(voteA.Hash, prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(5), votesForA)
 
-	votesForB, err := gs.getVotesForBlock(voteB.hash, prevote)
+	votesForB, err := gs.getVotesForBlock(voteB.Hash, prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(4), votesForB)
 }
@@ -238,16 +238,16 @@ func TestGetVotesForBlock_DescendantVotes(t *testing.T) {
 		}
 	}
 
-	votesForA, err := gs.getVotesForBlock(voteA.hash, prevote)
+	votesForA, err := gs.getVotesForBlock(voteA.Hash, prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), votesForA)
 
 	// votesForB should be # of votes for A + # of votes for B
-	votesForB, err := gs.getVotesForBlock(voteB.hash, prevote)
+	votesForB, err := gs.getVotesForBlock(voteB.Hash, prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(5), votesForB)
 
-	votesForC, err := gs.getVotesForBlock(voteC.hash, prevote)
+	votesForC, err := gs.getVotesForBlock(voteC.Hash, prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(4), votesForC)
 }
@@ -465,7 +465,7 @@ func TestGetPossibleSelectedBlocks_OneBlock(t *testing.T) {
 	blocks, err := gs.getPossibleSelectedBlocks(prevote, gs.state.threshold())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
-	require.Equal(t, voteA.number, blocks[voteA.hash])
+	require.Equal(t, voteA.Number, blocks[voteA.Hash])
 }
 
 func TestGetPossibleSelectedBlocks_EqualVotes_SameAncestor(t *testing.T) {
@@ -733,8 +733,8 @@ func TestGetPreVotedBlock_MultipleCandidates(t *testing.T) {
 
 	block, err := gs.getPreVotedBlock()
 	require.NoError(t, err)
-	require.Equal(t, expected, block.hash)
-	require.Equal(t, uint32(7), block.number)
+	require.Equal(t, expected, block.Hash)
+	require.Equal(t, uint32(7), block.Number)
 }
 
 func TestGetPreVotedBlock_EvenMoreCandidates(t *testing.T) {
@@ -808,8 +808,8 @@ func TestGetPreVotedBlock_EvenMoreCandidates(t *testing.T) {
 
 	block, err := gs.getPreVotedBlock()
 	require.NoError(t, err)
-	require.Equal(t, expected, block.hash)
-	require.Equal(t, uint32(5), block.number)
+	require.Equal(t, expected, block.Hash)
+	require.Equal(t, uint32(5), block.Number)
 }
 
 func TestIsCompletable(t *testing.T) {
@@ -868,7 +868,7 @@ func TestFindParentWithNumber(t *testing.T) {
 	expected, err := st.Block.GetBlockByNumber(big.NewInt(1))
 	require.NoError(t, err)
 
-	require.Equal(t, expected.Header.Hash(), p.hash)
+	require.Equal(t, expected.Header.Hash(), p.Hash)
 }
 
 func TestGetBestFinalCandidate_OneBlock(t *testing.T) {
@@ -1025,12 +1025,12 @@ func TestGetBestFinalCandidate_PrecommitOnAnotherChain(t *testing.T) {
 		}
 	}
 
-	pred, err := st.Block.HighestCommonAncestor(voteA.hash, voteB.hash)
+	pred, err := st.Block.HighestCommonAncestor(voteA.Hash, voteB.Hash)
 	require.NoError(t, err)
 
 	bfc, err := gs.getBestFinalCandidate()
 	require.NoError(t, err)
-	require.Equal(t, pred, bfc.hash)
+	require.Equal(t, pred, bfc.Hash)
 }
 
 func TestDeterminePreVote_NoPrimaryPreVote(t *testing.T) {
@@ -1042,7 +1042,7 @@ func TestDeterminePreVote_NoPrimaryPreVote(t *testing.T) {
 
 	header, err := st.Block.BestBlockHeader()
 	require.NoError(t, err)
-	require.Equal(t, header.Hash(), pv.hash)
+	require.Equal(t, header.Hash(), pv.Hash)
 }
 
 func TestDeterminePreVote_WithPrimaryPreVote(t *testing.T) {
@@ -1083,7 +1083,7 @@ func TestDeterminePreVote_WithInvalidPrimaryPreVote(t *testing.T) {
 
 	pv, err := gs.determinePreVote()
 	require.NoError(t, err)
-	require.Equal(t, gs.head.Hash(), pv.hash)
+	require.Equal(t, gs.head.Hash(), pv.Hash)
 }
 
 func TestIsFinalisable_True(t *testing.T) {
@@ -1160,7 +1160,7 @@ func TestIsFinalisable_False(t *testing.T) {
 	// previous round has finalised block # higher than current, so round is not finalisable
 	gs.state.round = 1
 	gs.bestFinalCandidate[0] = &Vote{
-		number: 4,
+		Number: 4,
 	}
 	gs.preVotedBlock[gs.state.round] = voteA
 
@@ -1196,12 +1196,12 @@ func TestGetGrandpaGHOST_CommonAncestor(t *testing.T) {
 		}
 	}
 
-	pred, err := gs.blockState.HighestCommonAncestor(voteA.hash, voteB.hash)
+	pred, err := gs.blockState.HighestCommonAncestor(voteA.Hash, voteB.Hash)
 	require.NoError(t, err)
 
 	block, err := gs.getGrandpaGHOST()
 	require.NoError(t, err)
-	require.Equal(t, pred, block.hash)
+	require.Equal(t, pred, block.Hash)
 }
 
 func TestGetGrandpaGHOST_MultipleCandidates(t *testing.T) {
@@ -1249,8 +1249,8 @@ func TestGetGrandpaGHOST_MultipleCandidates(t *testing.T) {
 
 	block, err := gs.getGrandpaGHOST()
 	require.NoError(t, err)
-	require.Equal(t, expected, block.hash)
-	require.Equal(t, uint32(3), block.number)
+	require.Equal(t, expected, block.Hash)
+	require.Equal(t, uint32(3), block.Number)
 
 	pv, err := gs.getPreVotedBlock()
 	require.NoError(t, err)

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -78,8 +78,8 @@ func (m *SignedMessage) Decode(r io.Reader) (err error) {
 		return err
 	}
 
-	m.Hash = vote.hash
-	m.Number = vote.number
+	m.Hash = vote.Hash
+	m.Number = vote.Number
 
 	sig, err := common.Read64Bytes(r)
 	if err != nil {

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -301,6 +301,23 @@ func justificationToCompact(just []*SignedVote) ([]*Vote, []*AuthData) {
 	return precommits, authData
 }
 
+func compactToJustification(vs []*Vote, auths []*AuthData) ([]*SignedVote, error) {
+	if len(vs) != len(auths) {
+		return nil, errVoteToSignatureMismatch
+	}
+
+	just := make([]*SignedVote, len(vs))
+	for i, v := range vs {
+		just[i] = &SignedVote{
+			Vote:        v,
+			Signature:   auths[i].Signature,
+			AuthorityID: auths[i].AuthorityID,
+		}
+	}
+
+	return just, nil
+}
+
 type catchUpRequest struct {
 	Round uint64
 	SetID uint64

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -271,16 +271,19 @@ func (f *CommitMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 	}, nil
 }
 
-func (s *Service) newCommitMessage(header *types.Header, round uint64) *CommitMessage {
-	// TODO: get justification from database and parse for precommits
-	just := s.justification[round]
-	precommits, authData := justificationToCompact(just)
+func (s *Service) newCommitMessage(header *types.Header, round uint64) (*CommitMessage, error) {
+	pcs, err := s.grandpaState.GetPrecommits(round, s.state.setID)
+	if err != nil {
+		return nil, err
+	}
+
+	precommits, authData := justificationToCompact(pcs)
 	return &CommitMessage{
 		Round:      round,
 		Vote:       NewVoteFromHeader(header),
 		Precommits: precommits,
 		AuthData:   authData,
-	}
+	}, nil
 }
 
 func justificationToCompact(just []*SignedVote) ([]*Vote, []*AuthData) {

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -273,6 +273,7 @@ func (f *CommitMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 }
 
 func (s *Service) newCommitMessage(header *types.Header, round uint64) *CommitMessage {
+	// TODO: get justification from database and parse for precommits
 	just := s.justification[round]
 	precommits, authData := justificationToCompact(just)
 	return &CommitMessage{

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -221,13 +221,20 @@ func (h *MessageHandler) handleCatchUpResponse(msg *catchUpResponse) error {
 		return err
 	}
 
+	// set prevotes and precommits in db
+	if err = h.grandpa.grandpaState.SetPrevotes(msg.Round, msg.SetID, msg.PreVoteJustification); err != nil {
+		return err
+	}
+
+	if err = h.grandpa.grandpaState.SetPrecommits(msg.Round, msg.SetID, msg.PreCommitJustification); err != nil {
+		return err
+	}
+
 	// update state and signal to grandpa we are ready to initiate
 	head, err := h.grandpa.blockState.GetHeader(msg.Hash)
 	if err != nil {
 		return err
 	}
-
-	// TODO: set prevotes and precommits in db
 
 	h.grandpa.head = head
 	h.grandpa.state.round = msg.Round

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -126,7 +126,7 @@ func (h *MessageHandler) handleCommitMessage(msg *CommitMessage) (*ConsensusMess
 	}
 
 	// set finalised head for round in db
-	if err := h.blockState.SetFinalizedHash(msg.Vote.hash, msg.Round, h.grandpa.state.setID); err != nil {
+	if err := h.blockState.SetFinalizedHash(msg.Vote.Hash, msg.Round, h.grandpa.state.setID); err != nil {
 		return nil, err
 	}
 
@@ -141,7 +141,7 @@ func (h *MessageHandler) handleCommitMessage(msg *CommitMessage) (*ConsensusMess
 
 	if msg.Round >= h.grandpa.state.round {
 		// set latest finalised head in db
-		err = h.blockState.SetFinalizedHash(msg.Vote.hash, 0, 0)
+		err = h.blockState.SetFinalizedHash(msg.Vote.Hash, 0, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -275,7 +275,7 @@ func (h *MessageHandler) verifyCommitMessageJustification(fm *CommitMessage) err
 			continue
 		}
 
-		isDescendant, err := h.blockState.IsDescendantOf(fm.Vote.hash, just.Vote.hash)
+		isDescendant, err := h.blockState.IsDescendantOf(fm.Vote.Hash, just.Vote.Hash)
 		if err != nil {
 			logger.Warn("verifyCommitMessageJustification", "error", err)
 		}
@@ -306,7 +306,7 @@ func (h *MessageHandler) verifyPreVoteJustification(msg *catchUpResponse) (commo
 			continue
 		}
 
-		votes[just.Vote.hash]++
+		votes[just.Vote.Hash]++
 	}
 
 	var prevote common.Hash
@@ -333,7 +333,7 @@ func (h *MessageHandler) verifyPreCommitJustification(msg *catchUpResponse) erro
 			continue
 		}
 
-		if just.Vote.hash == msg.Hash && just.Vote.number == msg.Number {
+		if just.Vote.Hash == msg.Hash && just.Vote.Number == msg.Number {
 			count++
 		}
 	}
@@ -422,11 +422,11 @@ func (s *Service) VerifyBlockJustification(justification []byte) error {
 	}
 
 	for _, just := range fj.Commit.Precommits {
-		if just.Vote.hash != fj.Commit.Hash {
+		if just.Vote.Hash != fj.Commit.Hash {
 			return ErrJustificationHashMismatch
 		}
 
-		if just.Vote.number != fj.Commit.Number {
+		if just.Vote.Number != fj.Commit.Number {
 			return ErrJustificationNumberMismatch
 		}
 

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -336,11 +336,6 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 	setID := uint64(0)
 	gs.state.round = round + 1
 
-	v := &Vote{
-		Hash:   testHeader.Hash(),
-		Number: 1,
-	}
-
 	err := st.Block.AddBlock(testBlock)
 	require.NoError(t, err)
 
@@ -357,9 +352,6 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 		},
 	}
 
-	pvjEnc, err := scale.Encode(pvj)
-	require.NoError(t, err)
-
 	pcj := []*SignedVote{
 		{
 			Vote:        testVote2,
@@ -368,10 +360,9 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 		},
 	}
 
-	pcjEnc, err := scale.Encode(pcj)
+	err = gs.grandpaState.SetPrevotes(round, setID, pvj)
 	require.NoError(t, err)
-
-	err = gs.blockState.SetJustification(v.Hash, append(pvjEnc, pcjEnc...))
+	err = gs.grandpaState.SetPrecommits(round, setID, pcj)
 	require.NoError(t, err)
 
 	resp, err := gs.newCatchUpResponse(round, setID)

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -109,8 +109,8 @@ func TestDecodeMessage_CommitMessage(t *testing.T) {
 		Round: 77,
 		SetID: 1,
 		Vote: &Vote{
-			hash:   common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
-			number: 99,
+			Hash:   common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
+			Number: 99,
 		},
 		Precommits: []*Vote{
 			testVote,
@@ -171,7 +171,7 @@ func TestMessageHandler_VoteMessage(t *testing.T) {
 
 	gs.state.setID = 99
 	gs.state.round = 77
-	v.number = 0x7777
+	v.Number = 0x7777
 	_, vm, err := gs.createSignedVoteAndVoteMessage(v, precommit)
 	require.NoError(t, err)
 
@@ -237,12 +237,15 @@ func TestMessageHandler_CommitMessage_NoCatchUpRequest_ValidSig(t *testing.T) {
 
 	round := uint64(77)
 	gs.state.round = round
-	gs.justification[round] = buildTestJustification(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
+	just := buildTestJustification(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
+	err := st.Grandpa.SetPrecommits(round, gs.state.setID, just)
+	require.NoError(t, err)
 
-	fm := gs.newCommitMessage(gs.head, round)
+	fm, err := gs.newCommitMessage(gs.head, round)
+	require.NoError(t, err)
 	fm.Vote = NewVote(testHash, uint32(round))
 
-	err := st.Block.AddBlock(testBlock)
+	err = st.Block.AddBlock(testBlock)
 	require.NoError(t, err)
 
 	h := NewMessageHandler(gs, st.Block)
@@ -252,11 +255,11 @@ func TestMessageHandler_CommitMessage_NoCatchUpRequest_ValidSig(t *testing.T) {
 
 	hash, err := st.Block.GetFinalizedHash(0, 0)
 	require.NoError(t, err)
-	require.Equal(t, fm.Vote.hash, hash)
+	require.Equal(t, fm.Vote.Hash, hash)
 
 	hash, err = st.Block.GetFinalizedHash(fm.Round, gs.state.setID)
 	require.NoError(t, err)
-	require.Equal(t, fm.Vote.hash, hash)
+	require.Equal(t, fm.Vote.Hash, hash)
 }
 
 func TestMessageHandler_CommitMessage_NoCatchUpRequest_MinVoteError(t *testing.T) {
@@ -265,9 +268,12 @@ func TestMessageHandler_CommitMessage_NoCatchUpRequest_MinVoteError(t *testing.T
 	round := uint64(77)
 	gs.state.round = round
 
-	gs.justification[round] = buildTestJustification(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
+	just := buildTestJustification(t, int(gs.state.threshold()), round, gs.state.setID, kr, precommit)
+	err := st.Grandpa.SetPrecommits(round, gs.state.setID, just)
+	require.NoError(t, err)
 
-	fm := gs.newCommitMessage(gs.head, round)
+	fm, err := gs.newCommitMessage(gs.head, round)
+	require.NoError(t, err)
 
 	h := NewMessageHandler(gs, st.Block)
 	out, err := h.handleMessage("", fm)
@@ -278,15 +284,19 @@ func TestMessageHandler_CommitMessage_NoCatchUpRequest_MinVoteError(t *testing.T
 func TestMessageHandler_CommitMessage_WithCatchUpRequest(t *testing.T) {
 	gs, st := newTestService(t)
 
-	gs.justification[77] = []*SignedVote{
+	just := []*SignedVote{
 		{
 			Vote:        testVote,
 			Signature:   testSignature,
 			AuthorityID: gs.publicKeyBytes(),
 		},
 	}
+	err := st.Grandpa.SetPrecommits(77, gs.state.setID, just)
+	require.NoError(t, err)
 
-	fm := gs.newCommitMessage(gs.head, 77)
+	fm, err := gs.newCommitMessage(gs.head, 77)
+	require.NoError(t, err)
+
 	gs.state.voters = gs.state.voters[:1]
 
 	h := NewMessageHandler(gs, st.Block)
@@ -327,8 +337,8 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 	gs.state.round = round + 1
 
 	v := &Vote{
-		hash:   testHeader.Hash(),
-		number: 1,
+		Hash:   testHeader.Hash(),
+		Number: 1,
 	}
 
 	err := st.Block.AddBlock(testBlock)
@@ -361,7 +371,7 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 	pcjEnc, err := scale.Encode(pcj)
 	require.NoError(t, err)
 
-	err = gs.blockState.SetJustification(v.hash, append(pvjEnc, pcjEnc...))
+	err = gs.blockState.SetJustification(v.Hash, append(pvjEnc, pcjEnc...))
 	require.NoError(t, err)
 
 	resp, err := gs.newCatchUpResponse(round, setID)
@@ -386,7 +396,7 @@ func TestVerifyJustification(t *testing.T) {
 	vote := NewVote(testHash, 123)
 	just := &SignedVote{
 		Vote:        vote,
-		Signature:   createSignedVoteMsg(t, vote.number, 77, gs.state.setID, kr.Alice().(*ed25519.Keypair), precommit),
+		Signature:   createSignedVoteMsg(t, vote.Number, 77, gs.state.setID, kr.Alice().(*ed25519.Keypair), precommit),
 		AuthorityID: kr.Alice().Public().(*ed25519.PublicKey).AsBytes(),
 	}
 
@@ -402,7 +412,7 @@ func TestVerifyJustification_InvalidSignature(t *testing.T) {
 	just := &SignedVote{
 		Vote: vote,
 		// create signed vote with mismatched vote number
-		Signature:   createSignedVoteMsg(t, vote.number+1, 77, gs.state.setID, kr.Alice().(*ed25519.Keypair), precommit),
+		Signature:   createSignedVoteMsg(t, vote.Number+1, 77, gs.state.setID, kr.Alice().(*ed25519.Keypair), precommit),
 		AuthorityID: kr.Alice().Public().(*ed25519.PublicKey).AsBytes(),
 	}
 
@@ -420,7 +430,7 @@ func TestVerifyJustification_InvalidAuthority(t *testing.T) {
 	vote := NewVote(testHash, 123)
 	just := &SignedVote{
 		Vote:        vote,
-		Signature:   createSignedVoteMsg(t, vote.number, 77, gs.state.setID, fakeKey, precommit),
+		Signature:   createSignedVoteMsg(t, vote.Number, 77, gs.state.setID, fakeKey, precommit),
 		AuthorityID: fakeKey.Public().(*ed25519.PublicKey).AsBytes(),
 	}
 

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/scale"
 
 	"github.com/stretchr/testify/require"
 )
@@ -84,6 +83,7 @@ func TestCommitMessageToConsensusMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	fm, err := gs.newCommitMessage(gs.head, 77)
+	require.NoError(t, err)
 	precommits, authData := justificationToCompact(just)
 
 	expected := &CommitMessage{
@@ -123,9 +123,6 @@ func TestNewCatchUpResponse(t *testing.T) {
 		},
 	}
 
-	pvjEnc, err := scale.Encode(pvj)
-	require.NoError(t, err)
-
 	pcj := []*SignedVote{
 		{
 			Vote:        testVote2,
@@ -134,10 +131,9 @@ func TestNewCatchUpResponse(t *testing.T) {
 		},
 	}
 
-	pcjEnc, err := scale.Encode(pcj)
+	err = gs.grandpaState.SetPrevotes(round, setID, pvj)
 	require.NoError(t, err)
-
-	err = gs.blockState.SetJustification(v.Hash, append(pvjEnc, pcjEnc...))
+	err = gs.grandpaState.SetPrecommits(round, setID, pcj)
 	require.NoError(t, err)
 
 	resp, err := gs.newCatchUpResponse(round, setID)

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 var testVote = &Vote{
-	hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
-	number: 999,
+	Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+	Number: 999,
 }
 
 var testVote2 = &Vote{
-	hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
-	number: 333,
+	Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+	Number: 333,
 }
 
 var testSignature = [64]byte{1, 2, 3, 4}
@@ -32,7 +32,7 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 
 	gs.state.setID = 99
 	gs.state.round = 77
-	v.number = 0x7777
+	v.Number = 0x7777
 
 	// test precommit
 	_, vm, err := gs.createSignedVoteAndVoteMessage(v, precommit)
@@ -44,8 +44,8 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 		SetID: gs.state.setID,
 		Message: &SignedMessage{
 			Stage:       precommit,
-			Hash:        v.hash,
-			Number:      v.number,
+			Hash:        v.Hash,
+			Number:      v.Number,
 			AuthorityID: gs.keypair.Public().(*ed25519.PublicKey).AsBytes(),
 		},
 	}
@@ -62,8 +62,8 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 		SetID: gs.state.setID,
 		Message: &SignedMessage{
 			Stage:       prevote,
-			Hash:        v.hash,
-			Number:      v.number,
+			Hash:        v.Hash,
+			Number:      v.Number,
 			AuthorityID: gs.keypair.Public().(*ed25519.PublicKey).AsBytes(),
 		},
 	}
@@ -72,17 +72,19 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 }
 
 func TestCommitMessageToConsensusMessage(t *testing.T) {
-	gs, _ := newTestService(t)
-	gs.justification[77] = []*SignedVote{
+	gs, st := newTestService(t)
+	just := []*SignedVote{
 		{
 			Vote:        testVote,
 			Signature:   testSignature,
 			AuthorityID: gs.publicKeyBytes(),
 		},
 	}
+	err := st.Grandpa.SetPrecommits(77, gs.state.setID, just)
+	require.NoError(t, err)
 
-	fm := gs.newCommitMessage(gs.head, 77)
-	precommits, authData := justificationToCompact(gs.justification[77])
+	fm, err := gs.newCommitMessage(gs.head, 77)
+	precommits, authData := justificationToCompact(just)
 
 	expected := &CommitMessage{
 		Round:      77,
@@ -101,8 +103,8 @@ func TestNewCatchUpResponse(t *testing.T) {
 	setID := uint64(1)
 
 	v := &Vote{
-		hash:   testHeader.Hash(),
-		number: 1,
+		Hash:   testHeader.Hash(),
+		Number: 1,
 	}
 
 	err := st.Block.AddBlock(testBlock)
@@ -135,7 +137,7 @@ func TestNewCatchUpResponse(t *testing.T) {
 	pcjEnc, err := scale.Encode(pcj)
 	require.NoError(t, err)
 
-	err = gs.blockState.SetJustification(v.hash, append(pvjEnc, pcjEnc...))
+	err = gs.blockState.SetJustification(v.Hash, append(pvjEnc, pcjEnc...))
 	require.NoError(t, err)
 
 	resp, err := gs.newCatchUpResponse(round, setID)
@@ -146,8 +148,8 @@ func TestNewCatchUpResponse(t *testing.T) {
 		SetID:                  setID,
 		PreVoteJustification:   pvj,
 		PreCommitJustification: pcj,
-		Hash:                   v.hash,
-		Number:                 v.number,
+		Hash:                   v.Hash,
+		Number:                 v.Number,
 	}
 
 	require.Equal(t, expected, resp)

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -128,8 +128,8 @@ func TestMessageTracker_ProcessMessage(t *testing.T) {
 
 	time.Sleep(time.Second)
 	expected := &Vote{
-		hash:   msg.Message.Hash,
-		number: msg.Message.Number,
+		Hash:   msg.Message.Hash,
+		Number: msg.Message.Number,
 	}
 	pv, has := gs.prevotes.Load(kr.Alice().Public().(*ed25519.PublicKey).AsBytes())
 	require.True(t, has)

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -49,15 +49,19 @@ func TestGrandpaHandshake_Encode(t *testing.T) {
 func TestHandleNetworkMessage(t *testing.T) {
 	gs, st := newTestService(t)
 
-	gs.justification[77] = []*SignedVote{
+	just := []*SignedVote{
 		{
 			Vote:        testVote,
 			Signature:   testSignature,
 			AuthorityID: gs.publicKeyBytes(),
 		},
 	}
+	err := st.Grandpa.SetPrecommits(77, gs.state.setID, just)
+	require.NoError(t, err)
 
-	fm := gs.newCommitMessage(gs.head, 77)
+	fm, err := gs.newCommitMessage(gs.head, 77)
+	require.NoError(t, err)
+
 	cm, err := fm.ToConsensusMessage()
 	require.NoError(t, err)
 	gs.state.voters = gs.state.voters[:1]

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -607,7 +607,7 @@ func TestPlayGrandpaRound_MultipleRounds(t *testing.T) {
 		head := gss[0].blockState.(*state.BlockState).BestBlockHash()
 		for _, fb := range finalised {
 			require.NotNil(t, fb)
-			require.Equal(t, head, fb.Vote.hash)
+			require.Equal(t, head, fb.Vote.Hash)
 			require.GreaterOrEqual(t, len(fb.Precommits), len(kr.Keys)/2)
 			require.GreaterOrEqual(t, len(fb.AuthData), len(kr.Keys)/2)
 			finalised[0].Precommits = []*Vote{}

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -58,6 +58,8 @@ type GrandpaState interface { //nolint
 	GetCurrentSetID() (uint64, error)
 	GetAuthorities(setID uint64) ([]*types.GrandpaVoter, error)
 	GetSetIDByBlockNumber(num *big.Int) (uint64, error)
+	SetLatestRound(round uint64) error
+	GetLatestRound() (uint64, error)
 }
 
 // DigestHandler is the interface required by GRANDPA for the digest handler

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -60,6 +60,10 @@ type GrandpaState interface { //nolint
 	GetSetIDByBlockNumber(num *big.Int) (uint64, error)
 	SetLatestRound(round uint64) error
 	GetLatestRound() (uint64, error)
+	SetPrevotes(round, setID uint64, data []*SignedVote) error
+	SetPrecommits(round, setID uint64, data []*SignedVote) error
+	GetPrevotes(round, setID uint64) ([]*SignedVote, error)
+	GetPrecommits(round, setID uint64) ([]*SignedVote, error)
 }
 
 // DigestHandler is the interface required by GRANDPA for the digest handler

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -18,8 +18,6 @@ package grandpa
 
 import (
 	"bytes"
-	"encoding/binary"
-	"fmt"
 	"io"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -30,8 +28,9 @@ import (
 
 //nolint
 type (
-	Voter  = types.GrandpaVoter
-	Voters = types.GrandpaVoters
+	Voter      = types.GrandpaVoter
+	Voters     = types.GrandpaVoters
+	SignedVote = types.GrandpaSignedVote
 )
 
 type subround byte
@@ -121,25 +120,21 @@ func (s *State) threshold() uint64 {
 	return uint64(2 * len(s.voters) / 3)
 }
 
-// Vote represents a vote for a block with the given hash and number
-type Vote struct {
-	hash   common.Hash
-	number uint32
-}
+type Vote = types.GrandpaVote
 
 // NewVote returns a new Vote given a block hash and number
 func NewVote(hash common.Hash, number uint32) *Vote {
 	return &Vote{
-		hash:   hash,
-		number: number,
+		Hash:   hash,
+		Number: number,
 	}
 }
 
 // NewVoteFromHeader returns a new Vote for a given header
 func NewVoteFromHeader(h *types.Header) *Vote {
 	return &Vote{
-		hash:   h.Hash(),
-		number: uint32(h.Number.Int64()),
+		Hash:   h.Hash(),
+		Number: uint32(h.Number.Int64()),
 	}
 }
 
@@ -160,80 +155,6 @@ func NewVoteFromHash(hash common.Hash, blockState BlockState) (*Vote, error) {
 	}
 
 	return NewVoteFromHeader(h), nil
-}
-
-// Encode returns the SCALE encoding of a Vote
-func (v *Vote) Encode() ([]byte, error) {
-	buf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(buf, v.number)
-	return append(v.hash[:], buf...), nil
-}
-
-// Decode returns the SCALE decoded Vote
-func (v *Vote) Decode(r io.Reader) (*Vote, error) {
-	if v == nil {
-		v = new(Vote)
-	}
-
-	var err error
-	v.hash, err = common.ReadHash(r)
-	if err != nil {
-		return nil, err
-	}
-
-	v.number, err = common.ReadUint32(r)
-	if err != nil {
-		return nil, err
-	}
-
-	return v, nil
-}
-
-// String returns the Vote as a string
-func (v *Vote) String() string {
-	return fmt.Sprintf("hash=%s number=%d", v.hash, v.number)
-}
-
-// SignedVote represents a signed precommit message for a finalised block
-type SignedVote struct {
-	Vote        *Vote
-	Signature   [64]byte
-	AuthorityID ed25519.PublicKeyBytes
-}
-
-func (s *SignedVote) String() string {
-	return fmt.Sprintf("SignedVote hash=%s number=%d authority=%s",
-		s.Vote.hash,
-		s.Vote.number,
-		s.AuthorityID,
-	)
-}
-
-// Encode returns the SCALE encoded Justification
-func (s *SignedVote) Encode() ([]byte, error) {
-	enc, err := s.Vote.Encode()
-	if err != nil {
-		return nil, err
-	}
-
-	enc = append(enc, s.Signature[:]...)
-	enc = append(enc, s.AuthorityID[:]...)
-	return enc, nil
-}
-
-// Decode returns the SCALE decoded Justification
-func (s *SignedVote) Decode(r io.Reader) (*SignedVote, error) {
-	sd := &scale.Decoder{Reader: r}
-	i, err := sd.Decode(s)
-	if err != nil {
-		return nil, err
-	}
-
-	d := i.(*SignedVote)
-	s.Vote = d.Vote
-	s.Signature = d.Signature
-	s.AuthorityID = d.AuthorityID
-	return s, nil
 }
 
 // Commit contains all the signed precommits for a given block

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -260,12 +260,12 @@ func newJustification(round uint64, hash common.Hash, number uint32, j []*Signed
 	}
 }
 
-// Encode returns the SCALE encoding of a FullJustification
+// Encode returns the SCALE encoding of a Justification
 func (j *Justification) Encode() ([]byte, error) {
 	return scale.Encode(j)
 }
 
-// Decode returns a SCALE decoded FullJustification
+// Decode returns a SCALE decoded Justification
 func (j *Justification) Decode(r io.Reader) error {
 	sd := &scale.Decoder{Reader: r}
 	i, err := sd.Decode(&Justification{Commit: &Commit{}})

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -30,6 +30,7 @@ import (
 type (
 	Voter      = types.GrandpaVoter
 	Voters     = types.GrandpaVoters
+	Vote       = types.GrandpaVote
 	SignedVote = types.GrandpaSignedVote
 )
 
@@ -119,8 +120,6 @@ func (s *State) pubkeyToVoter(pk *ed25519.PublicKey) (*Voter, error) {
 func (s *State) threshold() uint64 {
 	return uint64(2 * len(s.voters) / 3)
 }
-
-type Vote = types.GrandpaVote
 
 // NewVote returns a new Vote given a block hash and number
 func NewVote(hash common.Hash, number uint32) *Vote {

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -163,8 +163,13 @@ func (s *Service) validateMessage(m *VoteMessage) (*Vote, error) {
 				return nil, err
 			}
 
+			cm, err := s.newCommitMessage(header, m.Round)
+			if err != nil {
+				return nil, err
+			}
+
 			// send finalised block from previous round to network
-			msg, err := s.newCommitMessage(header, m.Round).ToConsensusMessage()
+			msg, err := cm.ToConsensusMessage()
 			if err != nil {
 				return nil, err
 			}

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -99,8 +99,8 @@ func (s *Service) createSignedVoteAndVoteMessage(vote *Vote, stage subround) (*S
 
 	sm := &SignedMessage{
 		Stage:       stage,
-		Hash:        pc.Vote.hash,
-		Number:      pc.Vote.number,
+		Hash:        pc.Vote.Hash,
+		Number:      pc.Vote.Number,
 		Signature:   ed25519.NewSignatureBytes(sig),
 		AuthorityID: s.keypair.Public().(*ed25519.PublicKey).AsBytes(),
 	}
@@ -134,12 +134,12 @@ func (s *Service) validateMessage(m *VoteMessage) (*Vote, error) {
 	switch m.Message.Stage {
 	case prevote, primaryProposal:
 		pv, has := s.loadVote(pk.AsBytes(), prevote)
-		if has && pv.Vote.hash.Equal(m.Message.Hash) {
+		if has && pv.Vote.Hash.Equal(m.Message.Hash) {
 			return nil, errVoteExists
 		}
 	case precommit:
 		pc, has := s.loadVote(pk.AsBytes(), precommit)
-		if has && pc.Vote.hash.Equal(m.Message.Hash) {
+		if has && pc.Vote.Hash.Equal(m.Message.Hash) {
 			return nil, errVoteExists
 		}
 	}
@@ -200,7 +200,7 @@ func (s *Service) validateMessage(m *VoteMessage) (*Vote, error) {
 	if errors.Is(err, ErrBlockDoesNotExist) || errors.Is(err, blocktree.ErrEndNodeNotFound) {
 		// TODO: cancel if block is imported; if we refactor the syncing this will likely become cleaner
 		// as we can have an API to synchronously sync and import a block
-		go s.network.SendBlockReqestByHash(vote.hash)
+		go s.network.SendBlockReqestByHash(vote.Hash)
 		s.tracker.add(m)
 	}
 	if err != nil {
@@ -259,7 +259,7 @@ func (s *Service) checkForEquivocation(voter *Voter, vote *SignedVote, stage sub
 		return false
 	}
 
-	if has && existingVote.Vote.hash != vote.Vote.hash {
+	if has && existingVote.Vote.Hash != vote.Vote.Hash {
 		// the voter has already voted, all their votes are now equivocatory
 		eq[v] = []*SignedVote{existingVote, vote}
 		s.deleteVote(v, stage)
@@ -273,7 +273,7 @@ func (s *Service) checkForEquivocation(voter *Voter, vote *SignedVote, stage sub
 // previously finalised block.
 func (s *Service) validateVote(v *Vote) error {
 	// check if v.hash corresponds to a valid block
-	has, err := s.blockState.HasHeader(v.hash)
+	has, err := s.blockState.HasHeader(v.Hash)
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (s *Service) validateVote(v *Vote) error {
 	}
 
 	// check if the block is an eventual descendant of a previously finalised block
-	isDescendant, err := s.blockState.IsDescendantOf(s.head.Hash(), v.hash)
+	isDescendant, err := s.blockState.IsDescendantOf(s.head.Hash(), v.Hash)
 	if err != nil {
 		return err
 	}

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -201,7 +201,7 @@ func TestValidateMessage_Valid(t *testing.T) {
 
 	vote, err := gs.validateMessage(msg)
 	require.NoError(t, err)
-	require.Equal(t, h.Hash(), vote.hash)
+	require.Equal(t, h.Hash(), vote.Hash)
 }
 
 func TestValidateMessage_InvalidSignature(t *testing.T) {


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add getters and setters for prevotes and precommits for each round/setID to `state.GrandpaState`
- store prevotes, precommits, justification for each round separately in the db (previously was storing it all under justification, but that was incorrect)
- remove `grandpa.Service.justification` map, just load from db when justification is needed
- get latest round from db on restart and use when initiating grandpa

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/state
go test ./lib/grandpa -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- related to #1680
