### PR TITLE
feat(devsetup): VSCode devcontainer configuration

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+devcontainer.json
+docker-compose.yml
+Dockerfile
+README.md

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM qmcgaw/godevcontainer:debian
+ENV CGO_ENABLED=1
+RUN apt-get update && \
+  apt-get install -y make
+RUN wget -qO- https://deb.nodesource.com/setup_14.x | bash - && \
+  apt-get install -y nodejs
+
+# TODO: once Alpine is properly supported
+# ARG GLIBC_VERSION=2.34-r0
+# RUN wget -qO /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+#   wget -qO /tmp/glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
+#   apk add /tmp/glibc.apk && \
+#   rm /tmp/glibc.apk

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,62 @@
+# Development container
+
+Development container that can be used with VSCode.
+
+It works on Linux, Windows and OSX.
+
+## Requirements
+
+- [VS code](https://code.visualstudio.com/download) installed
+- [VS code remote containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed
+- [Docker](https://www.docker.com/products/docker-desktop) installed and running
+- [Docker Compose](https://docs.docker.com/compose/install/) installed
+
+## Setup
+
+1. Create the following files on your host if you don't have them:
+
+    ```sh
+    touch ~/.gitconfig ~/.zsh_history
+    ```
+
+    Note that the development container will create the empty directories `~/.docker`, `~/.ssh` and `~/.kube` if you don't have them.
+
+1. **For Docker on OSX or Windows without WSL**: ensure your home directory `~` is accessible by Docker.
+1. **For Docker on Windows without WSL:** if you want to use SSH keys, bind mount your host `~/.ssh` to `/tmp/.ssh` instead of `~/.ssh` by changing the `volumes` section in the [docker-compose.yml](docker-compose.yml).
+1. Open the command palette in Visual Studio Code (CTRL+SHIFT+P).
+1. Select `Remote-Containers: Open Folder in Container...` and choose the project directory.
+
+## Customization
+
+### Customize the image
+
+You can make changes to the [Dockerfile](Dockerfile) and then rebuild the image.
+
+To rebuild the image, open the VSCode command palette (`CTRL`+`SHIFT`+`P`), select `Remote-Containers: Rebuild and reopen in container`
+
+### Customize VS code settings
+
+You can customize **settings** and **extensions** in the [devcontainer.json](devcontainer.json) definition file. You will have to re-build the container for them to take effect. Alternatively you can still use the `.vscode` directory in the repository for user settings that take precedence.
+
+### Entrypoint script
+
+You can bind mount a shell script to `/home/vscode/.welcome.sh` to replace the current welcome script.
+
+### Publish a port
+
+To access a port from your host to your development container, publish a port in [docker-compose.yml](docker-compose.yml). You can also now do it directly with VSCode without restarting the container.
+
+### Run other services
+
+1. Modify [docker-compose.yml](docker-compose.yml) to launch other services at the same time as this development container, such as a test database:
+
+    ```yml
+      database:
+        image: postgres
+        restart: always
+        environment:
+          POSTGRES_PASSWORD: password
+    ```
+
+1. In [devcontainer.json](devcontainer.json), change the line `"runServices": ["vscode"],` to `"runServices": ["vscode", "database"],`.
+1. In the VS code command palette, rebuild the container.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,87 @@
+{
+    "name": "gossamer-dev",
+    "dockerComposeFile": [
+        "docker-compose.yml"
+    ],
+    "service": "vscode",
+    "runServices": [
+        "vscode"
+    ],
+    "shutdownAction": "stopCompose",
+    "postCreateCommand": "source ~/.windows.sh && go mod download && go mod tidy",
+    "workspaceFolder": "/workspace",
+    // "overrideCommand": "",
+    "extensions": [
+        "golang.go",
+        "eamodio.gitlens", // IDE Git information
+        "davidanson.vscode-markdownlint",
+        "ms-azuretools.vscode-docker", // Docker integration and linting
+        "shardulm94.trailing-spaces", // Show trailing spaces
+        "Gruntfuggly.todo-tree", // Highlights TODO comments
+        "bierner.emojisense", // Emoji sense for markdown
+        "stkb.rewrap", // rewrap comments after n characters on one line
+        "vscode-icons-team.vscode-icons", // Better file extension icons
+        "github.vscode-pull-request-github", // Github interaction
+        "redhat.vscode-yaml", // Kubernetes, Drone syntax highlighting
+        "bajdzis.vscode-database", // Supports connections to mysql or postgres, over SSL, socked
+        "IBM.output-colorizer", // Colorize your output/test logs
+        // "mohsen1.prettify-json", // Prettify JSON data
+        // "zxh404.vscode-proto3", // Supports Proto syntax
+        // "jrebocho.vscode-random", // Generates random values
+        // "alefragnani.Bookmarks", // Manage bookmarks
+        // "quicktype.quicktype", // Paste JSON as code
+        // "spikespaz.vscode-smoothtype", // smooth cursor animation
+    ],
+    "settings": {
+        "files.eol": "\n",
+        "remote.extensionKind": {
+            "ms-azuretools.vscode-docker": "workspace"
+        },
+        "editor.codeActionsOnSaveTimeout": 3000,
+        "go.useLanguageServer": true,
+        "[go]": {
+            "editor.formatOnSave": true,
+            "editor.codeActionsOnSave": {
+                "source.organizeImports": true,
+            },
+            // Optional: Disable snippets, as they conflict with completion ranking.
+            "editor.snippetSuggestions": "none"
+        },
+        "[go.mod]": {
+            "editor.formatOnSave": true,
+            "editor.codeActionsOnSave": {
+                "source.organizeImports": true,
+            },
+        },
+        "gopls": {
+            "usePlaceholders": false,
+            "staticcheck": true
+        },
+        "go.autocompleteUnimportedPackages": true,
+        "go.gotoSymbol.includeImports": true,
+        "go.gotoSymbol.includeGoroot": true,
+        "go.lintTool": "golangci-lint",
+        "go.buildOnSave": "workspace",
+        "go.lintOnSave": "package",
+        "go.vetOnSave": "package",
+        "editor.formatOnSave": true,
+        "go.toolsEnvVars": {
+            "GOFLAGS": "-tags=integration",
+            "CGO_ENABLED": 1 // for the race detector
+        },
+        "gopls.env": {
+            "GOFLAGS": "-tags=integration"
+        },
+        "go.testEnvVars": {
+            "": "",
+        },
+        "go.testFlags": [
+            "-v",
+            "-race"
+        ],
+        "go.testTimeout": "60s",
+        "go.coverOnSingleTest": true,
+        "go.coverOnSingleTestFile": true,
+        "go.coverOnTestPackage": true
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.7"
+
+services:
+  vscode:
+    build: .
+    image: godevcontainer
+    volumes:
+      - ../:/workspace
+      # Docker
+      - ~/.docker:/root/.docker:z
+      # Docker socket to access Docker server
+      - /var/run/docker.sock:/var/run/docker.sock
+      # SSH directory for Linux, OSX and WSL
+      - ~/.ssh:/root/.ssh:z
+      # For Windows without WSL, a copy will be made
+      # from /tmp/.ssh to ~/.ssh to fix permissions
+      # - ~/.ssh:/tmp/.ssh:ro
+      # Shell history persistence
+      - ~/.zsh_history:/root/.zsh_history:z
+      # Git config
+      - ~/.gitconfig:/root/.gitconfig:z
+      # Kubernetes
+      - ~/.kube:/root/.kube:z
+    environment:
+      - TZ=
+    cap_add:
+      # For debugging with dlv
+      - SYS_PTRACE
+    security_opt:
+      # For debugging with dlv
+      - seccomp:unconfined
+    entrypoint: zsh -c "while sleep 1000; do :; done"


### PR DESCRIPTION
## Changes

- Add VSCode development container configuration files with documentation, shamlessly taken from my [repository](https://github.com/qdm12/godevcontainer)
- Dockerfile slightly modified to work with this repository (`CGO_ENABLED=1`, `make` and `nodejs` installed)
- Note: sharing this so @jimjbrettj can try/use it
- **Question**: this relies on my personal public image [`qmcgaw/godevcontainer`](https://github.com/qdm12/godevcontainer) (used by a bunch of random people out there), is this ok or do we want to fork it? Alternatively, we could specify a certain commit hash in the Dockerfile if you are skeptical about future changes.

## Tests

- Not relevant

## Issues

- No issue

## Primary Reviewer 

- No primary reviewer.
