### PR TITLE
docs(codestyle): `String() string` methods

### DIFF
--- a/.github/CODE_STYLE.md
+++ b/.github/CODE_STYLE.md
@@ -1,3 +1,8 @@
 # Code style
 
 🚧 work in progress! 🚧
+
+## Add `String() string` methods
+
+Add `String() string` methods to new types, so they can easily be logged.
+💁 You should try de-referencing pointer fields in your method, to avoid logging pointer addresses.


### PR DESCRIPTION
## Changes

- Add `String() string` method for new types in code style

## Tests

## Issues

## Primary Reviewer
