### PR TITLE
fix(lib/grandpa): use `defaultGrandpaInterval` if not set, fixes error on startup

### DIFF
--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -101,9 +101,6 @@ var (
 	// ErrAuthorityNotInSet is returned when a precommit within a justification is signed by a key not in the authority set
 	ErrAuthorityNotInSet = errors.New("authority is not in set")
 
-	// ErrZeroInterval is returned when the grandpa sub-round interval is set to 0
-	ErrZeroInterval = errors.New("cannot have zero second interval")
-
 	errVoteExists              = errors.New("already have vote")
 	errVoteToSignatureMismatch = errors.New("votes and authority count mismatch")
 	errInvalidVoteBlock        = errors.New("block in vote is not descendant of previously finalised block")

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	finalityGrandpaRoundMetrics = "gossamer/finality/grandpa/round"
+	defaultGrandpaInterval      = time.Second
 )
 
 var (
@@ -147,7 +148,7 @@ func NewService(cfg *Config) (*Service, error) {
 	}
 
 	if cfg.Interval == 0 {
-		return nil, ErrZeroInterval
+		cfg.Interval = defaultGrandpaInterval
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- recent PR that got merged broke starting with `--chain kusama` and `--chain polkadot`, this fixes it by using the default grandpa interval of 1s if the interval is not set


## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
make gossamer
./bin/gossamer --chain polkadot
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- n/a

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @EclesioMeloJunior 
