### PR TITLE
docs(copyright): Update copyright generation and notice per file

### DIFF
--- a/.github/PULL_REQUEST/pull_request.go
+++ b/.github/PULL_REQUEST/pull_request.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/.github/PULL_REQUEST/pull_request.go
+++ b/.github/PULL_REQUEST/pull_request.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,0 +1,34 @@
+name: Copyright check
+on:
+  pull_request:
+    branches:
+      - development
+    paths:
+      - .github/workflows/copyright.yml
+      - "**/*.go"
+      - "**/*.proto"
+
+jobs:
+  copyright-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: go install github.com/google/addlicense@v1.0.0
+
+      - name: copyright check with addlicense
+        run: |
+          addlicense -v -check \
+            -s=only \
+            -f ./copyright.txt \
+            -c "ChainSafe Systems (ON)" \
+            -ignore "**/*.md" \
+            -ignore "**/*.html" \
+            -ignore "**/*.css" \
+            -ignore "**/*.scss" \
+            -ignore "**/*.yml" \
+            -ignore "**/*.yaml" \
+            -ignore "**/*.js" \
+            -ignore "**/*.sh" \
+            -ignore "*Dockerfile" \
+            .

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           addlicense -v -check \
             -s=only \
+            -l="LGPL-3.0-only" \
             -f ./copyright.txt \
             -c "ChainSafe Systems (ON)" \
             -ignore "**/*.md" \

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.17"
+
       - run: go install github.com/google/addlicense@v1.0.0
 
       - name: copyright check with addlicense

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,20 @@ $(ADDLICENSE):
 .PHONY: license
 license: $(ADDLICENSE)
 	@echo "  >  \033[32mAdding license headers...\033[0m "
-	addlicense -c gossamer -f ./copyright.txt -y 2019 .
+	addlicense -v \
+		-s=only \
+		-f ./copyright.txt \
+		-c "ChainSafe Systems (ON)" \
+		-ignore "**/*.md" \
+		-ignore "**/*.html" \
+		-ignore "**/*.css" \
+		-ignore "**/*.scss" \
+		-ignore "**/*.yml" \
+		-ignore "**/*.yaml" \
+		-ignore "**/*.js" \
+		-ignore "**/*.sh" \
+		-ignore "*Dockerfile" \
+		.
 
 docker: docker-build
 	@echo "  >  \033[32mStarting Gossamer Container...\033[0m "

--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,11 @@ start:
 	@echo "  >  \033[32mStarting node...\033[0m "
 	./bin/gossamer --key alice
 
-$(ADDLICENSE):
-	go install github.com/google/addlicense@v1.0.0
-
 ## license: Adds license header to missing files, go install addlicense if it's missing.
 .PHONY: license
-license: $(ADDLICENSE)
+license:
 	@echo "  >  \033[32mAdding license headers...\033[0m "
+	go install github.com/google/addlicense@v1.0.0
 	addlicense -v \
 		-s=only \
 		-f ./copyright.txt \

--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,9 @@ start:
 	./bin/gossamer --key alice
 
 $(ADDLICENSE):
-	go get -u github.com/google/addlicense
+	go install github.com/google/addlicense@v1.0.0
 
-## license: Adds license header to missing files, go gets addLicense if missing. Runs `addlicense -c gossamer -f ./copyright.txt -y 2019 .` on project files.
+## license: Adds license header to missing files, go install addlicense if it's missing.
 .PHONY: license
 license: $(ADDLICENSE)
 	@echo "  >  \033[32mAdding license headers...\033[0m "

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ license:
 	go install github.com/google/addlicense@v1.0.0
 	addlicense -v \
 		-s=only \
+		-l="LGPL-3.0-only" \
 		-f ./copyright.txt \
 		-c "ChainSafe Systems (ON)" \
 		-ignore "**/*.md" \

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dev
 

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dev
 
 import (

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dev
 
 import (

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package gssmr
 
 import (

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package gssmr
 
 import (

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package gssmr
 

--- a/chain/kusama/defaults.go
+++ b/chain/kusama/defaults.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package kusama
 

--- a/chain/kusama/defaults.go
+++ b/chain/kusama/defaults.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package kusama
 
 import (

--- a/chain/kusama/defaults.go
+++ b/chain/kusama/defaults.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package kusama
 
 import (

--- a/chain/polkadot/defaults.go
+++ b/chain/polkadot/defaults.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package polkadot
 
 import (

--- a/chain/polkadot/defaults.go
+++ b/chain/polkadot/defaults.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package polkadot
 

--- a/chain/polkadot/defaults.go
+++ b/chain/polkadot/defaults.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package polkadot
 
 import (

--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/account_test.go
+++ b/cmd/gossamer/account_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/account_test.go
+++ b/cmd/gossamer/account_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/account_test.go
+++ b/cmd/gossamer/account_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/import_runtime.go
+++ b/cmd/gossamer/import_runtime.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/import_runtime.go
+++ b/cmd/gossamer/import_runtime.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/import_runtime.go
+++ b/cmd/gossamer/import_runtime.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/import_runtime_test.go
+++ b/cmd/gossamer/import_runtime_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/import_runtime_test.go
+++ b/cmd/gossamer/import_runtime_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/import_runtime_test.go
+++ b/cmd/gossamer/import_runtime_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/profile.go
+++ b/cmd/gossamer/profile.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/profile.go
+++ b/cmd/gossamer/profile.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/profile.go
+++ b/cmd/gossamer/profile.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/prune_test.go
+++ b/cmd/gossamer/prune_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/prune_test.go
+++ b/cmd/gossamer/prune_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/toml_config.go
+++ b/cmd/gossamer/toml_config.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/toml_config.go
+++ b/cmd/gossamer/toml_config.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/toml_config.go
+++ b/cmd/gossamer/toml_config.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/toml_config_test.go
+++ b/cmd/gossamer/toml_config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/toml_config_test.go
+++ b/cmd/gossamer/toml_config_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package main
 

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package main
 
 import (

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,4 +1,4 @@
-Copyright 2019 ChainSafe Systems (ON) Corp.
+Copyright 2021 ChainSafe Systems (ON) Corp.
 This file is part of gossamer.
 
 The gossamer library is free software: you can redistribute it and/or modify

--- a/dot/build_spec.go
+++ b/dot/build_spec.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/build_spec.go
+++ b/dot/build_spec.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/build_spec.go
+++ b/dot/build_spec.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/build_spec_test.go
+++ b/dot/build_spec_test.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package dot
 
 import (

--- a/dot/build_spec_test.go
+++ b/dot/build_spec_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/build_spec_test.go
+++ b/dot/build_spec_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/config.go
+++ b/dot/config.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/config.go
+++ b/dot/config.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/config.go
+++ b/dot/config.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package toml
 
 // Config is a collection of configurations throughout the system

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package toml
 

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package toml
 
 // Config is a collection of configurations throughout the system

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package core
 
 import (

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package core
 
 import (

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package core
 
 import (

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package core
 
 import (

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package core
 
 import (

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package core
 
 import (

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package core
 
 import (

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package core
 

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import (

--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package digest
 
 import (

--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package digest
 

--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package digest
 
 import (

--- a/dot/digest/digest_test.go
+++ b/dot/digest/digest_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package digest
 
 import (

--- a/dot/digest/digest_test.go
+++ b/dot/digest/digest_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package digest
 

--- a/dot/digest/digest_test.go
+++ b/dot/digest/digest_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package digest
 
 import (

--- a/dot/digest/interface.go
+++ b/dot/digest/interface.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package digest
 
 import (

--- a/dot/digest/interface.go
+++ b/dot/digest/interface.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package digest
 

--- a/dot/digest/interface.go
+++ b/dot/digest/interface.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package digest
 
 import (

--- a/dot/errors.go
+++ b/dot/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/errors.go
+++ b/dot/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/errors.go
+++ b/dot/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/import.go
+++ b/dot/import.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/import.go
+++ b/dot/import.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/import.go
+++ b/dot/import.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/metrics/collector.go
+++ b/dot/metrics/collector.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package metrics
 
 import (

--- a/dot/metrics/collector.go
+++ b/dot/metrics/collector.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package metrics
 

--- a/dot/metrics/collector.go
+++ b/dot/metrics/collector.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import (

--- a/dot/metrics/metrics.go
+++ b/dot/metrics/metrics.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package metrics
 
 import (

--- a/dot/metrics/metrics.go
+++ b/dot/metrics/metrics.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package metrics
 

--- a/dot/metrics/metrics.go
+++ b/dot/metrics/metrics.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import (

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/connmgr_test.go
+++ b/dot/network/connmgr_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/connmgr_test.go
+++ b/dot/network/connmgr_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/connmgr_test.go
+++ b/dot/network/connmgr_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/discovery_test.go
+++ b/dot/network/discovery_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/discovery_test.go
+++ b/dot/network/discovery_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/discovery_test.go
+++ b/dot/network/discovery_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/gossip.go
+++ b/dot/network/gossip.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/gossip.go
+++ b/dot/network/gossip.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/gossip.go
+++ b/dot/network/gossip.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more detailg.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/gossip_test.go
+++ b/dot/network/gossip_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/light.go
+++ b/dot/network/light.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/light.go
+++ b/dot/network/light.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/light_test.go
+++ b/dot/network/light_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/light_test.go
+++ b/dot/network/light_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/mdns.go
+++ b/dot/network/mdns.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/mdns.go
+++ b/dot/network/mdns.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/mdns.go
+++ b/dot/network/mdns.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more detailg.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/mdns_test.go
+++ b/dot/network/mdns_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/mdns_test.go
+++ b/dot/network/mdns_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/mdns_test.go
+++ b/dot/network/mdns_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/message_cache.go
+++ b/dot/network/message_cache.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/message_cache.go
+++ b/dot/network/message_cache.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/message_cache_test.go
+++ b/dot/network/message_cache_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/message_cache_test.go
+++ b/dot/network/message_cache_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/message_test.go
+++ b/dot/network/message_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/message_test.go
+++ b/dot/network/message_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/message_test.go
+++ b/dot/network/message_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/pool.go
+++ b/dot/network/pool.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 // sizedBufferPool is a pool of buffers used for reading from streams

--- a/dot/network/pool.go
+++ b/dot/network/pool.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/pool.go
+++ b/dot/network/pool.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 // sizedBufferPool is a pool of buffers used for reading from streams

--- a/dot/network/proto/api.v1.proto
+++ b/dot/network/proto/api.v1.proto
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 // Schema definition for block request/response messages.
 

--- a/dot/network/proto/api.v1.proto
+++ b/dot/network/proto/api.v1.proto
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema definition for block request/response messages.
 
 syntax = "proto3";

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/state.go
+++ b/dot/network/state.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/state.go
+++ b/dot/network/state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/state.go
+++ b/dot/network/state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/stream_manager.go
+++ b/dot/network/stream_manager.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/stream_manager.go
+++ b/dot/network/stream_manager.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/stream_manager_test.go
+++ b/dot/network/stream_manager_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/stream_manager_test.go
+++ b/dot/network/stream_manager_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/sync_test.go
+++ b/dot/network/sync_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/sync_test.go
+++ b/dot/network/sync_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/sync_test.go
+++ b/dot/network/sync_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/test_helpers.go
+++ b/dot/network/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/test_helpers.go
+++ b/dot/network/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/transaction.go
+++ b/dot/network/transaction.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/transaction.go
+++ b/dot/network/transaction.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/transaction.go
+++ b/dot/network/transaction.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/transaction_test.go
+++ b/dot/network/transaction_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/transaction_test.go
+++ b/dot/network/transaction_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/transaction_test.go
+++ b/dot/network/transaction_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/utils_test.go
+++ b/dot/network/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package network
 
 import (

--- a/dot/network/utils_test.go
+++ b/dot/network/utils_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package network
 

--- a/dot/network/utils_test.go
+++ b/dot/network/utils_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more detailg.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package network
 
 import (

--- a/dot/node.go
+++ b/dot/node.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/node.go
+++ b/dot/node.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/node.go
+++ b/dot/node.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/peerset/constants.go
+++ b/dot/peerset/constants.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import "math"

--- a/dot/peerset/errors.go
+++ b/dot/peerset/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import "errors"

--- a/dot/peerset/handler.go
+++ b/dot/peerset/handler.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import "github.com/libp2p/go-libp2p-core/peer"

--- a/dot/peerset/peerset.go
+++ b/dot/peerset/peerset.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import (

--- a/dot/peerset/peerset_test.go
+++ b/dot/peerset/peerset_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import (

--- a/dot/peerset/peerstate.go
+++ b/dot/peerset/peerstate.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import (

--- a/dot/peerset/peerstate_test.go
+++ b/dot/peerset/peerstate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import (

--- a/dot/peerset/test_helpers.go
+++ b/dot/peerset/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package peerset
 
 import (

--- a/dot/rpc/dot_up_codec.go
+++ b/dot/rpc/dot_up_codec.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/dot_up_codec.go
+++ b/dot/rpc/dot_up_codec.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/dot/rpc/dot_up_codec.go
+++ b/dot/rpc/dot_up_codec.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/dot_up_codec_test.go
+++ b/dot/rpc/dot_up_codec_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/dot_up_codec_test.go
+++ b/dot/rpc/dot_up_codec_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/dot/rpc/dot_up_codec_test.go
+++ b/dot/rpc/dot_up_codec_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/helpers.go
+++ b/dot/rpc/helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/dot/rpc/helpers.go
+++ b/dot/rpc/helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/helpers.go
+++ b/dot/rpc/helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/json2/server.go
+++ b/dot/rpc/json2/server.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package json2
 

--- a/dot/rpc/json2/server.go
+++ b/dot/rpc/json2/server.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package json2
 
 import (

--- a/dot/rpc/json2/server.go
+++ b/dot/rpc/json2/server.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package json2
 
 import (

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/api_mocks.go
+++ b/dot/rpc/modules/api_mocks.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/api_mocks.go
+++ b/dot/rpc/modules/api_mocks.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/api_mocks_test.go
+++ b/dot/rpc/modules/api_mocks_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/api_mocks_test.go
+++ b/dot/rpc/modules/api_mocks_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/api_mocks_test.go
+++ b/dot/rpc/modules/api_mocks_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/author.go
+++ b/dot/rpc/modules/author.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build integration
 // +build integration
 

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
 // +build integration

--- a/dot/rpc/modules/author_test.go
+++ b/dot/rpc/modules/author_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/author_test.go
+++ b/dot/rpc/modules/author_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/childstate.go
+++ b/dot/rpc/modules/childstate.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/childstate.go
+++ b/dot/rpc/modules/childstate.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/childstate.go
+++ b/dot/rpc/modules/childstate.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/errors.go
+++ b/dot/rpc/modules/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import "errors"

--- a/dot/rpc/modules/errors.go
+++ b/dot/rpc/modules/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/errors.go
+++ b/dot/rpc/modules/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import "errors"

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/grandpa_test.go
+++ b/dot/rpc/modules/grandpa_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/grandpa_test.go
+++ b/dot/rpc/modules/grandpa_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/grandpa_test.go
+++ b/dot/rpc/modules/grandpa_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/offchain.go
+++ b/dot/rpc/modules/offchain.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/offchain.go
+++ b/dot/rpc/modules/offchain.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/offchain_test.go
+++ b/dot/rpc/modules/offchain_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/offchain_test.go
+++ b/dot/rpc/modules/offchain_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/payment.go
+++ b/dot/rpc/modules/payment.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/payment.go
+++ b/dot/rpc/modules/payment.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/payment_test.go
+++ b/dot/rpc/modules/payment_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/payment_test.go
+++ b/dot/rpc/modules/payment_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/rpc.go
+++ b/dot/rpc/modules/rpc.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/rpc.go
+++ b/dot/rpc/modules/rpc.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/rpc.go
+++ b/dot/rpc/modules/rpc.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/state.go
+++ b/dot/rpc/modules/state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/state.go
+++ b/dot/rpc/modules/state.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/state.go
+++ b/dot/rpc/modules/state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package modules
 
 import (

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/sync_state.go
+++ b/dot/rpc/modules/sync_state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/sync_state.go
+++ b/dot/rpc/modules/sync_state.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/sync_state.go
+++ b/dot/rpc/modules/sync_state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/sync_state_test.go
+++ b/dot/rpc/modules/sync_state_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/sync_state_test.go
+++ b/dot/rpc/modules/sync_state_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package modules
 

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package modules
 
 import (

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package modules
 
 import (

--- a/dot/rpc/service.go
+++ b/dot/rpc/service.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/dot/rpc/service.go
+++ b/dot/rpc/service.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/service.go
+++ b/dot/rpc/service.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/service_test.go
+++ b/dot/rpc/service_test.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package rpc
 
 import (

--- a/dot/rpc/service_test.go
+++ b/dot/rpc/service_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/service_test.go
+++ b/dot/rpc/service_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package subscription
 
 import (

--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package subscription
 

--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package subscription
 
 import (

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package subscription
 
 import (

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package subscription
 

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package subscription
 
 import (

--- a/dot/rpc/subscription/messages.go
+++ b/dot/rpc/subscription/messages.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package subscription
 

--- a/dot/rpc/subscription/messages.go
+++ b/dot/rpc/subscription/messages.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package subscription
 
 // BaseResponseJSON for base json response

--- a/dot/rpc/subscription/messages.go
+++ b/dot/rpc/subscription/messages.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package subscription
 
 // BaseResponseJSON for base json response

--- a/dot/rpc/subscription/subscription.go
+++ b/dot/rpc/subscription/subscription.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package subscription
 
 import (

--- a/dot/rpc/subscription/subscription.go
+++ b/dot/rpc/subscription/subscription.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package subscription
 

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package subscription
 
 import (

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package subscription
 

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package subscription
 
 import (

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package subscription
 
 import (

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package subscription
 

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package rpc
 
 import (

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/dot/services.go
+++ b/dot/services.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/services.go
+++ b/dot/services.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/services.go
+++ b/dot/services.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/state/base.go
+++ b/dot/state/base.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/base.go
+++ b/dot/state/base.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/base.go
+++ b/dot/state/base.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/base_test.go
+++ b/dot/state/base_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/base_test.go
+++ b/dot/state/base_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_data.go
+++ b/dot/state/block_data.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_data.go
+++ b/dot/state/block_data.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_data.go
+++ b/dot/state/block_data.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_notify.go
+++ b/dot/state/block_notify.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_notify.go
+++ b/dot/state/block_notify.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_notify.go
+++ b/dot/state/block_notify.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/bloom.go
+++ b/dot/state/bloom.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/bloom.go
+++ b/dot/state/bloom.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/pruner/pruner.go
+++ b/dot/state/pruner/pruner.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package pruner
 

--- a/dot/state/pruner/pruner.go
+++ b/dot/state/pruner/pruner.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package pruner
 
 import (

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/storage_notify.go
+++ b/dot/state/storage_notify.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/storage_notify.go
+++ b/dot/state/storage_notify.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/storage_notify.go
+++ b/dot/state/storage_notify.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package state
 
 import (

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package state
 
 import (

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package state
 
 import (

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/transaction.go
+++ b/dot/state/transaction.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/transaction.go
+++ b/dot/state/transaction.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/state/transaction_test.go
+++ b/dot/state/transaction_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package state
 
 import (

--- a/dot/state/transaction_test.go
+++ b/dot/state/transaction_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package state
 

--- a/dot/sync/benchmark.go
+++ b/dot/sync/benchmark.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/benchmark.go
+++ b/dot/sync/benchmark.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/benchmark.go
+++ b/dot/sync/benchmark.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/block_queue.go
+++ b/dot/sync/block_queue.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/block_queue.go
+++ b/dot/sync/block_queue.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/block_queue.go
+++ b/dot/sync/block_queue.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/bootstrap_syncer.go
+++ b/dot/sync/bootstrap_syncer.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/bootstrap_syncer.go
+++ b/dot/sync/bootstrap_syncer.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/bootstrap_syncer.go
+++ b/dot/sync/bootstrap_syncer.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/bootstrap_syncer_test.go
+++ b/dot/sync/bootstrap_syncer_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/bootstrap_syncer_test.go
+++ b/dot/sync/bootstrap_syncer_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/bootstrap_syncer_test.go
+++ b/dot/sync/bootstrap_syncer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/disjoint_block_set.go
+++ b/dot/sync/disjoint_block_set.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/disjoint_block_set.go
+++ b/dot/sync/disjoint_block_set.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/disjoint_block_set.go
+++ b/dot/sync/disjoint_block_set.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/disjoint_block_set_test.go
+++ b/dot/sync/disjoint_block_set_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/disjoint_block_set_test.go
+++ b/dot/sync/disjoint_block_set_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/disjoint_block_set_test.go
+++ b/dot/sync/disjoint_block_set_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/errors.go
+++ b/dot/sync/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/errors.go
+++ b/dot/sync/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/errors.go
+++ b/dot/sync/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/message.go
+++ b/dot/sync/message.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/message.go
+++ b/dot/sync/message.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/message.go
+++ b/dot/sync/message.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/message_test.go
+++ b/dot/sync/message_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/message_test.go
+++ b/dot/sync/message_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/test_helpers.go
+++ b/dot/sync/test_helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/test_helpers.go
+++ b/dot/sync/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/test_helpers.go
+++ b/dot/sync/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/tip_syncer_test.go
+++ b/dot/sync/tip_syncer_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/tip_syncer_test.go
+++ b/dot/sync/tip_syncer_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/tip_syncer_test.go
+++ b/dot/sync/tip_syncer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync
 
 import (

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/dot/system/service.go
+++ b/dot/system/service.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package system
 
 import (

--- a/dot/system/service.go
+++ b/dot/system/service.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package system
 
 import (

--- a/dot/system/service.go
+++ b/dot/system/service.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package system
 

--- a/dot/system/service_test.go
+++ b/dot/system/service_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package system
 
 import (

--- a/dot/system/service_test.go
+++ b/dot/system/service_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package system
 
 import (

--- a/dot/system/service_test.go
+++ b/dot/system/service_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package system
 

--- a/dot/telemetry/block_import.go
+++ b/dot/telemetry/block_import.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/block_import.go
+++ b/dot/telemetry/block_import.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/block_import.go
+++ b/dot/telemetry/block_import.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import (

--- a/dot/telemetry/network_state.go
+++ b/dot/telemetry/network_state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/network_state.go
+++ b/dot/telemetry/network_state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/network_state.go
+++ b/dot/telemetry/network_state.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import (

--- a/dot/telemetry/notify_finalized.go
+++ b/dot/telemetry/notify_finalized.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/notify_finalized.go
+++ b/dot/telemetry/notify_finalized.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/notify_finalized.go
+++ b/dot/telemetry/notify_finalized.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import (

--- a/dot/telemetry/prepared_block_for_proposing.go
+++ b/dot/telemetry/prepared_block_for_proposing.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/prepared_block_for_proposing.go
+++ b/dot/telemetry/prepared_block_for_proposing.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/prepared_block_for_proposing.go
+++ b/dot/telemetry/prepared_block_for_proposing.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import (

--- a/dot/telemetry/system_connected.go
+++ b/dot/telemetry/system_connected.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import "github.com/ChainSafe/gossamer/lib/common"

--- a/dot/telemetry/system_connected.go
+++ b/dot/telemetry/system_connected.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/system_connected.go
+++ b/dot/telemetry/system_connected.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import "github.com/ChainSafe/gossamer/lib/common"

--- a/dot/telemetry/system_interval.go
+++ b/dot/telemetry/system_interval.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/system_interval.go
+++ b/dot/telemetry/system_interval.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/system_interval.go
+++ b/dot/telemetry/system_interval.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import (

--- a/dot/telemetry/telemetry.go
+++ b/dot/telemetry/telemetry.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/telemetry.go
+++ b/dot/telemetry/telemetry.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/telemetry/telemetry.go
+++ b/dot/telemetry/telemetry.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package telemetry
 
 import (

--- a/dot/telemetry/telemetry_test.go
+++ b/dot/telemetry/telemetry_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/dot/telemetry/telemetry_test.go
+++ b/dot/telemetry/telemetry_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package telemetry
 

--- a/dot/types/account.go
+++ b/dot/types/account.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/account.go
+++ b/dot/types/account.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/authority.go
+++ b/dot/types/authority.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/authority.go
+++ b/dot/types/authority.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package types
 
 import (

--- a/dot/types/authority.go
+++ b/dot/types/authority.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/babe.go
+++ b/dot/types/babe.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/babe.go
+++ b/dot/types/babe.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package types
 
 import (

--- a/dot/types/babe.go
+++ b/dot/types/babe.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/babe_digest.go
+++ b/dot/types/babe_digest.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/babe_digest.go
+++ b/dot/types/babe_digest.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/babe_digest.go
+++ b/dot/types/babe_digest.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/babe_digest_test.go
+++ b/dot/types/babe_digest_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/babe_digest_test.go
+++ b/dot/types/babe_digest_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/babe_digest_test.go
+++ b/dot/types/babe_digest_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/babe_test.go
+++ b/dot/types/babe_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/babe_test.go
+++ b/dot/types/babe_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/block.go
+++ b/dot/types/block.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/block.go
+++ b/dot/types/block.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/block.go
+++ b/dot/types/block.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/block_data.go
+++ b/dot/types/block_data.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/block_data.go
+++ b/dot/types/block_data.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/block_data.go
+++ b/dot/types/block_data.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/block_data_test.go
+++ b/dot/types/block_data_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/block_data_test.go
+++ b/dot/types/block_data_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/block_data_test.go
+++ b/dot/types/block_data_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/block_test.go
+++ b/dot/types/block_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/block_test.go
+++ b/dot/types/block_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/block_test.go
+++ b/dot/types/block_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/body.go
+++ b/dot/types/body.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/body.go
+++ b/dot/types/body.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/body.go
+++ b/dot/types/body.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/body_test.go
+++ b/dot/types/body_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/body_test.go
+++ b/dot/types/body_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/body_test.go
+++ b/dot/types/body_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/consensus_digest.go
+++ b/dot/types/consensus_digest.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/consensus_digest.go
+++ b/dot/types/consensus_digest.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/consensus_digest_test.go
+++ b/dot/types/consensus_digest_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/consensus_digest_test.go
+++ b/dot/types/consensus_digest_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/consensus_digest_test.go
+++ b/dot/types/consensus_digest_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/digest_test.go
+++ b/dot/types/digest_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/digest_test.go
+++ b/dot/types/digest_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/digest_test.go
+++ b/dot/types/digest_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/extrinsic.go
+++ b/dot/types/extrinsic.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/extrinsic.go
+++ b/dot/types/extrinsic.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/extrinsic.go
+++ b/dot/types/extrinsic.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/header.go
+++ b/dot/types/header.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/header.go
+++ b/dot/types/header.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/header.go
+++ b/dot/types/header.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/header_test.go
+++ b/dot/types/header_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/header_test.go
+++ b/dot/types/header_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/header_test.go
+++ b/dot/types/header_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/inherents.go
+++ b/dot/types/inherents.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/inherents.go
+++ b/dot/types/inherents.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/inherents.go
+++ b/dot/types/inherents.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/roles.go
+++ b/dot/types/roles.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/roles.go
+++ b/dot/types/roles.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 const (

--- a/dot/types/roles.go
+++ b/dot/types/roles.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 const (

--- a/dot/types/system.go
+++ b/dot/types/system.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 // SystemInfo struct to hold system related information

--- a/dot/types/system.go
+++ b/dot/types/system.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/types/tx.go
+++ b/dot/types/tx.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/dot/types/tx.go
+++ b/dot/types/tx.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/dot/types/tx.go
+++ b/dot/types/tx.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package dot
 
 import (

--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package dot
 
 import (

--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package dot
 

--- a/internal/log/caller.go
+++ b/internal/log/caller.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/caller_test.go
+++ b/internal/log/caller_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/caller_test.go
+++ b/internal/log/caller_test.go
@@ -31,7 +31,7 @@ func Test_getCallerString(t *testing.T) {
 				line: boolPtr(true),
 				funC: boolPtr(false),
 			},
-			s: "caller_test.go:L55",
+			s: "caller_test.go:L58",
 		},
 		"show all": {
 			settings: callerSettings{
@@ -39,7 +39,7 @@ func Test_getCallerString(t *testing.T) {
 				line: boolPtr(true),
 				funC: boolPtr(true),
 			},
-			s: "caller_test.go:L55:func2",
+			s: "caller_test.go:L58:func2",
 		},
 	}
 

--- a/internal/log/format.go
+++ b/internal/log/format.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 // Format is the format to use.

--- a/internal/log/global.go
+++ b/internal/log/global.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 // TODO do not use a global logger.

--- a/internal/log/global_test.go
+++ b/internal/log/global_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/helpers_test.go
+++ b/internal/log/helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 // RFC3339 format

--- a/internal/log/interfaces.go
+++ b/internal/log/interfaces.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 // ChildConstructor is the interface to create child loggers.

--- a/internal/log/level.go
+++ b/internal/log/level.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/level_test.go
+++ b/internal/log/level_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package log
 
 import (

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package log
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/options.go
+++ b/internal/log/options.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/patch.go
+++ b/internal/log/patch.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 // Patch patches the existing settings with any option given.

--- a/internal/log/patch_test.go
+++ b/internal/log/patch_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/race_test.go
+++ b/internal/log/race_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/internal/log/settings.go
+++ b/internal/log/settings.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package log
 
 import (

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/build_test.go
+++ b/lib/babe/build_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/build_test.go
+++ b/lib/babe/build_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/build_test.go
+++ b/lib/babe/build_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/crypto.go
+++ b/lib/babe/crypto.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/crypto.go
+++ b/lib/babe/crypto.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package babe
 
 import (

--- a/lib/babe/crypto.go
+++ b/lib/babe/crypto.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/crypto_test.go
+++ b/lib/babe/crypto_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/crypto_test.go
+++ b/lib/babe/crypto_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/epoch_test.go
+++ b/lib/babe/epoch_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/epoch_test.go
+++ b/lib/babe/epoch_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/epoch_test.go
+++ b/lib/babe/epoch_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/errors.go
+++ b/lib/babe/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 // The gossamer library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by

--- a/lib/babe/errors.go
+++ b/lib/babe/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 // The gossamer library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/lib/babe/errors_test.go
+++ b/lib/babe/errors_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/errors_test.go
+++ b/lib/babe/errors_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/secondary.go
+++ b/lib/babe/secondary.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/secondary.go
+++ b/lib/babe/secondary.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package babe
 
 import (

--- a/lib/babe/secondary.go
+++ b/lib/babe/secondary.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/secondary_test.go
+++ b/lib/babe/secondary_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/secondary_test.go
+++ b/lib/babe/secondary_test.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package babe
 
 import (

--- a/lib/babe/secondary_test.go
+++ b/lib/babe/secondary_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/types.go
+++ b/lib/babe/types.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/types.go
+++ b/lib/babe/types.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/types.go
+++ b/lib/babe/types.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package babe
 
 import (

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package babe
 
 import (

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package babe
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package blocktree
 
 import (

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package blocktree
 
 import (

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package blocktree
 

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package blocktree
 
 import (

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package blocktree
 
 import (

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package blocktree
 

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package blocktree
 
 import (

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package blocktree
 

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package blocktree
 
 import (

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package blocktree
 
 import (

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package blocktree
 

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package blocktree
 
 import (

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package blocktree
 
 import (

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package blocktree
 

--- a/lib/blocktree/node_test.go
+++ b/lib/blocktree/node_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package blocktree
 
 import (

--- a/lib/blocktree/node_test.go
+++ b/lib/blocktree/node_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package blocktree
 
 import (

--- a/lib/blocktree/node_test.go
+++ b/lib/blocktree/node_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package blocktree
 

--- a/lib/common/address.go
+++ b/lib/common/address.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/address.go
+++ b/lib/common/address.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 // Address represents a base58 encoded public key

--- a/lib/common/address.go
+++ b/lib/common/address.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 // Address represents a base58 encoded public key

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 import (

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 import (

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/db_keys.go
+++ b/lib/common/db_keys.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/db_keys.go
+++ b/lib/common/db_keys.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 var (

--- a/lib/common/db_keys.go
+++ b/lib/common/db_keys.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 var (

--- a/lib/common/hash.go
+++ b/lib/common/hash.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/hash.go
+++ b/lib/common/hash.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 import (

--- a/lib/common/hash.go
+++ b/lib/common/hash.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/hash_test.go
+++ b/lib/common/hash_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/hash_test.go
+++ b/lib/common/hash_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 import (

--- a/lib/common/hash_test.go
+++ b/lib/common/hash_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/hasher.go
+++ b/lib/common/hasher.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/hasher.go
+++ b/lib/common/hasher.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 import (

--- a/lib/common/hasher.go
+++ b/lib/common/hasher.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/hasher_test.go
+++ b/lib/common/hasher_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common_test
 
 import (

--- a/lib/common/hasher_test.go
+++ b/lib/common/hasher_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common_test
 

--- a/lib/common/hasher_test.go
+++ b/lib/common/hasher_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common_test
 
 import (

--- a/lib/common/network.go
+++ b/lib/common/network.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/network.go
+++ b/lib/common/network.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common
 
 import ma "github.com/multiformats/go-multiaddr"

--- a/lib/common/network.go
+++ b/lib/common/network.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import ma "github.com/multiformats/go-multiaddr"

--- a/lib/common/network_test.go
+++ b/lib/common/network_test.go
@@ -1,1 +1,4 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common

--- a/lib/common/network_test.go
+++ b/lib/common/network_test.go
@@ -1,17 +1,1 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package common

--- a/lib/common/network_test.go
+++ b/lib/common/network_test.go
@@ -1,4 +1,4 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common

--- a/lib/common/types/errors.go
+++ b/lib/common/types/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import "errors"

--- a/lib/common/types/errors.go
+++ b/lib/common/types/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import "errors"

--- a/lib/common/types/errors.go
+++ b/lib/common/types/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/lib/common/types/result.go
+++ b/lib/common/types/result.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/lib/common/types/result.go
+++ b/lib/common/types/result.go
@@ -1,19 +1,3 @@
-// Copyright 2021 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package types
 
 import (

--- a/lib/common/types/result.go
+++ b/lib/common/types/result.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package types
 

--- a/lib/common/uint128.go
+++ b/lib/common/uint128.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/uint128.go
+++ b/lib/common/uint128.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package common
 
 import (

--- a/lib/common/uint128.go
+++ b/lib/common/uint128.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/uint128_test.go
+++ b/lib/common/uint128_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/uint128_test.go
+++ b/lib/common/uint128_test.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package common
 
 import (

--- a/lib/common/uint128_test.go
+++ b/lib/common/uint128_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 import (

--- a/lib/common/variadic/uint64OrHash.go
+++ b/lib/common/variadic/uint64OrHash.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package variadic
 

--- a/lib/common/variadic/uint64OrHash.go
+++ b/lib/common/variadic/uint64OrHash.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package variadic
 
 import (

--- a/lib/common/variadic/uint64OrHash.go
+++ b/lib/common/variadic/uint64OrHash.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package variadic
 
 import (

--- a/lib/common/variadic/uint64OrHash_test.go
+++ b/lib/common/variadic/uint64OrHash_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package variadic
 

--- a/lib/common/variadic/uint64OrHash_test.go
+++ b/lib/common/variadic/uint64OrHash_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package variadic
 
 import (

--- a/lib/common/variadic/uint64OrHash_test.go
+++ b/lib/common/variadic/uint64OrHash_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package variadic
 
 import (

--- a/lib/common/well_known_keys.go
+++ b/lib/common/well_known_keys.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package common
 

--- a/lib/common/well_known_keys.go
+++ b/lib/common/well_known_keys.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package common
 
 var (

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package ed25519
 

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package ed25519
 
 import (

--- a/lib/crypto/ed25519/ed25519.go
+++ b/lib/crypto/ed25519/ed25519.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package ed25519
 
 import (

--- a/lib/crypto/ed25519/ed25519_test.go
+++ b/lib/crypto/ed25519/ed25519_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package ed25519
 

--- a/lib/crypto/ed25519/ed25519_test.go
+++ b/lib/crypto/ed25519/ed25519_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package ed25519
 
 import (

--- a/lib/crypto/ed25519/ed25519_test.go
+++ b/lib/crypto/ed25519/ed25519_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package ed25519
 
 import (

--- a/lib/crypto/keypair.go
+++ b/lib/crypto/keypair.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package crypto
 
 import (

--- a/lib/crypto/keypair.go
+++ b/lib/crypto/keypair.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package crypto
 

--- a/lib/crypto/keypair.go
+++ b/lib/crypto/keypair.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package crypto
 
 import (

--- a/lib/crypto/keypair_test.go
+++ b/lib/crypto/keypair_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package crypto_test
 
 import (

--- a/lib/crypto/keypair_test.go
+++ b/lib/crypto/keypair_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package crypto_test
 

--- a/lib/crypto/secp256k1/secp256k1.go
+++ b/lib/crypto/secp256k1/secp256k1.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package secp256k1
 
 import (

--- a/lib/crypto/secp256k1/secp256k1.go
+++ b/lib/crypto/secp256k1/secp256k1.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package secp256k1
 
 import (

--- a/lib/crypto/secp256k1/secp256k1.go
+++ b/lib/crypto/secp256k1/secp256k1.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package secp256k1
 

--- a/lib/crypto/secp256k1/secp256k1_test.go
+++ b/lib/crypto/secp256k1/secp256k1_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package secp256k1
 
 import (

--- a/lib/crypto/secp256k1/secp256k1_test.go
+++ b/lib/crypto/secp256k1/secp256k1_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package secp256k1
 
 import (

--- a/lib/crypto/secp256k1/secp256k1_test.go
+++ b/lib/crypto/secp256k1/secp256k1_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package secp256k1
 

--- a/lib/crypto/sr25519/sr25519.go
+++ b/lib/crypto/sr25519/sr25519.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sr25519
 
 import (

--- a/lib/crypto/sr25519/sr25519.go
+++ b/lib/crypto/sr25519/sr25519.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sr25519
 
 import (

--- a/lib/crypto/sr25519/sr25519.go
+++ b/lib/crypto/sr25519/sr25519.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sr25519
 

--- a/lib/crypto/sr25519/sr25519_test.go
+++ b/lib/crypto/sr25519/sr25519_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sr25519
 
 import (

--- a/lib/crypto/sr25519/sr25519_test.go
+++ b/lib/crypto/sr25519/sr25519_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sr25519
 
 import (

--- a/lib/crypto/sr25519/sr25519_test.go
+++ b/lib/crypto/sr25519/sr25519_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sr25519
 

--- a/lib/crypto/transcript.go
+++ b/lib/crypto/transcript.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package crypto
 
 import (

--- a/lib/crypto/transcript.go
+++ b/lib/crypto/transcript.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package crypto
 
 import (

--- a/lib/crypto/transcript.go
+++ b/lib/crypto/transcript.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package crypto
 

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package genesis
 
 import (

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package genesis
 
 import (

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package genesis
 

--- a/lib/genesis/genesis_test.go
+++ b/lib/genesis/genesis_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package genesis
 
 import (

--- a/lib/genesis/genesis_test.go
+++ b/lib/genesis/genesis_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package genesis
 
 import (

--- a/lib/genesis/genesis_test.go
+++ b/lib/genesis/genesis_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package genesis
 

--- a/lib/genesis/helpers.go
+++ b/lib/genesis/helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package genesis
 
 import (

--- a/lib/genesis/helpers.go
+++ b/lib/genesis/helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package genesis
 
 import (

--- a/lib/genesis/helpers.go
+++ b/lib/genesis/helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package genesis
 

--- a/lib/genesis/helpers_test.go
+++ b/lib/genesis/helpers_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package genesis
 
 import (

--- a/lib/genesis/helpers_test.go
+++ b/lib/genesis/helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package genesis
 
 import (

--- a/lib/genesis/helpers_test.go
+++ b/lib/genesis/helpers_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package genesis
 

--- a/lib/genesis/pallet.go
+++ b/lib/genesis/pallet.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package genesis
 

--- a/lib/genesis/pallet.go
+++ b/lib/genesis/pallet.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package genesis
 
 import "github.com/ChainSafe/gossamer/pkg/scale"

--- a/lib/genesis/test_utils.go
+++ b/lib/genesis/test_utils.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package genesis
 
 import (

--- a/lib/genesis/test_utils.go
+++ b/lib/genesis/test_utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package genesis
 
 import (

--- a/lib/genesis/test_utils.go
+++ b/lib/genesis/test_utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package genesis
 

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/network.go
+++ b/lib/grandpa/network.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/network_test.go
+++ b/lib/grandpa/network_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/round_test.go
+++ b/lib/grandpa/round_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/types.go
+++ b/lib/grandpa/types.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/types_test.go
+++ b/lib/grandpa/types_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/types_test.go
+++ b/lib/grandpa/types_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/types_test.go
+++ b/lib/grandpa/types_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package grandpa
 
 import (

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package grandpa
 

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package grandpa
 
 import (

--- a/lib/keystore/basic_keystore.go
+++ b/lib/keystore/basic_keystore.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/basic_keystore.go
+++ b/lib/keystore/basic_keystore.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/basic_keystore.go
+++ b/lib/keystore/basic_keystore.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/basic_keystore_test.go
+++ b/lib/keystore/basic_keystore_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/basic_keystore_test.go
+++ b/lib/keystore/basic_keystore_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/basic_keystore_test.go
+++ b/lib/keystore/basic_keystore_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/encrypt.go
+++ b/lib/keystore/encrypt.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/encrypt.go
+++ b/lib/keystore/encrypt.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/encrypt.go
+++ b/lib/keystore/encrypt.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/encrypt_test.go
+++ b/lib/keystore/encrypt_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/encrypt_test.go
+++ b/lib/keystore/encrypt_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/encrypt_test.go
+++ b/lib/keystore/encrypt_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/generic_keystore.go
+++ b/lib/keystore/generic_keystore.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/generic_keystore.go
+++ b/lib/keystore/generic_keystore.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/generic_keystore.go
+++ b/lib/keystore/generic_keystore.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/generic_keystore_test.go
+++ b/lib/keystore/generic_keystore_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/generic_keystore_test.go
+++ b/lib/keystore/generic_keystore_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/generic_keystore_test.go
+++ b/lib/keystore/generic_keystore_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/keyring.go
+++ b/lib/keystore/keyring.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/keyring.go
+++ b/lib/keystore/keyring.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/keyring.go
+++ b/lib/keystore/keyring.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/keyring_test.go
+++ b/lib/keystore/keyring_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/keyring_test.go
+++ b/lib/keystore/keyring_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/keyring_test.go
+++ b/lib/keystore/keyring_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/keystore/keystore.go
+++ b/lib/keystore/keystore.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package keystore
 
 import (

--- a/lib/keystore/keystore.go
+++ b/lib/keystore/keystore.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package keystore
 
 import (

--- a/lib/keystore/keystore.go
+++ b/lib/keystore/keystore.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package keystore
 

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/common.go
+++ b/lib/runtime/common.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/common.go
+++ b/lib/runtime/common.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 // Int64ToPointerAndSize converts an int64 into a int32 pointer and a int32 length

--- a/lib/runtime/common.go
+++ b/lib/runtime/common.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 // Int64ToPointerAndSize converts an int64 into a int32 pointer and a int32 length

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/errors.go
+++ b/lib/runtime/errors.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/errors.go
+++ b/lib/runtime/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/errors.go
+++ b/lib/runtime/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/life/exports.go
+++ b/lib/runtime/life/exports.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package life
 
 import (

--- a/lib/runtime/life/exports.go
+++ b/lib/runtime/life/exports.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package life
 

--- a/lib/runtime/life/exports_test.go
+++ b/lib/runtime/life/exports_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package life
 
 import (

--- a/lib/runtime/life/exports_test.go
+++ b/lib/runtime/life/exports_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package life
 

--- a/lib/runtime/life/instance.go
+++ b/lib/runtime/life/instance.go
@@ -1,18 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package life
 
 import (

--- a/lib/runtime/life/instance.go
+++ b/lib/runtime/life/instance.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package life
 
 import (

--- a/lib/runtime/life/instance.go
+++ b/lib/runtime/life/instance.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package life
 

--- a/lib/runtime/life/resolver.go
+++ b/lib/runtime/life/resolver.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package life
 
 import (

--- a/lib/runtime/life/resolver.go
+++ b/lib/runtime/life/resolver.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package life
 

--- a/lib/runtime/life/resolver_test.go
+++ b/lib/runtime/life/resolver_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package life
 
 import (

--- a/lib/runtime/life/resolver_test.go
+++ b/lib/runtime/life/resolver_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package life
 
 import (

--- a/lib/runtime/life/resolver_test.go
+++ b/lib/runtime/life/resolver_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package life
 

--- a/lib/runtime/life/test_helpers.go
+++ b/lib/runtime/life/test_helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package life
 
 import (

--- a/lib/runtime/life/test_helpers.go
+++ b/lib/runtime/life/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package life
 
 import (

--- a/lib/runtime/life/test_helpers.go
+++ b/lib/runtime/life/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package life
 

--- a/lib/runtime/memory.go
+++ b/lib/runtime/memory.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/memory.go
+++ b/lib/runtime/memory.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 // PageSize is 65kb

--- a/lib/runtime/memory.go
+++ b/lib/runtime/memory.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 // PageSize is 65kb

--- a/lib/runtime/offchain/httpset.go
+++ b/lib/runtime/offchain/httpset.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package offchain
 
 import (

--- a/lib/runtime/offchain/httpset_test.go
+++ b/lib/runtime/offchain/httpset_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package offchain
 
 import (

--- a/lib/runtime/sig_verifier.go
+++ b/lib/runtime/sig_verifier.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/sig_verifier.go
+++ b/lib/runtime/sig_verifier.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package storage
 
 import (

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package storage
 

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package storage
 
 import (

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package storage
 
 import (

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package storage
 

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/types_test.go
+++ b/lib/runtime/types_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/types_test.go
+++ b/lib/runtime/types_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/version.go
+++ b/lib/runtime/version.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package runtime
 
 import (

--- a/lib/runtime/version.go
+++ b/lib/runtime/version.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/version.go
+++ b/lib/runtime/version.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/version_test.go
+++ b/lib/runtime/version_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package runtime
 

--- a/lib/runtime/version_test.go
+++ b/lib/runtime/version_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package runtime
 
 import (

--- a/lib/runtime/wasmer/exports.go
+++ b/lib/runtime/wasmer/exports.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/exports.go
+++ b/lib/runtime/wasmer/exports.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/exports.go
+++ b/lib/runtime/wasmer/exports.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package wasmer
 
 // #include <stdlib.h>

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 // #include <stdlib.h>

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package wasmer
 

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package wasmer
 
 import (

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package wasmer
 
 import (

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package services
 
 import (

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package services
 

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package services
 
 import (

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package services
 
 import (

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package services
 

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package services
 
 import (

--- a/lib/transaction/pool.go
+++ b/lib/transaction/pool.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package transaction
 
 import (

--- a/lib/transaction/pool.go
+++ b/lib/transaction/pool.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package transaction
 
 import (

--- a/lib/transaction/pool.go
+++ b/lib/transaction/pool.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package transaction
 

--- a/lib/transaction/pool_test.go
+++ b/lib/transaction/pool_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package transaction
 
 import (

--- a/lib/transaction/pool_test.go
+++ b/lib/transaction/pool_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package transaction
 

--- a/lib/transaction/priority_queue.go
+++ b/lib/transaction/priority_queue.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package transaction
 
 import (

--- a/lib/transaction/priority_queue.go
+++ b/lib/transaction/priority_queue.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package transaction
 
 import (

--- a/lib/transaction/priority_queue.go
+++ b/lib/transaction/priority_queue.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package transaction
 

--- a/lib/transaction/priority_queue_test.go
+++ b/lib/transaction/priority_queue_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package transaction
 
 import (

--- a/lib/transaction/priority_queue_test.go
+++ b/lib/transaction/priority_queue_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package transaction
 
 import (

--- a/lib/transaction/priority_queue_test.go
+++ b/lib/transaction/priority_queue_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package transaction
 

--- a/lib/transaction/types.go
+++ b/lib/transaction/types.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package transaction
 
 import (

--- a/lib/transaction/types.go
+++ b/lib/transaction/types.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package transaction
 
 import (

--- a/lib/transaction/types.go
+++ b/lib/transaction/types.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package transaction
 

--- a/lib/transaction/types_test.go
+++ b/lib/transaction/types_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package transaction
 
 import (

--- a/lib/transaction/types_test.go
+++ b/lib/transaction/types_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package transaction
 

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/child_storage_test.go
+++ b/lib/trie/child_storage_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/child_storage_test.go
+++ b/lib/trie/child_storage_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/child_storage_test.go
+++ b/lib/trie/child_storage_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/codec.go
+++ b/lib/trie/codec.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/codec.go
+++ b/lib/trie/codec.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 // keyToNibbles turns bytes into nibbles

--- a/lib/trie/codec.go
+++ b/lib/trie/codec.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 // keyToNibbles turns bytes into nibbles

--- a/lib/trie/codec_test.go
+++ b/lib/trie/codec_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/codec_test.go
+++ b/lib/trie/codec_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/codec_test.go
+++ b/lib/trie/codec_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/hash_test.go
+++ b/lib/trie/hash_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/hash_test.go
+++ b/lib/trie/hash_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/hash_test.go
+++ b/lib/trie/hash_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/lookup.go
+++ b/lib/trie/lookup.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/lookup.go
+++ b/lib/trie/lookup.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 // Modified Merkle-Patricia Trie
 // See https://github.com/w3f/polkadot-spec/blob/master/runtime-environment-spec/polkadot_re_spec.pdf for the full specification.
 //

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 // Modified Merkle-Patricia Trie
 // See https://github.com/w3f/polkadot-spec/blob/master/runtime-environment-spec/polkadot_re_spec.pdf for the full specification.
 //

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 // Modified Merkle-Patricia Trie
 // See https://github.com/w3f/polkadot-spec/blob/master/runtime-environment-spec/polkadot_re_spec.pdf for the full specification.

--- a/lib/trie/node_test.go
+++ b/lib/trie/node_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/node_test.go
+++ b/lib/trie/node_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/node_test.go
+++ b/lib/trie/node_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/print.go
+++ b/lib/trie/print.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/print.go
+++ b/lib/trie/print.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/print.go
+++ b/lib/trie/print.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/proof.go
+++ b/lib/trie/proof.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/proof.go
+++ b/lib/trie/proof.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/proof.go
+++ b/lib/trie/proof.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/recorder.go
+++ b/lib/trie/recorder.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/recorder.go
+++ b/lib/trie/recorder.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 // nodeRecord represets a record of a visited node

--- a/lib/trie/test_utils.go
+++ b/lib/trie/test_utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/test_utils.go
+++ b/lib/trie/test_utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package trie
 

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package trie
 
 import (

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package trie
 
 import (

--- a/lib/utils/pull_request.go
+++ b/lib/utils/pull_request.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/lib/utils/pull_request.go
+++ b/lib/utils/pull_request.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/lib/utils/pull_request_test.go
+++ b/lib/utils/pull_request_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/lib/utils/pull_request_test.go
+++ b/lib/utils/pull_request_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/lib/utils/test_utils.go
+++ b/lib/utils/test_utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/lib/utils/test_utils.go
+++ b/lib/utils/test_utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/lib/utils/test_utils.go
+++ b/lib/utils/test_utils.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/lib/utils/test_utils_test.go
+++ b/lib/utils/test_utils_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/lib/utils/test_utils_test.go
+++ b/lib/utils/test_utils_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/lib/utils/test_utils_test.go
+++ b/lib/utils/test_utils_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/pkg/scale/decode.go
+++ b/pkg/scale/decode.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/decode.go
+++ b/pkg/scale/decode.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/decode.go
+++ b/pkg/scale/decode.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/decode_test.go
+++ b/pkg/scale/decode_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/decode_test.go
+++ b/pkg/scale/decode_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/decode_test.go
+++ b/pkg/scale/decode_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/encode_test.go
+++ b/pkg/scale/encode_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/encode_test.go
+++ b/pkg/scale/encode_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/encode_test.go
+++ b/pkg/scale/encode_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/result.go
+++ b/pkg/scale/result.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/result.go
+++ b/pkg/scale/result.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/result.go
+++ b/pkg/scale/result.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/result_example_test.go
+++ b/pkg/scale/result_example_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale_test
 

--- a/pkg/scale/result_example_test.go
+++ b/pkg/scale/result_example_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale_test
 
 import (

--- a/pkg/scale/result_test.go
+++ b/pkg/scale/result_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/result_test.go
+++ b/pkg/scale/result_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/result_test.go
+++ b/pkg/scale/result_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/scale_test.go
+++ b/pkg/scale/scale_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/scale_test.go
+++ b/pkg/scale/scale_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/scale_test.go
+++ b/pkg/scale/scale_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/uint128.go
+++ b/pkg/scale/uint128.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/uint128.go
+++ b/pkg/scale/uint128.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/uint128.go
+++ b/pkg/scale/uint128.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/uint128_test.go
+++ b/pkg/scale/uint128_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/uint128_test.go
+++ b/pkg/scale/uint128_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/uint128_test.go
+++ b/pkg/scale/uint128_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/pkg/scale/varying_data_type_example_test.go
+++ b/pkg/scale/varying_data_type_example_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale_test
 

--- a/pkg/scale/varying_data_type_example_test.go
+++ b/pkg/scale/varying_data_type_example_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale_test
 
 import (

--- a/pkg/scale/varying_data_type_test.go
+++ b/pkg/scale/varying_data_type_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package scale
 

--- a/pkg/scale/varying_data_type_test.go
+++ b/pkg/scale/varying_data_type_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package scale
 
 import (

--- a/pkg/scale/varying_data_type_test.go
+++ b/pkg/scale/varying_data_type_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package scale
 
 import (

--- a/tests/polkadotjs_test/empty.go
+++ b/tests/polkadotjs_test/empty.go
@@ -1,4 +1,4 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package polkadotjs

--- a/tests/polkadotjs_test/empty.go
+++ b/tests/polkadotjs_test/empty.go
@@ -1,16 +1,1 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package polkadotjs

--- a/tests/polkadotjs_test/empty.go
+++ b/tests/polkadotjs_test/empty.go
@@ -1,1 +1,4 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package polkadotjs

--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package polkadotjs_test
 

--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -1,18 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
 package polkadotjs_test
 
 import (

--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package polkadotjs_test
 
 import (

--- a/tests/rpc/empty.go
+++ b/tests/rpc/empty.go
@@ -1,1 +1,4 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc

--- a/tests/rpc/empty.go
+++ b/tests/rpc/empty.go
@@ -1,4 +1,4 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc

--- a/tests/rpc/empty.go
+++ b/tests/rpc/empty.go
@@ -1,17 +1,1 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc

--- a/tests/rpc/rpc_00_test.go
+++ b/tests/rpc/rpc_00_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_00_test.go
+++ b/tests/rpc/rpc_00_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_00_test.go
+++ b/tests/rpc/rpc_00_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/rpc/system_integration_test.go
+++ b/tests/rpc/system_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package rpc
 
 import (

--- a/tests/rpc/system_integration_test.go
+++ b/tests/rpc/system_integration_test.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package rpc
 
 import (

--- a/tests/rpc/system_integration_test.go
+++ b/tests/rpc/system_integration_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package rpc
 

--- a/tests/stress/empty.go
+++ b/tests/stress/empty.go
@@ -1,17 +1,1 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package stress

--- a/tests/stress/empty.go
+++ b/tests/stress/empty.go
@@ -1,1 +1,4 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package stress

--- a/tests/stress/empty.go
+++ b/tests/stress/empty.go
@@ -1,4 +1,4 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package stress

--- a/tests/stress/errors.go
+++ b/tests/stress/errors.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package stress
 

--- a/tests/stress/errors.go
+++ b/tests/stress/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package stress
 
 import (

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package stress
 

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package stress
 
 import (

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package stress
 
 import (

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package stress
 

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package stress
 
 import (

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package stress
 
 import (

--- a/tests/stress/network_test.go
+++ b/tests/stress/network_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package stress
 

--- a/tests/stress/network_test.go
+++ b/tests/stress/network_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package stress
 
 import (

--- a/tests/stress/network_test.go
+++ b/tests/stress/network_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package stress
 
 import (

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package stress
 

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package stress
 
 import (

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package stress
 
 import (

--- a/tests/sync/empty.go
+++ b/tests/sync/empty.go
@@ -1,17 +1,1 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package sync

--- a/tests/sync/empty.go
+++ b/tests/sync/empty.go
@@ -1,4 +1,4 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync

--- a/tests/sync/empty.go
+++ b/tests/sync/empty.go
@@ -1,1 +1,4 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync

--- a/tests/sync/sync_test.go
+++ b/tests/sync/sync_test.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package sync
 

--- a/tests/sync/sync_test.go
+++ b/tests/sync/sync_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package sync
 
 import (

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -1,19 +1,3 @@
-// Copyright 2019 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/framework.go
+++ b/tests/utils/framework.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/framework.go
+++ b/tests/utils/framework.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/header.go
+++ b/tests/utils/header.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/header.go
+++ b/tests/utils/header.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/header.go
+++ b/tests/utils/header.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/request_utils.go
+++ b/tests/utils/request_utils.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/request_utils.go
+++ b/tests/utils/request_utils.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/request_utils.go
+++ b/tests/utils/request_utils.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/rpc_methods.go
+++ b/tests/utils/rpc_methods.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/rpc_methods.go
+++ b/tests/utils/rpc_methods.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 //nolint

--- a/tests/utils/rpc_methods.go
+++ b/tests/utils/rpc_methods.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 //nolint

--- a/tests/utils/state.go
+++ b/tests/utils/state.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/state.go
+++ b/tests/utils/state.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/state.go
+++ b/tests/utils/state.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (

--- a/tests/utils/system.go
+++ b/tests/utils/system.go
@@ -1,5 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: LGPL-3.0-only
 
 package utils
 

--- a/tests/utils/system.go
+++ b/tests/utils/system.go
@@ -1,3 +1,6 @@
+// Copyright 2021 ChainSafe Systems (ON)
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/tests/utils/system.go
+++ b/tests/utils/system.go
@@ -1,19 +1,3 @@
-// Copyright 2020 ChainSafe Systems (ON) Corp.
-// This file is part of gossamer.
-//
-// The gossamer library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The gossamer library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the gossamer library. If not, see <http://www.gnu.org/licenses/>.
-
 package utils
 
 import (


### PR DESCRIPTION
## Changes

- Update copyright notice to 2021
- Update copyright for all Go and Proto files
- Install `addlicense` `v1.0.0` in `Makefile`
- Update `make license` command
    - Only include SPDX indentifier
    - Set copyright holder to 'Chainsafe Systems (ON)'
    - Set year to current year
    - Ignore all files that *should* be ignored
    - Run with verbosity
- Add copyright check CI workflow

## Tests

- Copyright CI check passing

## Issues

## Primary Reviewer

- @danforbes 