### PR TITLE
chore(ci): pin `golangci-lint` version to `v1.43`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,8 +14,8 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        with:          
-          version: 'latest'
+        with:
+          version: v1.43
           args: -v
 
   vet-check:
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.x'
+          go-version: "1.15.x"
       - uses: actions/checkout@v2
 
       - name: Run go vet

--- a/scripts/install-lint.sh
+++ b/scripts/install-lint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [[ -z "${GOPATH}" ]]; then 
+if [[ -z "${GOPATH}" ]]; then
 	export GOPATH=~/go
 fi
 
 if ! command -v golangci-lint &> /dev/null
 then
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.0
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
 fi
 
 export PATH=$PATH:$(go env GOPATH)/bin


### PR DESCRIPTION
## Changes

- Update `install-lint.sh` to use v1.43.0
- Pin golangci-lint workflow to use v1.43

## Tests

## Issues

## Primary Reviewer
