### PR TITLE
fix(dot/state): update `*state.BlockState.AddBlockToBlockTree` to store block in `unfinalisedBlocksMap`

### DIFF
--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -164,6 +164,7 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 			continue
 		}
 
+		// blocks were deleted from the unfinalisedBlockMap in `handleFinalisedBlock()`
 		logger.Trace("pruned block", "hash", hash, "number", block.Header.Number)
 
 		go func(header *types.Header) {
@@ -252,7 +253,8 @@ func (bs *BlockState) handleFinalisedBlock(curr common.Hash) error {
 			return err
 		}
 
-		bs.deleteUnfinalisedBlock(hash)
+		// the block will be deleted from the unfinalisedBlockMap in the pruning loop
+		// in `SetFinalisedHash()`, which calls this function
 	}
 
 	return batch.Flush()

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -164,7 +164,6 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 			continue
 		}
 
-		// blocks were deleted from the unfinalisedBlockMap in `handleFinalisedBlock()`
 		logger.Trace("pruned block", "hash", hash, "number", block.Header.Number)
 
 		go func(header *types.Header) {
@@ -195,7 +194,6 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 		return fmt.Errorf("could not send 'notify.finalized' telemetry message, error: %s", err)
 	}
 
-	// return bs.setHighestRoundAndSetID(round, setID)
 	bs.lastFinalised = hash
 	return nil
 }

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -470,7 +470,10 @@ func TestAddBlockToBlockTree(t *testing.T) {
 	err := bs.setArrivalTime(header.Hash(), time.Now())
 	require.NoError(t, err)
 
-	err = bs.AddBlockToBlockTree(header)
+	err = bs.AddBlockToBlockTree(&types.Block{
+		Header: *header,
+		Body:   types.Body{},
+	})
 	require.NoError(t, err)
 	require.Equal(t, bs.BestBlockHash(), header.Hash())
 }

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -130,7 +130,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 
 		logger.Debug("skipping block, already have", "hash", bd.Hash, "number", block.Header.Number)
 
-		err = s.blockState.AddBlockToBlockTree(&block.Header)
+		err = s.blockState.AddBlockToBlockTree(block)
 		if errors.Is(err, blocktree.ErrBlockExists) {
 			return nil
 		} else if err != nil {

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -50,7 +50,7 @@ type BlockState interface {
 	GetJustification(common.Hash) ([]byte, error)
 	SetJustification(hash common.Hash, data []byte) error
 	SetFinalisedHash(hash common.Hash, round, setID uint64) error
-	AddBlockToBlockTree(header *types.Header) error
+	AddBlockToBlockTree(block *types.Block) error
 	GetHashByNumber(*big.Int) (common.Hash, error)
 	GetBlockByHash(common.Hash) (*types.Block, error)
 	GetRuntime(*common.Hash) (runtime.Instance, error)

--- a/dot/sync/mocks/block_state.go
+++ b/dot/sync/mocks/block_state.go
@@ -32,13 +32,13 @@ func (_m *BlockState) AddBlock(_a0 *types.Block) error {
 	return r0
 }
 
-// AddBlockToBlockTree provides a mock function with given fields: header
-func (_m *BlockState) AddBlockToBlockTree(header *types.Header) error {
-	ret := _m.Called(header)
+// AddBlockToBlockTree provides a mock function with given fields: block
+func (_m *BlockState) AddBlockToBlockTree(block *types.Block) error {
+	ret := _m.Called(block)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*types.Header) error); ok {
-		r0 = rf(header)
+	if rf, ok := ret.Get(0).(func(*types.Block) error); ok {
+		r0 = rf(block)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- update `*state.BlockState.AddBlockToBlockTree` to store block in `unfinalisedBlocksMap`, previously it was not storing them in there, resulting in blocks being unable to finalize due to blocks missing from that map in the subchain to be finalized


## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/state
go test ./dot/sync
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- n/a

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @jimjbrettj 
