### PR TITLE
fix(dot/state): fix runtime panic due to stopped runtime

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -267,6 +267,8 @@ func (s *Service) handleCodeSubstitution(hash common.Hash) error {
 		return err
 	}
 
+	// TODO: this needs to create a new runtime instance, otherwise it will update
+	// the blocks that reference the current runtime version to use the code substition
 	err = rt.UpdateRuntimeCode(code)
 	if err != nil {
 		return err

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -294,6 +294,10 @@ func (in *Instance) exec(function string, data []byte) ([]byte, error) {
 	in.Lock()
 	defer in.Unlock()
 
+	if in.isClosed {
+		return nil, errors.New("instance is stopped")
+	}
+
 	ptr, err := in.malloc(uint32(len(data)))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- runtime was being stopped when it was pruned; however valid blocks might be pruned from the blocktree if they're past the most recent finalized head, causing the runtime referenced by newer blocks also to be stopped
- don't stop runtime in blocktree prune anymore since unpruned blocks might reference it

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

run a dev node before/after and see that this no longer panics

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- related to #592 
