### PR TITLE
chore(dot/peerset): remove `log15` usage

### DIFF
--- a/dot/peerset/peerstate.go
+++ b/dot/peerset/peerstate.go
@@ -235,7 +235,7 @@ func (ps *PeersState) hasFreeIncomingSlot(set int) bool {
 // has no effect if the node was already in the group.
 func (ps *PeersState) addNoSlotNode(idx int, peerID peer.ID) {
 	if _, ok := ps.sets[idx].noSlotNodes[peerID]; ok {
-		logger.Debug("peer is already exists in no slot node", "peer", peerID)
+		logger.Debugf("peer %s already exists in no slot node", peerID)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ChainSafe/gossamer
 require (
 	github.com/ChainSafe/chaindb v0.1.5-0.20210608140454-9606fe8c3985
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20210318173838-ccb5cd955283
-	github.com/ChainSafe/log15 v1.0.0
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/centrifuge/go-substrate-rpc-client/v3 v3.0.0
@@ -46,6 +45,7 @@ require (
 )
 
 require (
+	github.com/ChainSafe/log15 v1.0.0 // indirect
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect


### PR DESCRIPTION
## Changes

- Just migrates to use `internal/log` instead of `log15` in `dot/peerset`. My bad, I merged development in the log package PR before merging it in dev, but didn't notice the log15 sneaking back in.

## Tests

## Issues

## Primary Reviewer
