### PR TITLE
fix(dot/network): fix memory allocations with `sizedBufferPool`

### DIFF
--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -402,7 +402,7 @@ func (s *Service) readHandshake(stream libp2pnetwork.Stream, decoder HandshakeDe
 	go func() {
 		msgBytes := s.bufPool.get()
 		defer func() {
-			s.bufPool.put(&msgBytes)
+			s.bufPool.put(msgBytes)
 			close(hsC)
 		}()
 

--- a/dot/network/pool.go
+++ b/dot/network/pool.go
@@ -21,10 +21,10 @@ type sizedBufferPool struct {
 	c chan []byte
 }
 
-func newSizedBufferPool(min, max int) (bp *sizedBufferPool) {
-	bufferCh := make(chan []byte, max)
+func newSizedBufferPool(preAllocate, size int) (bp *sizedBufferPool) {
+	bufferCh := make(chan []byte, size)
 
-	for i := 0; i < min; i++ {
+	for i := 0; i < preAllocate; i++ {
 		buf := make([]byte, maxMessageSize)
 		bufferCh <- buf
 	}

--- a/dot/network/pool_test.go
+++ b/dot/network/pool_test.go
@@ -1,0 +1,21 @@
+package network
+
+import "testing"
+
+func Benchmark_sizedBufferPool(b *testing.B) {
+	sbp := newSizedBufferPool(100, 200)
+
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			buffer := sbp.get()
+			buffer[0] = 1
+			buffer[len(buffer)-1] = 1
+			sbp.put(buffer)
+		}
+	})
+}
+
+// Before: 				104853	    	 11119 ns/op	   65598 B/op	       1 allocs/op
+// Array ptr: 		2742781	       438.3 ns/op	       2 B/op	       0 allocs/op
+// Slices: 				2560960	       463.8 ns/op	       2 B/op	       0 allocs/op
+// Slice pointer: 2683528	       460.8 ns/op	       2 B/op	       0 allocs/op

--- a/dot/network/pool_test.go
+++ b/dot/network/pool_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func Benchmark_sizedBufferPool(b *testing.B) {
-	sbp := newSizedBufferPool(100, 200)
+	const preAllocate = 100
+	const poolSize = 200
+	sbp := newSizedBufferPool(preAllocate, poolSize)
 
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
@@ -31,10 +33,10 @@ func Test_sizedBufferPool(t *testing.T) {
 	t.Parallel()
 
 	const preAlloc = 1
-	const maxQueueSize = 2
+	const poolSize = 2
 	const maxIndex = maxMessageSize - 1
 
-	pool := newSizedBufferPool(preAlloc, maxQueueSize)
+	pool := newSizedBufferPool(preAlloc, poolSize)
 
 	first := pool.get() // pre-allocated one
 	first[maxIndex] = 1
@@ -64,9 +66,9 @@ func Test_sizedBufferPool_race(t *testing.T) {
 	t.Parallel()
 
 	const preAlloc = 1
-	const maxQueueSize = 2
+	const poolSize = 2
 
-	pool := newSizedBufferPool(preAlloc, maxQueueSize)
+	pool := newSizedBufferPool(preAlloc, poolSize)
 
 	const parallelism = 4
 

--- a/dot/network/pool_test.go
+++ b/dot/network/pool_test.go
@@ -15,7 +15,7 @@ func Benchmark_sizedBufferPool(b *testing.B) {
 	})
 }
 
-// Before: 				104853	    	 11119 ns/op	   65598 B/op	       1 allocs/op
-// Array ptr: 		2742781	       438.3 ns/op	       2 B/op	       0 allocs/op
-// Slices: 				2560960	       463.8 ns/op	       2 B/op	       0 allocs/op
+// Before:        104853	    	 11119 ns/op	   65598 B/op	       1 allocs/op
+// Array ptr:     2742781	       438.3 ns/op	       2 B/op	       0 allocs/op
+// Slices:        2560960	       463.8 ns/op	       2 B/op	       0 allocs/op
 // Slice pointer: 2683528	       460.8 ns/op	       2 B/op	       0 allocs/op

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -148,12 +148,13 @@ func NewService(cfg *Config) (*Service, error) {
 	// pre-allocate pool of buffers used to read from streams.
 	// initially allocate as many buffers as liekly necessary which is the number inbound streams we will have,
 	// which should equal average number of peers times the number of notifications protocols, which is currently 3.
-	var bufPool *sizedBufferPool
-	preAllocatedInPool := 0
-	if !cfg.noPreAllocate {
-		preAllocatedInPool = cfg.MinPeers * 3
+	preAllocateInPool := cfg.MinPeers * 3
+	poolSize := cfg.MaxPeers * 3
+	if cfg.noPreAllocate { // testing
+		preAllocateInPool = 0
+		poolSize = cfg.MinPeers * 3
 	}
-	bufPool = newSizedBufferPool(preAllocatedInPool, cfg.MinPeers*3)
+	bufPool := newSizedBufferPool(preAllocateInPool, poolSize)
 
 	network := &Service{
 		ctx:                    ctx,


### PR DESCRIPTION
## Changes

- Use a slice instead of an array, since returning the array was effectively copying it

## Tests

```
go test -benchmem -run=Benchmark_sizedBufferPool github.com/ChainSafe/gossamer/dot/network
```

## Issues

- Related to #1936 and found by reviewing PR #1913 

## Primary Reviewer

- Anyone is welcome