### PR TITLE
chore(lint): disable shadowing checks with `govet`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,10 @@ run:
 
 # all available settings of specific linters
 linters-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true
@@ -112,6 +116,10 @@ issues:
     - text: "exported: exported var Err*"
       linters:
         - revive
+
+    - text: "shadow: declaration of \"err\" shadows declaration*"
+      linters:
+        - govet
 
     # Exclude known linters from partially hard-vendored code,
     # which is impossible to exclude via "nolint" comments.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,10 +31,6 @@ run:
 
 # all available settings of specific linters
 linters-settings:
-  govet:
-    # report about shadowed variables
-    check-shadowing: true
-
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,7 +117,11 @@ issues:
       linters:
         - revive
 
-    - text: "shadow: declaration of \"err\" shadows declaration*"
+    - text: 'shadow: declaration of "err" shadows declaration*'
+      linters:
+        - govet
+
+    - text: 'shadow: declaration of "ok" shadows declaration*'
       linters:
         - govet
 


### PR DESCRIPTION
## Changes

- Disable shadowing check (disabled by default) with `govet`
- In my opinion:
    - these make the code longer since we need to pre-declare things
    - you can't have locally-scoped variables in an if or for block for example if the variable name is already used in the upper scope.

Feel free to comment & close it if you disagree with the change 😉 

## Tests


```
golangci-lint run
```

## Issues

- No issue

## Primary Reviewer

- No-one