### PR TITLE
fix(docs): improve build-spec usage docs

### DIFF
--- a/docs/docs/usage/import-runtime.md
+++ b/docs/docs/usage/import-runtime.md
@@ -30,7 +30,7 @@ Note: the `import-runtime` subcommand does not validate that the runtime in the 
 To create the raw genesis file used by the node, you can use the `gossamer build-spec` subcommand.
 
 ```
-./bin/gossamer build-spec --raw --genesis genesis-spec.json > genesis.json
+./bin/gossamer build-spec --raw --genesis-spec genesis-spec.json > genesis.json
 ```
 
 This creates a genesis file `genesis.json` that is usable by the node.

--- a/docs/docs/usage/import-runtime.md
+++ b/docs/docs/usage/import-runtime.md
@@ -31,6 +31,8 @@ To create the raw genesis file used by the node, you can use the `gossamer build
 
 ```
 ./bin/gossamer build-spec --raw --genesis-spec genesis-spec.json > genesis.json
+or
+./bin/gossamer build-spec --raw --genesis-spec genesis-spec.json --output genesis.json
 ```
 
 This creates a genesis file `genesis.json` that is usable by the node.


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Update the [Import Runtime usage documentation](https://chainsafe.github.io/gossamer/usage/import-runtime/#2-create-raw-genesis-file-from-genesis-spec) the right flag is `--genesis-spec`, and add an alternative command using the `--output` flag

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
N/A
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- N/A
