### PR TITLE
chore(lib/runtime): stub v0.9.8 runtime funcs, partially implement storage ext_ funcs

### DIFF
--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -24,10 +24,15 @@ var runtimes = []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, NODE_RUNTIME, D
 
 //nolint
 const (
-	// v0.8 substrate runtime
+	// v0.9 substrate runtime
 	NODE_RUNTIME     = "node_runtime"
 	NODE_RUNTIME_FP  = "node_runtime.compact.wasm"
 	NODE_RUNTIME_URL = "https://github.com/noot/substrate/blob/noot/v0.9/target/debug/wbuild/node-runtime/node_runtime.compact.wasm?raw=true"
+
+	// v0.9.8 substrate runtime
+	NODE_RUNTIME_v098     = "node_runtime-v0.9.8"
+	NODE_RUNTIME_FP_v098  = "node_runtime-v0.9.8.compact.wasm"
+	NODE_RUNTIME_URL_v098 = "https://github.com/noot/substrate/blob/noot/v0.9.8/target/debug/wbuild/node-runtime/node_runtime.compact.wasm?raw=true"
 
 	// v0.8 polkadot runtime
 	POLKADOT_RUNTIME     = "polkadot_runtime"

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -52,21 +52,20 @@ func NewInMemoryDB(t *testing.T) chaindb.Database {
 
 // GetRuntimeVars returns the testRuntimeFilePath and testRuntimeURL
 func GetRuntimeVars(targetRuntime string) (string, string) {
-	var testRuntimeFilePath string
-	var testRuntimeURL string
-
 	switch targetRuntime {
 	case NODE_RUNTIME:
-		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(NODE_RUNTIME_FP), NODE_RUNTIME_URL
+		return GetAbsolutePath(NODE_RUNTIME_FP), NODE_RUNTIME_URL
+	case NODE_RUNTIME_v098:
+		return GetAbsolutePath(NODE_RUNTIME_FP_v098), NODE_RUNTIME_URL_v098
 	case POLKADOT_RUNTIME:
-		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(POLKADOT_RUNTIME_FP), POLKADOT_RUNTIME_URL
+		return GetAbsolutePath(POLKADOT_RUNTIME_FP), POLKADOT_RUNTIME_URL
 	case HOST_API_TEST_RUNTIME:
-		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(HOST_API_TEST_RUNTIME_FP), HOST_API_TEST_RUNTIME_URL
+		return GetAbsolutePath(HOST_API_TEST_RUNTIME_FP), HOST_API_TEST_RUNTIME_URL
 	case DEV_RUNTIME:
-		testRuntimeFilePath, testRuntimeURL = GetAbsolutePath(DEV_RUNTIME_FP), DEV_RUNTIME_URL
+		return GetAbsolutePath(DEV_RUNTIME_FP), DEV_RUNTIME_URL
+	default:
+		return "", ""
 	}
-
-	return testRuntimeFilePath, testRuntimeURL
 }
 
 // GetAbsolutePath returns the completePath for a given targetDir

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -63,6 +63,64 @@ func createTestExtrinsic(t *testing.T, rt runtime.Instance, genHash common.Hash,
 	return types.Extrinsic(common.MustHexToBytes(extEnc))
 }
 
+func TestInstance_Version_NodeRuntime_v098(t *testing.T) {
+	expected := runtime.NewVersionData(
+		[]byte("node"),
+		[]byte("substrate-node"),
+		10,
+		267,
+		0,
+		nil,
+		2,
+	)
+
+	// rfp := "/home/elizabeth/substrate/target/debug/wbuild/node-runtime/node_runtime.compact.wasm"
+
+	// s, err := storage.NewTrieState(trie.NewEmptyTrie())
+	// require.NoError(t, err)
+
+	// fp, err := filepath.Abs(rfp)
+	// require.NoError(t, err)
+
+	// ns := runtime.NodeStorage{
+	// 	LocalStorage:      runtime.NewInMemoryDB(t),
+	// 	PersistentStorage: runtime.NewInMemoryDB(t), // we're using a local storage here since this is a test runtime
+	// }
+	// cfg := &Config{
+	// 	Imports: ImportsNodeRuntime,
+	// }
+	// cfg.Storage = s
+	// cfg.Keystore = keystore.NewGlobalKeystore()
+	// cfg.LogLvl = log.LvlInfo
+	// cfg.NodeStorage = ns
+	// cfg.Network = new(runtime.TestRuntimeNetwork)
+	// cfg.Transaction = NewTransactionStateMock()
+	// cfg.Role = 1
+
+	// instance, err := NewInstanceFromFile(fp, cfg)
+	// require.NoError(t, err)
+
+	instance := NewTestInstance(t, runtime.NODE_RUNTIME_v098)
+
+	version, err := instance.Version()
+	require.Nil(t, err)
+
+	t.Logf("SpecName: %s\n", version.SpecName())
+	t.Logf("ImplName: %s\n", version.ImplName())
+	t.Logf("AuthoringVersion: %d\n", version.AuthoringVersion())
+	t.Logf("SpecVersion: %d\n", version.SpecVersion())
+	t.Logf("ImplVersion: %d\n", version.ImplVersion())
+	t.Logf("TransactionVersion: %d\n", version.TransactionVersion())
+
+	require.Equal(t, 13, len(version.APIItems()))
+	require.Equal(t, expected.SpecName(), version.SpecName())
+	require.Equal(t, expected.ImplName(), version.ImplName())
+	require.Equal(t, expected.AuthoringVersion(), version.AuthoringVersion())
+	require.Equal(t, expected.SpecVersion(), version.SpecVersion())
+	require.Equal(t, expected.ImplVersion(), version.ImplVersion())
+	require.Equal(t, expected.TransactionVersion(), version.TransactionVersion())
+}
+
 func TestInstance_Version_PolkadotRuntime(t *testing.T) {
 	expected := runtime.NewVersionData(
 		[]byte("polkadot"),

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -74,32 +74,6 @@ func TestInstance_Version_NodeRuntime_v098(t *testing.T) {
 		2,
 	)
 
-	// rfp := "/home/elizabeth/substrate/target/debug/wbuild/node-runtime/node_runtime.compact.wasm"
-
-	// s, err := storage.NewTrieState(trie.NewEmptyTrie())
-	// require.NoError(t, err)
-
-	// fp, err := filepath.Abs(rfp)
-	// require.NoError(t, err)
-
-	// ns := runtime.NodeStorage{
-	// 	LocalStorage:      runtime.NewInMemoryDB(t),
-	// 	PersistentStorage: runtime.NewInMemoryDB(t), // we're using a local storage here since this is a test runtime
-	// }
-	// cfg := &Config{
-	// 	Imports: ImportsNodeRuntime,
-	// }
-	// cfg.Storage = s
-	// cfg.Keystore = keystore.NewGlobalKeystore()
-	// cfg.LogLvl = log.LvlInfo
-	// cfg.NodeStorage = ns
-	// cfg.Network = new(runtime.TestRuntimeNetwork)
-	// cfg.Transaction = NewTransactionStateMock()
-	// cfg.Role = 1
-
-	// instance, err := NewInstanceFromFile(fp, cfg)
-	// require.NoError(t, err)
-
 	instance := NewTestInstance(t, runtime.NODE_RUNTIME_v098)
 
 	version, err := instance.Version()

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -45,11 +45,12 @@ package wasmer
 //
 // extern int32_t ext_trie_blake2_256_root_version_1(void *context, int64_t a);
 // extern int32_t ext_trie_blake2_256_ordered_root_version_1(void *context, int64_t a);
+// extern int32_t ext_trie_blake2_256_verify_proof_version_1(void *context, int32_t a, int64_t b, int64_t c, int64_t d);
 //
+// extern int64_t ext_misc_runtime_version_version_1(void *context, int64_t a);
 // extern void ext_misc_print_hex_version_1(void *context, int64_t a);
 // extern void ext_misc_print_num_version_1(void *context, int64_t a);
 // extern void ext_misc_print_utf8_version_1(void *context, int64_t a);
-// extern int64_t ext_misc_runtime_version_version_1(void *context, int64_t a);
 //
 // extern void ext_default_child_storage_clear_version_1(void *context, int64_t a, int64_t b);
 // extern int64_t ext_default_child_storage_get_version_1(void *context, int64_t a, int64_t b);
@@ -59,6 +60,7 @@ package wasmer
 // extern void ext_default_child_storage_set_version_1(void *context, int64_t a, int64_t b, int64_t c);
 // extern void ext_default_child_storage_storage_kill_version_1(void *context, int64_t a);
 // extern int32_t ext_default_child_storage_storage_kill_version_2(void *context, int64_t a, int64_t b);
+// extern int64_t ext_default_child_storage_storage_kill_version_3(void *context, int64_t a, int64_t b);
 // extern void ext_default_child_storage_clear_prefix_version_1(void *context, int64_t a, int64_t b);
 // extern int32_t ext_default_child_storage_exists_version_1(void *context, int64_t a, int64_t b);
 //
@@ -75,17 +77,20 @@ package wasmer
 //
 // extern void ext_offchain_index_set_version_1(void *context, int64_t a, int64_t b);
 // extern int32_t ext_offchain_is_validator_version_1(void *context);
+// extern void ext_offchain_local_storage_clear_version_1(void *context, int32_t a, int64_t b);
 // extern int32_t ext_offchain_local_storage_compare_and_set_version_1(void *context, int32_t a, int64_t b, int64_t c, int64_t d);
 // extern int64_t ext_offchain_local_storage_get_version_1(void *context, int32_t a, int64_t b);
 // extern void ext_offchain_local_storage_set_version_1(void *context, int32_t a, int64_t b, int64_t c);
 // extern int64_t ext_offchain_network_state_version_1(void *context);
 // extern int32_t ext_offchain_random_seed_version_1(void *context);
 // extern int64_t ext_offchain_submit_transaction_version_1(void *context, int64_t a);
+// extern int64_t ext_offchain_timestamp_version_1(void *context);
 //
 // extern void ext_storage_append_version_1(void *context, int64_t a, int64_t b);
 // extern int64_t ext_storage_changes_root_version_1(void *context, int64_t a);
 // extern void ext_storage_clear_version_1(void *context, int64_t a);
 // extern void ext_storage_clear_prefix_version_1(void *context, int64_t a);
+// extern int64_t ext_storage_clear_prefix_version_2(void *context, int64_t a, int64_t b);
 // extern void ext_storage_commit_transaction_version_1(void *context);
 // extern int32_t ext_storage_exists_version_1(void *context, int64_t a);
 // extern int64_t ext_storage_get_version_1(void *context, int64_t a);
@@ -95,6 +100,9 @@ package wasmer
 // extern int64_t ext_storage_root_version_1(void *context);
 // extern void ext_storage_set_version_1(void *context, int64_t a, int64_t b);
 // extern void ext_storage_start_transaction_version_1(void *context);
+//
+// extern void ext_transaction_index_index_version_1(void *context, int32_t a, int32_t b, int32_t c);
+// extern void ext_transaction_index_renew_version_1(void *context, int32_t a, int32_t b);
 import "C"
 
 import (
@@ -152,6 +160,18 @@ func ext_logging_log_version_1(context unsafe.Pointer, level C.int32_t, targetDa
 func ext_logging_max_level_version_1(context unsafe.Pointer) C.int32_t {
 	logger.Trace("[ext_logging_max_level_version_1] executing...")
 	return 4
+}
+
+//export ext_transaction_index_index_version_1
+func ext_transaction_index_index_version_1(context unsafe.Pointer, a, b, c C.int32_t) {
+	logger.Trace("[ext_transaction_index_index_version_1] executing...")
+	logger.Warn("[ext_transaction_index_index_version_1] unimplemented")
+}
+
+//export ext_transaction_index_renew_version_1
+func ext_transaction_index_renew_version_1(context unsafe.Pointer, a, b C.int32_t) {
+	logger.Trace("[ext_transaction_index_renew_version_1] executing...")
+	logger.Warn("[ext_transaction_index_renew_version_1] unimplemented")
 }
 
 //export ext_sandbox_instance_teardown_version_1
@@ -835,6 +855,13 @@ func ext_trie_blake2_256_ordered_root_version_1(context unsafe.Pointer, dataSpan
 	return C.int32_t(ptr)
 }
 
+//export ext_trie_blake2_256_verify_proof_version_1
+func ext_trie_blake2_256_verify_proof_version_1(context unsafe.Pointer, a C.int32_t, b, c, d C.int64_t) C.int32_t {
+	logger.Debug("[ext_trie_blake2_256_verify_proof_version_1] executing...")
+	logger.Warn("[ext_trie_blake2_256_verify_proof_version_1] unimplemented")
+	return 0
+}
+
 //export ext_misc_print_hex_version_1
 func ext_misc_print_hex_version_1(context unsafe.Pointer, dataSpan C.int64_t) {
 	logger.Trace("[ext_misc_print_hex_version_1] executing...")
@@ -1099,6 +1126,13 @@ func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer, a,
 	return 0
 }
 
+//export ext_default_child_storage_storage_kill_version_3
+func ext_default_child_storage_storage_kill_version_3(context unsafe.Pointer, a, b C.int64_t) C.int64_t {
+	logger.Debug("[ext_default_child_storage_storage_kill_version_3] executing...")
+	logger.Warn("[ext_default_child_storage_storage_kill_version_3] unimplemented")
+	return 0
+}
+
 //export ext_allocator_free_version_1
 func ext_allocator_free_version_1(context unsafe.Pointer, addr C.int32_t) {
 	logger.Trace("[ext_allocator_free_version_1] executing...")
@@ -1297,6 +1331,12 @@ func ext_offchain_index_set_version_1(context unsafe.Pointer, keySpan, valueSpan
 	logger.Warn("[ext_offchain_index_set_version_1] unimplemented")
 }
 
+//export ext_offchain_local_storage_clear_version_1
+func ext_offchain_local_storage_clear_version_1(context unsafe.Pointer, a C.int32_t, b C.int64_t) {
+	logger.Trace("[ext_offchain_local_storage_clear_version_1] executing...")
+	logger.Warn("[ext_offchain_local_storage_clear_version_1] unimplemented")
+}
+
 //export ext_offchain_is_validator_version_1
 func ext_offchain_is_validator_version_1(context unsafe.Pointer) C.int32_t {
 	logger.Debug("[ext_offchain_is_validator_version_1] executing...")
@@ -1478,6 +1518,13 @@ func ext_offchain_submit_transaction_version_1(context unsafe.Pointer, data C.in
 	return C.int64_t(ptr)
 }
 
+//export ext_offchain_timestamp_version_1
+func ext_offchain_timestamp_version_1(context unsafe.Pointer) C.int64_t {
+	logger.Trace("[ext_offchain_timestamp_version_1] executing...")
+	logger.Warn("[ext_offchain_timestamp_version_1] unimplemented")
+	return 0
+}
+
 func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 	nextLength := big.NewInt(1)
 	var valueRes []byte
@@ -1582,6 +1629,13 @@ func ext_storage_clear_prefix_version_1(context unsafe.Pointer, prefixSpan C.int
 	if err != nil {
 		logger.Error("[ext_storage_clear_prefix_version_1]", "error", err)
 	}
+}
+
+//export ext_storage_clear_prefix_version_2
+func ext_storage_clear_prefix_version_2(context unsafe.Pointer, prefixSpan, _ C.int64_t) C.int64_t {
+	logger.Debug("[ext_storage_clear_prefix_version_2] executing...")
+	logger.Warn("[ext_storage_clear_prefix_version_2] unimplemented")
+	return 0
 }
 
 //export ext_storage_exists_version_1
@@ -1961,6 +2015,10 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 	if err != nil {
 		return nil, err
 	}
+	_, err = imports.Append("ext_default_child_storage_storage_kill_version_3", ext_default_child_storage_storage_kill_version_3, C.ext_default_child_storage_storage_kill_version_3)
+	if err != nil {
+		return nil, err
+	}
 
 	_, err = imports.Append("ext_hashing_blake2_128_version_1", ext_hashing_blake2_128_version_1, C.ext_hashing_blake2_128_version_1)
 	if err != nil {
@@ -2025,6 +2083,10 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 	if err != nil {
 		return nil, err
 	}
+	_, err = imports.Append("ext_offchain_local_storage_clear_version_1", ext_offchain_local_storage_clear_version_1, C.ext_offchain_local_storage_clear_version_1)
+	if err != nil {
+		return nil, err
+	}
 	_, err = imports.Append("ext_offchain_local_storage_compare_and_set_version_1", ext_offchain_local_storage_compare_and_set_version_1, C.ext_offchain_local_storage_compare_and_set_version_1)
 	if err != nil {
 		return nil, err
@@ -2046,6 +2108,10 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 		return nil, err
 	}
 	_, err = imports.Append("ext_offchain_submit_transaction_version_1", ext_offchain_submit_transaction_version_1, C.ext_offchain_submit_transaction_version_1)
+	if err != nil {
+		return nil, err
+	}
+	_, err = imports.Append("ext_offchain_timestamp_version_1", ext_offchain_timestamp_version_1, C.ext_offchain_timestamp_version_1)
 	if err != nil {
 		return nil, err
 	}
@@ -2095,6 +2161,10 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 	if err != nil {
 		return nil, err
 	}
+	_, err = imports.Append("ext_storage_clear_prefix_version_2", ext_storage_clear_prefix_version_2, C.ext_storage_clear_prefix_version_2)
+	if err != nil {
+		return nil, err
+	}
 	_, err = imports.Append("ext_storage_commit_transaction_version_1", ext_storage_commit_transaction_version_1, C.ext_storage_commit_transaction_version_1)
 	if err != nil {
 		return nil, err
@@ -2137,6 +2207,19 @@ func ImportsNodeRuntime() (*wasm.Imports, error) { //nolint
 		return nil, err
 	}
 	_, err = imports.Append("ext_trie_blake2_256_root_version_1", ext_trie_blake2_256_root_version_1, C.ext_trie_blake2_256_root_version_1)
+	if err != nil {
+		return nil, err
+	}
+	_, err = imports.Append("ext_trie_blake2_256_verify_proof_version_1", ext_trie_blake2_256_verify_proof_version_1, C.ext_trie_blake2_256_verify_proof_version_1)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = imports.Append("ext_transaction_index_index_version_1", ext_transaction_index_index_version_1, C.ext_transaction_index_index_version_1)
+	if err != nil {
+		return nil, err
+	}
+	_, err = imports.Append("ext_transaction_index_renew_version_1", ext_transaction_index_renew_version_1, C.ext_transaction_index_renew_version_1)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1139,7 +1139,7 @@ func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer, ch
 //export ext_default_child_storage_storage_kill_version_3
 func ext_default_child_storage_storage_kill_version_3(context unsafe.Pointer, childStorageKeySpan, _ C.int64_t) C.int64_t {
 	logger.Debug("[ext_default_child_storage_storage_kill_version_3] executing...")
-	logger.Warn("[ext_default_child_storage_storage_kill_version_2] somewhat unimplemented")
+	logger.Warn("[ext_default_child_storage_storage_kill_version_3] somewhat unimplemented")
 	// TODO: need to use `limit` parameter
 
 	instanceContext := wasm.IntoInstanceContext(context)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1120,16 +1120,36 @@ func ext_default_child_storage_storage_kill_version_1(context unsafe.Pointer, ch
 }
 
 //export ext_default_child_storage_storage_kill_version_2
-func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer, a, b C.int64_t) C.int32_t {
+func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer, childStorageKeySpan, _ C.int64_t) C.int32_t {
 	logger.Debug("[ext_default_child_storage_storage_kill_version_2] executing...")
-	logger.Warn("[ext_default_child_storage_storage_kill_version_2] unimplemented")
+	logger.Warn("[ext_default_child_storage_storage_kill_version_2] somewhat unimplemented")
+	// TODO: need to use `limit` parameter
+
+	instanceContext := wasm.IntoInstanceContext(context)
+	ctx := instanceContext.Data().(*runtime.Context)
+	storage := ctx.Storage
+
+	childStorageKey := asMemorySlice(instanceContext, childStorageKeySpan)
+	storage.DeleteChild(childStorageKey)
+
+	// note: this function always returns `KillStorageResult::AllRemoved`, which is 0
 	return 0
 }
 
 //export ext_default_child_storage_storage_kill_version_3
-func ext_default_child_storage_storage_kill_version_3(context unsafe.Pointer, a, b C.int64_t) C.int64_t {
+func ext_default_child_storage_storage_kill_version_3(context unsafe.Pointer, childStorageKeySpan, _ C.int64_t) C.int64_t {
 	logger.Debug("[ext_default_child_storage_storage_kill_version_3] executing...")
-	logger.Warn("[ext_default_child_storage_storage_kill_version_3] unimplemented")
+	logger.Warn("[ext_default_child_storage_storage_kill_version_2] somewhat unimplemented")
+	// TODO: need to use `limit` parameter
+
+	instanceContext := wasm.IntoInstanceContext(context)
+	ctx := instanceContext.Data().(*runtime.Context)
+	storage := ctx.Storage
+
+	childStorageKey := asMemorySlice(instanceContext, childStorageKeySpan)
+	storage.DeleteChild(childStorageKey)
+
+	// TODO: this function returns a `KillStorageResult` which may be `AllRemoved` (0) or `SomeRemaining` (1)
 	return 0
 }
 
@@ -1633,9 +1653,23 @@ func ext_storage_clear_prefix_version_1(context unsafe.Pointer, prefixSpan C.int
 
 //export ext_storage_clear_prefix_version_2
 func ext_storage_clear_prefix_version_2(context unsafe.Pointer, prefixSpan, _ C.int64_t) C.int64_t {
-	logger.Debug("[ext_storage_clear_prefix_version_2] executing...")
-	logger.Warn("[ext_storage_clear_prefix_version_2] unimplemented")
-	return 0
+	logger.Trace("[ext_storage_clear_prefix_version_2] executing...")
+	logger.Warn("[ext_storage_clear_prefix_version_2] somewhat unimplemented")
+	// TODO: need to use unused `limit` parameter
+
+	instanceContext := wasm.IntoInstanceContext(context)
+	ctx := instanceContext.Data().(*runtime.Context)
+	storage := ctx.Storage
+
+	prefix := asMemorySlice(instanceContext, prefixSpan)
+	logger.Debug("[ext_storage_clear_prefix_version_1]", "prefix", fmt.Sprintf("0x%x", prefix))
+
+	err := storage.ClearPrefix(prefix)
+	if err != nil {
+		logger.Error("[ext_storage_clear_prefix_version_1]", "error", err)
+	}
+
+	return 1
 }
 
 //export ext_storage_exists_version_1

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -28,7 +28,6 @@ import (
 	log "github.com/ChainSafe/log15"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	wasm "github.com/wasmerio/go-ext-wasm/wasmer"
 )
 
 // DefaultTestLogLvl is the log level used for test runtime instances
@@ -57,27 +56,8 @@ func NewTestInstanceWithRole(t *testing.T, targetRuntime string, role byte) *Ins
 	return r
 }
 
-// GetRuntimeImports ...
-func GetRuntimeImports(targetRuntime string) func() (*wasm.Imports, error) {
-	var registerImports func() (*wasm.Imports, error)
-
-	switch targetRuntime {
-	case runtime.NODE_RUNTIME:
-		registerImports = ImportsNodeRuntime
-	case runtime.POLKADOT_RUNTIME:
-		registerImports = ImportsNodeRuntime
-	case runtime.HOST_API_TEST_RUNTIME:
-		registerImports = ImportsNodeRuntime
-	default:
-		registerImports = ImportsNodeRuntime
-	}
-
-	return registerImports
-}
-
 func setupConfig(t *testing.T, targetRuntime string, tt *trie.Trie, lvl log.Lvl, role byte) (string, *Config) {
 	testRuntimeFilePath, testRuntimeURL := runtime.GetRuntimeVars(targetRuntime)
-	importsFunc := GetRuntimeImports(targetRuntime)
 
 	_, err := runtime.GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL)
 	require.Nil(t, err, "Fail: could not get runtime", "targetRuntime", targetRuntime)
@@ -93,7 +73,7 @@ func setupConfig(t *testing.T, targetRuntime string, tt *trie.Trie, lvl log.Lvl,
 		PersistentStorage: runtime.NewInMemoryDB(t), // we're using a local storage here since this is a test runtime
 	}
 	cfg := &Config{
-		Imports: importsFunc,
+		Imports: ImportsNodeRuntime,
 	}
 	cfg.Storage = s
 	cfg.Keystore = keystore.NewGlobalKeystore()


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- stub v0.9.8 runtime funcs
- partially implement `ext_storage_clear_prefix_version_2`, `ext_default_child_storage_storage_kill_version_2`, `ext_default_child_storage_storage_kill_version_3`- need to update trie functions to accept `limit` parameter
- updated original issue with new `ext_`s to be implemented

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/runtime/wasmer
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- related to #1688
