### PR TITLE
fix(lib/grandpa): Fix max value for digest.

### DIFF
--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -19,6 +19,7 @@ package digest
 import (
 	"context"
 	"errors"
+	"math"
 	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -28,7 +29,7 @@ import (
 	log "github.com/ChainSafe/log15"
 )
 
-var maxUint64 = uint64(2^64) - 1
+var maxUint64 = uint64(math.MaxUint64)
 
 var (
 	_      services.Service = &Handler{}

--- a/go.sum
+++ b/go.sum
@@ -273,7 +273,6 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -710,11 +710,11 @@ func (s *Service) determinePreVote() (*Vote, error) {
 
 	nextChange := s.digestHandler.NextGrandpaAuthorityChange()
 	if uint64(vote.number) > nextChange {
-		header, err := s.blockState.GetHeaderByNumber(big.NewInt(int64(nextChange)))
+		headerNum := new(big.Int).SetUint64(nextChange)
+		header, err := s.blockState.GetHeaderByNumber(headerNum)
 		if err != nil {
 			return nil, err
 		}
-
 		vote = NewVoteFromHeader(header)
 	}
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Fix max value for digest.
- `2^64` does bitwise xor. Hence `2^64 = 66`

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```

```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- #592
- closes #1680