### PR TITLE
feat(dot/rpc) implement `chain_subscribeAllHeads` RPC

### DIFF
--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -214,7 +214,7 @@ func (l *BlockFinalizedListener) Stop() error {
 	return cancelWithTimeout(l.cancel, l.done, l.cancelTimeout)
 }
 
-// AllBlocksListener is a listener that enables to be awere about new blocks and finalised ones
+// AllBlocksListener is a listener that is aware of new and newly finalised blocks```
 type AllBlocksListener struct {
 	finalizedChan chan *types.FinalisationInfo
 	importedChan  chan *types.Block

--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -35,6 +35,7 @@ const (
 	authorExtrinsicUpdatesMethod = "author_extrinsicUpdate"
 	chainFinalizedHeadMethod     = "chain_finalizedHead"
 	chainNewHeadMethod           = "chain_newHead"
+	chainAllHeadMethod           = "chain_allHead"
 	stateStorageMethod           = "state_storage"
 )
 
@@ -210,6 +211,81 @@ func (l *BlockFinalizedListener) Listen() {
 
 // Stop to cancel the running goroutines to this listener
 func (l *BlockFinalizedListener) Stop() error {
+	return cancelWithTimeout(l.cancel, l.done, l.cancelTimeout)
+}
+
+type AllBlocksListener struct {
+	finalizedChan chan *types.FinalisationInfo
+	importedChan  chan *types.Block
+
+	wsconn          *WSConn
+	finalizedChanID byte
+	importedChanID  byte
+	subID           uint32
+	done            chan struct{}
+	cancel          chan struct{}
+	cancelTimeout   time.Duration
+}
+
+func (l *AllBlocksListener) Listen() {
+	go func() {
+		defer func() {
+			l.wsconn.BlockAPI.UnregisterImportedChannel(l.importedChanID)
+			l.wsconn.BlockAPI.UnregisterFinalisedChannel(l.finalizedChanID)
+			close(l.done)
+		}()
+
+		for {
+			select {
+			case <-l.cancel:
+				return
+			case fin, ok := <-l.finalizedChan:
+				if !ok {
+					return
+				}
+
+				if fin == nil || fin.Header == nil {
+					continue
+				}
+
+				finHead, err := modules.HeaderToJSON(*fin.Header)
+				if err != nil {
+					logger.Error("failed to convert finalized block header to JSON", "error", err)
+					continue
+				}
+
+				res := newSubcriptionBaseResponseJSON()
+				res.Method = chainAllHeadMethod
+				res.Params.Result = finHead
+				res.Params.SubscriptionID = l.subID
+				l.wsconn.safeSend(res)
+
+			case imp, ok := <-l.importedChan:
+				if !ok {
+					return
+				}
+
+				if imp == nil || imp.Header == nil {
+					continue
+				}
+
+				impHead, err := modules.HeaderToJSON(*imp.Header)
+				if err != nil {
+					logger.Error("failed to convert imported block header to JSON", "error", err)
+					continue
+				}
+
+				res := newSubcriptionBaseResponseJSON()
+				res.Method = chainNewHeadMethod
+				res.Params.Result = impHead
+				res.Params.SubscriptionID = l.subID
+				l.wsconn.safeSend(res)
+			}
+		}
+	}()
+}
+
+func (l *AllBlocksListener) Stop() error {
 	return cancelWithTimeout(l.cancel, l.done, l.cancelTimeout)
 }
 

--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -276,7 +276,7 @@ func (l *AllBlocksListener) Listen() {
 				}
 
 				res := newSubcriptionBaseResponseJSON()
-				res.Method = chainNewHeadMethod
+				res.Method = chainAllHeadMethod
 				res.Params.Result = impHead
 				res.Params.SubscriptionID = l.subID
 				l.wsconn.safeSend(res)

--- a/dot/rpc/subscription/subscription.go
+++ b/dot/rpc/subscription/subscription.go
@@ -11,6 +11,7 @@ const (
 	chainSubscribeNewHeads         string = "chain_subscribeNewHeads"
 	chainSubscribeNewHead          string = "chain_subscribeNewHead"
 	chainSubscribeFinalizedHeads   string = "chain_subscribeFinalizedHeads"
+	chainSubscribeAllHeads         string = "chain_subscribeAllHeads"
 	stateSubscribeStorage          string = "state_subscribeStorage"
 	stateSubscribeRuntimeVersion   string = "state_subscribeRuntimeVersion"
 	grandpaSubscribeJustifications string = "grandpa_subscribeJustifications"
@@ -35,6 +36,8 @@ func (c *WSConn) getSetupListener(method string) setupListener {
 		return c.initStorageChangeListener
 	case chainSubscribeFinalizedHeads:
 		return c.initBlockFinalizedListener
+	case chainSubscribeAllHeads:
+		return c.initAllBlocksListerner
 	case stateSubscribeRuntimeVersion:
 		return c.initRuntimeVersionListener
 	case grandpaSubscribeJustifications:

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -279,13 +279,7 @@ func (c *WSConn) initBlockFinalizedListener(reqID float64, _ interface{}) (Liste
 }
 
 func (c *WSConn) initAllBlocksListerner(reqID float64, _ interface{}) (Listener, error) {
-	listener := new(AllBlocksListener)
-	listener.cancel = make(chan struct{})
-	listener.done = make(chan struct{})
-	listener.cancelTimeout = defaultCancelTimeout
-	listener.wsconn = c
-	listener.finalizedChan = make(chan *types.FinalisationInfo, DEFAULT_BUFFER_SIZE)
-	listener.importedChan = make(chan *types.Block, DEFAULT_BUFFER_SIZE)
+	listener := newAllBlockListener(c)
 
 	if c.BlockAPI == nil {
 		c.safeSendError(reqID, nil, "error BlockAPI not set")

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -301,8 +301,8 @@ func (c *WSConn) initAllBlocksListerner(reqID float64, _ interface{}) (Listener,
 
 	listener.finalizedChanID, err = c.BlockAPI.RegisterFinalizedChannel(listener.finalizedChan)
 	if err != nil {
-		c.safeSendError(reqID, nil, "could not register finalized channel")
-		return nil, fmt.Errorf("could not register finalized channel")
+		c.safeSendError(reqID, nil, "could not register finalised channel")
+		return nil, fmt.Errorf("could not register finalised channel")
 	}
 
 	c.mu.Lock()

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -284,6 +284,8 @@ func (c *WSConn) initAllBlocksListerner(reqID float64, _ interface{}) (Listener,
 	listener.done = make(chan struct{})
 	listener.cancelTimeout = defaultCancelTimeout
 	listener.wsconn = c
+	listener.finalizedChan = make(chan *types.FinalisationInfo, DEFAULT_BUFFER_SIZE)
+	listener.importedChan = make(chan *types.Block, DEFAULT_BUFFER_SIZE)
 
 	if c.BlockAPI == nil {
 		c.safeSendError(reqID, nil, "error BlockAPI not set")

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -305,7 +305,7 @@ func TestSubscribeAllHeads(t *testing.T) {
 		Return(uint8(0), errors.New("failed")).Once()
 
 	_, err = wsconn.initAllBlocksListerner(1, nil)
-	require.Error(t, err, "could not register finalized channel")
+	require.Error(t, err, "could not register finalised channel")
 	c.ReadMessage()
 
 	importedChanID := uint8(10)

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -1,11 +1,13 @@
 package subscription
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/gossamer/dot/rpc/modules/mocks"
 	modulesmocks "github.com/ChainSafe/gossamer/dot/rpc/modules/mocks"
 
 	"github.com/ChainSafe/gossamer/dot/rpc/modules"
@@ -269,4 +271,115 @@ func TestWSConn_HandleComm(t *testing.T) {
 
 	err = listener.Stop()
 	require.NoError(t, err)
+}
+
+func TestSubscribeAllHeads(t *testing.T) {
+	wsconn, c, cancel := setupWSConn(t)
+	wsconn.Subscriptions = make(map[uint32]Listener)
+	defer cancel()
+
+	go wsconn.HandleComm()
+	time.Sleep(time.Second * 2)
+
+	_, err := wsconn.initAllBlocksListerner(1, nil)
+	require.EqualError(t, err, "error BlockAPI not set")
+	_, msg, err := c.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"jsonrpc":"2.0","error":{"code":null,"message":"error BlockAPI not set"},"id":1}`+"\n"), msg)
+
+	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI.On("RegisterImportedChannel", mock.AnythingOfType("chan<- *types.Block")).
+		Return(uint8(0), errors.New("some mocked error")).Once()
+
+	wsconn.BlockAPI = mockBlockAPI
+	_, err = wsconn.initAllBlocksListerner(1, nil)
+	require.Error(t, err, "could not register imported channel")
+
+	_, msg, err = c.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"jsonrpc":"2.0","error":{"code":null,"message":"could not register imported channel"},"id":1}`+"\n"), msg)
+
+	mockBlockAPI.On("RegisterImportedChannel", mock.AnythingOfType("chan<- *types.Block")).
+		Return(uint8(10), nil).Once()
+	mockBlockAPI.On("RegisterFinalizedChannel", mock.AnythingOfType("chan<- *types.FinalisationInfo")).
+		Return(uint8(0), errors.New("failed")).Once()
+
+	_, err = wsconn.initAllBlocksListerner(1, nil)
+	require.Error(t, err, "could not register finalized channel")
+	c.ReadMessage()
+
+	importedChanID := uint8(10)
+	finalizedChanID := uint8(11)
+
+	var fCh chan<- *types.FinalisationInfo
+	var iCh chan<- *types.Block
+
+	mockBlockAPI.On("RegisterImportedChannel", mock.AnythingOfType("chan<- *types.Block")).
+		Run(func(args mock.Arguments) {
+			ch := args.Get(0).(chan<- *types.Block)
+			iCh = ch
+		}).Return(importedChanID, nil).Once()
+
+	mockBlockAPI.On("RegisterFinalizedChannel", mock.AnythingOfType("chan<- *types.FinalisationInfo")).
+		Run(func(args mock.Arguments) {
+			ch := args.Get(0).(chan<- *types.FinalisationInfo)
+			fCh = ch
+		}).
+		Return(finalizedChanID, nil).Once()
+
+	l, err := wsconn.initAllBlocksListerner(1, nil)
+	require.NoError(t, err)
+	require.NotNil(t, l)
+	require.IsType(t, &AllBlocksListener{}, l)
+	require.Len(t, wsconn.Subscriptions, 1)
+
+	_, msg, err = c.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":1,"id":1}`+"\n"), msg)
+
+	l.Listen()
+	time.Sleep(time.Millisecond * 500)
+
+	expected := fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"chain_allHead","params":{"result":{"parentHash":"%s","number":"0x00","stateRoot":"%s","extrinsicsRoot":"%s","digest":{"logs":["0x064241424504ff"]}},"subscription":1}}`,
+		common.EmptyHash,
+		common.EmptyHash,
+		common.EmptyHash,
+	)
+
+	fCh <- &types.FinalisationInfo{
+		Header: &types.Header{
+			ParentHash:     common.EmptyHash,
+			Number:         big.NewInt(0),
+			StateRoot:      common.EmptyHash,
+			ExtrinsicsRoot: common.EmptyHash,
+			Digest:         types.NewDigest(types.NewBABEPreRuntimeDigest([]byte{0xff})),
+		},
+	}
+
+	time.Sleep(time.Millisecond * 500)
+	_, msg, err = c.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, expected+"\n", string(msg))
+
+	iCh <- &types.Block{
+		Header: &types.Header{
+			ParentHash:     common.EmptyHash,
+			Number:         big.NewInt(0),
+			StateRoot:      common.EmptyHash,
+			ExtrinsicsRoot: common.EmptyHash,
+			Digest:         types.NewDigest(types.NewBABEPreRuntimeDigest([]byte{0xff})),
+		},
+	}
+	time.Sleep(time.Millisecond * 500)
+	_, msg, err = c.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, []byte(expected+"\n"), msg)
+
+	mockBlockAPI.On("UnregisterImportedChannel", importedChanID)
+	mockBlockAPI.On("UnregisterFinalisedChannel", finalizedChanID)
+
+	require.NoError(t, l.Stop())
+	mockBlockAPI.AssertCalled(t, "UnregisterImportedChannel", importedChanID)
+	mockBlockAPI.AssertCalled(t, "UnregisterFinalisedChannel", finalizedChanID)
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Implement `chain_subscribeAllHeads` and `chain_unsubscribeAllHeads`
- Create channels and register them into `BlockAPI` and notify the websocket every new block or finalization

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test -run ^TestSubscribeAllHeads$ github.com/ChainSafe/gossamer/dot/rpc/subscription
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes to #1741 

## Primary Reviewer 

<!-- 
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot) 
-->

- @timwu20 
