### PR TITLE
chore(type): Change block number `*big.Int` to `uint`

### DIFF
--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -43,7 +43,7 @@ var (
 	// DefaultPruningMode is the default pruning mode
 	DefaultPruningMode = "archive"
 	// DefaultRetainBlocks is the default retained blocks
-	DefaultRetainBlocks = int64(512)
+	DefaultRetainBlocks uint32 = 512
 
 	// DefaultTelemetryURLs is the default URL of the telemetry server to connect to.
 	DefaultTelemetryURLs []genesis.TelemetryEndpoint

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -45,7 +45,7 @@ var (
 	// DefaultPruningMode is the default pruning mode
 	DefaultPruningMode = "archive"
 	// DefaultRetainBlocks is the default retained blocks
-	DefaultRetainBlocks = int64(512)
+	DefaultRetainBlocks uint32 = 512
 
 	// DefaultTelemetryURLs is the default URL of the telemetry server to connect to.
 	DefaultTelemetryURLs []genesis.TelemetryEndpoint

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -151,8 +151,8 @@ func createDotConfig(ctx *cli.Context) (*dot.Config, error) {
 	setDotNetworkConfig(ctx, tomlCfg.Network, &cfg.Network)
 	setDotRPCConfig(ctx, tomlCfg.RPC, &cfg.RPC)
 
-	if rewind := ctx.GlobalInt(RewindFlag.Name); rewind != 0 {
-		cfg.State.Rewind = rewind
+	if rewind := ctx.GlobalUint(RewindFlag.Name); rewind != 0 {
+		cfg.State.Rewind = uint32(rewind)
 	}
 
 	// set system info
@@ -487,7 +487,7 @@ func setDotGlobalConfigFromFlags(ctx *cli.Context, cfg *dot.GlobalConfig) error 
 		cfg.MetricsPort = uint32(metricsPort)
 	}
 
-	cfg.RetainBlocks = ctx.Int64(RetainBlockNumberFlag.Name)
+	cfg.RetainBlocks = uint32(ctx.Uint(RetainBlockNumberFlag.Name))
 	cfg.Pruning = pruner.Mode(ctx.String(PruningFlag.Name))
 	cfg.NoTelemetry = ctx.Bool("no-telemetry")
 

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -314,10 +314,10 @@ var (
 	}
 
 	// RetainBlockNumberFlag retain number of block from latest block while pruning, valid for the use with prune-state subcommand
-	RetainBlockNumberFlag = cli.Int64Flag{
+	RetainBlockNumberFlag = cli.UintFlag{
 		Name:  "retain-blocks",
-		Usage: "Retain number of block from latest block while pruning",
-		Value: dev.DefaultRetainBlocks,
+		Usage: "Retain number of blocks from latest block while pruning",
+		Value: uint(dev.DefaultRetainBlocks),
 	}
 
 	// PruningFlag triggers the online pruning of historical state tries. It's either full or archive. To enable pruning the value

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -440,9 +440,9 @@ func pruneState(ctx *cli.Context) error {
 	}
 
 	bloomSize := ctx.GlobalUint64(BloomFilterSizeFlag.Name)
-	retainBlocks := ctx.GlobalInt64(RetainBlockNumberFlag.Name)
+	retainBlocks := uint32(ctx.GlobalUint(RetainBlockNumberFlag.Name))
 
-	pruner, err := state.NewOfflinePruner(inputDBPath, prunedDBPath, bloomSize, retainBlocks)
+	pruner, err := state.NewOfflinePruner(inputDBPath, prunedDBPath, bloomSize, uint(retainBlocks))
 	if err != nil {
 		return err
 	}

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -43,6 +43,8 @@ func newTestContext(description string, flags []string, values []interface{}) (*
 			set.String(flags[i], v, "")
 		case uint:
 			set.Uint(flags[i], v, "")
+		case uint32:
+			set.Uint64(flags[i], uint64(v), "")
 		case int64:
 			set.Int64(flags[i], v, "")
 		case []string:
@@ -70,6 +72,11 @@ func newTestContext(description string, flags []string, values []interface{}) (*
 			err := ctx.Set(flags[i], strconv.Itoa(int(values[i].(uint))))
 			if err != nil {
 				return nil, fmt.Errorf("failed to set cli flag: %T, err: %w", flags[i], err)
+			}
+		case uint32:
+			err := ctx.Set(flags[i], strconv.Itoa(int(v)))
+			if err != nil {
+				return nil, fmt.Errorf("failed to set cli flag: %T", flags[i])
 			}
 		case int64:
 			err := ctx.Set(flags[i], strconv.Itoa(int(values[i].(int64))))

--- a/dot/config.go
+++ b/dot/config.go
@@ -56,7 +56,7 @@ type GlobalConfig struct {
 	MetricsPort    uint32
 	NoTelemetry    bool
 	TelemetryURLs  []genesis.TelemetryEndpoint
-	RetainBlocks   int64
+	RetainBlocks   uint32
 	Pruning        pruner.Mode
 }
 
@@ -131,7 +131,7 @@ func (r *RPCConfig) isWSEnabled() bool {
 
 // StateConfig is the config for the State service
 type StateConfig struct {
-	Rewind int
+	Rewind uint32
 }
 
 // String will return the json representation for a Config

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -34,7 +34,7 @@ type GlobalConfig struct {
 	BasePath     string `toml:"basepath,omitempty"`
 	LogLvl       string `toml:"log,omitempty"`
 	MetricsPort  uint32 `toml:"metrics-port,omitempty"`
-	RetainBlocks int64  `toml:"retain-blocks,omitempty"`
+	RetainBlocks uint32 `toml:"retain-blocks,omitempty"`
 	Pruning      string `toml:"pruning,omitempty"`
 }
 

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -58,6 +58,12 @@ var (
 	// ErrNilDigestHandler is returned when the DigestHandler interface is nil
 	ErrNilDigestHandler = errors.New("cannot have nil DigestHandler")
 
+	// ErrNilBlock is returned when the block is nil
+	ErrNilBlock = errors.New("cannot have nil block")
+
+	// ErrNilBlockHeaderNumber is returned when the block header number is nil
+	ErrNilBlockHeaderNumber = errors.New("cannot have nil block header number")
+
 	errNilCodeSubstitutedState = errors.New("cannot have nil CodeSubstitutedStat")
 )
 

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"math/big"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -34,7 +33,7 @@ import (
 type BlockState interface {
 	BestBlockHash() common.Hash
 	BestBlockHeader() (*types.Header, error)
-	BestBlockNumber() (*big.Int, error)
+	BestBlockNumber() (uint, error)
 	BestBlockStateRoot() (common.Hash, error)
 	BestBlock() (*types.Block, error)
 	AddBlock(*types.Block) error

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -99,7 +99,7 @@ func TestService_HandleBlockProduced(t *testing.T) {
 
 	newBlock := types.Block{
 		Header: types.Header{
-			Number:     big.NewInt(1),
+			Number:     1,
 			ParentHash: s.blockState.BestBlockHash(),
 			Digest:     digest,
 		},
@@ -108,7 +108,7 @@ func TestService_HandleBlockProduced(t *testing.T) {
 
 	expected := &network.BlockAnnounceMessage{
 		ParentHash:     newBlock.Header.ParentHash,
-		Number:         newBlock.Header.Number,
+		Number:         big.NewInt(int64(newBlock.Header.Number)),
 		StateRoot:      newBlock.Header.StateRoot,
 		ExtrinsicsRoot: newBlock.Header.ExtrinsicsRoot,
 		Digest:         digest,

--- a/dot/core/mocks/block_state.go
+++ b/dot/core/mocks/block_state.go
@@ -3,8 +3,6 @@
 package mocks
 
 import (
-	big "math/big"
-
 	common "github.com/ChainSafe/gossamer/lib/common"
 
 	mock "github.com/stretchr/testify/mock"
@@ -98,16 +96,14 @@ func (_m *BlockState) BestBlockHeader() (*types.Header, error) {
 }
 
 // BestBlockNumber provides a mock function with given fields:
-func (_m *BlockState) BestBlockNumber() (*big.Int, error) {
+func (_m *BlockState) BestBlockNumber() (uint, error) {
 	ret := _m.Called()
 
-	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+	var r0 uint
+	if rf, ok := ret.Get(0).(func() uint); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*big.Int)
-		}
+		r0 = ret.Get(0).(uint)
 	}
 
 	var r1 error

--- a/dot/digest/digest_test.go
+++ b/dot/digest/digest_test.go
@@ -18,7 +18,6 @@ package digest
 
 import (
 	"io/ioutil"
-	"math/big"
 	"testing"
 	"time"
 
@@ -86,7 +85,7 @@ func TestHandler_GrandpaScheduledChange(t *testing.T) {
 	}
 
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	err = handler.handleConsensusDigest(d, header)
@@ -145,7 +144,7 @@ func TestHandler_GrandpaForcedChange(t *testing.T) {
 	}
 
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	err = handler.handleConsensusDigest(d, header)
@@ -191,7 +190,7 @@ func TestHandler_GrandpaPauseAndResume(t *testing.T) {
 	require.NoError(t, err)
 	nextPause, err := handler.grandpaState.(*state.GrandpaState).GetNextPause()
 	require.NoError(t, err)
-	require.Equal(t, big.NewInt(int64(p.Delay)), nextPause)
+	require.Equal(t, uint(p.Delay), nextPause)
 
 	headers, _ := state.AddBlocksToState(t, handler.blockState.(*state.BlockState), 3, false)
 	for i, h := range headers {
@@ -226,7 +225,7 @@ func TestHandler_GrandpaPauseAndResume(t *testing.T) {
 
 	nextResume, err := handler.grandpaState.(*state.GrandpaState).GetNextResume()
 	require.NoError(t, err)
-	require.Equal(t, big.NewInt(int64(r.Delay)+int64(p.Delay)), nextResume)
+	require.Equal(t, uint(r.Delay+p.Delay), nextResume)
 }
 
 func TestNextGrandpaAuthorityChange_OneChange(t *testing.T) {
@@ -252,14 +251,14 @@ func TestNextGrandpaAuthorityChange_OneChange(t *testing.T) {
 		Data:              data,
 	}
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	err = handler.handleConsensusDigest(d, header)
 	require.NoError(t, err)
 
 	next := handler.NextGrandpaAuthorityChange()
-	require.Equal(t, uint64(block), next)
+	require.Equal(t, uint(block), next)
 
 	nextSetID := uint64(1)
 	auths, err := handler.grandpaState.(*state.GrandpaState).GetAuthorities(nextSetID)
@@ -296,7 +295,7 @@ func TestNextGrandpaAuthorityChange_MultipleChanges(t *testing.T) {
 	}
 
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	err = handler.handleConsensusDigest(d, header)
@@ -309,7 +308,7 @@ func TestNextGrandpaAuthorityChange_MultipleChanges(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, auths)
 
-	earlier := uint32(4)
+	const earlier = 4
 	fc := types.GrandpaForcedChange{
 		Auths: []types.GrandpaAuthoritiesRaw{
 			{Key: kr.Alice().Public().(*ed25519.PublicKey).AsBytes(), ID: 0},
@@ -333,7 +332,7 @@ func TestNextGrandpaAuthorityChange_MultipleChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	next := handler.NextGrandpaAuthorityChange()
-	require.Equal(t, uint64(earlier+1), next)
+	require.Equal(t, uint(earlier+1), next)
 
 	auths, err = handler.grandpaState.(*state.GrandpaState).GetAuthorities(nextSetID)
 	require.NoError(t, err)
@@ -345,7 +344,7 @@ func TestNextGrandpaAuthorityChange_MultipleChanges(t *testing.T) {
 func TestHandler_HandleBABEOnDisabled(t *testing.T) {
 	handler := newTestHandler(t)
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	var digest = types.NewBabeConsensusDigest()

--- a/dot/digest/interface.go
+++ b/dot/digest/interface.go
@@ -17,8 +17,6 @@
 package digest
 
 import (
-	"math/big"
-
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/grandpa"
 )
@@ -41,9 +39,9 @@ type EpochState interface {
 
 // GrandpaState is the interface for the state.GrandpaState
 type GrandpaState interface {
-	SetNextChange(authorities []grandpa.Voter, number *big.Int) error
+	SetNextChange(authorities []grandpa.Voter, number uint) error
 	IncrementSetID() error
-	SetNextPause(number *big.Int) error
-	SetNextResume(number *big.Int) error
+	SetNextPause(number uint) error
+	SetNextResume(number uint) error
 	GetCurrentSetID() (uint64, error)
 }

--- a/dot/import.go
+++ b/dot/import.go
@@ -19,6 +19,7 @@ package dot
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -83,6 +84,10 @@ func newTrieFromPairs(filename string) (*trie.Trie, error) {
 	return tr, nil
 }
 
+var (
+	errHeaderNumberFieldNotValid = errors.New("invalid number field in header JSON")
+)
+
 func newHeaderFromFile(filename string) (*types.Header, error) {
 	data, err := ioutil.ReadFile(filepath.Clean(filename))
 	if err != nil {
@@ -97,10 +102,13 @@ func newHeaderFromFile(filename string) (*types.Header, error) {
 
 	hexNum, ok := jsonHeader["number"].(string)
 	if !ok {
-		return nil, errors.New("invalid number field in header JSON")
+		return nil, errHeaderNumberFieldNotValid
 	}
 
-	num := common.MustHexToBigInt(hexNum)
+	num, err := common.HexToUint(hexNum)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errHeaderNumberFieldNotValid, err)
+	}
 
 	parentHashStr, ok := jsonHeader["parentHash"].(string)
 	if !ok {

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -19,7 +19,6 @@ package dot
 import (
 	"encoding/json"
 	"io/ioutil"
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -52,7 +51,7 @@ func setupStateFile(t *testing.T) string {
 }
 
 func setupHeaderFile(t *testing.T) string {
-	headerStr := "{\"digest\":{\"logs\":[\"0x0642414245b501013c0000009659bd0f0000000070edad1c9064fff78cb18435223d8adaf5ea04c24b1a8766e3dc01eb03cc6a0c11b79793d4e31cc0990838229c44fed1669a7c7c79e1e6d0a96374d6496728069d1ef739e290497a0e3b728fa88fcbdd3a5504e0efde0242e7a806dd4fa9260c\",\"0x054241424501019e7f28dddcf27c1e6b328d5694c368d5b2ec5dbe0e412ae1c98f88d53be4d8502fac571f3f19c9caaf281a673319241e0c5095a683ad34316204088a36a4bd86\"]},\"extrinsicsRoot\":\"0xda26dc8c1455f8f81cae12e4fc59e23ce961b2c837f6d3f664283af906d344e0\",\"number\":\"0x169d12\",\"parentHash\":\"0x3b45c9c22dcece75a30acc9c2968cb311e6b0557350f83b430f47559db786975\",\"stateRoot\":\"0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb\"}"
+	headerStr := "{\"digest\":{\"logs\":[\"0x0642414245b501013c0000009659bd0f0000000070edad1c9064fff78cb18435223d8adaf5ea04c24b1a8766e3dc01eb03cc6a0c11b79793d4e31cc0990838229c44fed1669a7c7c79e1e6d0a96374d6496728069d1ef739e290497a0e3b728fa88fcbdd3a5504e0efde0242e7a806dd4fa9260c\",\"0x054241424501019e7f28dddcf27c1e6b328d5694c368d5b2ec5dbe0e412ae1c98f88d53be4d8502fac571f3f19c9caaf281a673319241e0c5095a683ad34316204088a36a4bd86\"]},\"extrinsicsRoot\":\"0xda26dc8c1455f8f81cae12e4fc59e23ce961b2c837f6d3f664283af906d344e0\",\"number\":\"0x129d1600\",\"parentHash\":\"0x3b45c9c22dcece75a30acc9c2968cb311e6b0557350f83b430f47559db786975\",\"stateRoot\":\"0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb\"}"
 	fp := "./test_data/header.json"
 	err := ioutil.WriteFile(fp, []byte(headerStr), 0777)
 	require.NoError(t, err)
@@ -81,7 +80,7 @@ func TestNewHeaderFromFile(t *testing.T) {
 
 	expected := &types.Header{
 		ParentHash:     common.MustHexToHash("0x3b45c9c22dcece75a30acc9c2968cb311e6b0557350f83b430f47559db786975"),
-		Number:         big.NewInt(1482002),
+		Number:         1482002,
 		StateRoot:      common.MustHexToHash("0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb"),
 		ExtrinsicsRoot: common.MustHexToHash("0xda26dc8c1455f8f81cae12e4fc59e23ce961b2c837f6d3f664283af906d344e0"),
 		Digest:         digest,

--- a/dot/network/message_test.go
+++ b/dot/network/message_test.go
@@ -175,7 +175,7 @@ func TestEncodeBlockResponseMessage_Empty(t *testing.T) {
 func TestEncodeBlockResponseMessage_WithBody(t *testing.T) {
 	hash := common.NewHash([]byte{0})
 	testHash := common.NewHash([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
-	header, err := types.NewHeader(testHash, testHash, testHash, big.NewInt(1), types.NewDigest())
+	header, err := types.NewHeader(testHash, testHash, testHash, 1, types.NewDigest())
 	require.NoError(t, err)
 
 	exts := [][]byte{{1, 3, 5, 7}, {9, 1, 2}, {3, 4, 5}}
@@ -221,7 +221,7 @@ func TestEncodeBlockResponseMessage_WithAll(t *testing.T) {
 	hash := common.NewHash([]byte{0})
 	testHash := common.NewHash([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
 
-	header, err := types.NewHeader(testHash, testHash, testHash, big.NewInt(1), types.NewDigest())
+	header, err := types.NewHeader(testHash, testHash, testHash, 1, types.NewDigest())
 	require.NoError(t, err)
 
 	exts := [][]byte{{1, 3, 5, 7}, {9, 1, 2}, {3, 4, 5}}

--- a/dot/network/mock_block_state.go
+++ b/dot/network/mock_block_state.go
@@ -3,8 +3,6 @@
 package network
 
 import (
-	big "math/big"
-
 	common "github.com/ChainSafe/gossamer/lib/common"
 	mock "github.com/stretchr/testify/mock"
 
@@ -40,16 +38,14 @@ func (_m *MockBlockState) BestBlockHeader() (*types.Header, error) {
 }
 
 // BestBlockNumber provides a mock function with given fields:
-func (_m *MockBlockState) BestBlockNumber() (*big.Int, error) {
+func (_m *MockBlockState) BestBlockNumber() (uint, error) {
 	ret := _m.Called()
 
-	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+	var r0 uint
+	if rf, ok := ret.Get(0).(func() uint); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*big.Int)
-		}
+		r0 = ret.Get(0).(uint)
 	}
 
 	var r1 error
@@ -79,11 +75,11 @@ func (_m *MockBlockState) GenesisHash() common.Hash {
 }
 
 // GetHashByNumber provides a mock function with given fields: num
-func (_m *MockBlockState) GetHashByNumber(num *big.Int) (common.Hash, error) {
+func (_m *MockBlockState) GetHashByNumber(num uint) (common.Hash, error) {
 	ret := _m.Called(num)
 
 	var r0 common.Hash
-	if rf, ok := ret.Get(0).(func(*big.Int) common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(uint) common.Hash); ok {
 		r0 = rf(num)
 	} else {
 		if ret.Get(0) != nil {
@@ -92,7 +88,7 @@ func (_m *MockBlockState) GetHashByNumber(num *big.Int) (common.Hash, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint) error); ok {
 		r1 = rf(num)
 	} else {
 		r1 = ret.Error(1)

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -298,7 +298,7 @@ func (s *Service) collectNetworkMetrics() {
 		if err != nil {
 			syncedBlocks.Update(0)
 		} else {
-			syncedBlocks.Update(num.Int64())
+			syncedBlocks.Update(int64(num))
 		}
 
 		time.Sleep(gssmrmetrics.RefreshInterval)
@@ -726,13 +726,13 @@ func (s *Service) CollectGauge() map[string]int64 {
 }
 
 // HighestBlock returns the highest known block number
-func (*Service) HighestBlock() int64 {
+func (*Service) HighestBlock() uint32 {
 	// TODO: refactor this to get the data from the sync service (#1857)
 	return 0
 }
 
 // StartingBlock return the starting block number that's currently being synced
-func (*Service) StartingBlock() int64 {
+func (*Service) StartingBlock() uint32 {
 	// TODO: refactor this to get the data from the sync service (#1857)
 	return 0
 }

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -78,7 +78,7 @@ func createTestService(t *testing.T, cfg *Config) (srvc *Service) {
 	}
 
 	if cfg.BlockState == nil {
-		cfg.BlockState = NewMockBlockState(nil)
+		cfg.BlockState = NewMockBlockState(1)
 	}
 
 	if cfg.TransactionHandler == nil {

--- a/dot/network/state.go
+++ b/dot/network/state.go
@@ -17,8 +17,6 @@
 package network
 
 import (
-	"math/big"
-
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 
@@ -30,11 +28,11 @@ import (
 // BlockState interface for block state methods
 type BlockState interface {
 	BestBlockHeader() (*types.Header, error)
-	BestBlockNumber() (*big.Int, error)
+	BestBlockNumber() (uint, error)
 	GenesisHash() common.Hash
 	HasBlockBody(common.Hash) (bool, error)
 	GetHighestFinalisedHeader() (*types.Header, error)
-	GetHashByNumber(num *big.Int) (common.Hash, error)
+	GetHashByNumber(num uint) (common.Hash, error)
 }
 
 //go:generate mockery --name Syncer --structname MockSyncer --case underscore --inpackage

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -17,7 +17,6 @@
 package dot
 
 import (
-	"math/big"
 	"reflect"
 	"sync"
 	"testing"
@@ -220,7 +219,7 @@ func TestInitNode_LoadGenesisData(t *testing.T) {
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
-	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), genTrie.MustHash(), trie.EmptyHash, big.NewInt(0), types.NewDigest())
+	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), genTrie.MustHash(), trie.EmptyHash, 0, types.NewDigest())
 	require.NoError(t, err)
 
 	err = stateSrvc.Initialise(gen, genesisHeader, genTrie)
@@ -251,7 +250,7 @@ func TestInitNode_LoadGenesisData(t *testing.T) {
 	require.NoError(t, err)
 
 	stateRoot := genesisHeader.StateRoot
-	expectedHeader, err := types.NewHeader(common.NewHash([]byte{0}), stateRoot, trie.EmptyHash, big.NewInt(0), types.NewDigest())
+	expectedHeader, err := types.NewHeader(common.NewHash([]byte{0}), stateRoot, trie.EmptyHash, 0, types.NewDigest())
 	require.NoError(t, err)
 	require.Equal(t, expectedHeader.Hash(), genesisHeader.Hash())
 }

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -1,8 +1,6 @@
 package modules
 
 import (
-	"math/big"
-
 	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -38,7 +36,7 @@ type BlockAPI interface {
 	GetHeader(hash common.Hash) (*types.Header, error)
 	BestBlockHash() common.Hash
 	GetBlockByHash(hash common.Hash) (*types.Block, error)
-	GetBlockHash(blockNumber *big.Int) (common.Hash, error)
+	GetBlockHash(blockNumber uint) (common.Hash, error)
 	GetFinalisedHash(uint64, uint64) (common.Hash, error)
 	GetHighestFinalisedHash() (common.Hash, error)
 	HasJustification(hash common.Hash) (bool, error)
@@ -64,8 +62,8 @@ type NetworkAPI interface {
 	Stop() error
 	Start() error
 	IsStopped() bool
-	HighestBlock() int64
-	StartingBlock() int64
+	HighestBlock() uint32
+	StartingBlock() uint32
 	AddReservedPeers(addrs ...string) error
 	RemoveReservedPeers(addrs ...string) error
 }

--- a/dot/rpc/modules/api_mocks.go
+++ b/dot/rpc/modules/api_mocks.go
@@ -28,7 +28,7 @@ func NewMockBlockAPI() *modulesmocks.BlockAPI {
 	m.On("GetHeader", mock.AnythingOfType("common.Hash")).Return(nil, nil)
 	m.On("BestBlockHash").Return(common.Hash{})
 	m.On("GetBlockByHash", mock.AnythingOfType("common.Hash")).Return(nil, nil)
-	m.On("GetBlockHash", mock.AnythingOfType("*big.Int")).Return(nil, nil)
+	m.On("GetBlockHash", mock.AnythingOfType("uint")).Return(nil, nil)
 	m.On("GetFinalisedHash", mock.AnythingOfType("uint64"), mock.AnythingOfType("uint64")).Return(common.Hash{}, nil)
 	m.On("GetHighestFinalisedHash").Return(common.Hash{}, nil)
 	m.On("GetImportedBlockNotifierChannel").Return(make(chan *types.Block, 5))

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -18,7 +18,6 @@ package modules
 
 import (
 	"io/ioutil"
-	"math/big"
 	"path/filepath"
 	"testing"
 
@@ -63,7 +62,7 @@ func TestChainGetHeader_Genesis(t *testing.T) {
 
 	expected := &ChainBlockHeaderResponse{
 		ParentHash:     header.ParentHash.String(),
-		Number:         common.BytesToHex(header.Number.Bytes()),
+		Number:         common.Uint64ToHex(uint64(header.Number)), // TODO-1785 is this fine?
 		StateRoot:      header.StateRoot.String(),
 		ExtrinsicsRoot: header.ExtrinsicsRoot.String(),
 		Digest: ChainBlockHeaderDigest{
@@ -99,7 +98,7 @@ func TestChainGetHeader_Latest(t *testing.T) {
 
 	expected := &ChainBlockHeaderResponse{
 		ParentHash:     header.ParentHash.String(),
-		Number:         common.BytesToHex(header.Number.Bytes()),
+		Number:         common.Uint64ToHex(uint64(header.Number)), // TODO-1785 is this fine?
 		StateRoot:      header.StateRoot.String(),
 		ExtrinsicsRoot: header.ExtrinsicsRoot.String(),
 		Digest: ChainBlockHeaderDigest{
@@ -147,7 +146,7 @@ func TestChainGetBlock_Genesis(t *testing.T) {
 
 	expectedHeader := &ChainBlockHeaderResponse{
 		ParentHash:     header.ParentHash.String(),
-		Number:         common.BytesToHex(header.Number.Bytes()),
+		Number:         common.Uint64ToHex(uint64(header.Number)), // TODO-1785 is this fine?
 		StateRoot:      header.StateRoot.String(),
 		ExtrinsicsRoot: header.ExtrinsicsRoot.String(),
 		Digest: ChainBlockHeaderDigest{
@@ -191,7 +190,7 @@ func TestChainGetBlock_Latest(t *testing.T) {
 
 	expectedHeader := &ChainBlockHeaderResponse{
 		ParentHash:     header.ParentHash.String(),
-		Number:         common.BytesToHex(header.Number.Bytes()),
+		Number:         common.Uint64ToHex(uint64(header.Number)), // TODO-1785 is this fine?
 		StateRoot:      header.StateRoot.String(),
 		ExtrinsicsRoot: header.ExtrinsicsRoot.String(),
 		Digest: ChainBlockHeaderDigest{
@@ -254,7 +253,7 @@ func TestChainGetBlockHash_ByNumber(t *testing.T) {
 	err := svc.GetBlockHash(nil, &req, &res)
 	require.Nil(t, err)
 
-	expected, err := state.Block.GetBlockByNumber(big.NewInt(1))
+	expected, err := state.Block.GetBlockByNumber(1)
 	require.NoError(t, err)
 	require.Equal(t, expected.Header.Hash().String(), res)
 }
@@ -270,7 +269,7 @@ func TestChainGetBlockHash_ByHex(t *testing.T) {
 	err := svc.GetBlockHash(nil, &req, &res)
 	require.NoError(t, err)
 
-	expected, err := state.Block.GetBlockByNumber(big.NewInt(1))
+	expected, err := state.Block.GetBlockByNumber(1)
 	require.NoError(t, err)
 	require.Equal(t, expected.Header.Hash().String(), res)
 }
@@ -290,9 +289,9 @@ func TestChainGetBlockHash_Array(t *testing.T) {
 	err := svc.GetBlockHash(nil, &req, &res)
 	require.Nil(t, err)
 
-	expected0, err := state.Block.GetBlockByNumber(big.NewInt(0))
+	expected0, err := state.Block.GetBlockByNumber(0)
 	require.NoError(t, err)
-	expected1, err := state.Block.GetBlockByNumber(big.NewInt(1))
+	expected1, err := state.Block.GetBlockByNumber(1)
 	require.NoError(t, err)
 	expected := []string{expected0.Header.Hash().String(), expected1.Header.Hash().String()}
 
@@ -331,7 +330,7 @@ func TestChainGetFinalizedHeadByRound(t *testing.T) {
 	require.NoError(t, err)
 	header := &types.Header{
 		ParentHash: genesisHeader.Hash(),
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 	}
 	err = state.Block.AddBlock(&types.Block{
@@ -394,7 +393,7 @@ func newTestStateService(t *testing.T) *state.Service {
 
 func loadTestBlocks(t *testing.T, gh common.Hash, bs *state.BlockState, rt runtime.Instance) {
 	header1 := &types.Header{
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     types.NewDigest(),
 		ParentHash: gh,
 		StateRoot:  trie.EmptyHash,
@@ -416,7 +415,7 @@ func loadTestBlocks(t *testing.T, gh common.Hash, bs *state.BlockState, rt runti
 	require.NoError(t, err)
 
 	header2 := &types.Header{
-		Number:     big.NewInt(2),
+		Number:     1,
 		Digest:     digest,
 		ParentHash: header1.Hash(),
 		StateRoot:  trie.EmptyHash,

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -19,7 +19,6 @@ package modules
 import (
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/chaindb"
@@ -280,7 +279,7 @@ func setupChildStateStorage(t *testing.T) (*ChildStateModule, common.Hash) {
 	b := &types.Block{
 		Header: types.Header{
 			ParentHash: bb.Header.Hash(),
-			Number:     big.NewInt(0).Add(big.NewInt(1), bb.Header.Number),
+			Number:     1 + bb.Header.Number,
 			StateRoot:  stateRoot,
 		},
 		Body: types.Body{},

--- a/dot/rpc/modules/errors.go
+++ b/dot/rpc/modules/errors.go
@@ -18,5 +18,10 @@ package modules
 
 import "errors"
 
-// ErrSubscriptionTransport error sent when trying to access websocket subscriptions via http
-var ErrSubscriptionTransport = errors.New("subscriptions are not available on this transport")
+var (
+	// ErrSubscriptionTransport error sent when trying to access websocket subscriptions via http
+	ErrSubscriptionTransport = errors.New("subscriptions are not available on this transport")
+
+	// ErrBlockHeaderNumberIsNil is returned when the block header number field is nil.
+	ErrBlockHeaderNumberIsNil = errors.New("block header number field is nil")
+)

--- a/dot/rpc/modules/helper_test.go
+++ b/dot/rpc/modules/helper_test.go
@@ -1,0 +1,3 @@
+package modules
+
+func uintPtr(n uint) *uint { return &n }

--- a/dot/rpc/modules/mocks/block_api.go
+++ b/dot/rpc/modules/mocks/block_api.go
@@ -3,8 +3,6 @@
 package mocks
 
 import (
-	big "math/big"
-
 	common "github.com/ChainSafe/gossamer/lib/common"
 	mock "github.com/stretchr/testify/mock"
 
@@ -68,11 +66,11 @@ func (_m *BlockAPI) GetBlockByHash(hash common.Hash) (*types.Block, error) {
 }
 
 // GetBlockHash provides a mock function with given fields: blockNumber
-func (_m *BlockAPI) GetBlockHash(blockNumber *big.Int) (common.Hash, error) {
+func (_m *BlockAPI) GetBlockHash(blockNumber uint) (common.Hash, error) {
 	ret := _m.Called(blockNumber)
 
 	var r0 common.Hash
-	if rf, ok := ret.Get(0).(func(*big.Int) common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(uint) common.Hash); ok {
 		r0 = rf(blockNumber)
 	} else {
 		if ret.Get(0) != nil {
@@ -81,7 +79,7 @@ func (_m *BlockAPI) GetBlockHash(blockNumber *big.Int) (common.Hash, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint) error); ok {
 		r1 = rf(blockNumber)
 	} else {
 		r1 = ret.Error(1)

--- a/dot/rpc/modules/mocks/network_api.go
+++ b/dot/rpc/modules/mocks/network_api.go
@@ -47,14 +47,14 @@ func (_m *NetworkAPI) Health() common.Health {
 }
 
 // HighestBlock provides a mock function with given fields:
-func (_m *NetworkAPI) HighestBlock() int64 {
+func (_m *NetworkAPI) HighestBlock() uint32 {
 	ret := _m.Called()
 
-	var r0 int64
-	if rf, ok := ret.Get(0).(func() int64); ok {
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Get(0).(uint32)
 	}
 
 	return r0
@@ -153,14 +153,14 @@ func (_m *NetworkAPI) Start() error {
 }
 
 // StartingBlock provides a mock function with given fields:
-func (_m *NetworkAPI) StartingBlock() int64 {
+func (_m *NetworkAPI) StartingBlock() uint32 {
 	ret := _m.Called()
 
-	var r0 int64
-	if rf, ok := ret.Get(0).(func() int64); ok {
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Get(0).(uint32)
 	}
 
 	return r0

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"sort"
 	"strings"
 	"testing"
@@ -541,7 +540,7 @@ func setupStateModule(t *testing.T) (*StateModule, *common.Hash, *common.Hash) {
 	b := &types.Block{
 		Header: types.Header{
 			ParentHash: chain.Block.BestBlockHash(),
-			Number:     big.NewInt(3),
+			Number:     3,
 			StateRoot:  sr1,
 		},
 		Body: *types.NewBody([]types.Extrinsic{[]byte{}}),
@@ -555,7 +554,7 @@ func setupStateModule(t *testing.T) (*StateModule, *common.Hash, *common.Hash) {
 
 	chain.Block.StoreRuntime(b.Header.Hash(), rt)
 
-	hash, _ := chain.Block.GetBlockHash(big.NewInt(3))
+	hash, _ := chain.Block.GetBlockHash(3)
 	core := newCoreService(t, chain)
 	return NewStateModule(net, chain.Storage, core), &hash, &sr1
 }

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -246,7 +246,7 @@ func (sm *SystemModule) SyncState(r *http.Request, req *EmptyRequest, res *SyncS
 	}
 
 	*res = SyncStateResponse{
-		CurrentBlock:  uint32(h.Number.Int64()),
+		CurrentBlock:  uint32(h.Number),
 		HighestBlock:  uint32(sm.networkAPI.HighestBlock()),
 		StartingBlock: uint32(sm.networkAPI.StartingBlock()),
 	}

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -60,7 +60,7 @@ func newNetworkService(t *testing.T) *network.Service {
 	testDir := path.Join(os.TempDir(), "test_data")
 
 	cfg := &network.Config{
-		BlockState:         network.NewMockBlockState(nil),
+		BlockState:         network.NewMockBlockState(1),
 		BasePath:           testDir,
 		Syncer:             network.NewMockSyncer(),
 		TransactionHandler: network.NewMockTransactionHandler(),
@@ -308,7 +308,7 @@ func setupSystemModule(t *testing.T) *SystemModule {
 	require.NoError(t, err)
 	err = chain.Block.AddBlock(&types.Block{
 		Header: types.Header{
-			Number:     big.NewInt(3),
+			Number:     3,
 			ParentHash: chain.Block.BestBlockHash(),
 			StateRoot:  ts.MustRoot(),
 		},
@@ -359,7 +359,7 @@ func newCoreService(t *testing.T, srvc *state.Service) *core.Service {
 func TestSyncState(t *testing.T) {
 	fakeCommonHash := common.NewHash([]byte("fake"))
 	fakeHeader := &types.Header{
-		Number: big.NewInt(int64(49)),
+		Number: 49,
 	}
 
 	blockapiMock := new(mocks.BlockAPI)

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -112,7 +111,7 @@ func TestBlockListener_Listen(t *testing.T) {
 
 	//block := types.NewEmptyBlock()
 	block := types.NewBlock(*types.NewEmptyHeader(), *new(types.Body))
-	block.Header.Number = big.NewInt(1)
+	block.Header.Number = 1
 
 	go bl.Listen()
 	defer func() {

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -2,7 +2,6 @@ package subscription
 
 import (
 	"fmt"
-	"math/big"
 	"testing"
 	"time"
 
@@ -247,7 +246,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 
 	listener.Listen()
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	fCh <- &types.FinalisationInfo{
@@ -315,7 +314,6 @@ func TestSubscribeAllHeads(t *testing.T) {
 	require.NoError(t, err)
 	fCh <- &types.FinalisationInfo{
 		Header: types.Header{
-			Number: big.NewInt(0),
 			Digest: digest,
 		},
 	}
@@ -331,7 +329,6 @@ func TestSubscribeAllHeads(t *testing.T) {
 
 	iCh <- &types.Block{
 		Header: types.Header{
-			Number: big.NewInt(0),
 			Digest: digest,
 		},
 	}

--- a/dot/services.go
+++ b/dot/services.go
@@ -68,7 +68,7 @@ func createStateService(cfg *Config) (*state.Service, error) {
 	}
 
 	if cfg.State.Rewind != 0 {
-		err = stateSrvc.Rewind(int64(cfg.State.Rewind))
+		err = stateSrvc.Rewind(uint(cfg.State.Rewind))
 		if err != nil {
 			return nil, fmt.Errorf("failed to rewind state: %w", err)
 		}

--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -32,7 +31,6 @@ func TestGetSet_ReceiptMessageQueue_Justification(t *testing.T) {
 	require.NotNil(t, s)
 
 	var genesisHeader = &types.Header{
-		Number:    big.NewInt(0),
 		StateRoot: trie.EmptyHash,
 		Digest:    types.NewDigest(),
 	}
@@ -48,7 +46,7 @@ func TestGetSet_ReceiptMessageQueue_Justification(t *testing.T) {
 
 	header := &types.Header{
 		ParentHash:     parentHash,
-		Number:         big.NewInt(1),
+		Number:         1,
 		StateRoot:      stateRoot,
 		ExtrinsicsRoot: extrinsicsRoot,
 		Digest:         types.NewDigest(),

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -19,7 +19,6 @@ package state
 import (
 	"encoding/binary"
 	"fmt"
-	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/telemetry"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -39,13 +38,13 @@ func (bs *BlockState) HasFinalisedBlock(round, setID uint64) (bool, error) {
 }
 
 // NumberIsFinalised checks if a block number is finalised or not
-func (bs *BlockState) NumberIsFinalised(num *big.Int) (bool, error) {
+func (bs *BlockState) NumberIsFinalised(num uint) (bool, error) {
 	header, err := bs.GetHighestFinalisedHeader()
 	if err != nil {
 		return false, err
 	}
 
-	return num.Cmp(header.Number) <= 0, nil
+	return num <= header.Number, nil
 }
 
 // GetFinalisedHeader returns the finalised block header by round and setID
@@ -187,7 +186,7 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 	err = telemetry.GetInstance().SendMessage(
 		telemetry.NewNotifyFinalizedTM(
 			header.Hash(),
-			header.Number.String(),
+			fmt.Sprint(header.Number),
 		),
 	)
 	if err != nil {
@@ -248,7 +247,7 @@ func (bs *BlockState) handleFinalisedBlock(curr common.Hash) error {
 			return err
 		}
 
-		if err = batch.Put(headerHashKey(block.Header.Number.Uint64()), hash.ToBytes()); err != nil {
+		if err = batch.Put(headerHashKey(uint64(block.Header.Number)), hash.ToBytes()); err != nil {
 			return err
 		}
 	}
@@ -257,7 +256,7 @@ func (bs *BlockState) handleFinalisedBlock(curr common.Hash) error {
 }
 
 func (bs *BlockState) setFirstSlotOnFinalisation() error {
-	header, err := bs.GetHeaderByNumber(big.NewInt(1))
+	header, err := bs.GetHeaderByNumber(1)
 	if err != nil {
 		return err
 	}

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -87,7 +86,7 @@ func TestBlockState_SetFinalisedHash(t *testing.T) {
 	require.NoError(t, err)
 	header := &types.Header{
 		ParentHash: testGenesisHeader.Hash(),
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 	}
 
@@ -127,13 +126,13 @@ func TestSetFinalisedHash_setFirstSlotOnFinalisation(t *testing.T) {
 	require.NoError(t, err)
 
 	header1 := types.Header{
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 		ParentHash: testGenesisHeader.Hash(),
 	}
 
 	header2 := types.Header{
-		Number:     big.NewInt(2),
+		Number:     2,
 		Digest:     digest2,
 		ParentHash: header1.Hash(),
 	}

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -94,21 +93,19 @@ func TestImportChannel_Multi(t *testing.T) {
 	for i, ch := range chs {
 
 		go func(i int, ch <-chan *types.Block) {
+			defer wg.Done()
 			select {
 			case b := <-ch:
-				require.Equal(t, big.NewInt(1), b.Header.Number)
+				require.Equal(t, uint(1), b.Header.Number)
 			case <-time.After(testMessageTimeout):
 				t.Error("did not receive imported block: ch=", i)
 			}
-			wg.Done()
 		}(i, ch)
-
 	}
 
 	time.Sleep(time.Millisecond * 10)
 	AddBlocksToState(t, bs, 1, false)
 	wg.Wait()
-
 }
 
 func TestFinalizedChannel_Multi(t *testing.T) {

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"math/big"
 	"runtime"
 	"sync"
 	"testing"
@@ -46,7 +45,7 @@ func TestConcurrencySetHeader(t *testing.T) {
 			require.NoError(t, err)
 
 			header := &types.Header{
-				Number:    big.NewInt(1),
+				Number:    1,
 				StateRoot: trie.EmptyHash,
 				Digest:    types.NewDigest(),
 			}

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -20,7 +20,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ChainSafe/chaindb"
@@ -355,9 +354,7 @@ func (s *EpochState) SetFirstSlot(slot uint64) error {
 	header, err := s.blockState.GetHighestFinalisedHeader()
 	if err != nil {
 		return err
-	}
-
-	if header.Number.Cmp(big.NewInt(1)) > -1 {
+	} else if header.Number >= 1 {
 		return errors.New("first slot has already been set")
 	}
 

--- a/dot/state/errors.go
+++ b/dot/state/errors.go
@@ -1,0 +1,8 @@
+package state
+
+import "errors"
+
+var (
+	// ErrBlockHeaderNumberIsNil is returned if the block header is nil
+	ErrBlockHeaderNumberIsNil = errors.New("block header number field is nil")
+)

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -17,7 +17,6 @@
 package state
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -49,7 +48,7 @@ func TestNewGrandpaStateFromGenesis(t *testing.T) {
 
 	num, err := gs.GetSetIDChange(0)
 	require.NoError(t, err)
-	require.Equal(t, big.NewInt(0), num)
+	require.Zero(t, num)
 }
 
 func TestGrandpaState_SetNextChange(t *testing.T) {
@@ -57,7 +56,7 @@ func TestGrandpaState_SetNextChange(t *testing.T) {
 	gs, err := NewGrandpaStateFromGenesis(db, testAuths)
 	require.NoError(t, err)
 
-	err = gs.SetNextChange(testAuths, big.NewInt(1))
+	err = gs.SetNextChange(testAuths, 1)
 	require.NoError(t, err)
 
 	auths, err := gs.GetAuthorities(genesisSetID + 1)
@@ -66,7 +65,7 @@ func TestGrandpaState_SetNextChange(t *testing.T) {
 
 	atBlock, err := gs.GetSetIDChange(genesisSetID + 1)
 	require.NoError(t, err)
-	require.Equal(t, big.NewInt(1), atBlock)
+	require.Equal(t, uint(1), atBlock)
 }
 
 func TestGrandpaState_IncrementSetID(t *testing.T) {
@@ -87,29 +86,29 @@ func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
 	gs, err := NewGrandpaStateFromGenesis(db, testAuths)
 	require.NoError(t, err)
 
-	err = gs.SetNextChange(testAuths, big.NewInt(100))
+	err = gs.SetNextChange(testAuths, 100)
 	require.NoError(t, err)
 
-	setID, err := gs.GetSetIDByBlockNumber(big.NewInt(50))
-	require.NoError(t, err)
-	require.Equal(t, genesisSetID, setID)
-
-	setID, err = gs.GetSetIDByBlockNumber(big.NewInt(100))
+	setID, err := gs.GetSetIDByBlockNumber(50)
 	require.NoError(t, err)
 	require.Equal(t, genesisSetID, setID)
 
-	setID, err = gs.GetSetIDByBlockNumber(big.NewInt(101))
+	setID, err = gs.GetSetIDByBlockNumber(100)
+	require.NoError(t, err)
+	require.Equal(t, genesisSetID, setID)
+
+	setID, err = gs.GetSetIDByBlockNumber(101)
 	require.NoError(t, err)
 	require.Equal(t, genesisSetID+1, setID)
 
 	err = gs.IncrementSetID()
 	require.NoError(t, err)
 
-	setID, err = gs.GetSetIDByBlockNumber(big.NewInt(100))
+	setID, err = gs.GetSetIDByBlockNumber(100)
 	require.NoError(t, err)
 	require.Equal(t, genesisSetID, setID)
 
-	setID, err = gs.GetSetIDByBlockNumber(big.NewInt(101))
+	setID, err = gs.GetSetIDByBlockNumber(101)
 	require.NoError(t, err)
 	require.Equal(t, genesisSetID+1, setID)
 }

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -73,7 +73,7 @@ func NewStorageState(db chaindb.Database, blockState *BlockState, t *trie.Trie, 
 	var p pruner.Pruner
 	if onlinePruner.Mode == pruner.Full {
 		var err error
-		p, err = pruner.NewFullNode(db, storageTable, onlinePruner.RetainedBlocks, logger)
+		p, err = pruner.NewFullNode(db, storageTable, uint(onlinePruner.RetainedBlocks), logger)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +125,7 @@ func (s *StorageState) StoreTrie(ts *rtstorage.TrieState, header *types.Header) 
 		}
 
 		delKeys := ts.GetDeletedNodeHashes()
-		err = s.pruner.StoreJournalRecord(delKeys, insKeys, header.Hash(), header.Number.Int64())
+		err = s.pruner.StoreJournalRecord(delKeys, insKeys, header.Hash(), header.Number)
 		if err != nil {
 			return err
 		}

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"math/big"
 	"sync"
 	"testing"
 	"time"
@@ -63,7 +62,7 @@ func TestStorage_GetStorageByBlockHash(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash: testGenesisHeader.Hash(),
-			Number:     big.NewInt(1),
+			Number:     1,
 			StateRoot:  root,
 		},
 		Body: *body,

--- a/dot/sync/benchmark.go
+++ b/dot/sync/benchmark.go
@@ -22,7 +22,7 @@ import (
 
 type syncBenchmarker struct {
 	start           time.Time
-	startBlock      uint64
+	startBlock      uint
 	blocksPerSecond []float64
 }
 
@@ -32,12 +32,12 @@ func newSyncBenchmarker() *syncBenchmarker {
 	}
 }
 
-func (b *syncBenchmarker) begin(block uint64) {
+func (b *syncBenchmarker) begin(block uint) {
 	b.start = time.Now()
 	b.startBlock = block
 }
 
-func (b *syncBenchmarker) end(block uint64) {
+func (b *syncBenchmarker) end(block uint) {
 	duration := time.Since(b.start)
 	blocks := block - b.startBlock
 	if blocks == 0 {

--- a/dot/sync/block_queue.go
+++ b/dot/sync/block_queue.go
@@ -25,13 +25,13 @@ import (
 
 type blockQueue struct {
 	sync.RWMutex
-	cap    int
+	cap    uint32
 	ch     chan *types.BlockData
 	blocks map[common.Hash]*types.BlockData
 }
 
 // newBlockQueue initialises a queue of *types.BlockData with the given capacity.
-func newBlockQueue(cap int) *blockQueue {
+func newBlockQueue(cap uint32) *blockQueue {
 	return &blockQueue{
 		cap:    cap,
 		ch:     make(chan *types.BlockData, cap),

--- a/dot/sync/bootstrap_syncer_test.go
+++ b/dot/sync/bootstrap_syncer_test.go
@@ -17,7 +17,6 @@
 package sync
 
 import (
-	"math/big"
 	"testing"
 
 	syncmocks "github.com/ChainSafe/gossamer/dot/sync/mocks"
@@ -29,10 +28,10 @@ import (
 )
 
 func newTestBootstrapSyncer(t *testing.T) *bootstrapSyncer {
-	header, err := types.NewHeader(common.NewHash([]byte{0}), trie.EmptyHash, trie.EmptyHash, big.NewInt(100), types.NewDigest())
+	header, err := types.NewHeader(common.NewHash([]byte{0}), trie.EmptyHash, trie.EmptyHash, 100, types.NewDigest())
 	require.NoError(t, err)
 
-	finHeader, err := types.NewHeader(common.NewHash([]byte{0}), trie.EmptyHash, trie.EmptyHash, big.NewInt(200), types.NewDigest())
+	finHeader, err := types.NewHeader(common.NewHash([]byte{0}), trie.EmptyHash, trie.EmptyHash, 200, types.NewDigest())
 	require.NoError(t, err)
 
 	bs := new(syncmocks.BlockState)
@@ -48,13 +47,13 @@ func TestBootstrapSyncer_handleWork(t *testing.T) {
 	// peer's state is equal or lower than ours
 	// should not create a worker for bootstrap mode
 	w, err := s.handleNewPeerState(&peerState{
-		number: big.NewInt(100),
+		number: uintPtr(100),
 	})
 	require.NoError(t, err)
 	require.Nil(t, w)
 
 	w, err = s.handleNewPeerState(&peerState{
-		number: big.NewInt(99),
+		number: uintPtr(99),
 	})
 	require.NoError(t, err)
 	require.Nil(t, w)
@@ -62,12 +61,12 @@ func TestBootstrapSyncer_handleWork(t *testing.T) {
 	// if peer's number is highest, return worker w/ their block as target
 	expected := &worker{
 		requestData:  bootstrapRequestData,
-		startNumber:  big.NewInt(101),
+		startNumber:  uintPtr(101),
 		targetHash:   common.NewHash([]byte{1}),
-		targetNumber: big.NewInt(101),
+		targetNumber: uintPtr(101),
 	}
 	w, err = s.handleNewPeerState(&peerState{
-		number: big.NewInt(101),
+		number: uintPtr(101),
 		hash:   common.NewHash([]byte{1}),
 	})
 	require.NoError(t, err)
@@ -75,12 +74,12 @@ func TestBootstrapSyncer_handleWork(t *testing.T) {
 
 	expected = &worker{
 		requestData:  bootstrapRequestData,
-		startNumber:  big.NewInt(101),
+		startNumber:  uintPtr(101),
 		targetHash:   common.NewHash([]byte{1}),
-		targetNumber: big.NewInt(9999),
+		targetNumber: uintPtr(9999),
 	}
 	w, err = s.handleNewPeerState(&peerState{
-		number: big.NewInt(9999),
+		number: uintPtr(9999),
 		hash:   common.NewHash([]byte{1}),
 	})
 	require.NoError(t, err)
@@ -100,15 +99,15 @@ func TestBootstrapSyncer_handleWorkerResult(t *testing.T) {
 	// startNumber = bestBlockNumber + 1 and the same target as previously
 	expected := &worker{
 		requestData:  bootstrapRequestData,
-		startNumber:  big.NewInt(101),
+		startNumber:  uintPtr(101),
 		targetHash:   common.NewHash([]byte{1}),
-		targetNumber: big.NewInt(201),
+		targetNumber: uintPtr(201),
 	}
 
 	res = &worker{
 		requestData:  bootstrapRequestData,
 		targetHash:   common.NewHash([]byte{1}),
-		targetNumber: big.NewInt(201),
+		targetNumber: uintPtr(201),
 		err:          &workerError{},
 	}
 
@@ -124,15 +123,15 @@ func TestBootstrapSyncer_handleWorkerResult_errUnknownParent(t *testing.T) {
 	// startNumber = bestBlockNumber + 1 and the same target as previously
 	expected := &worker{
 		requestData:  bootstrapRequestData,
-		startNumber:  big.NewInt(200),
+		startNumber:  uintPtr(200),
 		targetHash:   common.NewHash([]byte{1}),
-		targetNumber: big.NewInt(300),
+		targetNumber: uintPtr(300),
 	}
 
 	res := &worker{
 		requestData:  bootstrapRequestData,
 		targetHash:   common.NewHash([]byte{1}),
-		targetNumber: big.NewInt(300),
+		targetNumber: uintPtr(300),
 		err: &workerError{
 			err: errUnknownParent,
 		},

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -187,7 +187,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 	}
 
 	if bd.Justification != nil && bd.Header != nil {
-		logger.Debug("handling Justification...", "number", bd.Number(), "hash", bd.Hash)
+		logger.Debug("handling Justification...", "number", bd.NumberString(), "hash", bd.Hash)
 		s.handleJustification(bd.Header, *bd.Justification)
 	}
 

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -18,7 +18,6 @@ package sync
 
 import (
 	"errors"
-	"math/big"
 	"testing"
 	"time"
 
@@ -50,7 +49,7 @@ func TestChainProcessor_HandleBlockResponse_ValidChain(t *testing.T) {
 	}
 
 	// syncer makes request for chain
-	startNum := 1
+	var startNum uint = 1
 	start, err := variadic.NewUint64OrHash(startNum)
 	require.NoError(t, err)
 
@@ -121,7 +120,7 @@ func TestChainProcessor_HandleBlockResponse_MissingBlocks(t *testing.T) {
 		parent = &block.Header
 	}
 
-	startNum := 15
+	const startNum uint = 15
 	start, err := variadic.NewUint64OrHash(startNum)
 	require.NoError(t, err)
 
@@ -225,7 +224,7 @@ func TestChainProcessor_HandleJustification(t *testing.T) {
 
 	header := &types.Header{
 		ParentHash: syncer.blockState.(*state.BlockState).GenesisHash(),
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 	}
 
@@ -251,7 +250,7 @@ func TestChainProcessor_processReadyBlocks_errFailedToGetParent(t *testing.T) {
 	defer processor.cancel()
 
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 
 	processor.readyBlocks.push(&types.BlockData{

--- a/dot/sync/disjoint_block_set_test.go
+++ b/dot/sync/disjoint_block_set_test.go
@@ -17,7 +17,6 @@
 package sync
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -30,34 +29,34 @@ func TestDisjointBlockSet(t *testing.T) {
 	s := newDisjointBlockSet(pendingBlocksLimit)
 
 	hash := common.Hash{0xa, 0xb}
-	number := big.NewInt(100)
+	const number uint = 100
 	s.addHashAndNumber(hash, number)
 	require.True(t, s.hasBlock(hash))
 	require.Equal(t, 1, s.size())
 
 	expected := &pendingBlock{
 		hash:   hash,
-		number: number,
+		number: uintPtr(number),
 	}
 	blocks := s.getBlocks()
 	require.Equal(t, 1, len(blocks))
 	require.Equal(t, expected, blocks[0])
 
 	header := &types.Header{
-		Number: big.NewInt(100),
+		Number: number,
 	}
 	s.addHeader(header)
 	require.True(t, s.hasBlock(header.Hash()))
 	require.Equal(t, 2, s.size())
 	expected = &pendingBlock{
 		hash:   header.Hash(),
-		number: header.Number,
+		number: uintPtr(header.Number),
 		header: header,
 	}
 	require.Equal(t, expected, s.getBlock(header.Hash()))
 
 	header2 := &types.Header{
-		Number: big.NewInt(999),
+		Number: 999,
 	}
 	s.addHashAndNumber(header2.Hash(), header2.Number)
 	require.Equal(t, 3, s.size())
@@ -65,7 +64,7 @@ func TestDisjointBlockSet(t *testing.T) {
 	require.Equal(t, 3, s.size())
 	expected = &pendingBlock{
 		hash:   header2.Hash(),
-		number: header2.Number,
+		number: uintPtr(header2.Number),
 		header: header2,
 	}
 	require.Equal(t, expected, s.getBlock(header2.Hash()))
@@ -78,7 +77,7 @@ func TestDisjointBlockSet(t *testing.T) {
 	require.Equal(t, 3, s.size())
 	expected = &pendingBlock{
 		hash:   header2.Hash(),
-		number: header2.Number,
+		number: uintPtr(header2.Number),
 		header: header2,
 		body:   &block.Body,
 	}
@@ -88,7 +87,7 @@ func TestDisjointBlockSet(t *testing.T) {
 	require.Equal(t, 2, s.size())
 	require.False(t, s.hasBlock(hash))
 
-	s.removeLowerBlocks(big.NewInt(998))
+	s.removeLowerBlocks(998)
 	require.Equal(t, 1, s.size())
 	require.False(t, s.hasBlock(header.Hash()))
 	require.True(t, s.hasBlock(header2.Hash()))
@@ -97,9 +96,9 @@ func TestDisjointBlockSet(t *testing.T) {
 func TestPendingBlock_toBlockData(t *testing.T) {
 	pb := &pendingBlock{
 		hash:   common.Hash{0xa, 0xb, 0xc},
-		number: big.NewInt(1),
+		number: uintPtr(1),
 		header: &types.Header{
-			Number: big.NewInt(1),
+			Number: 1,
 		},
 		body: &types.Body{{0x1, 0x2, 0x3}},
 	}
@@ -118,7 +117,7 @@ func TestDisjointBlockSet_getReadyDescendants(t *testing.T) {
 
 	// test that descendant chain gets returned by getReadyDescendants on block 1 being ready
 	header1 := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 	block1 := &types.Block{
 		Header: *header1,
@@ -127,7 +126,7 @@ func TestDisjointBlockSet_getReadyDescendants(t *testing.T) {
 
 	header2 := &types.Header{
 		ParentHash: header1.Hash(),
-		Number:     big.NewInt(2),
+		Number:     2,
 	}
 	block2 := &types.Block{
 		Header: *header2,
@@ -137,7 +136,7 @@ func TestDisjointBlockSet_getReadyDescendants(t *testing.T) {
 
 	header3 := &types.Header{
 		ParentHash: header2.Hash(),
-		Number:     big.NewInt(3),
+		Number:     3,
 	}
 	block3 := &types.Block{
 		Header: *header3,
@@ -147,7 +146,7 @@ func TestDisjointBlockSet_getReadyDescendants(t *testing.T) {
 
 	header2NotDescendant := &types.Header{
 		ParentHash: common.Hash{0xff},
-		Number:     big.NewInt(2),
+		Number:     2,
 	}
 	block2NotDescendant := &types.Block{
 		Header: *header2NotDescendant,
@@ -169,7 +168,7 @@ func TestDisjointBlockSet_getReadyDescendants_blockNotComplete(t *testing.T) {
 	// test that descendant chain gets returned by getReadyDescendants on block 1 being ready
 	// the ready list should contain only block 1 and 2, as block 3 is incomplete (body is missing)
 	header1 := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 	}
 	block1 := &types.Block{
 		Header: *header1,
@@ -178,7 +177,7 @@ func TestDisjointBlockSet_getReadyDescendants_blockNotComplete(t *testing.T) {
 
 	header2 := &types.Header{
 		ParentHash: header1.Hash(),
-		Number:     big.NewInt(2),
+		Number:     2,
 	}
 	block2 := &types.Block{
 		Header: *header2,
@@ -188,13 +187,13 @@ func TestDisjointBlockSet_getReadyDescendants_blockNotComplete(t *testing.T) {
 
 	header3 := &types.Header{
 		ParentHash: header2.Hash(),
-		Number:     big.NewInt(3),
+		Number:     3,
 	}
 	s.addHeader(header3)
 
 	header2NotDescendant := &types.Header{
 		ParentHash: common.Hash{0xff},
-		Number:     big.NewInt(2),
+		Number:     2,
 	}
 	block2NotDescendant := &types.Block{
 		Header: *header2NotDescendant,

--- a/dot/sync/errors.go
+++ b/dot/sync/errors.go
@@ -29,6 +29,12 @@ var (
 	errNilNetwork            = errors.New("cannot have nil Network")
 	errNilFinalityGadget     = errors.New("cannot have nil FinalityGadget")
 	errNilTransactionState   = errors.New("cannot have nil TransactionState")
+	errNilBlockHeaderNumber  = errors.New("cannot have nil block header number")
+	errNilPeerStateNumber    = errors.New("cannot have nil peer state number")
+	errNilWorkerTargetNumber = errors.New("cannot have nil worker target number")
+	errNilWorkerStartNumber  = errors.New("cannot have nil worker start number")
+	errNilPendingBlockNumber = errors.New("cannot have nil pending block number")
+	errHasCurrentWorkerCheck = errors.New("cannot check if worker handler has the workers already")
 
 	// ErrNilBlockData is returned when trying to process a BlockResponseMessage with nil BlockData
 	ErrNilBlockData = errors.New("got nil BlockData")
@@ -60,7 +66,6 @@ var (
 	errUnknownParent                = errors.New("parent of first block in block response is unknown")
 	errUnknownBlockForJustification = errors.New("received justification for unknown block")
 	errFailedToGetParent            = errors.New("failed to get parent header")
-	errNilDescendantNumber          = errors.New("descendant number is nil")
 	errStartAndEndMismatch          = errors.New("request start and end hash are not on the same chain")
 	errFailedToGetDescendant        = errors.New("failed to find descendant block")
 )

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -17,7 +17,6 @@
 package sync
 
 import (
-	"math/big"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -35,10 +34,10 @@ import (
 type BlockState interface {
 	BestBlockHash() common.Hash
 	BestBlockHeader() (*types.Header, error)
-	BestBlockNumber() (*big.Int, error)
+	BestBlockNumber() (uint, error)
 	AddBlock(*types.Block) error
 	CompareAndSetBlockData(bd *types.BlockData) error
-	GetBlockByNumber(*big.Int) (*types.Block, error)
+	GetBlockByNumber(uint) (*types.Block, error)
 	HasBlockBody(hash common.Hash) (bool, error)
 	GetBlockBody(common.Hash) (*types.Body, error)
 	SetHeader(*types.Header) error
@@ -51,14 +50,14 @@ type BlockState interface {
 	SetJustification(hash common.Hash, data []byte) error
 	SetFinalisedHash(hash common.Hash, round, setID uint64) error
 	AddBlockToBlockTree(header *types.Header) error
-	GetHashByNumber(*big.Int) (common.Hash, error)
+	GetHashByNumber(uint) (common.Hash, error)
 	GetBlockByHash(common.Hash) (*types.Block, error)
 	GetRuntime(*common.Hash) (runtime.Instance, error)
 	StoreRuntime(common.Hash, runtime.Instance)
 	GetHighestFinalisedHeader() (*types.Header, error)
 	GetFinalisedNotifierChannel() chan *types.FinalisationInfo
-	GetHeaderByNumber(num *big.Int) (*types.Header, error)
-	GetAllBlocksAtNumber(num *big.Int) ([]common.Hash, error)
+	GetHeaderByNumber(num uint) (*types.Header, error)
+	GetAllBlocksAtNumber(num uint) ([]common.Hash, error)
 	IsDescendantOf(parent, child common.Hash) (bool, error)
 }
 

--- a/dot/sync/mocks/block_state.go
+++ b/dot/sync/mocks/block_state.go
@@ -3,8 +3,6 @@
 package mocks
 
 import (
-	big "math/big"
-
 	common "github.com/ChainSafe/gossamer/lib/common"
 	mock "github.com/stretchr/testify/mock"
 
@@ -86,16 +84,14 @@ func (_m *BlockState) BestBlockHeader() (*types.Header, error) {
 }
 
 // BestBlockNumber provides a mock function with given fields:
-func (_m *BlockState) BestBlockNumber() (*big.Int, error) {
+func (_m *BlockState) BestBlockNumber() (uint, error) {
 	ret := _m.Called()
 
-	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+	var r0 uint
+	if rf, ok := ret.Get(0).(func() uint); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*big.Int)
-		}
+		r0 = ret.Get(0).(uint)
 	}
 
 	var r1 error
@@ -123,11 +119,11 @@ func (_m *BlockState) CompareAndSetBlockData(bd *types.BlockData) error {
 }
 
 // GetAllBlocksAtNumber provides a mock function with given fields: num
-func (_m *BlockState) GetAllBlocksAtNumber(num *big.Int) ([]common.Hash, error) {
+func (_m *BlockState) GetAllBlocksAtNumber(num uint) ([]common.Hash, error) {
 	ret := _m.Called(num)
 
 	var r0 []common.Hash
-	if rf, ok := ret.Get(0).(func(*big.Int) []common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(uint) []common.Hash); ok {
 		r0 = rf(num)
 	} else {
 		if ret.Get(0) != nil {
@@ -136,7 +132,7 @@ func (_m *BlockState) GetAllBlocksAtNumber(num *big.Int) ([]common.Hash, error) 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint) error); ok {
 		r1 = rf(num)
 	} else {
 		r1 = ret.Error(1)
@@ -192,11 +188,11 @@ func (_m *BlockState) GetBlockByHash(_a0 common.Hash) (*types.Block, error) {
 }
 
 // GetBlockByNumber provides a mock function with given fields: _a0
-func (_m *BlockState) GetBlockByNumber(_a0 *big.Int) (*types.Block, error) {
+func (_m *BlockState) GetBlockByNumber(_a0 uint) (*types.Block, error) {
 	ret := _m.Called(_a0)
 
 	var r0 *types.Block
-	if rf, ok := ret.Get(0).(func(*big.Int) *types.Block); ok {
+	if rf, ok := ret.Get(0).(func(uint) *types.Block); ok {
 		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
@@ -205,7 +201,7 @@ func (_m *BlockState) GetBlockByNumber(_a0 *big.Int) (*types.Block, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint) error); ok {
 		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
@@ -231,11 +227,11 @@ func (_m *BlockState) GetFinalisedNotifierChannel() chan *types.FinalisationInfo
 }
 
 // GetHashByNumber provides a mock function with given fields: _a0
-func (_m *BlockState) GetHashByNumber(_a0 *big.Int) (common.Hash, error) {
+func (_m *BlockState) GetHashByNumber(_a0 uint) (common.Hash, error) {
 	ret := _m.Called(_a0)
 
 	var r0 common.Hash
-	if rf, ok := ret.Get(0).(func(*big.Int) common.Hash); ok {
+	if rf, ok := ret.Get(0).(func(uint) common.Hash); ok {
 		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
@@ -244,7 +240,7 @@ func (_m *BlockState) GetHashByNumber(_a0 *big.Int) (common.Hash, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint) error); ok {
 		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
@@ -277,11 +273,11 @@ func (_m *BlockState) GetHeader(_a0 common.Hash) (*types.Header, error) {
 }
 
 // GetHeaderByNumber provides a mock function with given fields: num
-func (_m *BlockState) GetHeaderByNumber(num *big.Int) (*types.Header, error) {
+func (_m *BlockState) GetHeaderByNumber(num uint) (*types.Header, error) {
 	ret := _m.Called(num)
 
 	var r0 *types.Header
-	if rf, ok := ret.Get(0).(func(*big.Int) *types.Header); ok {
+	if rf, ok := ret.Get(0).(func(uint) *types.Header); ok {
 		r0 = rf(num)
 	} else {
 		if ret.Get(0) != nil {
@@ -290,7 +286,7 @@ func (_m *BlockState) GetHeaderByNumber(num *big.Int) (*types.Header, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+	if rf, ok := ret.Get(1).(func(uint) error); ok {
 		r1 = rf(num)
 	} else {
 		r1 = ret.Error(1)

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -18,7 +18,6 @@ package sync
 
 import (
 	"io/ioutil"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -162,7 +161,7 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (*genesis.Genesis, *trie.Trie
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
-	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), genTrie.MustHash(), trie.EmptyHash, big.NewInt(0), types.NewDigest())
+	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), genTrie.MustHash(), trie.EmptyHash, 0, types.NewDigest())
 	require.NoError(t, err)
 	return gen, genTrie, genesisHeader
 }

--- a/dot/sync/test_helpers.go
+++ b/dot/sync/test_helpers.go
@@ -17,7 +17,6 @@
 package sync
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -37,7 +36,7 @@ func BuildBlock(t *testing.T, instance runtime.Instance, parent *types.Header, e
 	require.NoError(t, err)
 	header := &types.Header{
 		ParentHash: parent.Hash(),
-		Number:     big.NewInt(0).Add(parent.Number, big.NewInt(1)),
+		Number:     parent.Number + 1,
 		Digest:     digest,
 	}
 

--- a/dot/sync/utils.go
+++ b/dot/sync/utils.go
@@ -1,0 +1,3 @@
+package sync
+
+func uintPtr(n uint) *uint { return &n }

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -18,7 +18,6 @@ package sync
 
 import (
 	"context"
-	"math/big"
 	"sync"
 	"time"
 
@@ -84,9 +83,9 @@ type worker struct {
 	id  uint64
 
 	startHash    common.Hash
-	startNumber  *big.Int
+	startNumber  *uint
 	targetHash   common.Hash
-	targetNumber *big.Int
+	targetNumber *uint
 
 	// bitmap of fields to request
 	requestData byte

--- a/dot/telemetry/block_import.go
+++ b/dot/telemetry/block_import.go
@@ -17,20 +17,18 @@
 package telemetry
 
 import (
-	"math/big"
-
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
 // blockImportTM struct to hold block import telemetry messages
 type blockImportTM struct {
 	BestHash *common.Hash `json:"best"`
-	Height   *big.Int     `json:"height"`
+	Height   uint         `json:"height"`
 	Origin   string       `json:"origin"`
 }
 
 // NewBlockImportTM function to create new Block Import Telemetry Message
-func NewBlockImportTM(bestHash *common.Hash, height *big.Int, origin string) Message {
+func NewBlockImportTM(bestHash *common.Hash, height uint, origin string) Message {
 	return &blockImportTM{
 		BestHash: bestHash,
 		Height:   height,

--- a/dot/telemetry/system_interval.go
+++ b/dot/telemetry/system_interval.go
@@ -28,9 +28,9 @@ type systemIntervalTM struct {
 	BandwidthUpload    float64      `json:"bandwidth_upload,omitempty"`
 	Peers              int          `json:"peers,omitempty"`
 	BestHash           *common.Hash `json:"best,omitempty"`
-	BestHeight         *big.Int     `json:"height,omitempty"`
+	BestHeight         uint         `json:"height,omitempty"`
 	FinalisedHash      *common.Hash `json:"finalized_hash,omitempty"`   // nolint
-	FinalisedHeight    *big.Int     `json:"finalized_height,omitempty"` // nolint
+	FinalisedHeight    uint         `json:"finalized_height,omitempty"` // nolint
 	TxCount            *big.Int     `json:"txcount,omitempty"`
 	UsedStateCacheSize *big.Int     `json:"used_state_cache_size,omitempty"`
 }
@@ -45,8 +45,8 @@ func NewBandwidthTM(bandwidthDownload, bandwidthUpload float64, peers int) Messa
 }
 
 // NewBlockIntervalTM function to create new Block Interval Telemetry Message
-func NewBlockIntervalTM(beshHash *common.Hash, bestHeight *big.Int, finalisedHash *common.Hash,
-	finalisedHeight, txCount, usedStateCacheSize *big.Int) Message {
+func NewBlockIntervalTM(beshHash *common.Hash, bestHeight uint, finalisedHash *common.Hash,
+	finalisedHeight uint, txCount, usedStateCacheSize *big.Int) Message {
 	return &systemIntervalTM{
 		BestHash:           beshHash,
 		BestHeight:         bestHeight,

--- a/dot/telemetry/telemetry_test.go
+++ b/dot/telemetry/telemetry_test.go
@@ -58,7 +58,7 @@ func TestHandler_SendMulti(t *testing.T) {
 
 	go func() {
 		bh := common.MustHexToHash("0x07b749b6e20fd5f1159153a2e790235018621dd06072a62bcd25e8576f6ff5e6")
-		GetInstance().SendMessage(NewBlockImportTM(&bh, big.NewInt(2), "NetworkInitialSync"))
+		GetInstance().SendMessage(NewBlockImportTM(&bh, 2, "NetworkInitialSync"))
 
 		wg.Done()
 	}()
@@ -72,8 +72,10 @@ func TestHandler_SendMulti(t *testing.T) {
 	go func() {
 		bestHash := common.MustHexToHash("0x07b749b6e20fd5f1159153a2e790235018621dd06072a62bcd25e8576f6ff5e6")
 		finalisedHash := common.MustHexToHash("0x687197c11b4cf95374159843e7f46fbcd63558db981aaef01a8bac2a44a1d6b2")
-		GetInstance().SendMessage(NewBlockIntervalTM(&bestHash, big.NewInt(32375), &finalisedHash,
-			big.NewInt(32256), big.NewInt(0), big.NewInt(1234)))
+		const bestHeight = 32375
+		const finalisedHeight = 32256
+		GetInstance().SendMessage(NewBlockIntervalTM(&bestHash, bestHeight, &finalisedHash,
+			finalisedHeight, big.NewInt(0), big.NewInt(1234)))
 
 		wg.Done()
 	}()
@@ -129,7 +131,7 @@ func TestListenerConcurrency(t *testing.T) {
 	for i := 0; i < qty; i++ {
 		go func() {
 			bestHash := common.Hash{}
-			GetInstance().SendMessage(NewBlockImportTM(&bestHash, big.NewInt(2), "NetworkInitialSync"))
+			GetInstance().SendMessage(NewBlockImportTM(&bestHash, 2, "NetworkInitialSync"))
 
 			wg.Done()
 		}()
@@ -156,7 +158,7 @@ func TestDisableInstance(t *testing.T) {
 		}
 		go func() {
 			bh := common.MustHexToHash("0x07b749b6e20fd5f1159153a2e790235018621dd06072a62bcd25e8576f6ff5e6")
-			GetInstance().SendMessage(NewBlockImportTM(&bh, big.NewInt(2), "NetworkInitialSync"))
+			GetInstance().SendMessage(NewBlockImportTM(&bh, 2, "NetworkInitialSync"))
 			wg.Done()
 		}()
 	}

--- a/dot/types/block.go
+++ b/dot/types/block.go
@@ -18,8 +18,6 @@ package types
 
 import (
 	"fmt"
-
-	"github.com/ChainSafe/gossamer/pkg/scale"
 )
 
 // Block defines a state block
@@ -55,30 +53,6 @@ func (b *Block) String() string {
 // Empty returns a boolean indicating is the Block is empty
 func (b *Block) Empty() bool {
 	return b.Header.Empty() && len(b.Body) == 0
-}
-
-// Encode returns the SCALE encoding of a block
-func (b *Block) Encode() ([]byte, error) {
-	enc, err := scale.Marshal(b.Header)
-	if err != nil {
-		return nil, err
-	}
-
-	// get a SCALE encoded block body
-	encodedBody, err := scale.Marshal(b.Body)
-	if err != nil {
-		return nil, err
-	}
-	return append(enc, encodedBody...), nil
-}
-
-// MustEncode returns the SCALE encoded block and panics if it fails to encode
-func (b *Block) MustEncode() []byte {
-	enc, err := b.Encode()
-	if err != nil {
-		panic(err)
-	}
-	return enc
 }
 
 // DeepCopy returns a copy of the block

--- a/dot/types/block_data.go
+++ b/dot/types/block_data.go
@@ -18,7 +18,6 @@ package types
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 )
@@ -40,13 +39,15 @@ func NewEmptyBlockData() *BlockData {
 	return &BlockData{}
 }
 
-// Number returns the BlockNumber of the BlockData's header, nil if it doesn't exist
-func (bd *BlockData) Number() *big.Int {
+// NumberString returns the BlockNumber of the BlockData's header,
+// and <nil> if the block data, block data header, or header number is nil.
+// Note this is only used for debug logs.
+func (bd *BlockData) NumberString() string {
 	if bd == nil || bd.Header == nil {
-		return nil
+		return "<nil>"
 	}
 
-	return bd.Header.Number
+	return fmt.Sprint(bd.Header.Number)
 }
 
 func (bd *BlockData) String() string {

--- a/dot/types/block_data_test.go
+++ b/dot/types/block_data_test.go
@@ -17,7 +17,6 @@
 package types
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -44,7 +43,7 @@ var _ = testDigest.Add(
 func TestNumber(t *testing.T) {
 	testHash := common.NewHash([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
 
-	headerVdt, err := NewHeader(testHash, testHash, testHash, big.NewInt(5), testDigest)
+	headerVdt, err := NewHeader(testHash, testHash, testHash, 5, testDigest)
 	require.NoError(t, err)
 
 	bd := BlockData{
@@ -56,8 +55,8 @@ func TestNumber(t *testing.T) {
 		Justification: nil,
 	}
 
-	num := bd.Number()
-	require.Equal(t, big.NewInt(5), num)
+	num := bd.NumberString()
+	require.Equal(t, "5", num)
 }
 
 func TestBlockDataEncodeAndDecodeEmpty(t *testing.T) {
@@ -96,7 +95,7 @@ func TestBlockDataEncodeAndDecodeHeader(t *testing.T) {
 
 	testHash := common.NewHash([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
 
-	headerVdt, err := NewHeader(testHash, testHash, testHash, big.NewInt(1), testDigest)
+	headerVdt, err := NewHeader(testHash, testHash, testHash, 1, testDigest)
 	require.NoError(t, err)
 
 	bd := BlockData{
@@ -162,7 +161,7 @@ func TestBlockDataEncodeAndDecodeAll(t *testing.T) {
 	hash := common.NewHash([]byte{125})
 	testHash := common.NewHash([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf})
 
-	headerVdt, err := NewHeader(testHash, testHash, testHash, big.NewInt(1), testDigest)
+	headerVdt, err := NewHeader(testHash, testHash, testHash, 1, testDigest)
 	require.NoError(t, err)
 
 	bd := BlockData{

--- a/dot/types/body.go
+++ b/dot/types/body.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -75,7 +76,7 @@ func NewBodyFromExtrinsicStrings(ss []string) (*Body, error) {
 	exts := []Extrinsic{}
 	for _, s := range ss {
 		b, err := common.HexToBytes(s)
-		if err == common.ErrNoPrefix {
+		if errors.Is(err, common.ErrHexStringNoPrefix) {
 			b = []byte(s)
 		} else if err != nil {
 			return nil, err

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -206,3 +206,10 @@ type GrandpaVote struct {
 func (v *GrandpaVote) String() string {
 	return fmt.Sprintf("hash=%s number=%d", v.Hash, v.Number)
 }
+
+// DeepCopy deep copies the grandpa vote.
+func (v *GrandpaVote) DeepCopy() (copied *GrandpaVote) {
+	copy(copied.Hash[:], v.Hash[:])
+	copied.Number = v.Number
+	return copied
+}

--- a/dot/types/header_test.go
+++ b/dot/types/header_test.go
@@ -17,7 +17,6 @@
 package types
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -31,7 +30,7 @@ func TestEmptyHeader(t *testing.T) {
 	isEmpty := head.Empty()
 	require.True(t, isEmpty)
 
-	head.Number = big.NewInt(21)
+	head.Number = 21
 	isEmpty = head.Empty()
 	require.False(t, isEmpty)
 
@@ -44,13 +43,13 @@ func TestEmptyHeader(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	head2, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, big.NewInt(0), vdts)
+	head2, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, 0, vdts)
 	require.NoError(t, err)
 
 	isEmpty = head2.Empty()
 	require.False(t, isEmpty)
 
-	head3, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, big.NewInt(21), vdts)
+	head3, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, 21, vdts)
 	require.NoError(t, err)
 
 	isEmpty = head3.Empty()
@@ -78,7 +77,7 @@ func TestEncodeAndDecodeHeader(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	headerVdt, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, big.NewInt(0), vdts)
+	headerVdt, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, 0, vdts)
 	require.NoError(t, err)
 
 	encVdt, err := scale.Marshal(*headerVdt)
@@ -111,7 +110,7 @@ func TestHeaderDeepCopy(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	header, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, big.NewInt(1), vdts)
+	header, err := NewHeader(common.Hash{}, common.Hash{}, common.Hash{}, 1, vdts)
 	require.NoError(t, err)
 
 	dc, err := header.DeepCopy()

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -232,7 +232,7 @@ func (b *Service) waitForFirstBlock() error {
 				return errChannelClosed
 			}
 
-			if ok && block.Header.Number.Int64() > 0 {
+			if block.Header.Number > 0 {
 				cleanup()
 				return nil
 			}
@@ -576,7 +576,7 @@ func (b *Service) handleSlot(epoch, slotNum uint64) error {
 	err = telemetry.GetInstance().SendMessage(
 		telemetry.NewPreparedBlockForProposingTM(
 			block.Header.Hash(),
-			block.Header.Number.String(),
+			fmt.Sprint(block.Header.Number),
 		),
 	)
 	if err != nil {

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -19,7 +19,6 @@ package babe
 import (
 	"fmt"
 	"io/ioutil"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,7 +55,7 @@ var (
 
 	genesisHeader *types.Header
 	emptyHeader   = &types.Header{
-		Number: big.NewInt(0),
+		Number: 0,
 		Digest: types.NewDigest(),
 	}
 

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -112,7 +111,7 @@ func (b *BlockBuilder) buildBlock(parent *types.Header, slot Slot, rt runtime.In
 	logger.Trace("built pre-digest")
 
 	// create new block header
-	number := big.NewInt(0).Add(parent.Number, big.NewInt(1))
+	number := parent.Number + 1
 	digest := types.NewDigest()
 	err = digest.Add(*preDigest)
 	if err != nil {

--- a/lib/babe/build_test.go
+++ b/lib/babe/build_test.go
@@ -18,7 +18,6 @@ package babe
 
 import (
 	"bytes"
-	"math/big"
 	"testing"
 	"time"
 
@@ -59,7 +58,7 @@ func TestSeal(t *testing.T) {
 	zeroHash, err := common.HexToHash("0x00")
 	require.NoError(t, err)
 
-	header, err := types.NewHeader(zeroHash, zeroHash, zeroHash, big.NewInt(0), types.NewDigest())
+	header, err := types.NewHeader(zeroHash, zeroHash, zeroHash, 0, types.NewDigest())
 	require.NoError(t, err)
 
 	encHeader, err := scale.Marshal(*header)
@@ -188,7 +187,7 @@ func TestBuildBlock_ok(t *testing.T) {
 
 	expectedBlockHeader := &types.Header{
 		ParentHash: emptyHeader.Hash(),
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 	}
 
@@ -259,7 +258,7 @@ func TestApplyExtrinsic(t *testing.T) {
 	err = digest.Add(*preDigest)
 	require.NoError(t, err)
 
-	header, err := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, big.NewInt(1), digest)
+	header, err := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, 1, digest)
 	require.NoError(t, err)
 
 	//initialise block header
@@ -279,7 +278,7 @@ func TestApplyExtrinsic(t *testing.T) {
 	digest2 := types.NewDigest()
 	err = digest2.Add(*preDigest2)
 	require.NoError(t, err)
-	header2, err := types.NewHeader(header1.Hash(), common.Hash{}, common.Hash{}, big.NewInt(2), digest2)
+	header2, err := types.NewHeader(header1.Hash(), common.Hash{}, common.Hash{}, 2, digest2)
 	require.NoError(t, err)
 	err = rt.InitializeBlock(header2)
 	require.NoError(t, err)
@@ -305,7 +304,7 @@ func TestBuildAndApplyExtrinsic(t *testing.T) {
 	babeService.epochData.threshold = maxThreshold
 
 	parentHash := common.MustHexToHash("0x35a28a7dbaf0ba07d1485b0f3da7757e3880509edc8c31d0850cb6dd6219361d")
-	header, err := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, big.NewInt(1), types.NewDigest())
+	header, err := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, 1, types.NewDigest())
 	require.NoError(t, err)
 
 	rt, err := babeService.blockState.GetRuntime(nil)
@@ -411,7 +410,6 @@ func TestBuildBlock_failing(t *testing.T) {
 
 	parentHeader := &types.Header{
 		ParentHash: zeroHash,
-		Number:     big.NewInt(0),
 	}
 
 	duration, err := time.ParseDuration("1s")

--- a/lib/babe/errors.go
+++ b/lib/babe/errors.go
@@ -54,6 +54,9 @@ var (
 	// ErrNotAuthority is returned when trying to perform authority functions when not an authority
 	ErrNotAuthority = errors.New("node is not an authority")
 
+	// ErrBlockHeaderNumberIsNil is returned if the block header number field is nil.
+	ErrBlockHeaderNumberIsNil = errors.New("block header number is nil")
+
 	errNilBlockImportHandler = errors.New("cannot have nil BlockImportHandler")
 	errNilBlockState         = errors.New("cannot have nil BlockState")
 	errNilEpochState         = errors.New("cannot have nil EpochState")

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -17,7 +17,6 @@
 package babe
 
 import (
-	"math/big"
 	"sync"
 	"time"
 
@@ -32,20 +31,20 @@ import (
 type BlockState interface {
 	BestBlockHash() common.Hash
 	BestBlockHeader() (*types.Header, error)
-	BestBlockNumber() (*big.Int, error)
+	BestBlockNumber() (uint, error)
 	BestBlock() (*types.Block, error)
 	SubChain(start, end common.Hash) ([]common.Hash, error)
 	AddBlock(*types.Block) error
 	GetAllBlocksAtDepth(hash common.Hash) []common.Hash
 	GetHeader(common.Hash) (*types.Header, error)
-	GetBlockByNumber(*big.Int) (*types.Block, error)
+	GetBlockByNumber(uint) (*types.Block, error)
 	GetBlockByHash(common.Hash) (*types.Block, error)
 	GetArrivalTime(common.Hash) (time.Time, error)
 	GenesisHash() common.Hash
 	GetSlotForBlock(common.Hash) (uint64, error)
 	GetFinalisedHeader(uint64, uint64) (*types.Header, error)
 	IsDescendantOf(parent, child common.Hash) (bool, error)
-	NumberIsFinalised(num *big.Int) (bool, error)
+	NumberIsFinalised(num uint) (bool, error)
 	GetRuntime(*common.Hash) (runtime.Instance, error)
 	StoreRuntime(common.Hash, runtime.Instance)
 	ImportedBlockNotifierManager

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -19,7 +19,6 @@ package babe
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -40,7 +39,7 @@ type verifierInfo struct {
 // block for the rest of the epoch. the block hash is used to check if the block being verified
 // is a descendent of the block that included the `OnDisabled` digest.
 type onDisabledInfo struct {
-	blockNumber *big.Int
+	blockNumber uint
 	blockHash   common.Hash
 }
 
@@ -124,7 +123,7 @@ func (v *VerificationManager) SetOnDisabled(index uint32, header *types.Header) 
 			return err
 		}
 
-		if isDescendant && header.Number.Cmp(info.blockNumber) >= 0 {
+		if isDescendant && header.Number >= info.blockNumber {
 			// this authority has already been disabled on this branch
 			return ErrAuthorityAlreadyDisabled
 		}
@@ -148,8 +147,8 @@ func (v *VerificationManager) VerifyBlock(header *types.Header) error {
 
 	// special case for block 1 - the network doesn't necessarily start in epoch 1.
 	// if this happens, the database will be missing info for epochs before the first block.
-	if header.Number.Cmp(big.NewInt(1)) == 0 {
-		block1IsFinal, err := v.blockState.NumberIsFinalised(big.NewInt(1))
+	if header.Number == 1 {
+		block1IsFinal, err := v.blockState.NumberIsFinalised(1)
 		if err != nil {
 			return fmt.Errorf("failed to check if block 1 is finalised: %w", err)
 		}

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -38,5 +38,7 @@ var (
 	// ErrNumLowerThanRoot is returned when attempting to get a hash by number that is lower than the root node
 	ErrNumLowerThanRoot = errors.New("cannot find node with number lower than root node")
 
+	ErrBlockHeaderNumberIsNil = errors.New("block header number is nil")
+
 	errUnexpectedNumber = errors.New("block number is not parent number + 1")
 )

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -18,7 +18,6 @@ package blocktree
 
 import (
 	"errors"
-	"math/big"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -68,7 +67,7 @@ func (ls *leafMap) replace(oldNode, newNode *node) {
 // DeepestLeaf searches the stored leaves to the find the one with the greatest number.
 // If there are two leaves with the same number, choose the one with the earliest arrival time.
 func (ls *leafMap) deepestLeaf() *node {
-	max := big.NewInt(-1)
+	max := -1
 
 	var dLeaf *node
 	ls.smap.Range(func(h, n interface{}) bool {
@@ -78,10 +77,10 @@ func (ls *leafMap) deepestLeaf() *node {
 
 		node := n.(*node)
 
-		if max.Cmp(node.number) < 0 {
-			max = node.number
+		if max < int(node.number) {
+			max = int(node.number)
 			dLeaf = node
-		} else if max.Cmp(node.number) == 0 && node.arrivalTime.Before(dLeaf.arrivalTime) {
+		} else if max == int(node.number) && node.arrivalTime.Before(dLeaf.arrivalTime) {
 			dLeaf = node
 		}
 

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -18,7 +18,6 @@ package blocktree
 
 import (
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -30,7 +29,7 @@ type node struct {
 	hash        common.Hash // Block hash
 	parent      *node       // Parent Node
 	children    []*node     // Nodes of children blocks
-	number      *big.Int    // block number
+	number      uint        // block number
 	arrivalTime time.Time   // Arrival time of the block
 }
 
@@ -41,7 +40,7 @@ func (n *node) addChild(node *node) {
 
 // string returns stringified hash and number of node
 func (n *node) string() string {
-	return fmt.Sprintf("{hash: %s, number: %s, arrivalTime: %s}", n.hash.String(), n.number, n.arrivalTime)
+	return fmt.Sprintf("{hash: %s, number: %d, arrivalTime: %s}", n.hash.String(), n.number, n.arrivalTime)
 }
 
 // createTree adds all the nodes children to the existing printable tree.
@@ -70,15 +69,13 @@ func (n *node) getNode(h common.Hash) *node {
 }
 
 // getNodesWithNumber returns all descendent nodes with the desired number
-func (n *node) getNodesWithNumber(number *big.Int, hashes []common.Hash) []common.Hash {
+func (n *node) getNodesWithNumber(number uint, hashes []common.Hash) []common.Hash {
 	for _, child := range n.children {
-		// number matches
-		if child.number.Cmp(number) == 0 {
+		if child.number == number {
 			hashes = append(hashes, child.hash)
 		}
 
-		// are deeper than desired number, return
-		if child.number.Cmp(number) > 0 {
+		if child.number > number {
 			return hashes
 		}
 
@@ -190,10 +187,7 @@ func (n *node) deepCopy(parent *node) *node {
 	nCopy := new(node)
 	nCopy.hash = n.hash
 	nCopy.arrivalTime = n.arrivalTime
-
-	if n.number != nil {
-		nCopy.number = new(big.Int).Set(n.number)
-	}
+	nCopy.number = n.number
 
 	nCopy.children = make([]*node, len(n.children))
 	for i, child := range n.children {

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -105,6 +105,38 @@ func TestHexToHash(t *testing.T) {
 	}
 }
 
+func Test_Uint64ToHex(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in        uint64
+		hexString string
+	}{
+		"zero": {
+			hexString: "0x0000000000000000",
+		},
+		"one": {
+			in:        1,
+			hexString: "0x0100000000000000",
+		},
+		"max": {
+			in:        ^uint64(0),
+			hexString: "0xffffffffffffffff",
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			hexString := Uint64ToHex(testCase.in)
+
+			assert.Equal(t, testCase.hexString, hexString)
+		})
+	}
+}
+
 type concatTest struct {
 	a, b   []byte
 	output []byte
@@ -143,6 +175,38 @@ func TestUint16ToBytes(t *testing.T) {
 		if !bytes.Equal(res, test.expected) {
 			t.Errorf("Output doesn't match expected. got=%v expected=%v\n", res, test.expected)
 		}
+	}
+}
+
+func Test_uint64ToBytes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in  uint64
+		out []byte
+	}{
+		"zero": {
+			out: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		"one": {
+			in:  1,
+			out: []byte{1, 0, 0, 0, 0, 0, 0, 0},
+		},
+		"max": {
+			in:  ^uint64(0),
+			out: []byte{255, 255, 255, 255, 255, 255, 255, 255},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			out := uint64ToBytes(testCase.in)
+
+			assert.Equal(t, testCase.out, out)
+		})
 	}
 }
 

--- a/lib/common/variadic/uint64OrHash.go
+++ b/lib/common/variadic/uint64OrHash.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
-// Uint64OrHash represents an optional interface type (int,hash).
+// Uint64OrHash represents an optional interface type (uint64,hash).
 type Uint64OrHash struct {
 	value interface{}
 }

--- a/lib/genesis/helpers.go
+++ b/lib/genesis/helpers.go
@@ -96,7 +96,7 @@ func NewGenesisBlockFromTrie(t *trie.Trie) (*types.Header, error) {
 	}
 
 	// create genesis block header
-	header, err := types.NewHeader(common.NewHash([]byte{0}), stateRoot, trie.EmptyHash, big.NewInt(0), types.NewDigest())
+	header, err := types.NewHeader(common.NewHash([]byte{0}), stateRoot, trie.EmptyHash, 0, types.NewDigest())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create genesis block header: %s", err)
 	}

--- a/lib/genesis/test_utils.go
+++ b/lib/genesis/test_utils.go
@@ -19,7 +19,6 @@ package genesis
 import (
 	"encoding/json"
 	"io/ioutil"
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -145,7 +144,7 @@ func newGenesisTrieAndHeader(t *testing.T, gen *Genesis) (*trie.Trie, *types.Hea
 	genTrie, err := NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
-	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), genTrie.MustHash(), trie.EmptyHash, big.NewInt(0), types.NewDigest())
+	genesisHeader, err := types.NewHeader(common.NewHash([]byte{0}), genTrie.MustHash(), trie.EmptyHash, 0, types.NewDigest())
 	require.NoError(t, err)
 
 	return genTrie, genesisHeader

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -138,10 +138,15 @@ func (s *Service) newCommitMessage(header *types.Header, round uint64) (*CommitM
 		return nil, err
 	}
 
+	votePtr, err := NewVoteFromHeader(header)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", errNewVoteFromHeader, err)
+	}
+
 	precommits, authData := justificationToCompact(pcs)
 	return &CommitMessage{
 		Round:      round,
-		Vote:       *NewVoteFromHeader(header),
+		Vote:       *votePtr,
 		Precommits: precommits,
 		AuthData:   authData,
 	}, nil
@@ -266,7 +271,7 @@ func (s *Service) newCatchUpResponse(round, setID uint64) (*CatchUpResponse, err
 		PreVoteJustification:   pvs,
 		PreCommitJustification: pcs,
 		Hash:                   header.Hash(),
-		Number:                 uint32(header.Number.Uint64()),
+		Number:                 uint32(header.Number),
 	}, nil
 }
 

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math/big"
 	"reflect"
 
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -82,7 +81,7 @@ func (h *MessageHandler) handleNeighbourMessage(msg *NeighbourMessage) error {
 	}
 
 	// ignore neighbour messages where our best finalised number is greater than theirs
-	if uint32(currFinalized.Number.Int64()) >= msg.Number {
+	if currFinalized.Number >= uint(msg.Number) {
 		return nil
 	}
 
@@ -94,7 +93,7 @@ func (h *MessageHandler) handleNeighbourMessage(msg *NeighbourMessage) error {
 	}
 
 	// ignore neighbour messages that are above our head
-	if int64(msg.Number) > head.Int64() {
+	if uint(msg.Number) > head {
 		return nil
 	}
 
@@ -387,7 +386,7 @@ func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byt
 		return err
 	}
 
-	setID, err := s.grandpaState.GetSetIDByBlockNumber(big.NewInt(int64(fj.Commit.Number)))
+	setID, err := s.grandpaState.GetSetIDByBlockNumber(uint(fj.Commit.Number))
 	if err != nil {
 		return fmt.Errorf("cannot get set ID from block number: %w", err)
 	}

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -17,7 +17,6 @@
 package grandpa
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -33,7 +32,7 @@ import (
 
 var testHeader = &types.Header{
 	ParentHash: testGenesisHeader.Hash(),
-	Number:     big.NewInt(1),
+	Number:     1,
 	Digest:     newTestDigest(),
 }
 
@@ -212,7 +211,7 @@ func TestMessageHandler_NeighbourMessage(t *testing.T) {
 
 	block := &types.Block{
 		Header: types.Header{
-			Number:     big.NewInt(1),
+			Number:     1,
 			ParentHash: st.Block.GenesisHash(),
 			Digest:     digest,
 		},
@@ -263,7 +262,7 @@ func TestMessageHandler_CommitMessage_NoCatchUpRequest_ValidSig(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash: testGenesisHeader.Hash(),
-			Number:     big.NewInt(1),
+			Number:     1,
 			Digest:     digest,
 		},
 		Body: types.Body{},
@@ -358,7 +357,7 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash: testGenesisHeader.Hash(),
-			Number:     big.NewInt(1),
+			Number:     1,
 			Digest:     digest,
 		},
 		Body: types.Body{},
@@ -533,7 +532,7 @@ func TestMessageHandler_VerifyBlockJustification(t *testing.T) {
 	}
 
 	gs, st := newTestService(t)
-	err := st.Grandpa.SetNextChange(auths, big.NewInt(1))
+	err := st.Grandpa.SetNextChange(auths, 1)
 	require.NoError(t, err)
 
 	body, err := types.NewBodyFromBytes([]byte{0})

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -1,7 +1,6 @@
 package grandpa
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/state"
@@ -43,9 +42,12 @@ func TestCommitMessageEncode(t *testing.T) {
 	require.NoError(t, err)
 	precommits, authData := justificationToCompact(just)
 
+	votePtr, err := NewVoteFromHeader(gs.head)
+	require.NoError(t, err)
+
 	expected := CommitMessage{
 		Round:      77,
-		Vote:       *NewVoteFromHeader(gs.head),
+		Vote:       *votePtr,
 		Precommits: precommits,
 		AuthData:   authData,
 	}
@@ -123,9 +125,12 @@ func TestCommitMessageToConsensusMessage(t *testing.T) {
 	require.NoError(t, err)
 	precommits, authData := justificationToCompact(just)
 
+	expectedVotePtr, err := NewVoteFromHeader(gs.head)
+	require.NoError(t, err)
+
 	expected := &CommitMessage{
 		Round:      77,
-		Vote:       *NewVoteFromHeader(gs.head),
+		Vote:       *expectedVotePtr,
 		Precommits: precommits,
 		AuthData:   authData,
 	}
@@ -147,7 +152,7 @@ func TestNewCatchUpResponse(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash: testGenesisHeader.Hash(),
-			Number:     big.NewInt(1),
+			Number:     1,
 			Digest:     digest,
 		},
 		Body: types.Body{},

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -17,7 +17,6 @@
 package grandpa
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -38,12 +37,16 @@ func TestMessageTracker_ValidateMessage(t *testing.T) {
 	gs.tracker = newTracker(gs.blockState, gs.messageHandler)
 
 	fake := &types.Header{
-		Number: big.NewInt(77),
+		Number: 77,
 	}
 
 	gs.keypair = kr.Alice().(*ed25519.Keypair)
-	_, msg, err := gs.createSignedVoteAndVoteMessage(NewVoteFromHeader(fake), prevote)
+
+	vote, err := NewVoteFromHeader(fake)
 	require.NoError(t, err)
+	_, msg, err := gs.createSignedVoteAndVoteMessage(vote, prevote)
+	require.NoError(t, err)
+
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	expected := &networkVoteMessage{
@@ -70,11 +73,14 @@ func TestMessageTracker_SendMessage(t *testing.T) {
 
 	next := &types.Header{
 		ParentHash: parent.Hash(),
-		Number:     big.NewInt(4),
+		Number:     4,
 	}
 
 	gs.keypair = kr.Alice().(*ed25519.Keypair)
-	_, msg, err := gs.createSignedVoteAndVoteMessage(NewVoteFromHeader(next), prevote)
+
+	vote, err := NewVoteFromHeader(next)
+	require.NoError(t, err)
+	_, msg, err := gs.createSignedVoteAndVoteMessage(vote, prevote)
 	require.NoError(t, err)
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
@@ -116,11 +122,13 @@ func TestMessageTracker_ProcessMessage(t *testing.T) {
 
 	next := &types.Header{
 		ParentHash: parent.Hash(),
-		Number:     big.NewInt(4),
+		Number:     4,
 	}
 
 	gs.keypair = kr.Alice().(*ed25519.Keypair)
-	_, msg, err := gs.createSignedVoteAndVoteMessage(NewVoteFromHeader(next), prevote)
+	vote, err := NewVoteFromHeader(next)
+	require.NoError(t, err)
+	_, msg, err := gs.createSignedVoteAndVoteMessage(vote, prevote)
 	require.NoError(t, err)
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
@@ -157,7 +165,7 @@ func TestMessageTracker_MapInsideMap(t *testing.T) {
 	gs.tracker = newTracker(gs.blockState, gs.messageHandler)
 
 	header := &types.Header{
-		Number: big.NewInt(77),
+		Number: 77,
 	}
 
 	hash := header.Hash()
@@ -166,7 +174,9 @@ func TestMessageTracker_MapInsideMap(t *testing.T) {
 
 	gs.keypair = kr.Alice().(*ed25519.Keypair)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
-	_, msg, err := gs.createSignedVoteAndVoteMessage(NewVoteFromHeader(header), prevote)
+	vote, err := NewVoteFromHeader(header)
+	require.NoError(t, err)
+	_, msg, err := gs.createSignedVoteAndVoteMessage(vote, prevote)
 	require.NoError(t, err)
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 

--- a/lib/grandpa/mocks/digest_handler.go
+++ b/lib/grandpa/mocks/digest_handler.go
@@ -10,14 +10,14 @@ type DigestHandler struct {
 }
 
 // NextGrandpaAuthorityChange provides a mock function with given fields:
-func (_m *DigestHandler) NextGrandpaAuthorityChange() uint64 {
+func (_m *DigestHandler) NextGrandpaAuthorityChange() uint {
 	ret := _m.Called()
 
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func() uint64); ok {
+	var r0 uint
+	if rf, ok := ret.Get(0).(func() uint); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(uint64)
+		r0 = ret.Get(0).(uint)
 	}
 
 	return r0

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -211,7 +211,7 @@ func (s *Service) sendNeighbourMessage() {
 				Version: 1,
 				Round:   info.Round,
 				SetID:   info.SetID,
-				Number:  uint32(info.Header.Number.Int64()),
+				Number:  uint32(info.Header.Number),
 			}
 		}
 

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -17,7 +17,6 @@
 package grandpa
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -98,7 +97,7 @@ func TestSendNeighbourMessage(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash: st.Block.GenesisHash(),
-			Number:     big.NewInt(1),
+			Number:     1,
 			Digest:     digest,
 		},
 		Body: types.Body{},

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -177,7 +177,7 @@ func TestGrandpa_DifferentChains(t *testing.T) {
 		gs, _, _, _ = setupGrandpa(t, kr.Keys[i])
 		gss[i] = gs
 
-		r := rand.Intn(1)
+		r := uint(rand.Int31n(1))
 		state.AddBlocksToState(t, gs.blockState.(*state.BlockState), 4+r, false)
 		pv, err := gs.determinePreVote() //nolint
 		require.NoError(t, err)
@@ -326,7 +326,7 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 
 	// this represents the chains that will be slightly ahead of the others
 	headers := []*types.Header{}
-	diff := 1
+	const diff uint = 1
 
 	for i := range gss {
 		gs, in, out, fin := setupGrandpa(t, kr.Keys[i])
@@ -337,8 +337,7 @@ func TestPlayGrandpaRound_VaryingChain(t *testing.T) {
 		outs[i] = out
 		fins[i] = fin
 
-		r := 0
-		r = rand.Intn(diff)
+		r := uint(rand.Int31n(int32(diff)))
 		chain, _ := state.AddBlocksToState(t, gs.blockState.(*state.BlockState), 4+r, false)
 		if r == diff-1 {
 			headers = chain
@@ -433,7 +432,7 @@ func TestPlayGrandpaRound_WithEquivocation(t *testing.T) {
 		fins[i] = fin
 
 		// this creates a tree with 2 branches starting at depth 2
-		branches := make(map[int]int)
+		branches := make(map[uint]int)
 		branches[2] = 1
 		state.AddBlocksToStateWithFixedBranches(t, gs.blockState.(*state.BlockState), 4, branches, r)
 	}

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -17,8 +17,6 @@
 package grandpa
 
 import (
-	"math/big"
-
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -31,7 +29,7 @@ type BlockState interface {
 	GenesisHash() common.Hash
 	HasHeader(hash common.Hash) (bool, error)
 	GetHeader(hash common.Hash) (*types.Header, error)
-	GetHeaderByNumber(num *big.Int) (*types.Header, error)
+	GetHeaderByNumber(num uint) (*types.Header, error)
 	IsDescendantOf(parent, child common.Hash) (bool, error)
 	HighestCommonAncestor(a, b common.Hash) (common.Hash, error)
 	HasFinalisedBlock(round, setID uint64) (bool, error)
@@ -48,8 +46,8 @@ type BlockState interface {
 	SetJustification(hash common.Hash, data []byte) error
 	HasJustification(hash common.Hash) (bool, error)
 	GetJustification(hash common.Hash) ([]byte, error)
-	GetHashByNumber(num *big.Int) (common.Hash, error)
-	BestBlockNumber() (*big.Int, error)
+	GetHashByNumber(num uint) (common.Hash, error)
+	BestBlockNumber() (uint, error)
 	GetHighestRoundAndSetID() (uint64, uint64, error)
 }
 
@@ -57,7 +55,7 @@ type BlockState interface {
 type GrandpaState interface { //nolint
 	GetCurrentSetID() (uint64, error)
 	GetAuthorities(setID uint64) ([]types.GrandpaVoter, error)
-	GetSetIDByBlockNumber(num *big.Int) (uint64, error)
+	GetSetIDByBlockNumber(num uint) (uint64, error)
 	SetLatestRound(round uint64) error
 	GetLatestRound() (uint64, error)
 	SetPrevotes(round, setID uint64, data []SignedVote) error
@@ -70,7 +68,7 @@ type GrandpaState interface { //nolint
 
 // DigestHandler is the interface required by GRANDPA for the digest handler
 type DigestHandler interface { // TODO: use GrandpaState instead (#1871)
-	NextGrandpaAuthorityChange() uint64
+	NextGrandpaAuthorityChange() uint
 }
 
 //go:generate mockery --name Network --structname Network --case underscore --keeptree

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -108,11 +108,11 @@ func NewVote(hash common.Hash, number uint32) *Vote {
 }
 
 // NewVoteFromHeader returns a new Vote for a given header
-func NewVoteFromHeader(h *types.Header) *Vote {
+func NewVoteFromHeader(h *types.Header) (v *Vote, err error) {
 	return &Vote{
 		Hash:   h.Hash(),
-		Number: uint32(h.Number.Int64()),
-	}
+		Number: uint32(h.Number),
+	}, nil
 }
 
 // NewVoteFromHash returns a new Vote given a hash and a blockState
@@ -131,7 +131,7 @@ func NewVoteFromHash(hash common.Hash, blockState BlockState) (*Vote, error) {
 		return nil, err
 	}
 
-	return NewVoteFromHeader(h), nil
+	return NewVoteFromHeader(h)
 }
 
 // Commit contains all the signed precommits for a given block

--- a/lib/runtime/life/exports.go
+++ b/lib/runtime/life/exports.go
@@ -90,7 +90,7 @@ func (in *Instance) GrandpaAuthorities() ([]types.Authority, error) {
 
 // InitializeBlock calls runtime API function Core_initialise_block
 func (in *Instance) InitializeBlock(header *types.Header) error {
-	encodedHeader, err := scale.Marshal(*header)
+	encodedHeader, err := scale.Marshal(header)
 	if err != nil {
 		return fmt.Errorf("cannot encode header: %w", err)
 	}
@@ -155,7 +155,7 @@ func (in *Instance) ExecuteBlock(block *types.Block) ([]byte, error) {
 		}
 	}
 
-	bdEnc, err := b.Encode()
+	bdEnc, err := scale.Marshal(b)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime/life/exports_test.go
+++ b/lib/runtime/life/exports_test.go
@@ -1,7 +1,6 @@
 package life
 
 import (
-	"math/big"
 	"testing"
 	"time"
 
@@ -121,7 +120,7 @@ func TestInstance_GrandpaAuthorities_NodeRuntime(t *testing.T) {
 func buildBlock(t *testing.T, instance runtime.Instance) *types.Block {
 	header := &types.Header{
 		ParentHash: trie.EmptyHash,
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     types.NewDigest(),
 	}
 
@@ -176,7 +175,7 @@ func buildBlock(t *testing.T, instance runtime.Instance) *types.Block {
 
 	expected := &types.Header{
 		ParentHash: header.ParentHash,
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 	}
 
@@ -253,7 +252,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe"),
-			Number:         big.NewInt(1),
+			Number:         1,
 			StateRoot:      common.MustHexToHash("0xfabb0c6e92d29e8bb2167f3c6fb0ddeb956a4278a3cf853661af74a076fc9cb7"),
 			ExtrinsicsRoot: common.MustHexToHash("0xa35fb7f7616f5c979d48222b3d2fa7cb2331ef73954726714d91ca945cc34fd8"),
 			Digest:         digest,
@@ -303,7 +302,7 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"),
-			Number:         big.NewInt(1),
+			Number:         1,
 			StateRoot:      common.MustHexToHash("0xc56fcd6e7a757926ace3e1ecff9b4010fc78b90d459202a339266a7f6360002f"),
 			ExtrinsicsRoot: common.MustHexToHash("0x9a87f6af64ef97aff2d31bebfdd59f8fe2ef6019278b634b2515a38f1c4c2420"),
 			Digest:         digest,

--- a/lib/runtime/life/resolver.go
+++ b/lib/runtime/life/resolver.go
@@ -422,6 +422,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 		valueRes = valueToAppend
 	} else {
 		var currLength *big.Int
+		// TODO does this need to be modified?
 		err := scale.Unmarshal(valueCurr, &currLength)
 		if err != nil {
 			logger.Trace("[ext_storage_append_version_1] item in storage is not SCALE encoded, overwriting", "key", key)

--- a/lib/runtime/wasmer/exports.go
+++ b/lib/runtime/wasmer/exports.go
@@ -176,7 +176,7 @@ func (in *Instance) ExecuteBlock(block *types.Block) ([]byte, error) {
 		}
 	}
 
-	bdEnc, err := b.Encode()
+	bdEnc, err := scale.Marshal(b)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -330,7 +330,6 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	rt.(*Instance).ctx.Storage.Set(common.UpgradedToDualRefKey, []byte{1})
 
 	genesisHeader := &types.Header{
-		Number:    big.NewInt(0),
 		StateRoot: genTrie.MustHash(),
 	}
 
@@ -474,7 +473,7 @@ func TestInstance_InitializeBlock_NodeRuntime(t *testing.T) {
 	rt := NewTestInstance(t, runtime.NODE_RUNTIME)
 
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 		Digest: types.NewDigest(),
 	}
 
@@ -486,7 +485,7 @@ func TestInstance_InitializeBlock_PolkadotRuntime(t *testing.T) {
 	rt := NewTestInstance(t, runtime.POLKADOT_RUNTIME)
 
 	header := &types.Header{
-		Number: big.NewInt(1),
+		Number: 1,
 		Digest: types.NewDigest(),
 	}
 
@@ -497,7 +496,7 @@ func TestInstance_InitializeBlock_PolkadotRuntime(t *testing.T) {
 func buildBlockVdt(t *testing.T, instance runtime.Instance, parentHash common.Hash) *types.Block {
 	header := &types.Header{
 		ParentHash: parentHash,
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     types.NewDigest(),
 	}
 
@@ -553,7 +552,7 @@ func buildBlockVdt(t *testing.T, instance runtime.Instance, parentHash common.Ha
 
 	expected := &types.Header{
 		ParentHash: header.ParentHash,
-		Number:     big.NewInt(1),
+		Number:     1,
 		Digest:     digest,
 	}
 
@@ -643,7 +642,7 @@ func TestInstance_ApplyExtrinsic_GossamerRuntime(t *testing.T) {
 	instance.SetContextStorage(parentState)
 
 	parentHash := common.Hash{}
-	header, err := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, big.NewInt(1), types.NewDigest())
+	header, err := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, 1, types.NewDigest())
 	require.NoError(t, err)
 	err = instance.InitializeBlock(header)
 	require.NoError(t, err)
@@ -712,7 +711,7 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"),
-			Number:         big.NewInt(1),
+			Number:         1,
 			StateRoot:      common.MustHexToHash("0xc56fcd6e7a757926ace3e1ecff9b4010fc78b90d459202a339266a7f6360002f"),
 			ExtrinsicsRoot: common.MustHexToHash("0x9a87f6af64ef97aff2d31bebfdd59f8fe2ef6019278b634b2515a38f1c4c2420"),
 			Digest:         digest,
@@ -763,7 +762,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe"),
-			Number:         big.NewInt(1),
+			Number:         1,
 			StateRoot:      common.MustHexToHash("0xfabb0c6e92d29e8bb2167f3c6fb0ddeb956a4278a3cf853661af74a076fc9cb7"),
 			ExtrinsicsRoot: common.MustHexToHash("0xa35fb7f7616f5c979d48222b3d2fa7cb2331ef73954726714d91ca945cc34fd8"),
 			Digest:         digest,
@@ -809,7 +808,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock3784(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0x4843b4aa38cf2e3e2f6fae401b98dd705bed668a82dd3751dc38f1601c814ca8"),
-			Number:         big.NewInt(3784),
+			Number:         3784,
 			StateRoot:      common.MustHexToHash("0xac44cc18ec22f0f3fca39dfe8725c0383af1c982a833e081fbb2540e46eb09a5"),
 			ExtrinsicsRoot: common.MustHexToHash("0x52b7d4852fc648cb8f908901e1e36269593c25050c31718454bca74b69115d12"),
 			Digest:         digest,
@@ -855,7 +854,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0x68d9c5f75225f09d7ce493eff8aabac7bae8b65cb81a2fd532a99fbb8c663931"),
-			Number:         big.NewInt(901442),
+			Number:         901442,
 			StateRoot:      common.MustHexToHash("0x6ea065f850894c5b58cb1a73ec887e56842851943641149c57cea357cae4f596"),
 			ExtrinsicsRoot: common.MustHexToHash("0x13483a4c148fff5f072e86b5af52bf031556514e9c87ea19f9e31e7b13c0c414"),
 			Digest:         digest,
@@ -901,7 +900,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1377831(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0xca387b3cc045e8848277069d8794cbf077b08218c0b55f74d81dd750b14e768c"),
-			Number:         big.NewInt(1377831),
+			Number:         1377831,
 			StateRoot:      common.MustHexToHash("0x7e5569e652c4b1a3cecfcf5e5e64a97fe55071d34bab51e25626ec20cae05a02"),
 			ExtrinsicsRoot: common.MustHexToHash("0x7f3ea0ed63b4053d9b75e7ee3e5b3f6ce916e8f59b7b6c5e966b7a56ea0a563a"),
 			Digest:         digest,
@@ -948,7 +947,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1482003(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0x587f6da1bfa71a675f10dfa0f63edfcf168e8ece97eb5f526aaf0e8a8e82db3f"),
-			Number:         big.NewInt(1482003),
+			Number:         1482003,
 			StateRoot:      common.MustHexToHash("0xd2de750002f33968437bdd54912dd4f55c3bddc5a391a8e0b8332568e1efea8d"),
 			ExtrinsicsRoot: common.MustHexToHash("0xdf5da95780b77e83ad0bf820d5838f07a0d5131aa95a75f8dfbd01fbccb300bd"),
 			Digest:         digest,
@@ -992,7 +991,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock4939774(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0xac08290f49cb9760a3a4c5a49351af76ba9432add29178e5cc27d4451f9126c9"),
-			Number:         big.NewInt(4939774),
+			Number:         4939774,
 			StateRoot:      common.MustHexToHash("0x5d66f43cdbf1740b8ca41f0cd016602f1648fb08b74fe49f5f078845071d0a54"),
 			ExtrinsicsRoot: common.MustHexToHash("0x5d887e118ee6320aca38e49cbd98adc25472c6efbf77a695ab0d6c476a4ec6e9"),
 			Digest:         digest,
@@ -1037,7 +1036,7 @@ func TestInstance_ExecuteBlock_PolkadotBlock1089328(t *testing.T) {
 	block := &types.Block{
 		Header: types.Header{
 			ParentHash:     common.MustHexToHash("0x21dc35454805411be396debf3e1d5aad8d6e9d0d7679cce0cc632ba8a647d07c"),
-			Number:         big.NewInt(1089328),
+			Number:         1089328,
 			StateRoot:      common.MustHexToHash("0x257b1a7f6bc0287fcbf50676dd29817f2f7ae193cb65b31962e351917406fa23"),
 			ExtrinsicsRoot: common.MustHexToHash("0x950173af1d9fdcd0be5428fc3eaf05d5f34376bd3882d9a61b348fa2dc641012"),
 			Digest:         digest,

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1687,6 +1687,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 		valueRes = valueToAppend
 	} else {
 		var currLength *big.Int
+		// TODO does this need to be modified?
 		err := scale.Unmarshal(valueCurr, &currLength)
 		if err != nil {
 			logger.Trace("[ext_storage_append_version_1] item in storage is not SCALE encoded, overwriting", "key", key)

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1368,8 +1368,7 @@ func Test_ext_default_child_storage_storage_kill_version_2_limit_none(t *testing
 	encChildKey, err := scale.Marshal(testChildKey)
 	require.NoError(t, err)
 
-	var val *[]byte // nolint
-	val = nil
+	var val *[]byte
 	optLimit, err := scale.Marshal(val)
 	require.NoError(t, err)
 

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -18,7 +18,6 @@ package stress
 
 import (
 	"fmt"
-	"math/big"
 	"math/rand"
 	"os"
 	"strconv"
@@ -174,10 +173,10 @@ func TestSync_MultipleEpoch(t *testing.T) {
 
 	// Just checking that everythings operating as expected
 	header := utils.GetChainHead(t, nodes[0])
-	currentHeight := header.Number.Int64()
-	for i := int64(0); i < currentHeight; i++ {
+	currentHeight := header.Number
+	for i := uint(0); i < currentHeight; i++ {
 		t.Log("comparing...", i)
-		_, err = compareBlocksByNumberWithRetry(t, nodes, strconv.Itoa(int(i)))
+		_, err = compareBlocksByNumberWithRetry(t, nodes, fmt.Sprint(i))
 		require.NoError(t, err, i)
 	}
 }
@@ -212,7 +211,7 @@ func TestSync_SingleSyncingNode(t *testing.T) {
 
 func TestSync_Bench(t *testing.T) {
 	utils.SetLogLevel(log.LvlInfo)
-	numBlocks := 64
+	const numBlocks uint = 64
 
 	// start block producing node
 	alice, err := utils.RunGossamer(t, 0, utils.TestDir(t, utils.KeyList[1]), utils.GenesisDev, utils.ConfigNoGrandpa, false, true)
@@ -223,8 +222,9 @@ func TestSync_Bench(t *testing.T) {
 		if err != nil {
 			continue
 		}
+		require.NotNil(t, header.Number) // tolerable overhead due to the sleep below.
 
-		if header.Number.Int64() >= int64(numBlocks) {
+		if header.Number >= numBlocks {
 			break
 		}
 
@@ -246,7 +246,7 @@ func TestSync_Bench(t *testing.T) {
 	}()
 
 	// see how long it takes to sync to block numBlocks
-	last := big.NewInt(int64(numBlocks))
+	const last = numBlocks
 	start := time.Now()
 	var end time.Time
 
@@ -260,7 +260,7 @@ func TestSync_Bench(t *testing.T) {
 			continue
 		}
 
-		if head.Number.Cmp(last) >= 0 {
+		if head.Number >= last {
 			end = time.Now()
 			break
 		}
@@ -277,7 +277,7 @@ func TestSync_Bench(t *testing.T) {
 
 	// assert block is correct
 	t.Log("comparing block...", numBlocks)
-	_, err = compareBlocksByNumberWithRetry(t, nodes, strconv.Itoa(numBlocks))
+	_, err = compareBlocksByNumberWithRetry(t, nodes, fmt.Sprint(numBlocks))
 	require.NoError(t, err, numBlocks)
 	time.Sleep(time.Second * 3)
 }
@@ -429,7 +429,7 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 	// search from child -> parent blocks for extrinsic
 	var (
 		resExts    []gosstypes.Extrinsic
-		extInBlock *big.Int
+		extInBlock uint
 	)
 
 	for i := 0; i < maxRetries; i++ {
@@ -467,6 +467,6 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 
 	require.True(t, included)
 
-	hashes, err := compareBlocksByNumberWithRetry(t, nodes, extInBlock.String())
+	hashes, err := compareBlocksByNumberWithRetry(t, nodes, fmt.Sprint(extInBlock))
 	require.NoError(t, err, hashes)
 }

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"fmt"
-	"math/big"
 	"strconv"
 	"testing"
 
@@ -124,9 +123,8 @@ func GetBlock(t *testing.T, node *Node, hash common.Hash) *types.Block {
 	parentHash, err := common.HexToHash(header.ParentHash)
 	require.NoError(t, err)
 
-	nb, err := common.HexToBytes(header.Number)
+	number, err := common.HexToUint(header.Number)
 	require.NoError(t, err)
-	number := big.NewInt(0).SetBytes(nb)
 
 	stateRoot, err := common.HexToHash(header.StateRoot)
 	require.NoError(t, err)

--- a/tests/utils/header.go
+++ b/tests/utils/header.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/rpc/modules"
@@ -31,9 +30,8 @@ func HeaderResponseToHeader(t *testing.T, header *modules.ChainBlockHeaderRespon
 	parentHash, err := common.HexToHash(header.ParentHash)
 	require.NoError(t, err)
 
-	nb, err := common.HexToBytes(header.Number)
+	number, err := common.HexToUint(header.Number)
 	require.NoError(t, err)
-	number := big.NewInt(0).SetBytes(nb)
 
 	stateRoot, err := common.HexToHash(header.StateRoot)
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

- [x] Change `*big.Int` to `*uint32` for block headers and block number manipulation (**Except for network package to maintain interop**)
- [x] Conversions to 4 bytes (uint32) instead of 8 bytes (uint64) wherever possible
- [x] Use `uint32` instead of `uint64` in some places
- [x] `Uint64OrHash` to `Uint32OrHash`
- [x] Mocks re-generated
- [x] Adapt new Block and Header types to runtime compatible Block/Header
- [x] Change `*uint32` to `uint32`
- [ ] Fix remaining tests failing
- [ ] Remove any `TODO-1785` and `TODO` introduced
- [ ] Change `Uint64OrHash` to `Uint32OrHash`?

## Tests

- Run the entire test suite

## Issues

- #1785 

## Primary Reviewer

- Anyone, this is a draft PR
- Notes to reviewers: please make sure changes related to encoding are fine (e.g. uint64 to uint32)