### PR TITLE
chore(ioutil): move from io/ioutil to io and os packages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,6 +34,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17.x"
       - uses: actions/checkout@v2
       - name: Checks PR has title and body description
         run: |

--- a/cmd/gossamer/import_runtime.go
+++ b/cmd/gossamer/import_runtime.go
@@ -6,7 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
@@ -15,7 +15,7 @@ import (
 var defaultGenesisSpecPath = "./chain/gssmr/genesis-spec.json"
 
 func createGenesisWithRuntime(fp string) (string, error) {
-	runtime, err := ioutil.ReadFile(filepath.Clean(fp))
+	runtime, err := os.ReadFile(filepath.Clean(fp))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gossamer/import_runtime_test.go
+++ b/cmd/gossamer/import_runtime_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -20,11 +19,11 @@ func TestCreateGenesisWithRuntime(t *testing.T) {
 
 	testCode := []byte("somecode")
 	testHex := common.BytesToHex(testCode)
-	testFile, err := ioutil.TempFile("", "testcode-*.wasm")
+	testFile, err := os.CreateTemp("", "testcode-*.wasm")
 	require.NoError(t, err)
 	defer os.Remove(testFile.Name())
 
-	err = ioutil.WriteFile(testFile.Name(), testCode, 0777)
+	err = os.WriteFile(testFile.Name(), testCode, 0777)
 	require.NoError(t, err)
 
 	out, err := createGenesisWithRuntime(testFile.Name())

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sync"
@@ -91,7 +90,7 @@ func (tt *TestExecCommand) Run(name string, args ...string) {
 func (tt *TestExecCommand) ExpectExit() {
 	var output []byte
 	tt.withKillTimeout(func() {
-		output, _ = ioutil.ReadAll(tt.stdout)
+		output, _ = io.ReadAll(tt.stdout)
 	})
 	tt.WaitExit()
 	if tt.Cleanup != nil {
@@ -104,7 +103,7 @@ func (tt *TestExecCommand) ExpectExit() {
 
 func (tt *TestExecCommand) GetOutput() (stdout []byte, stderr []byte) {
 	tt.withSigTimeout(func() {
-		stdout, _ = ioutil.ReadAll(tt.stdout)
+		stdout, _ = io.ReadAll(tt.stdout)
 		stderr = tt.stderr.buf.Bytes()
 	})
 	tt.WaitExit()
@@ -220,7 +219,7 @@ func TestInvalidCommand(t *testing.T) {
 func TestInitCommand_RenameNodeWhenCalled(t *testing.T) {
 	genesisPath := utils.GetGssmrGenesisRawPath()
 
-	tempDir, err := ioutil.TempDir("", "gossamer-maintest-")
+	tempDir, err := os.MkdirTemp("", "gossamer-maintest-")
 	require.Nil(t, err)
 
 	nodeName := dot.RandomNodeName()

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -219,8 +219,7 @@ func TestInvalidCommand(t *testing.T) {
 func TestInitCommand_RenameNodeWhenCalled(t *testing.T) {
 	genesisPath := utils.GetGssmrGenesisRawPath()
 
-	tempDir, err := os.MkdirTemp("", "gossamer-maintest-")
-	require.Nil(t, err)
+	tempDir := t.TempDir()
 
 	nodeName := dot.RandomNodeName()
 	init := runTestGossamer(t,
@@ -233,7 +232,6 @@ func TestInitCommand_RenameNodeWhenCalled(t *testing.T) {
 	)
 
 	stdout, stderr := init.GetOutput()
-	require.Nil(t, err)
 
 	t.Log("init gossamer output, ", "stdout", string(stdout), "stderr", string(stderr))
 
@@ -249,7 +247,6 @@ func TestInitCommand_RenameNodeWhenCalled(t *testing.T) {
 	)
 
 	stdout, stderr = init.GetOutput()
-	require.Nil(t, err)
 
 	t.Log("init gossamer output, ", "stdout", string(stdout), "stderr", string(stderr))
 

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -110,7 +109,7 @@ func newTestConfig(t *testing.T) *dot.Config {
 func newTestConfigWithFile(t *testing.T) (*dot.Config, *os.File) {
 	cfg := newTestConfig(t)
 
-	file, err := ioutil.TempFile(cfg.Global.BasePath, "config-")
+	file, err := os.CreateTemp(cfg.Global.BasePath, "config-")
 	require.NoError(t, err)
 
 	tomlCfg := dotConfigToToml(cfg)

--- a/dot/build_spec_test.go
+++ b/dot/build_spec_test.go
@@ -6,7 +6,7 @@ package dot
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestBuildFromGenesis_WhenGenesisDoesNotExists(t *testing.T) {
 }
 
 func TestWriteGenesisSpecFileWhenFileAlreadyExists(t *testing.T) {
-	f, err := ioutil.TempFile("", "existing file data")
+	f, err := os.CreateTemp("", "existing file data")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 
@@ -105,7 +105,7 @@ func TestWriteGenesisSpecFile(t *testing.T) {
 		require.NoError(t, err)
 		defer file.Close()
 
-		genesisBytes, err := ioutil.ReadAll(file)
+		genesisBytes, err := io.ReadAll(file)
 		require.NoError(t, err)
 
 		gen := new(genesis.Genesis)

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -6,7 +6,6 @@ package core
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"sort"
@@ -549,7 +548,7 @@ func TestService_HandleRuntimeChanges(t *testing.T) {
 	err = s.blockState.HandleRuntimeChanges(ts, parentRt, bhash1)
 	require.NoError(t, err)
 
-	testRuntime, err := ioutil.ReadFile(updateNodeRuntimeWasmPath)
+	testRuntime, err := os.ReadFile(updateNodeRuntimeWasmPath)
 	require.NoError(t, err)
 
 	ts.Set(common.CodeKey, testRuntime)
@@ -578,7 +577,7 @@ func TestService_HandleRuntimeChanges(t *testing.T) {
 func TestService_HandleCodeSubstitutes(t *testing.T) {
 	s := NewTestService(t, nil)
 
-	testRuntime, err := ioutil.ReadFile(runtime.POLKADOT_RUNTIME_FP)
+	testRuntime, err := os.ReadFile(runtime.POLKADOT_RUNTIME_FP)
 	require.NoError(t, err)
 
 	blockHash := common.MustHexToHash("0x86aa36a140dfc449c30dbce16ce0fea33d5c3786766baa764e33f336841b9e29") // hash for known test code substitution
@@ -626,7 +625,7 @@ func TestService_HandleRuntimeChangesAfterCodeSubstitutes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, codeHashBefore, parentRt.GetCodeHash()) // codeHash should remain unchanged after code substitute
 
-	testRuntime, err := ioutil.ReadFile(runtime.POLKADOT_RUNTIME_FP)
+	testRuntime, err := os.ReadFile(runtime.POLKADOT_RUNTIME_FP)
 	require.NoError(t, err)
 
 	ts, err = s.storageState.TrieState(nil)

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -4,7 +4,7 @@
 package core
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -45,7 +45,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	cfg.LogLvl = 3
 
 	var stateSrvc *state.Service
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	gen, genTrie, genHeader := genesis.NewTestGenesisWithTrieAndHeader(t)

--- a/dot/core/test_helpers.go
+++ b/dot/core/test_helpers.go
@@ -4,7 +4,6 @@
 package core
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -45,8 +44,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	cfg.LogLvl = 3
 
 	var stateSrvc *state.Service
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	gen, genTrie, genHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
 
@@ -58,7 +56,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 		stateSrvc = state.NewService(config)
 		stateSrvc.UseMemDB()
 
-		err = stateSrvc.Initialise(gen, genHeader, genTrie)
+		err := stateSrvc.Initialise(gen, genHeader, genTrie)
 		require.Nil(t, err)
 
 		err = stateSrvc.Start()
@@ -88,6 +86,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	if cfg.Runtime == nil {
 		rtCfg := &wasmer.Config{}
 
+		var err error
 		rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
 		require.NoError(t, err)
 

--- a/dot/digest/digest_test.go
+++ b/dot/digest/digest_test.go
@@ -4,8 +4,8 @@
 package digest
 
 import (
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -23,7 +23,7 @@ import (
 )
 
 func newTestHandler(t *testing.T) *Handler {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	config := state.Config{

--- a/dot/digest/digest_test.go
+++ b/dot/digest/digest_test.go
@@ -5,7 +5,6 @@ package digest
 
 import (
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -23,8 +22,7 @@ import (
 )
 
 func newTestHandler(t *testing.T) *Handler {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	config := state.Config{
 		Path:     testDatadirPath,
@@ -34,7 +32,7 @@ func newTestHandler(t *testing.T) *Handler {
 	stateSrvc.UseMemDB()
 
 	gen, genTrie, genHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
-	err = stateSrvc.Initialise(gen, genHeader, genTrie)
+	err := stateSrvc.Initialise(gen, genHeader, genTrie)
 	require.NoError(t, err)
 
 	err = stateSrvc.Start()

--- a/dot/import.go
+++ b/dot/import.go
@@ -6,7 +6,7 @@ package dot
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ChainSafe/gossamer/dot/state"
@@ -41,7 +41,7 @@ func ImportState(basepath, stateFP, headerFP string, firstSlot uint64) error {
 }
 
 func newTrieFromPairs(filename string) (*trie.Trie, error) {
-	data, err := ioutil.ReadFile(filepath.Clean(filename))
+	data, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func newTrieFromPairs(filename string) (*trie.Trie, error) {
 }
 
 func newHeaderFromFile(filename string) (*types.Header, error) {
-	data, err := ioutil.ReadFile(filepath.Clean(filename))
+	data, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, err
 	}

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -5,8 +5,8 @@ package dot
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -20,7 +20,7 @@ import (
 func setupStateFile(t *testing.T) string {
 	filename := "../lib/runtime/test_data/kusama/block1482002.out"
 
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	require.NoError(t, err)
 
 	rpcPairs := make(map[string]interface{})
@@ -32,7 +32,7 @@ func setupStateFile(t *testing.T) string {
 	require.NoError(t, err)
 
 	fp := "./test_data/state.json"
-	err = ioutil.WriteFile(fp, bz, 0777)
+	err = os.WriteFile(fp, bz, 0777)
 	require.NoError(t, err)
 
 	return fp
@@ -41,7 +41,7 @@ func setupStateFile(t *testing.T) string {
 func setupHeaderFile(t *testing.T) string {
 	headerStr := "{\"digest\":{\"logs\":[\"0x0642414245b501013c0000009659bd0f0000000070edad1c9064fff78cb18435223d8adaf5ea04c24b1a8766e3dc01eb03cc6a0c11b79793d4e31cc0990838229c44fed1669a7c7c79e1e6d0a96374d6496728069d1ef739e290497a0e3b728fa88fcbdd3a5504e0efde0242e7a806dd4fa9260c\",\"0x054241424501019e7f28dddcf27c1e6b328d5694c368d5b2ec5dbe0e412ae1c98f88d53be4d8502fac571f3f19c9caaf281a673319241e0c5095a683ad34316204088a36a4bd86\"]},\"extrinsicsRoot\":\"0xda26dc8c1455f8f81cae12e4fc59e23ce961b2c837f6d3f664283af906d344e0\",\"number\":\"0x169d12\",\"parentHash\":\"0x3b45c9c22dcece75a30acc9c2968cb311e6b0557350f83b430f47559db786975\",\"stateRoot\":\"0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb\"}"
 	fp := "./test_data/header.json"
-	err := ioutil.WriteFile(fp, []byte(headerStr), 0777)
+	err := os.WriteFile(fp, []byte(headerStr), 0777)
 	require.NoError(t, err)
 	return fp
 }
@@ -78,7 +78,7 @@ func TestNewHeaderFromFile(t *testing.T) {
 }
 
 func TestImportState(t *testing.T) {
-	basepath, err := ioutil.TempDir("", "gossamer-test-*")
+	basepath, err := os.MkdirTemp("", "gossamer-test-*")
 	require.NoError(t, err)
 
 	cfg := NewTestConfig(t)

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -78,8 +78,7 @@ func TestNewHeaderFromFile(t *testing.T) {
 }
 
 func TestImportState(t *testing.T) {
-	basepath, err := os.MkdirTemp("", "gossamer-test-*")
-	require.NoError(t, err)
+	basepath := t.TempDir()
 
 	cfg := NewTestConfig(t)
 	require.NotNil(t, cfg)
@@ -92,7 +91,7 @@ func TestImportState(t *testing.T) {
 	cfg.Init.Genesis = genFile.Name()
 
 	cfg.Global.BasePath = basepath
-	err = InitNode(cfg)
+	err := InitNode(cfg)
 	require.NoError(t, err)
 
 	stateFP := setupStateFile(t)

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"os"
 	"path"
@@ -78,7 +77,7 @@ func loadKey(fp string) (crypto.PrivKey, error) {
 	if _, err := os.Stat(pth); os.IsNotExist(err) {
 		return nil, nil
 	}
-	keyData, err := ioutil.ReadFile(filepath.Clean(pth))
+	keyData, err := os.ReadFile(filepath.Clean(pth))
 	if err != nil {
 		return nil, err
 	}

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"testing"
@@ -279,7 +278,7 @@ func PostRequest(t *testing.T, url string, data io.Reader) (int, []byte) {
 
 	defer res.Body.Close()
 
-	resBody, err := ioutil.ReadAll(res.Body)
+	resBody, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
 
 	responseData := new(bytes.Buffer)

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -4,8 +4,8 @@
 package modules
 
 import (
-	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -338,7 +338,7 @@ func TestChainGetFinalizedHeadByRound(t *testing.T) {
 }
 
 func newTestStateService(t *testing.T) *state.Service {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	config := state.Config{

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -5,7 +5,6 @@ package modules
 
 import (
 	"math/big"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -338,8 +337,7 @@ func TestChainGetFinalizedHeadByRound(t *testing.T) {
 }
 
 func newTestStateService(t *testing.T) *state.Service {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	config := state.Config{
 		Path:     testDatadirPath,
@@ -350,7 +348,7 @@ func newTestStateService(t *testing.T) *state.Service {
 
 	gen, genTrie, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
 
-	err = stateSrvc.Initialise(gen, genesisHeader, genTrie)
+	err := stateSrvc.Initialise(gen, genesisHeader, genTrie)
 	require.NoError(t, err)
 
 	err = stateSrvc.Start()

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -7,8 +7,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -367,7 +367,7 @@ func TestStateModule_GetMetadata(t *testing.T) {
 	randomHash, err := common.HexToHash(RandomHash)
 	require.NoError(t, err)
 
-	expectedMetadata, err := ioutil.ReadFile("./test_data/expected_metadata")
+	expectedMetadata, err := os.ReadFile("./test_data/expected_metadata")
 	require.NoError(t, err)
 
 	testCases := []struct {

--- a/dot/rpc/modules/sync_state_test.go
+++ b/dot/rpc/modules/sync_state_test.go
@@ -5,7 +5,7 @@ package modules
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +19,7 @@ func TestSyncStateModule(t *testing.T) {
 	fp, err := filepath.Abs(GssmrGenesisPath)
 	require.NoError(t, err)
 
-	data, err := ioutil.ReadFile(filepath.Clean(fp))
+	data, err := os.ReadFile(filepath.Clean(fp))
 	require.NoError(t, err)
 
 	g := new(genesis.Genesis)

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -6,11 +6,11 @@ package subscription
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -355,7 +355,7 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 	require.NoError(t, err)
 	fp, err := filepath.Abs(runtime.POLKADOT_RUNTIME_FP)
 	require.NoError(t, err)
-	code, err := ioutil.ReadFile(fp)
+	code, err := os.ReadFile(fp)
 	require.NoError(t, err)
 	version, err := instance.CheckRuntimeVersion(code)
 	require.NoError(t, err)

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"strings"
@@ -424,7 +424,7 @@ func (c *WSConn) executeRequest(r *http.Request, d interface{}) error {
 		return err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		logger.Warnf("error reading response body: %s", err)
 		return err

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -37,8 +36,8 @@ func newTestService(t *testing.T) (state *Service) {
 	return state
 }
 
-func newTestMemDBService() *Service {
-	testDatadirPath, _ := os.MkdirTemp("/tmp", "test-datadir-*")
+func newTestMemDBService(t *testing.T) *Service {
+	testDatadirPath := t.TempDir()
 	config := Config{
 		Path:     testDatadirPath,
 		LogLevel: log.Info,
@@ -86,7 +85,7 @@ func TestService_Initialise(t *testing.T) {
 }
 
 func TestMemDB_Start(t *testing.T) {
-	state := newTestMemDBService()
+	state := newTestMemDBService(t)
 
 	genData, genTrie, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
 	err := state.Initialise(genData, genesisHeader, genTrie)

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -6,8 +6,8 @@ package state
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -38,7 +38,7 @@ func newTestService(t *testing.T) (state *Service) {
 }
 
 func newTestMemDBService() *Service {
-	testDatadirPath, _ := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, _ := os.MkdirTemp("/tmp", "test-datadir-*")
 	config := Config{
 		Path:     testDatadirPath,
 		LogLevel: log.Info,

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -172,16 +171,6 @@ func Test_Example(t *testing.T) {
 	bValue := []byte("b-value")
 
 	// Open the DB.
-	dir, err := os.MkdirTemp("", "badger-test")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(dir); err != nil {
-			log.Fatal(err)
-		}
-	}()
-
 	db := NewInMemoryDB(t)
 
 	// Create the context here so we can cancel it after sending the writes.
@@ -199,14 +188,14 @@ func Test_Example(t *testing.T) {
 			}
 			return nil
 		}
-		if err = db.Subscribe(ctx, cb, prefix); err != nil && err != context.Canceled {
+		if err := db.Subscribe(ctx, cb, prefix); err != nil && err != context.Canceled {
 			log.Fatal(err)
 		}
 		log.Printf("subscription closed")
 	}()
 
 	// Write both keys, but only one should be printed in the Output.
-	err = db.Put(aKey, aValue)
+	err := db.Put(aKey, aValue)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -173,7 +172,7 @@ func Test_Example(t *testing.T) {
 	bValue := []byte("b-value")
 
 	// Open the DB.
-	dir, err := ioutil.TempDir("", "badger-test")
+	dir, err := os.MkdirTemp("", "badger-test")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -6,8 +6,8 @@ package state
 import (
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -25,7 +25,7 @@ var inc, _ = time.ParseDuration("1s")
 
 // NewInMemoryDB creates a new in-memory database
 func NewInMemoryDB(t *testing.T) chaindb.Database {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	db, err := utils.SetupDatabase(testDatadirPath, true)

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -25,8 +24,7 @@ var inc, _ = time.ParseDuration("1s")
 
 // NewInMemoryDB creates a new in-memory database
 func NewInMemoryDB(t *testing.T) chaindb.Database {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	db, err := utils.SetupDatabase(testDatadirPath, true)
 	require.NoError(t, err)

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -64,7 +64,7 @@ func newTestSyncer(t *testing.T) *Service {
 	wasmer.DefaultTestLogLvl = 3
 
 	cfg := &Config{}
-	testDatadirPath, _ := os.MkdirTemp("/tmp", "test-datadir-*")
+	testDatadirPath := t.TempDir()
 
 	scfg := state.Config{
 		Path:     testDatadirPath,

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -4,7 +4,6 @@
 package sync
 
 import (
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -65,7 +64,7 @@ func newTestSyncer(t *testing.T) *Service {
 	wasmer.DefaultTestLogLvl = 3
 
 	cfg := &Config{}
-	testDatadirPath, _ := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, _ := os.MkdirTemp("/tmp", "test-datadir-*")
 
 	scfg := state.Config{
 		Path:     testDatadirPath,

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ func NewTestGenesis(t *testing.T) *genesis.Genesis {
 func NewTestGenesisRawFile(t *testing.T, cfg *Config) *os.File {
 	dir := utils.NewTestDir(t)
 
-	file, err := ioutil.TempFile(dir, "genesis-")
+	file, err := os.CreateTemp(dir, "genesis-")
 	require.Nil(t, err)
 
 	fp := utils.GetGssmrGenesisRawPath()
@@ -74,7 +73,7 @@ func NewTestGenesisRawFile(t *testing.T, cfg *Config) *os.File {
 func NewTestGenesisFile(t *testing.T, cfg *Config) *os.File {
 	dir := utils.NewTestDir(t)
 
-	file, err := ioutil.TempFile(dir, "genesis-")
+	file, err := os.CreateTemp(dir, "genesis-")
 	require.Nil(t, err)
 
 	fp := utils.GetGssmrGenesisPath()
@@ -107,7 +106,7 @@ func NewTestGenesisAndRuntime(t *testing.T) string {
 	_ = wasmer.NewTestInstance(t, runtime.NODE_RUNTIME)
 	runtimeFilePath := runtime.GetAbsolutePath(runtime.NODE_RUNTIME_FP)
 
-	runtimeData, err := ioutil.ReadFile(filepath.Clean(runtimeFilePath))
+	runtimeData, err := os.ReadFile(filepath.Clean(runtimeFilePath))
 	require.Nil(t, err)
 
 	gen := NewTestGenesis(t)
@@ -120,7 +119,7 @@ func NewTestGenesisAndRuntime(t *testing.T) string {
 	gen.Genesis.Raw["top"]["0x3a636f6465"] = "0x" + hex
 	gen.Genesis.Raw["top"]["0xcf722c0832b5231d35e29f319ff27389f5032bfc7bfc3ba5ed7839f2042fb99f"] = "0x0000000000000001"
 
-	genFile, err := ioutil.TempFile(dir, "genesis-")
+	genFile, err := os.CreateTemp(dir, "genesis-")
 	require.Nil(t, err)
 
 	genData, err := json.Marshal(gen)
@@ -158,7 +157,7 @@ func NewTestConfig(t *testing.T) *Config {
 func NewTestConfigWithFile(t *testing.T) (*Config, *os.File) {
 	cfg := NewTestConfig(t)
 
-	file, err := ioutil.TempFile(cfg.Global.BasePath, "config-")
+	file, err := os.CreateTemp(cfg.Global.BasePath, "config-")
 	require.NoError(t, err)
 
 	cfgFile := ExportConfig(cfg, file.Name())

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -5,7 +5,6 @@ package babe
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -91,7 +90,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		cfg.TransactionState = state.NewTransactionState()
 	}
 
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*") //nolint
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*") //nolint
 	require.NoError(t, err)
 
 	var dbSrv *state.Service
@@ -167,7 +166,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *types.BabeConfiguration) {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	config := state.Config{

--- a/lib/babe/babe_test.go
+++ b/lib/babe/babe_test.go
@@ -90,7 +90,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		cfg.TransactionState = state.NewTransactionState()
 	}
 
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*") //nolint
+	testDatadirPath := t.TempDir()
 	require.NoError(t, err)
 
 	var dbSrv *state.Service
@@ -166,8 +166,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *types.BabeConfiguration) {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	config := state.Config{
 		Path:     testDatadirPath,
@@ -177,7 +176,7 @@ func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *
 	dbSrv.UseMemDB()
 
 	gen, genTrie, genHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
-	err = dbSrv.Initialise(gen, genHeader, genTrie)
+	err := dbSrv.Initialise(gen, genHeader, genTrie)
 	require.NoError(t, err)
 
 	err = dbSrv.Start()

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -5,8 +5,8 @@ package babe
 
 import (
 	"errors"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -21,7 +21,7 @@ import (
 )
 
 func newTestVerificationManager(t *testing.T, genCfg *types.BabeConfiguration) *VerificationManager {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	config := state.Config{

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -6,7 +6,6 @@ package babe
 import (
 	"errors"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -21,8 +20,7 @@ import (
 )
 
 func newTestVerificationManager(t *testing.T, genCfg *types.BabeConfiguration) *VerificationManager {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	config := state.Config{
 		Path:     testDatadirPath,
@@ -36,7 +34,7 @@ func newTestVerificationManager(t *testing.T, genCfg *types.BabeConfiguration) *
 	}
 
 	gen, genTrie, genHeader := genesis.NewDevGenesisWithTrieAndHeader(t)
-	err = dbSrv.Initialise(gen, genHeader, genTrie)
+	err := dbSrv.Initialise(gen, genHeader, genTrie)
 	require.NoError(t, err)
 
 	err = dbSrv.Start()

--- a/lib/genesis/helpers.go
+++ b/lib/genesis/helpers.go
@@ -8,9 +8,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -49,7 +49,7 @@ func NewGenesisFromJSONRaw(file string) (*Genesis, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(filepath.Clean(fp))
+	data, err := os.ReadFile(filepath.Clean(fp))
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func NewGenesisSpecFromJSON(file string) (*Genesis, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(filepath.Clean(fp))
+	data, err := os.ReadFile(filepath.Clean(fp))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/genesis/helpers_test.go
+++ b/lib/genesis/helpers_test.go
@@ -6,7 +6,6 @@ package genesis
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,7 +17,7 @@ import (
 
 func TestNewGenesisRawFromJSON(t *testing.T) {
 	// Create temp file
-	file, err := ioutil.TempFile("", "genesis-test")
+	file, err := os.CreateTemp("", "genesis-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +85,7 @@ func TestNewGenesisFromJSON(t *testing.T) {
 	}
 
 	// Create temp file
-	file, err := ioutil.TempFile("", "genesis_hr-test")
+	file, err := os.CreateTemp("", "genesis_hr-test")
 	require.NoError(t, err)
 
 	defer os.Remove(file.Name())

--- a/lib/genesis/test_utils.go
+++ b/lib/genesis/test_utils.go
@@ -5,8 +5,8 @@ package genesis
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -65,7 +65,7 @@ var TestFieldsRaw = Fields{
 // CreateTestGenesisJSONFile utility to create mock test genesis JSON file
 func CreateTestGenesisJSONFile(asRaw bool) (string, error) {
 	// Create temp file
-	file, err := ioutil.TempFile("", "genesis-test")
+	file, err := os.CreateTemp("", "genesis-test")
 	if err != nil {
 		return "", err
 	}

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -5,9 +5,9 @@ package grandpa
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -50,7 +50,7 @@ func NewMockDigestHandler() *mocks.DigestHandler {
 }
 
 func newTestState(t *testing.T) *state.Service {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	db, err := utils.SetupDatabase(testDatadirPath, true)

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"math/big"
 	"math/rand"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -50,8 +49,7 @@ func NewMockDigestHandler() *mocks.DigestHandler {
 }
 
 func newTestState(t *testing.T) *state.Service {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	db, err := utils.SetupDatabase(testDatadirPath, true)
 	require.NoError(t, err)

--- a/lib/keystore/encrypt.go
+++ b/lib/keystore/encrypt.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -148,7 +147,7 @@ func ReadFromFileAndDecrypt(filename string, password []byte) (crypto.PrivateKey
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(filepath.Clean(fp))
+	data, err := os.ReadFile(filepath.Clean(fp))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -181,7 +180,7 @@ func ImportKeypair(fp, dir string) (string, error) {
 		return "", fmt.Errorf("failed to create keystore directory: %s", err)
 	}
 
-	keyData, err := ioutil.ReadFile(filepath.Clean(fp))
+	keyData, err := os.ReadFile(filepath.Clean(fp))
 	if err != nil {
 		return "", fmt.Errorf("failed to read keystore file: %s", err)
 	}
@@ -197,7 +196,7 @@ func ImportKeypair(fp, dir string) (string, error) {
 		return "", fmt.Errorf("failed to create keystore filepath: %s", err)
 	}
 
-	err = ioutil.WriteFile(keyFilePath, keyData, 0600)
+	err = os.WriteFile(keyFilePath, keyData, 0600)
 	if err != nil {
 		return "", fmt.Errorf("failed to write to keystore file: %s", err)
 	}

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -5,7 +5,6 @@ package keystore
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -100,7 +99,7 @@ func TestGenerateKey_Ed25519(t *testing.T) {
 		t.Fatalf("Fail: got %s expected %s", keys[0], keyfile)
 	}
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +137,7 @@ func TestGenerateKey_Secp256k1(t *testing.T) {
 		t.Fatalf("Fail: got %s expected %s", keys[0], keyfile)
 	}
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +162,7 @@ func TestGenerateKey_NoType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +298,7 @@ func TestImportRawPrivateKey_NoType(t *testing.T) {
 	keyfile, err := ImportRawPrivateKey("0x33a6f3093f158a7109f679410bef1a0c54168145e0cecb4df006c1c2fffb1f09", "", testdir, testPassword)
 	require.NoError(t, err)
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	require.NoError(t, err)
 
 	kscontents := new(EncryptedKeystore)
@@ -316,7 +315,7 @@ func TestImportRawPrivateKey_Sr25519(t *testing.T) {
 	keyfile, err := ImportRawPrivateKey("0x33a6f3093f158a7109f679410bef1a0c54168145e0cecb4df006c1c2fffb1f09", "sr25519", testdir, testPassword)
 	require.NoError(t, err)
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	require.NoError(t, err)
 
 	kscontents := new(EncryptedKeystore)
@@ -333,7 +332,7 @@ func TestImportRawPrivateKey_Ed25519(t *testing.T) {
 	keyfile, err := ImportRawPrivateKey("0x33a6f3093f158a7109f679410bef1a0c54168145e0cecb4df006c1c2fffb1f09", "ed25519", testdir, testPassword)
 	require.NoError(t, err)
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	require.NoError(t, err)
 
 	kscontents := new(EncryptedKeystore)
@@ -350,7 +349,7 @@ func TestImportRawPrivateKey_Secp256k1(t *testing.T) {
 	keyfile, err := ImportRawPrivateKey("0x33a6f3093f158a7109f679410bef1a0c54168145e0cecb4df006c1c2fffb1f09", "secp256k1", testdir, testPassword)
 	require.NoError(t, err)
 
-	contents, err := ioutil.ReadFile(keyfile)
+	contents, err := os.ReadFile(keyfile)
 	require.NoError(t, err)
 
 	kscontents := new(EncryptedKeystore)

--- a/lib/runtime/life/instance.go
+++ b/lib/runtime/life/instance.go
@@ -6,7 +6,7 @@ package life
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -68,7 +68,7 @@ func NewRuntimeFromGenesis(cfg *Config) (runtime.Instance, error) {
 // NewInstanceFromFile instantiates a runtime from a .wasm file
 func NewInstanceFromFile(fp string, cfg *Config) (*Instance, error) {
 	// Reads the WebAssembly module as bytes.
-	bytes, err := ioutil.ReadFile(filepath.Clean(fp))
+	bytes, err := os.ReadFile(filepath.Clean(fp))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -5,7 +5,7 @@ package runtime
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -23,7 +23,7 @@ import (
 
 // NewInMemoryDB creates a new in-memory database
 func NewInMemoryDB(t *testing.T) chaindb.Database {
-	testDatadirPath, err := ioutil.TempDir("/tmp", "test-datadir-*")
+	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
 	require.NoError(t, err)
 
 	db, err := chaindb.NewBadgerDB(&chaindb.Config{
@@ -89,13 +89,13 @@ func GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL string) error {
 		return err
 	}
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	return ioutil.WriteFile(testRuntimeFilePath, respBody, os.ModePerm)
+	return os.WriteFile(testRuntimeFilePath, respBody, os.ModePerm)
 }
 
 // TestRuntimeNetwork ...

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -23,8 +23,7 @@ import (
 
 // NewInMemoryDB creates a new in-memory database
 func NewInMemoryDB(t *testing.T) chaindb.Database {
-	testDatadirPath, err := os.MkdirTemp("/tmp", "test-datadir-*")
-	require.NoError(t, err)
+	testDatadirPath := t.TempDir()
 
 	db, err := chaindb.NewBadgerDB(&chaindb.Config{
 		DataDir:  testDatadirPath,

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -1137,7 +1137,7 @@ func TestInstance_PaymentQueryInfo(t *testing.T) {
 }
 
 func newTrieFromPairs(t *testing.T, filename string) *trie.Trie {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	require.NoError(t, err)
 
 	rpcPairs := make(map[string]interface{})

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1659,10 +1659,7 @@ func Test_ext_trie_blake2_256_root_version_1(t *testing.T) {
 func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := os.MkdirTemp("", "*-test-trie")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
 		InMemory: true,

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -6,7 +6,6 @@ package wasmer
 import (
 	"bytes"
 	"encoding/binary"
-	"io/ioutil"
 	"os"
 	"sort"
 	"testing"
@@ -1660,7 +1659,7 @@ func Test_ext_trie_blake2_256_root_version_1(t *testing.T) {
 func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "*-test-trie")
+	tmp, err := os.MkdirTemp("", "*-test-trie")
 	require.NoError(t, err)
 
 	defer os.RemoveAll(tmp)

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -4,7 +4,7 @@
 package wasmer
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,7 +40,7 @@ func TestInstance_CheckRuntimeVersion(t *testing.T) {
 	require.NoError(t, err)
 	fp, err := filepath.Abs(runtime.POLKADOT_RUNTIME_FP)
 	require.NoError(t, err)
-	code, err := ioutil.ReadFile(fp)
+	code, err := os.ReadFile(fp)
 	require.NoError(t, err)
 	version, err := instance.CheckRuntimeVersion(code)
 	require.NoError(t, err)

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -6,7 +6,6 @@ package trie
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 )
 
 func newTestDB(t *testing.T) chaindb.Database {
-	testDatadirPath, _ := ioutil.TempDir(os.TempDir(), "test-datadir-*")
+	testDatadirPath, _ := os.MkdirTemp(os.TempDir(), "test-datadir-*")
 	db, err := utils.SetupDatabase(testDatadirPath, true)
 	require.NoError(t, err)
 	return chaindb.NewTable(db, "trie")

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -6,7 +6,6 @@ package trie
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/ChainSafe/chaindb"
@@ -15,7 +14,7 @@ import (
 )
 
 func newTestDB(t *testing.T) chaindb.Database {
-	testDatadirPath, _ := os.MkdirTemp(os.TempDir(), "test-datadir-*")
+	testDatadirPath := t.TempDir()
 	db, err := utils.SetupDatabase(testDatadirPath, true)
 	require.NoError(t, err)
 	return chaindb.NewTable(db, "trie")

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -4,7 +4,6 @@
 package trie
 
 import (
-	"os"
 	"testing"
 
 	"github.com/ChainSafe/chaindb"
@@ -14,8 +13,7 @@ import (
 func TestProofGeneration(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := os.MkdirTemp("", "*-test-trie")
-	require.NoError(t, err)
+	tmp := t.TempDir()
 
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
 		InMemory: true,
@@ -55,8 +53,7 @@ func TestProofGeneration(t *testing.T) {
 func testGenerateProof(t *testing.T, entries []Pair, keys [][]byte) ([]byte, [][]byte, []Pair) {
 	t.Helper()
 
-	tmp, err := os.MkdirTemp("", "*-test-trie")
-	require.NoError(t, err)
+	tmp := t.TempDir()
 
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
 		InMemory: true,

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -4,7 +4,7 @@
 package trie
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/ChainSafe/chaindb"
@@ -14,7 +14,7 @@ import (
 func TestProofGeneration(t *testing.T) {
 	t.Parallel()
 
-	tmp, err := ioutil.TempDir("", "*-test-trie")
+	tmp, err := os.MkdirTemp("", "*-test-trie")
 	require.NoError(t, err)
 
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
@@ -55,7 +55,7 @@ func TestProofGeneration(t *testing.T) {
 func testGenerateProof(t *testing.T, entries []Pair, keys [][]byte) ([]byte, [][]byte, []Pair) {
 	t.Helper()
 
-	tmp, err := ioutil.TempDir("", "*-test-trie")
+	tmp, err := os.MkdirTemp("", "*-test-trie")
 	require.NoError(t, err)
 
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -116,7 +115,7 @@ func writeToTestFile(tests []Test) error {
 		return err
 	}
 	os.Remove(fp)
-	err = ioutil.WriteFile(fp, []byte(testString), 0644)
+	err = os.WriteFile(fp, []byte(testString), 0644)
 	if err != nil {
 		return err
 	}
@@ -278,7 +277,7 @@ func TestFailingTests(t *testing.T) {
 		t.Error(err)
 	}
 
-	data, err := ioutil.ReadFile(fp)
+	data, err := os.ReadFile(fp)
 	if err != nil {
 		t.SkipNow()
 	}
@@ -461,7 +460,7 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 }
 
 func TestTrieDiff(t *testing.T) {
-	testDataDirPath, _ := ioutil.TempDir(t.TempDir(), "test-badger-datadir")
+	testDataDirPath, _ := os.MkdirTemp(t.TempDir(), "test-badger-datadir")
 	defer os.RemoveAll(testDataDirPath)
 
 	cfg := &chaindb.Config{

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -460,8 +460,7 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 }
 
 func TestTrieDiff(t *testing.T) {
-	testDataDirPath, _ := os.MkdirTemp(t.TempDir(), "test-badger-datadir")
-	defer os.RemoveAll(testDataDirPath)
+	testDataDirPath := t.TempDir()
 
 	cfg := &chaindb.Config{
 		DataDir:  testDataDirPath,

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -115,7 +114,7 @@ func KeystoreFiles(basepath string) ([]string, error) {
 		return nil, fmt.Errorf("failed to get keystore directory: %s", err)
 	}
 
-	files, err := ioutil.ReadDir(keystorepath)
+	files, err := os.ReadDir(keystorepath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read keystore directory: %s", err)
 	}

--- a/pkg/scale/decode.go
+++ b/pkg/scale/decode.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"reflect"
 )
@@ -286,7 +285,7 @@ func (ds *decodeState) decodeResult(dstv reflect.Value) (err error) {
 		}
 		dstv.Set(reflect.ValueOf(res))
 	default:
-		bytes, _ := ioutil.ReadAll(ds.Reader)
+		bytes, _ := io.ReadAll(ds.Reader)
 		err = fmt.Errorf("unsupported Result value: %v, bytes: %v", rb, bytes)
 	}
 	return
@@ -319,7 +318,7 @@ func (ds *decodeState) decodePointer(dstv reflect.Value) (err error) {
 			dstv.Set(tempElem)
 		}
 	default:
-		bytes, _ := ioutil.ReadAll(ds.Reader)
+		bytes, _ := io.ReadAll(ds.Reader)
 		err = fmt.Errorf("unsupported Option value: %v, bytes: %v", rb, bytes)
 	}
 	return

--- a/tests/utils/framework.go
+++ b/tests/utils/framework.go
@@ -5,7 +5,7 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"testing"
 
@@ -28,7 +28,7 @@ func InitFramework(qtyNodes int) (*Framework, error) {
 	}
 	f.nodes = nodes
 
-	tempDir, err := ioutil.TempDir("", "gossamer-stress-db")
+	tempDir, err := os.MkdirTemp("", "gossamer-stress-db")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -193,7 +192,7 @@ func StartGossamer(t *testing.T, node *Node, websocket bool) error {
 		Logger.Infof("node started with key %s and cmd.Process.Pid %d", key, node.Process.Process.Pid)
 	} else {
 		Logger.Criticalf("node didn't start: %s", err)
-		errFileContents, _ := ioutil.ReadFile(errfile.Name())
+		errFileContents, _ := os.ReadFile(errfile.Name())
 		t.Logf("%s\n", errFileContents)
 		return err
 	}
@@ -256,7 +255,7 @@ func KillProcess(t *testing.T, cmd *exec.Cmd) error {
 // InitNodes initialises given number of nodes
 func InitNodes(num int, config string) ([]*Node, error) {
 	var nodes []*Node
-	tempDir, err := ioutil.TempDir("", "gossamer-stress-")
+	tempDir, err := os.MkdirTemp("", "gossamer-stress-")
 	if err != nil {
 		return nil, err
 	}

--- a/tests/utils/request_utils.go
+++ b/tests/utils/request_utils.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -52,7 +52,7 @@ func PostRPC(method, host, params string) ([]byte, error) {
 		_ = resp.Body.Close()
 	}()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 
 	return respBody, err
 


### PR DESCRIPTION
## Changes

The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since this project has been upgraded to Go 1.17 in #1933, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

## Tests

## Issues

## Primary Reviewer
