### PR TITLE
dot/network: create blockResponseBuf pool

### DIFF
--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -46,9 +46,7 @@ const (
 	blockAnnounceID = "/block-announces/1"
 	transactionsID  = "/transactions/1"
 
-	// maxMessageSize       = 1024 * 63       // 63kb for now
-	maxMessageSize       = 1024 * 1024 * 4 // 4mb
-	maxBlockResponseSize = 1024 * 1024 * 4 // 4mb
+	maxMessageSize = 1024 * 1024 * 4 // 4mb
 
 	gssmrIsMajorSyncMetric = "gossamer/network/is_major_syncing"
 )

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	blockRequestTimeout = time.Second * 5
+	maxBlockResponseSize uint64 = 1024 * 1024 * 4 // 4mb
+	blockRequestTimeout         = time.Second * 5
 )
 
 // DoBlockRequest sends a request to the given peer. If a response is received within a certain time period, it is returned, otherwise an error is returned.


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Created pool for blockResponseBuf and updated message size to work for both pools.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-Fixes #1858 

## Primary Reviewer 

<!-- 
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot) 
-->

- @noot 
