### PR TITLE
chore(ci): no PR title and description check for dependabot

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,6 +31,7 @@ jobs:
 
   check-description:
     name: Checks PR has title and body description
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes

- Only run PR body and description check when actor is not dependabot

## Tests

## Issues

## Primary Reviewer
