### PR TITLE
feat(flags): read log levels from flags

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -310,9 +311,14 @@ func getLogLevel(ctx getStringer, flagName, tomlValue string, defaultLevel log.L
 	return parseLogLevelString(tomlValue)
 }
 
+var ErrLogLevelIntegerOutOfRange = errors.New("log level integer can only be between 0 and 5 included")
+
 func parseLogLevelString(logLevelString string) (logLevel log.Lvl, err error) {
 	levelInt, err := strconv.Atoi(logLevelString)
 	if err == nil { // level given as an integer
+		if levelInt < 0 || levelInt > 5 {
+			return 0, fmt.Errorf("%w: log level given: %d", ErrLogLevelIntegerOutOfRange, levelInt)
+		}
 		logLevel = log.Lvl(levelInt)
 		return logLevel, nil
 	}

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -311,14 +310,9 @@ func getLogLevel(ctx getStringer, flagName, tomlValue string, defaultLevel log.L
 	return parseLogLevelString(tomlValue)
 }
 
-var regexDigits = regexp.MustCompile("^[0-9]+$")
-
 func parseLogLevelString(logLevelString string) (logLevel log.Lvl, err error) {
-	if regexDigits.MatchString(logLevelString) {
-		levelInt, err := strconv.Atoi(logLevelString)
-		if err != nil { // should never happen
-			return 0, fmt.Errorf("cannot parse log level digits: %w", err)
-		}
+	levelInt, err := strconv.Atoi(logLevelString)
+	if err == nil { // level given as an integer
 		logLevel = log.Lvl(levelInt)
 		return logLevel, nil
 	}

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -392,7 +392,7 @@ func setLogConfig(flagsKVStore stringKVStore, cfg *ctoml.Config, globalCfg *dot.
 		},
 		{
 			name:      "finality gadget",
-			flagName:  LogFinalityGadgetLevelFlag.Name,
+			flagName:  LogGrandpaLevelFlag.Name,
 			tomlValue: cfg.Log.FinalityGadgetLvl,
 			levelPtr:  &logCfg.FinalityGadgetLvl,
 		},

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -386,7 +386,7 @@ func setLogConfig(flagsKVStore stringKVStore, cfg *ctoml.Config, globalCfg *dot.
 		},
 		{
 			name:      "block producer",
-			flagName:  LogBlockProducerLevelFlag.Name,
+			flagName:  LogBabeLevelFlag.Name,
 			tomlValue: cfg.Log.BlockProducerLvl,
 			levelPtr:  &logCfg.BlockProducerLvl,
 		},

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -342,44 +342,74 @@ func setLogConfig(ctx getStringer, cfg *ctoml.Config, globalCfg *dot.GlobalConfi
 	}
 	cfg.Global.LogLvl = globalCfg.LogLvl.String()
 
-	logCfg.CoreLvl, err = getLogLevel(ctx, LogCoreLevelFlag.Name, cfg.Log.CoreLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get core log level: %w", err)
+	levelsData := []struct {
+		name      string
+		flagName  string
+		tomlValue string
+		levelPtr  *log.Lvl // pointer to value to modify
+	}{
+		{
+			name:      "core",
+			flagName:  LogCoreLevelFlag.Name,
+			tomlValue: cfg.Log.CoreLvl,
+			levelPtr:  &logCfg.CoreLvl,
+		},
+		{
+			name:      "sync",
+			flagName:  LogSyncLevelFlag.Name,
+			tomlValue: cfg.Log.SyncLvl,
+			levelPtr:  &logCfg.SyncLvl,
+		},
+		{
+			name:      "network",
+			flagName:  LogNetworkLevelFlag.Name,
+			tomlValue: cfg.Log.NetworkLvl,
+			levelPtr:  &logCfg.NetworkLvl,
+		},
+		{
+			name:      "RPC",
+			flagName:  LogRPCLevelFlag.Name,
+			tomlValue: cfg.Log.RPCLvl,
+			levelPtr:  &logCfg.RPCLvl,
+		},
+		{
+			name:      "state",
+			flagName:  LogStateLevelFlag.Name,
+			tomlValue: cfg.Log.StateLvl,
+			levelPtr:  &logCfg.StateLvl,
+		},
+		{
+			name:      "runtime",
+			flagName:  LogRuntimeLevelFlag.Name,
+			tomlValue: cfg.Log.RuntimeLvl,
+			levelPtr:  &logCfg.RuntimeLvl,
+		},
+		{
+			name:      "block producer",
+			flagName:  LogBlockProducerLevelFlag.Name,
+			tomlValue: cfg.Log.BlockProducerLvl,
+			levelPtr:  &logCfg.BlockProducerLvl,
+		},
+		{
+			name:      "finality gadget",
+			flagName:  LogFinalityGadgetLevelFlag.Name,
+			tomlValue: cfg.Log.FinalityGadgetLvl,
+			levelPtr:  &logCfg.FinalityGadgetLvl,
+		},
+		{
+			name:      "sync",
+			flagName:  LogSyncLevelFlag.Name,
+			tomlValue: cfg.Log.SyncLvl,
+			levelPtr:  &logCfg.SyncLvl,
+		},
 	}
 
-	logCfg.SyncLvl, err = getLogLevel(ctx, LogSyncLevelFlag.Name, cfg.Log.SyncLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get sync log level: %w", err)
-	}
-
-	logCfg.NetworkLvl, err = getLogLevel(ctx, LogNetworkLevelFlag.Name, cfg.Log.NetworkLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get network log level: %w", err)
-	}
-
-	logCfg.RPCLvl, err = getLogLevel(ctx, LogRPCLevelFlag.Name, cfg.Log.RPCLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get RPC log level: %w", err)
-	}
-
-	logCfg.StateLvl, err = getLogLevel(ctx, LogStateLevelFlag.Name, cfg.Log.StateLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get state log level: %w", err)
-	}
-
-	logCfg.RuntimeLvl, err = getLogLevel(ctx, LogRuntimeLevelFlag.Name, cfg.Log.RuntimeLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get runtime log level: %w", err)
-	}
-
-	logCfg.BlockProducerLvl, err = getLogLevel(ctx, LogBlockProducerLevelFlag.Name, cfg.Log.BlockProducerLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get block producer log level: %w", err)
-	}
-
-	logCfg.FinalityGadgetLvl, err = getLogLevel(ctx, LogFinalityGadgetLevelFlag.Name, cfg.Log.FinalityGadgetLvl, globalCfg.LogLvl)
-	if err != nil {
-		return fmt.Errorf("cannot get finality gadget log level: %w", err)
+	for _, levelData := range levelsData {
+		level, err := getLogLevel(ctx, levelData.flagName, levelData.tomlValue, globalCfg.LogLvl)
+		if err != nil {
+			return fmt.Errorf("cannot get %s log level: %w", levelData.name, err)
+		}
+		*levelData.levelPtr = level
 	}
 
 	logger.Debug("set log configuration", "--log", ctx.String(LogFlag.Name), "global", globalCfg.LogLvl)

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -24,12 +25,14 @@ import (
 	"github.com/ChainSafe/gossamer/chain/dev"
 	"github.com/ChainSafe/gossamer/chain/gssmr"
 	"github.com/ChainSafe/gossamer/dot"
+	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/utils"
 
 	log "github.com/ChainSafe/log15"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 )
@@ -1064,4 +1067,182 @@ func TestGlobalNodeNamePriorityOrder(t *testing.T) {
 		require.NotEmpty(t, createdCfg.Global.Name)
 		require.NotEqual(t, cfg.Global.Name, createdCfg.Global.Name)
 	})
+}
+
+type mockGetStringer struct {
+	kv map[string]string
+}
+
+func (m *mockGetStringer) String(key string) (value string) {
+	return m.kv[key]
+}
+
+func newMockGetStringer(keyValue map[string]string) *mockGetStringer {
+	kv := make(map[string]string, len(keyValue))
+	for k, v := range keyValue {
+		kv[k] = v
+	}
+	return &mockGetStringer{kv: kv}
+}
+
+func Test_getLogLevel(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		ctx          getStringer
+		flagName     string
+		tomlValue    string
+		defaultLevel log.Lvl
+		level        log.Lvl
+		err          error
+	}{
+		"no value with default": {
+			ctx:          newMockGetStringer(map[string]string{}),
+			defaultLevel: log.LvlError,
+			level:        log.LvlError,
+		},
+		"flag integer value": {
+			ctx:      newMockGetStringer(map[string]string{"x": "1"}),
+			flagName: "x",
+			level:    log.LvlError,
+		},
+		"flag string value": {
+			ctx:      newMockGetStringer(map[string]string{"x": "eror"}),
+			flagName: "x",
+			level:    log.LvlError,
+		},
+		"flag bad string value": {
+			ctx:      newMockGetStringer(map[string]string{"x": "garbage"}),
+			flagName: "x",
+			err:      errors.New("cannot parse log level string: Unknown level: garbage"),
+		},
+		"toml integer value": {
+			ctx:       newMockGetStringer(map[string]string{}),
+			tomlValue: "1",
+			level:     log.LvlError,
+		},
+		"toml string value": {
+			ctx:       newMockGetStringer(map[string]string{}),
+			tomlValue: "eror",
+			level:     log.LvlError,
+		},
+		"toml bad string value": {
+			ctx:       newMockGetStringer(map[string]string{}),
+			tomlValue: "garbage",
+			err:       errors.New("cannot parse log level string: Unknown level: garbage"),
+		},
+		"flag takes precedence": {
+			ctx:       newMockGetStringer(map[string]string{"x": "eror"}),
+			flagName:  "x",
+			tomlValue: "warn",
+			level:     log.LvlError,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			level, err := getLogLevel(testCase.ctx, testCase.flagName,
+				testCase.tomlValue, testCase.defaultLevel)
+
+			if testCase.err != nil {
+				assert.EqualError(t, err, testCase.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, testCase.level, level)
+		})
+	}
+}
+
+func Test_setLogConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		ctx               getStringer
+		initialCfg        ctoml.Config
+		initialGlobalCfg  dot.GlobalConfig
+		initialLogCfg     dot.LogConfig
+		expectedCfg       ctoml.Config
+		expectedGlobalCfg dot.GlobalConfig
+		expectedLogCfg    dot.LogConfig
+		err               error
+	}{
+		"no value": {
+			ctx: newMockGetStringer(map[string]string{}),
+			expectedCfg: ctoml.Config{
+				Global: ctoml.GlobalConfig{
+					LogLvl: log.LvlInfo.String(),
+				},
+			},
+			expectedGlobalCfg: dot.GlobalConfig{
+				LogLvl: log.LvlInfo,
+			},
+			expectedLogCfg: dot.LogConfig{
+				CoreLvl:           log.LvlInfo,
+				SyncLvl:           log.LvlInfo,
+				NetworkLvl:        log.LvlInfo,
+				RPCLvl:            log.LvlInfo,
+				StateLvl:          log.LvlInfo,
+				RuntimeLvl:        log.LvlInfo,
+				BlockProducerLvl:  log.LvlInfo,
+				FinalityGadgetLvl: log.LvlInfo,
+			},
+		},
+		"some values": {
+			ctx: newMockGetStringer(map[string]string{}),
+			initialCfg: ctoml.Config{
+				Log: ctoml.LogConfig{
+					CoreLvl:  log.LvlError.String(),
+					SyncLvl:  log.LvlDebug.String(),
+					StateLvl: log.LvlWarn.String(),
+				},
+			},
+			expectedCfg: ctoml.Config{
+				Global: ctoml.GlobalConfig{
+					LogLvl: log.LvlInfo.String(),
+				},
+				Log: ctoml.LogConfig{
+					CoreLvl:  log.LvlError.String(),
+					SyncLvl:  log.LvlDebug.String(),
+					StateLvl: log.LvlWarn.String(),
+				},
+			},
+			expectedGlobalCfg: dot.GlobalConfig{
+				LogLvl: log.LvlInfo,
+			},
+			expectedLogCfg: dot.LogConfig{
+				CoreLvl:           log.LvlError,
+				SyncLvl:           log.LvlDebug,
+				NetworkLvl:        log.LvlInfo,
+				RPCLvl:            log.LvlInfo,
+				StateLvl:          log.LvlWarn,
+				RuntimeLvl:        log.LvlInfo,
+				BlockProducerLvl:  log.LvlInfo,
+				FinalityGadgetLvl: log.LvlInfo,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := setLogConfig(testCase.ctx, &testCase.initialCfg,
+				&testCase.initialGlobalCfg, &testCase.initialLogCfg)
+
+			if testCase.err != nil {
+				assert.EqualError(t, err, testCase.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.expectedCfg, testCase.initialCfg)
+			assert.Equal(t, testCase.expectedGlobalCfg, testCase.initialGlobalCfg)
+			assert.Equal(t, testCase.expectedLogCfg, testCase.initialLogCfg)
+		})
+	}
 }

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -1089,7 +1089,7 @@ func Test_getLogLevel(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		ctx          getStringer
+		flagsKVStore stringKVStore
 		flagName     string
 		tomlValue    string
 		defaultLevel log.Lvl
@@ -1097,45 +1097,45 @@ func Test_getLogLevel(t *testing.T) {
 		err          error
 	}{
 		"no value with default": {
-			ctx:          newMockGetStringer(map[string]string{}),
+			flagsKVStore: newMockGetStringer(map[string]string{}),
 			defaultLevel: log.LvlError,
 			level:        log.LvlError,
 		},
 		"flag integer value": {
-			ctx:      newMockGetStringer(map[string]string{"x": "1"}),
-			flagName: "x",
-			level:    log.LvlError,
+			flagsKVStore: newMockGetStringer(map[string]string{"x": "1"}),
+			flagName:     "x",
+			level:        log.LvlError,
 		},
 		"flag string value": {
-			ctx:      newMockGetStringer(map[string]string{"x": "eror"}),
-			flagName: "x",
-			level:    log.LvlError,
+			flagsKVStore: newMockGetStringer(map[string]string{"x": "eror"}),
+			flagName:     "x",
+			level:        log.LvlError,
 		},
 		"flag bad string value": {
-			ctx:      newMockGetStringer(map[string]string{"x": "garbage"}),
-			flagName: "x",
-			err:      errors.New("cannot parse log level string: Unknown level: garbage"),
+			flagsKVStore: newMockGetStringer(map[string]string{"x": "garbage"}),
+			flagName:     "x",
+			err:          errors.New("cannot parse log level string: Unknown level: garbage"),
 		},
 		"toml integer value": {
-			ctx:       newMockGetStringer(map[string]string{}),
-			tomlValue: "1",
-			level:     log.LvlError,
+			flagsKVStore: newMockGetStringer(map[string]string{}),
+			tomlValue:    "1",
+			level:        log.LvlError,
 		},
 		"toml string value": {
-			ctx:       newMockGetStringer(map[string]string{}),
-			tomlValue: "eror",
-			level:     log.LvlError,
+			flagsKVStore: newMockGetStringer(map[string]string{}),
+			tomlValue:    "eror",
+			level:        log.LvlError,
 		},
 		"toml bad string value": {
-			ctx:       newMockGetStringer(map[string]string{}),
-			tomlValue: "garbage",
-			err:       errors.New("cannot parse log level string: Unknown level: garbage"),
+			flagsKVStore: newMockGetStringer(map[string]string{}),
+			tomlValue:    "garbage",
+			err:          errors.New("cannot parse log level string: Unknown level: garbage"),
 		},
 		"flag takes precedence": {
-			ctx:       newMockGetStringer(map[string]string{"x": "eror"}),
-			flagName:  "x",
-			tomlValue: "warn",
-			level:     log.LvlError,
+			flagsKVStore: newMockGetStringer(map[string]string{"x": "eror"}),
+			flagName:     "x",
+			tomlValue:    "warn",
+			level:        log.LvlError,
 		},
 	}
 
@@ -1144,7 +1144,7 @@ func Test_getLogLevel(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			level, err := getLogLevel(testCase.ctx, testCase.flagName,
+			level, err := getLogLevel(testCase.flagsKVStore, testCase.flagName,
 				testCase.tomlValue, testCase.defaultLevel)
 
 			if testCase.err != nil {
@@ -1207,7 +1207,7 @@ func Test_setLogConfig(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		ctx               getStringer
+		ctx               stringKVStore
 		initialCfg        ctoml.Config
 		initialGlobalCfg  dot.GlobalConfig
 		initialLogCfg     dot.LogConfig

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -1157,6 +1157,52 @@ func Test_getLogLevel(t *testing.T) {
 	}
 }
 
+func Test_parseLogLevelString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		logLevelString string
+		logLevel       log.Lvl
+		err            error
+	}{
+		"empty string": {
+			err: errors.New("cannot parse log level string: Unknown level: "),
+		},
+		"valid integer": {
+			logLevelString: "1",
+			logLevel:       log.LvlError,
+		},
+		"minus one": {
+			logLevelString: "-1",
+			err:            errors.New("log level integer can only be between 0 and 5 included: log level given: -1"),
+		},
+		"over 5": {
+			logLevelString: "6",
+			err:            errors.New("log level integer can only be between 0 and 5 included: log level given: 6"),
+		},
+		"valid string": {
+			logLevelString: "error",
+			logLevel:       log.LvlError,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			logLevel, err := parseLogLevelString(testCase.logLevelString)
+
+			if testCase.err != nil {
+				assert.EqualError(t, err, testCase.err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, testCase.logLevel, logLevel)
+		})
+	}
+}
+
 func Test_setLogConfig(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -89,9 +89,9 @@ var (
 		Usage: "Runtime package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: LogFlag.Value,
 	}
-	LogBlockProducerLevelFlag = cli.StringFlag{
+	LogBabeLevelFlag = cli.StringFlag{
 		Name:  "log-babe",
-		Usage: "Block producer package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Usage: "BABE package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: LogFlag.Value,
 	}
 	LogGrandpaLevelFlag = cli.StringFlag{
@@ -389,7 +389,7 @@ var (
 		LogRPCLevelFlag,
 		LogStateLevelFlag,
 		LogRuntimeLevelFlag,
-		LogBlockProducerLevelFlag,
+		LogBabeLevelFlag,
 		LogGrandpaLevelFlag,
 		NameFlag,
 		ChainFlag,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -56,9 +56,50 @@ var (
 	// LogFlag cli service settings
 	LogFlag = cli.StringFlag{
 		Name:  "log",
-		Usage: "Supports levels crit (silent) to trce (trace)",
+		Usage: "Global log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: log.LvlInfo.String(),
 	}
+	LogCoreLevelFlag = cli.StringFlag{
+		Name:  "log-core",
+		Usage: "Core package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogSyncLevelFlag = cli.StringFlag{
+		Name:  "log-sync",
+		Usage: "Sync package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogNetworkLevelFlag = cli.StringFlag{
+		Name:  "log-network",
+		Usage: "Network package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogRPCLevelFlag = cli.StringFlag{
+		Name:  "log-rpc",
+		Usage: "RPC package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogStateLevelFlag = cli.StringFlag{
+		Name:  "log-state",
+		Usage: "State package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogRuntimeLevelFlag = cli.StringFlag{
+		Name:  "log-runtime",
+		Usage: "Runtime package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogBlockProducerLevelFlag = cli.StringFlag{
+		Name:  "log-blockproducer",
+		Usage: "Block producer package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+	LogFinalityGadgetLevelFlag = cli.StringFlag{
+		Name:  "log-finalitygadget",
+		Usage: "Finality Gadget package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Value: LogFlag.Value,
+	}
+
 	// NameFlag node implementation name
 	NameFlag = cli.StringFlag{
 		Name:  "name",
@@ -342,6 +383,14 @@ var (
 	// GlobalFlags are flags that are valid for use with the root command and all subcommands
 	GlobalFlags = []cli.Flag{
 		LogFlag,
+		LogCoreLevelFlag,
+		LogSyncLevelFlag,
+		LogNetworkLevelFlag,
+		LogRPCLevelFlag,
+		LogStateLevelFlag,
+		LogRuntimeLevelFlag,
+		LogBlockProducerLevelFlag,
+		LogFinalityGadgetLevelFlag,
 		NameFlag,
 		ChainFlag,
 		ConfigFlag,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -95,7 +95,7 @@ var (
 		Value: LogFlag.Value,
 	}
 	LogFinalityGadgetLevelFlag = cli.StringFlag{
-		Name:  "log-finalitygadget",
+		Name:  "log-grandpa",
 		Usage: "Finality Gadget package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: LogFlag.Value,
 	}

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -90,7 +90,7 @@ var (
 		Value: LogFlag.Value,
 	}
 	LogBlockProducerLevelFlag = cli.StringFlag{
-		Name:  "log-blockproducer",
+		Name:  "log-babe",
 		Usage: "Block producer package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: LogFlag.Value,
 	}

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -94,9 +94,9 @@ var (
 		Usage: "Block producer package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: LogFlag.Value,
 	}
-	LogFinalityGadgetLevelFlag = cli.StringFlag{
+	LogGrandpaLevelFlag = cli.StringFlag{
 		Name:  "log-grandpa",
-		Usage: "Finality Gadget package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
+		Usage: "Grandpa package log level. Supports levels crit (silent), eror, warn, info, dbug and trce (trace)",
 		Value: LogFlag.Value,
 	}
 
@@ -390,7 +390,7 @@ var (
 		LogStateLevelFlag,
 		LogRuntimeLevelFlag,
 		LogBlockProducerLevelFlag,
-		LogFinalityGadgetLevelFlag,
+		LogGrandpaLevelFlag,
 		NameFlag,
 		ChainFlag,
 		ConfigFlag,


### PR DESCRIPTION
## Changes

- [x] Read log levels per package from flags
- [x] Flags take precedence over toml configuration file
- [x] Refactor code for simplicity and testability
- [x] Find substrate all possible target names (waiting on https://github.com/paritytech/substrate/issues/8025) and match them - ~they may not answer anytime soon~
- [x] Rebase on development once #1940 is merged to pass linting
- [x] Apply Eclesio's suggestion

## Tests

```
go test ^Test_setLogConfig$ github.com/ChainSafe/gossamer/cmd/gossamer
go test ^Test_getLogLevel$ github.com/ChainSafe/gossamer/cmd/gossamer
```

## Issues

- #1893 

## Primary Reviewer

- @noot 