### PR TITLE
feat(dot/rpc) implement RPC aliases

### DIFF
--- a/dot/rpc/dot_up_codec.go
+++ b/dot/rpc/dot_up_codec.go
@@ -24,6 +24,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/ChainSafe/gossamer/dot/rpc/json2"
+	"github.com/ChainSafe/gossamer/dot/rpc/modules"
 	"github.com/gorilla/rpc/v2"
 )
 
@@ -72,6 +73,10 @@ type DotUpCodecRequest struct {
 func (c *DotUpCodecRequest) Method() (string, error) {
 	m, err := c.CodecRequest.Method()
 	if len(m) > 1 && err == nil {
+		if concreteMethod, ok := modules.AliasesMethods[m]; ok {
+			m = concreteMethod
+		}
+
 		parts := strings.Split(m, "_")
 		if len(parts) < 2 {
 			return "", fmt.Errorf("rpc error method %s not found", m)

--- a/dot/rpc/dot_up_codec_test.go
+++ b/dot/rpc/dot_up_codec_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 ChainSafe Systems (ON) Corp.
+// This file is part of gossamer.
+//
+// The gossamer library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The gossamer library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
+
+package rpc
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testCases = []struct {
+	rpcDataBody string
+	expected    string
+}{
+	{
+		rpcDataBody: fmt.Sprintf(
+			`{"jsonrpc":"2.0","method":"%s","params":[],"id":1}`,
+			"chain_getFinalisedHead",
+		),
+		expected: "chain.GetFinalizedHead",
+	},
+	{
+		rpcDataBody: fmt.Sprintf(
+			`{"jsonrpc":"2.0","method":"%s","params":["..."],"id":1}`,
+			"account_nextIndex",
+		),
+		expected: "system.AccountNextIndex",
+	},
+	{
+		rpcDataBody: fmt.Sprintf(
+			`{"jsonrpc":"2.0","method":"%s","params":[50, "0x64", 200],"id":1}`,
+			"chain_getHead",
+		),
+		expected: "chain.GetBlockHash",
+	},
+}
+
+func TestAliasesMethodReplace(t *testing.T) {
+	c := NewDotUpCodec()
+
+	for _, test := range testCases {
+		buf := new(bytes.Buffer)
+		buf.Write([]byte(test.rpcDataBody))
+
+		testRequest, err := http.NewRequest(http.MethodPost, "http://fake_url", buf)
+		require.NoError(t, err)
+
+		codecRequest := c.NewRequest(testRequest)
+		got, err := codecRequest.Method()
+		require.NoError(t, err)
+		require.Equal(t, test.expected, got)
+	}
+}

--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -128,11 +128,6 @@ func (cm *ChainModule) GetBlockHash(r *http.Request, req *ChainBlockNumberReques
 	return err
 }
 
-// GetHead alias for GetBlockHash
-func (cm *ChainModule) GetHead(r *http.Request, req *ChainBlockNumberRequest, res *ChainHashResponse) error {
-	return cm.GetBlockHash(r, req, res)
-}
-
 // GetFinalizedHead returns the most recently finalised block hash
 func (cm *ChainModule) GetFinalizedHead(r *http.Request, req *EmptyRequest, res *ChainHashResponse) error {
 	h, err := cm.blockAPI.GetHighestFinalisedHash()

--- a/dot/rpc/modules/rpc.go
+++ b/dot/rpc/modules/rpc.go
@@ -34,6 +34,7 @@ var (
 		"state_queryStorage",
 	}
 
+	// AliasesMethods is a map that links the original methods to their aliases
 	AliasesMethods = map[string]string{
 		"chain_getHead":          "chain_getBlockHash",
 		"account_nextIndex":      "system_accountNextIndex",

--- a/dot/rpc/modules/rpc.go
+++ b/dot/rpc/modules/rpc.go
@@ -33,6 +33,12 @@ var (
 		"state_getKeysPaged",
 		"state_queryStorage",
 	}
+
+	AliasesMethods = map[string]string{
+		"chain_getHead":          "chain_getBlockHash",
+		"account_nextIndex":      "system_accountNextIndex",
+		"chain_getFinalisedHead": "chain_getFinalizedHead",
+	}
 )
 
 // RPCModule is a RPC module providing access to RPC methods

--- a/dot/rpc/subscription/subscription.go
+++ b/dot/rpc/subscription/subscription.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/ChainSafe/gossamer/dot/rpc/modules"
 )
 
 const (
@@ -26,6 +28,10 @@ var (
 )
 
 func (c *WSConn) getSetupListener(method string) setupListener {
+	if concreteMethod, ok := modules.AliasesMethods[method]; ok {
+		method = concreteMethod
+	}
+
 	switch method {
 	case authorSubmitAndWatchExtrinsic:
 		return c.initExtrinsicWatch

--- a/dot/rpc/subscription/subscription.go
+++ b/dot/rpc/subscription/subscription.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-
-	"github.com/ChainSafe/gossamer/dot/rpc/modules"
 )
 
 const (
@@ -28,10 +26,6 @@ var (
 )
 
 func (c *WSConn) getSetupListener(method string) setupListener {
-	if concreteMethod, ok := modules.AliasesMethods[method]; ok {
-		method = concreteMethod
-	}
-
 	switch method {
 	case authorSubmitAndWatchExtrinsic:
 		return c.initExtrinsicWatch


### PR DESCRIPTION
## Changes
- Add `rpc/modules.AliasesMethods` that is a `map[string]string` which links the alias to the original method, both in the snake case.
- Inside the `dot_up_coded.go` file I've added the code to check if the method is an alias and get the original method name

## Tests

```
go test  -run ^TestAliasesMethodReplace$ github.com/ChainSafe/gossamer/dot/rpc
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #1391

## Primary Reviewer 

<!-- 
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot) 
-->

- @edwardmack 