### PR TITLE
Revert "feat(dot/rpc) implement `author_hasSessionKeys` RPC call"

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -461,16 +461,6 @@ func (s *Service) HasKey(pubKeyStr, keyType string) (bool, error) {
 	return keystore.HasKey(pubKeyStr, keyType, s.keys.Acco)
 }
 
-// DecodeSessionKeys executes the runtime DecodeSessionKeys and return the scale encoded keys
-func (s *Service) DecodeSessionKeys(enc []byte) ([]byte, error) {
-	rt, err := s.blockState.GetRuntime(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return rt.DecodeSessionKeys(enc)
-}
-
 // GetRuntimeVersion gets the current RuntimeVersion
 func (s *Service) GetRuntimeVersion(bhash *common.Hash) (runtime.Version, error) {
 	var stateRootHash *common.Hash

--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -233,13 +233,15 @@ func (h *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // NewWSConn to create new WebSocket Connection struct
 func NewWSConn(conn *websocket.Conn, cfg *HTTPServerConfig) *subscription.WSConn {
 	c := &subscription.WSConn{
-		Wsconn:        conn,
-		Subscriptions: make(map[uint32]subscription.Listener),
-		StorageAPI:    cfg.StorageAPI,
-		BlockAPI:      cfg.BlockAPI,
-		CoreAPI:       cfg.CoreAPI,
-		TxStateAPI:    cfg.TransactionQueueAPI,
-		RPCHost:       fmt.Sprintf("http://%s:%d/", cfg.Host, cfg.RPCPort),
+		Wsconn:             conn,
+		Subscriptions:      make(map[uint]subscription.Listener),
+		BlockSubChannels:   make(map[uint]byte),
+		StorageSubChannels: make(map[int]byte),
+		StorageAPI:         cfg.StorageAPI,
+		BlockAPI:           cfg.BlockAPI,
+		CoreAPI:            cfg.CoreAPI,
+		TxStateAPI:         cfg.TransactionQueueAPI,
+		RPCHost:            fmt.Sprintf("http://%s:%d/", cfg.Host, cfg.RPCPort),
 		HTTP: &http.Client{
 			Timeout: time.Second * 30,
 		},

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -76,7 +76,6 @@ type CoreAPI interface {
 	GetRuntimeVersion(bhash *common.Hash) (runtime.Version, error)
 	HandleSubmittedExtrinsic(types.Extrinsic) error
 	GetMetadata(bhash *common.Hash) ([]byte, error)
-	DecodeSessionKeys(enc []byte) ([]byte, error)
 }
 
 // RPCAPI is the interface for methods related to RPC service

--- a/dot/rpc/modules/mocks/core_api.go
+++ b/dot/rpc/modules/mocks/core_api.go
@@ -18,29 +18,6 @@ type MockCoreAPI struct {
 	mock.Mock
 }
 
-// DecodeSessionKeys provides a mock function with given fields: enc
-func (_m *MockCoreAPI) DecodeSessionKeys(enc []byte) ([]byte, error) {
-	ret := _m.Called(enc)
-
-	var r0 []byte
-	if rf, ok := ret.Get(0).(func([]byte) []byte); ok {
-		r0 = rf(enc)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func([]byte) error); ok {
-		r1 = rf(enc)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetMetadata provides a mock function with given fields: bhash
 func (_m *MockCoreAPI) GetMetadata(bhash *common.Hash) ([]byte, error) {
 	ret := _m.Called(bhash)
@@ -125,4 +102,18 @@ func (_m *MockCoreAPI) HasKey(pubKeyStr string, keyType string) (bool, error) {
 // InsertKey provides a mock function with given fields: kp
 func (_m *MockCoreAPI) InsertKey(kp crypto.Keypair) {
 	_m.Called(kp)
+}
+
+// IsBlockProducer provides a mock function with given fields:
+func (_m *MockCoreAPI) IsBlockProducer() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }

--- a/dot/rpc/service_test.go
+++ b/dot/rpc/service_test.go
@@ -35,7 +35,7 @@ func TestNewService(t *testing.T) {
 func TestService_Methods(t *testing.T) {
 	qtySystemMethods := 13
 	qtyRPCMethods := 1
-	qtyAuthorMethods := 8
+	qtyAuthorMethods := 7
 
 	rpcService := NewService()
 	sysMod := modules.NewSystemModule(nil, nil, nil, nil, nil, nil)

--- a/dot/rpc/subscription/messages.go
+++ b/dot/rpc/subscription/messages.go
@@ -25,7 +25,7 @@ type BaseResponseJSON struct {
 // Params for json param response
 type Params struct {
 	Result         interface{} `json:"result"`
-	SubscriptionID uint32      `json:"subscription"`
+	SubscriptionID uint        `json:"subscription"`
 }
 
 // InvalidRequestCode error code returned for invalid request parameters, value derived from Substrate node output
@@ -40,7 +40,7 @@ func newSubcriptionBaseResponseJSON() BaseResponseJSON {
 	}
 }
 
-func newSubscriptionResponse(method string, subID uint32, result interface{}) BaseResponseJSON {
+func newSubscriptionResponse(method string, subID uint, result interface{}) BaseResponseJSON {
 	return BaseResponseJSON{
 		Jsonrpc: "2.0",
 		Method:  method,
@@ -54,12 +54,12 @@ func newSubscriptionResponse(method string, subID uint32, result interface{}) Ba
 // ResponseJSON for json subscription responses
 type ResponseJSON struct {
 	Jsonrpc string  `json:"jsonrpc"`
-	Result  uint32  `json:"result"`
+	Result  uint    `json:"result"`
 	ID      float64 `json:"id"`
 }
 
 // NewSubscriptionResponseJSON builds a Response JSON object
-func NewSubscriptionResponseJSON(subID uint32, reqID float64) ResponseJSON {
+func NewSubscriptionResponseJSON(subID uint, reqID float64) ResponseJSON {
 	return ResponseJSON{
 		Jsonrpc: "2.0",
 		Result:  subID,

--- a/dot/rpc/subscription/subscription.go
+++ b/dot/rpc/subscription/subscription.go
@@ -24,8 +24,6 @@ func (c *WSConn) getSetupListener(method string) setupListener {
 		return c.initBlockFinalizedListener
 	case "state_subscribeRuntimeVersion":
 		return c.initRuntimeVersionListener
-	case "grandpa_subscribeJustifications":
-		return c.initGrandpaJustificationListener
 	default:
 		return nil
 	}
@@ -47,8 +45,6 @@ func (c *WSConn) getUnsubListener(method string, params interface{}) (unsubListe
 	switch method {
 	case "state_unsubscribeStorage":
 		unsub = c.unsubscribeStorageListener
-	case "grandpa_unsubscribeJustifications":
-		unsub = c.unsubscribeGrandpaJustificationListener
 	default:
 		return nil, nil, errCannotFindUnsubsriber
 	}
@@ -56,7 +52,7 @@ func (c *WSConn) getUnsubListener(method string, params interface{}) (unsubListe
 	return unsub, listener, nil
 }
 
-func parseSubscribeID(p interface{}) (uint32, error) {
+func parseSubscribeID(p interface{}) (uint, error) {
 	switch v := p.(type) {
 	case []interface{}:
 		if len(v) == 0 {
@@ -66,16 +62,16 @@ func parseSubscribeID(p interface{}) (uint32, error) {
 		return 0, errUknownParamSubscribeID
 	}
 
-	var id uint32
+	var id uint
 	switch v := p.([]interface{})[0].(type) {
 	case float64:
-		id = uint32(v)
+		id = uint(v)
 	case string:
 		i, err := strconv.ParseUint(v, 10, 32)
 		if err != nil {
 			return 0, errCannotParseID
 		}
-		id = uint32(i)
+		id = uint(i)
 	default:
 		return 0, errUknownParamSubscribeID
 	}

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=

--- a/lib/crypto/sr25519/sr25519.go
+++ b/lib/crypto/sr25519/sr25519.go
@@ -83,13 +83,9 @@ func NewKeypairFromPrivate(priv *PrivateKey) (*Keypair, error) {
 }
 
 // NewKeypairFromSeed returns a new sr25519 Keypair given a seed
-func NewKeypairFromSeed(keystr []byte) (*Keypair, error) {
-	if len(keystr) != SeedLength {
-		return nil, errors.New("cannot generate key from seed: seed is not 32 bytes long")
-	}
-
+func NewKeypairFromSeed(seed []byte) (*Keypair, error) {
 	buf := [SeedLength]byte{}
-	copy(buf[:], keystr)
+	copy(buf[:], seed)
 	msc, err := sr25519.NewMiniSecretKeyFromRaw(buf)
 	if err != nil {
 		return nil, err
@@ -156,30 +152,6 @@ func NewPrivateKey(in []byte) (*PrivateKey, error) {
 	priv := new(PrivateKey)
 	err := priv.Decode(in)
 	return priv, err
-}
-
-// NewPrivateKeyFromHex returns a private key from a hex-encoded private key
-func NewPrivateKeyFromHex(keystr string) (*PrivateKey, error) {
-	seedBytes, err := common.HexToBytes(keystr)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(seedBytes) != PrivateKeyLength {
-		return nil, errors.New("cannot create public key: input is not 32 bytes")
-	}
-
-	var privKeyBytes [32]byte
-	copy(privKeyBytes[:], seedBytes)
-
-	miniSecretKey, err := sr25519.NewMiniSecretKeyFromRaw(privKeyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return &PrivateKey{
-		key: miniSecretKey.ExpandUniform(),
-	}, nil
 }
 
 // GenerateKeypair returns a new sr25519 keypair

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -64,20 +64,6 @@ func DecodePrivateKey(in []byte, keytype crypto.KeyType) (priv crypto.PrivateKey
 	return priv, err
 }
 
-// DecodeKeyPairFromHex turns an hex-encoded private key into a keypair
-func DecodeKeyPairFromHex(keystr []byte, keytype crypto.KeyType) (kp crypto.Keypair, err error) {
-	switch keytype {
-	case crypto.Sr25519Type:
-		kp, err = sr25519.NewKeypairFromSeed(keystr)
-	case crypto.Ed25519Type:
-		kp, err = ed25519.NewKeypairFromSeed(keystr)
-	default:
-		return nil, errors.New("cannot decode key: invalid key type")
-	}
-
-	return kp, err
-}
-
 // GenerateKeypair create a new keypair with the corresponding type and saves
 // it to basepath/keystore/[public key].key in json format encrypted using the
 // specified password and returns the resulting filepath of the new key

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -67,8 +67,6 @@ var (
 	BlockBuilderApplyExtrinsic = "BlockBuilder_apply_extrinsic"
 	// BlockBuilderFinalizeBlock is the runtime API call BlockBuilder_finalize_block
 	BlockBuilderFinalizeBlock = "BlockBuilder_finalize_block"
-	// DecodeSessionKeys is the runtime API call SessionKeys_decode_session_keys
-	DecodeSessionKeys = "SessionKeys_decode_session_keys"
 )
 
 // GrandpaAuthoritiesKey is the location of GRANDPA authority data in the storage trie for LEGACY_NODE_RUNTIME and NODE_RUNTIME

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -47,7 +47,6 @@ type Instance interface {
 	ApplyExtrinsic(data types.Extrinsic) ([]byte, error)
 	FinalizeBlock() (*types.Header, error)
 	ExecuteBlock(block *types.Block) ([]byte, error)
-	DecodeSessionKeys(enc []byte) ([]byte, error)
 
 	// TODO: parameters and return values for these are undefined in the spec
 	CheckInherents()

--- a/lib/runtime/life/exports.go
+++ b/lib/runtime/life/exports.go
@@ -150,11 +150,6 @@ func (in *Instance) ExecuteBlock(block *types.Block) ([]byte, error) {
 	return in.Exec(runtime.CoreExecuteBlock, bdEnc)
 }
 
-// DecodeSessionKeys decodes the given public session keys. Returns a list of raw public keys including their key type.
-func (in *Instance) DecodeSessionKeys(enc []byte) ([]byte, error) {
-	return in.Exec(runtime.DecodeSessionKeys, enc)
-}
-
 func (in *Instance) CheckInherents()      {} //nolint
 func (in *Instance) RandomSeed()          {} //nolint
 func (in *Instance) OffchainWorker()      {} //nolint

--- a/lib/runtime/wasmer/exports.go
+++ b/lib/runtime/wasmer/exports.go
@@ -174,11 +174,6 @@ func (in *Instance) ExecuteBlock(block *types.Block) ([]byte, error) {
 	return in.exec(runtime.CoreExecuteBlock, bdEnc)
 }
 
-// DecodeSessionKeys decodes the given public session keys. Returns a list of raw public keys including their key type.
-func (in *Instance) DecodeSessionKeys(enc []byte) ([]byte, error) {
-	return in.exec(runtime.DecodeSessionKeys, enc)
-}
-
 func (in *Instance) CheckInherents()      {} //nolint
 func (in *Instance) RandomSeed()          {} //nolint
 func (in *Instance) OffchainWorker()      {} //nolint

--- a/lib/runtime/wasmtime/exports.go
+++ b/lib/runtime/wasmtime/exports.go
@@ -150,11 +150,6 @@ func (in *Instance) ExecuteBlock(block *types.Block) ([]byte, error) {
 	return in.exec(runtime.CoreExecuteBlock, bdEnc)
 }
 
-// DecodeSessionKeys decodes the given public session keys. Returns a list of raw public keys including their key type.
-func (in *Instance) DecodeSessionKeys(enc []byte) ([]byte, error) {
-	return in.exec(runtime.DecodeSessionKeys, enc)
-}
-
 func (in *Instance) CheckInherents()      {} //nolint
 func (in *Instance) RandomSeed()          {} //nolint
 func (in *Instance) OffchainWorker()      {} //nolint


### PR DESCRIPTION
## Description

We noticed the PR #1704  merged code related to PR #1672. Then this revert is needed to remove those changes from `development` and a new PR will be made removing all the changes related to **PR-1672** and keeping just the ones related to the `author_hasSessionKeys` RPC call