### PR TITLE
fix(trie): memory leak fix in `lib/trie`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/urfave/cli v1.22.5
 	github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec
 	golang.org/x/crypto v0.0.0-20210813211128-0a44fdfbc16e
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	google.golang.org/protobuf v1.27.1
 )
@@ -174,6 +173,7 @@ require (
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -121,7 +121,7 @@ func encodeAndHash(n node) ([]byte, error) {
 	return scEncChild, nil
 }
 
-// encodeBranch encodes a branch with the encoding specified in hashedOrEncodedNode
+// encodeBranch encodes a branch with the encoding specified at the top of this package
 // to the buffer given.
 func encodeBranch(b *branch, buffer *bytes.Buffer, parallel bool) (err error) {
 	if !b.dirty && b.encoding != nil {

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -208,6 +208,13 @@ func encodeChildsInParallel(children [16]node, buffer *bytes.Buffer) (err error)
 		}
 	}
 
+	for _, buffer := range resultBuffers {
+		if buffer == nil { // already emptied and put back in pool
+			continue
+		}
+		encodingBufferPool.Put(buffer)
+	}
+
 	return err
 }
 

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -151,12 +151,12 @@ func encodeBranch(b *branch, buffer *bytes.Buffer, parallel bool) (err error) {
 	}
 
 	if parallel {
-		return encodeChildsInParallel(b.children, buffer)
+		return encodeChildrenInParallel(b.children, buffer)
 	}
 	return encodeChildsSequentially(b.children, buffer)
 }
 
-func encodeChildsInParallel(children [16]node, buffer *bytes.Buffer) (err error) {
+func encodeChildrenInParallel(children [16]node, buffer *bytes.Buffer) (err error) {
 	type result struct {
 		index  int
 		buffer *bytes.Buffer

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -98,6 +98,8 @@ func encodeNode(n node, buffer *bytes.Buffer, parallel bool) (err error) {
 		n.encodingMu.Lock()
 		defer n.encodingMu.Unlock()
 
+		// TODO remove this copying since it defeats the purpose of `buffer`
+		// and the sync.Pool.
 		n.encoding = make([]byte, buffer.Len())
 		copy(n.encoding, buffer.Bytes())
 		return nil

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -275,15 +275,14 @@ func encodeChild(child node, buffer io.Writer) (err error) {
 // specified at the top of this package.
 func encodeLeaf(l *leaf, buffer io.Writer) (err error) {
 	l.encodingMu.RLock()
+	defer l.encodingMu.RUnlock()
 	if !l.dirty && l.encoding != nil {
 		_, err = buffer.Write(l.encoding)
-		l.encodingMu.RUnlock()
 		if err != nil {
 			return fmt.Errorf("cannot write stored encoding to buffer: %w", err)
 		}
 		return nil
 	}
-	l.encodingMu.RUnlock()
 
 	encoding, err := l.header()
 	if err != nil {

--- a/lib/trie/hash.go
+++ b/lib/trie/hash.go
@@ -153,7 +153,7 @@ func encodeBranch(b *branch, buffer *bytes.Buffer, parallel bool) (err error) {
 	if parallel {
 		return encodeChildrenInParallel(b.children, buffer)
 	}
-	return encodeChildsSequentially(b.children, buffer)
+	return encodeChildrenSequentially(b.children, buffer)
 }
 
 func encodeChildrenInParallel(children [16]node, buffer *bytes.Buffer) (err error) {
@@ -218,7 +218,7 @@ func encodeChildrenInParallel(children [16]node, buffer *bytes.Buffer) (err erro
 	return err
 }
 
-func encodeChildsSequentially(children [16]node, buffer *bytes.Buffer) (err error) {
+func encodeChildrenSequentially(children [16]node, buffer *bytes.Buffer) (err error) {
 	for _, child := range children {
 		err = encodeChild(child, buffer)
 		if err != nil {

--- a/lib/trie/hash_test.go
+++ b/lib/trie/hash_test.go
@@ -7,86 +7,69 @@ import (
 	"bytes"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func generateRandBytes(size int) []byte {
-	r := *rand.New(rand.NewSource(rand.Int63()))
-	buf := make([]byte, r.Intn(size)+1)
-	r.Read(buf)
+	buf := make([]byte, rand.Intn(size)+1)
+	rand.Read(buf)
 	return buf
 }
 
 func generateRand(size int) [][]byte {
 	rt := make([][]byte, size)
-	r := *rand.New(rand.NewSource(rand.Int63()))
 	for i := range rt {
-		buf := make([]byte, r.Intn(379)+1)
-		r.Read(buf)
+		buf := make([]byte, rand.Intn(379)+1)
+		rand.Read(buf)
 		rt[i] = buf
 	}
 	return rt
 }
 
-func TestNewHasher(t *testing.T) {
-	hasher := newHasher(false)
-	defer hasher.returnToPool()
-
-	_, err := hasher.hash.Write([]byte("noot"))
-	if err != nil {
-		t.Error(err)
-	}
-
-	sum := hasher.hash.Sum(nil)
-	if sum == nil {
-		t.Error("did not sum hash")
-	}
-
-	hasher.hash.Reset()
-}
-
 func TestHashLeaf(t *testing.T) {
-	hasher := newHasher(false)
-	defer hasher.returnToPool()
-
 	n := &leaf{key: generateRandBytes(380), value: generateRandBytes(64)}
-	h, err := hasher.Hash(n)
+
+	buffer := bytes.NewBuffer(nil)
+	const parallel = false
+	err := encodeNode(n, buffer, parallel)
+
 	if err != nil {
 		t.Errorf("did not hash leaf node: %s", err)
-	} else if h == nil {
+	} else if buffer.Len() == 0 {
 		t.Errorf("did not hash leaf node: nil")
 	}
 }
 
 func TestHashBranch(t *testing.T) {
-	hasher := newHasher(false)
-	defer hasher.returnToPool()
-
 	n := &branch{key: generateRandBytes(380), value: generateRandBytes(380)}
 	n.children[3] = &leaf{key: generateRandBytes(380), value: generateRandBytes(380)}
-	h, err := hasher.Hash(n)
+
+	buffer := bytes.NewBuffer(nil)
+	const parallel = false
+	err := encodeNode(n, buffer, parallel)
+
 	if err != nil {
 		t.Errorf("did not hash branch node: %s", err)
-	} else if h == nil {
+	} else if buffer.Len() == 0 {
 		t.Errorf("did not hash branch node: nil")
 	}
 }
 
 func TestHashShort(t *testing.T) {
-	hasher := newHasher(false)
-	defer hasher.returnToPool()
-
-	n := &leaf{key: generateRandBytes(2), value: generateRandBytes(3)}
-	expected, err := hasher.encode(n)
-	if err != nil {
-		t.Fatal(err)
+	n := &leaf{
+		key:   generateRandBytes(2),
+		value: generateRandBytes(3),
 	}
 
-	h, err := hasher.Hash(n)
-	if err != nil {
-		t.Errorf("did not hash leaf node: %s", err)
-	} else if h == nil {
-		t.Errorf("did not hash leaf node: nil")
-	} else if !bytes.Equal(h[:], expected) {
-		t.Errorf("did not return encoded node padded to 32 bytes: got %s", h)
-	}
+	encodingBuffer := bytes.NewBuffer(nil)
+	const parallel = false
+	err := encodeNode(n, encodingBuffer, parallel)
+	require.NoError(t, err)
+
+	digestBuffer := bytes.NewBuffer(nil)
+	err = hashNode(n, digestBuffer)
+	require.NoError(t, err)
+	assert.Equal(t, encodingBuffer.Bytes(), digestBuffer.Bytes())
 }

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -230,13 +230,13 @@ func (b *branch) encodeAndHash() (encoding, hash []byte, err error) {
 	b.encoding = make([]byte, len(bufferBytes))
 	encoding = make([]byte, len(bufferBytes))
 	copy(b.encoding, bufferBytes)
-	copy(encoding, bufferBytes)
+	encoding = b.encoding // no need to copy
 
 	if buffer.Len() < 32 {
 		b.hash = make([]byte, len(bufferBytes))
 		hash = make([]byte, len(bufferBytes))
 		copy(b.hash, bufferBytes)
-		copy(hash, bufferBytes)
+		hash = b.hash // no need to copy
 		return encoding, hash, nil
 	}
 
@@ -246,7 +246,7 @@ func (b *branch) encodeAndHash() (encoding, hash []byte, err error) {
 		return nil, nil, err
 	}
 	b.hash = hashArray[:]
-	hash = hashArray[:]
+	hash = b.hash // no need to copy
 
 	return encoding, hash, nil
 }
@@ -268,15 +268,13 @@ func (l *leaf) encodeAndHash() (encoding, hash []byte, err error) {
 	bufferBytes := buffer.Bytes()
 
 	l.encoding = make([]byte, len(bufferBytes))
-	encoding = make([]byte, len(bufferBytes))
 	copy(l.encoding, bufferBytes)
-	copy(encoding, bufferBytes)
+	encoding = l.encoding // no need to copy
 
 	if len(bufferBytes) < 32 {
 		l.hash = make([]byte, len(bufferBytes))
-		hash = make([]byte, len(bufferBytes))
 		copy(l.hash, bufferBytes)
-		copy(hash, bufferBytes)
+		hash = l.hash // no need to copy
 		return encoding, hash, nil
 	}
 
@@ -287,7 +285,7 @@ func (l *leaf) encodeAndHash() (encoding, hash []byte, err error) {
 	}
 
 	l.hash = hashArray[:]
-	hash = hashArray[:]
+	hash = l.hash // no need to copy
 
 	return encoding, hash, nil
 }

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -87,7 +87,7 @@ func (b *branch) copy() node {
 	defer b.Unlock()
 	cpy := &branch{
 		key:        make([]byte, len(b.key)),
-		children:   [16]node{},
+		children:   b.children, // copy interface pointers
 		value:      nil,
 		dirty:      b.dirty,
 		hash:       make([]byte, len(b.hash)),
@@ -95,7 +95,6 @@ func (b *branch) copy() node {
 		generation: b.generation,
 	}
 	copy(cpy.key, b.key)
-	copy(cpy.children[:], b.children[:]) // copy interface pointers
 
 	// nil and []byte{} are encoded differently, watch out!
 	if b.value != nil {

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -233,7 +233,6 @@ func (b *branch) encodeAndHash() (encoding, hash []byte, err error) {
 
 	if buffer.Len() < 32 {
 		b.hash = make([]byte, len(bufferBytes))
-		hash = make([]byte, len(bufferBytes))
 		copy(b.hash, bufferBytes)
 		hash = b.hash // no need to copy
 		return encoding, hash, nil

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -95,7 +95,7 @@ func (b *branch) copy() node {
 		generation: b.generation,
 	}
 	copy(cpy.key, b.key)
-	copy(cpy.children[:], b.children[:])
+	copy(cpy.children[:], b.children[:]) // copy interface pointers
 
 	// nil and []byte{} are encoded differently, watch out!
 	if b.value != nil {
@@ -211,71 +211,93 @@ func (b *branch) setKey(key []byte) {
 	b.key = key
 }
 
-func (b *branch) encodeAndHash() ([]byte, []byte, error) {
+func (b *branch) encodeAndHash() (encoding, hash []byte, err error) {
 	if !b.dirty && b.encoding != nil && b.hash != nil {
 		return b.encoding, b.hash, nil
 	}
 
-	hasher := newHasher(false)
-	enc, err := hasher.encodeBranch(b)
+	buffer := encodingBufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	defer encodingBufferPool.Put(buffer)
+
+	err = encodeBranch(b, buffer, false)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if len(enc) < 32 {
-		b.encoding = enc
-		b.hash = enc
-		return enc, enc, nil
+	bufferBytes := buffer.Bytes()
+
+	b.encoding = make([]byte, len(bufferBytes))
+	encoding = make([]byte, len(bufferBytes))
+	copy(b.encoding, bufferBytes)
+	copy(encoding, bufferBytes)
+
+	if buffer.Len() < 32 {
+		b.hash = make([]byte, len(bufferBytes))
+		hash = make([]byte, len(bufferBytes))
+		copy(b.hash, bufferBytes)
+		copy(hash, bufferBytes)
+		return encoding, hash, nil
 	}
 
-	hash, err := common.Blake2bHash(enc)
+	// Note: using the sync.Pool's buffer is useful here.
+	hashArray, err := common.Blake2bHash(buffer.Bytes())
 	if err != nil {
 		return nil, nil, err
 	}
+	b.hash = hashArray[:]
+	hash = hashArray[:]
 
-	b.encoding = enc
-	b.hash = hash[:]
-	return enc, hash[:], nil
+	return encoding, hash, nil
 }
 
-func (l *leaf) encodeAndHash() ([]byte, []byte, error) {
+func (l *leaf) encodeAndHash() (encoding, hash []byte, err error) {
 	if !l.isDirty() && l.encoding != nil && l.hash != nil {
 		return l.encoding, l.hash, nil
 	}
-	hasher := newHasher(false)
-	enc, err := hasher.encodeLeaf(l)
 
+	buffer := encodingBufferPool.Get().(*bytes.Buffer)
+	buffer.Reset()
+	defer encodingBufferPool.Put(buffer)
+
+	err = encodeLeaf(l, buffer)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if len(enc) < 32 {
-		l.encoding = enc
-		l.hash = enc
-		return enc, enc, nil
+	bufferBytes := buffer.Bytes()
+
+	l.encoding = make([]byte, len(bufferBytes))
+	encoding = make([]byte, len(bufferBytes))
+	copy(l.encoding, bufferBytes)
+	copy(encoding, bufferBytes)
+
+	if len(bufferBytes) < 32 {
+		l.hash = make([]byte, len(bufferBytes))
+		hash = make([]byte, len(bufferBytes))
+		copy(l.hash, bufferBytes)
+		copy(hash, bufferBytes)
+		return encoding, hash, nil
 	}
 
-	hash, err := common.Blake2bHash(enc)
+	// Note: using the sync.Pool's buffer is useful here.
+	hashArray, err := common.Blake2bHash(buffer.Bytes())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	l.encoding = enc
-	l.hash = hash[:]
-	return enc, hash[:], nil
+	l.hash = hashArray[:]
+	hash = hashArray[:]
+
+	return encoding, hash, nil
 }
 
 func decodeBytes(in []byte) (node, error) {
-	r := &bytes.Buffer{}
-	_, err := r.Write(in)
-	if err != nil {
-		return nil, err
-	}
-
-	return decode(r)
+	buffer := bytes.NewBuffer(in)
+	return decode(buffer)
 }
 
-// Decode wraps the decoding of different node types back into a node
+// decode wraps the decoding of different node types back into a node
 func decode(r io.Reader) (node, error) {
 	header, err := readByte(r)
 	if err != nil {

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -237,7 +237,7 @@ func (b *branch) encodeAndHash() (encoding, hash []byte, err error) {
 
 	b.encoding = make([]byte, len(bufferBytes))
 	copy(b.encoding, bufferBytes)
-	encoding := b.encoding // no need to copy
+	encoding = b.encoding // no need to copy
 
 	if buffer.Len() < 32 {
 		b.hash = make([]byte, len(bufferBytes))

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -277,6 +277,8 @@ func (l *leaf) encodeAndHash() (encoding, hash []byte, err error) {
 	bufferBytes := buffer.Bytes()
 
 	l.encodingMu.Lock()
+	// TODO remove this copying since it defeats the purpose of `buffer`
+	// and the sync.Pool.
 	l.encoding = make([]byte, len(bufferBytes))
 	copy(l.encoding, bufferBytes)
 	l.encodingMu.Unlock()

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -236,9 +236,8 @@ func (b *branch) encodeAndHash() (encoding, hash []byte, err error) {
 	bufferBytes := buffer.Bytes()
 
 	b.encoding = make([]byte, len(bufferBytes))
-	encoding = make([]byte, len(bufferBytes))
 	copy(b.encoding, bufferBytes)
-	encoding = b.encoding // no need to copy
+	encoding := b.encoding // no need to copy
 
 	if buffer.Len() < 32 {
 		b.hash = make([]byte, len(bufferBytes))

--- a/lib/trie/node.go
+++ b/lib/trie/node.go
@@ -83,8 +83,9 @@ func (l *leaf) setGeneration(generation uint64) {
 }
 
 func (b *branch) copy() node {
-	b.Lock()
-	defer b.Unlock()
+	b.RLock()
+	defer b.RUnlock()
+
 	cpy := &branch{
 		key:        make([]byte, len(b.key)),
 		children:   b.children, // copy interface pointers
@@ -108,8 +109,9 @@ func (b *branch) copy() node {
 }
 
 func (l *leaf) copy() node {
-	l.Lock()
-	defer l.Unlock()
+	l.RLock()
+	defer l.RUnlock()
+
 	cpy := &leaf{
 		key:        make([]byte, len(l.key)),
 		value:      make([]byte, len(l.value)),

--- a/lib/trie/print.go
+++ b/lib/trie/print.go
@@ -53,6 +53,9 @@ func (t *Trie) string(tree gotree.Tree, curr node, idx int) {
 		buffer.Reset()
 
 		_ = encodeLeaf(c, buffer)
+
+		c.encodingMu.Lock()
+		defer c.encodingMu.Unlock()
 		c.encoding = buffer.Bytes()
 
 		var bstr string


### PR DESCRIPTION
## Changes

- Buffer and pool usage fixed and improved 
  - Fix buffers not put back in pool
  - Write to buffer passed as arguments
  - Decouple pools for encoding, digests and hashers
- Improve `sync.Pool` usage generally
- Improve parallel encoding of branches and remove dependency on `sync/x`
- Do not copy when not needed

## Tests

```
go test -race github.com/ChainSafe/gossamer/lib/trie
```

## Issues

- #1973 

## Primary Reviewer
