### PR TITLE
testing(lib/trie): change `lib/trie` slow and intensive benchmark-oriented tests to benchmarks

### DIFF
--- a/lib/trie/test_utils.go
+++ b/lib/trie/test_utils.go
@@ -3,7 +3,7 @@ package trie
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"math/big"
+	prand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,8 +32,11 @@ func GenerateRandomTests(t testing.TB, size int) []Test {
 	rt := make([]Test, size)
 	kv := make(map[string][]byte)
 
+	const seed = 912378
+	generator := prand.New(prand.NewSource(seed)) //nolint:gosec
+
 	for i := range rt {
-		test := generateRandomTest(t, kv)
+		test := generateRandomTest(t, kv, generator)
 		rt[i] = test
 		kv[string(test.key)] = rt[i].value
 	}
@@ -41,16 +44,15 @@ func GenerateRandomTests(t testing.TB, size int) []Test {
 	return rt
 }
 
-func generateRandomTest(t testing.TB, kv map[string][]byte) Test {
+func generateRandomTest(t testing.TB, kv map[string][]byte, generator *prand.Rand) Test {
 	test := Test{}
 
 	for {
-		n := 2 // arbitrary positive number
-		size, err := rand.Int(rand.Reader, big.NewInt(510))
-		require.NoError(t, err)
+		var n int64 = 2 // arbitrary positive number
+		size := int64(generator.Intn(510))
 
-		buf := make([]byte, size.Int64()+int64(n))
-		_, err = rand.Read(buf)
+		buf := make([]byte, size+n)
+		_, err := generator.Read(buf)
 		require.NoError(t, err)
 
 		key := binary.LittleEndian.Uint16(buf[:2])
@@ -58,11 +60,10 @@ func generateRandomTest(t testing.TB, kv map[string][]byte) Test {
 		if kv[string(buf)] == nil || key < 256 {
 			test.key = buf
 
-			size, err := rand.Int(rand.Reader, big.NewInt(128))
-			require.NoError(t, err)
+			size := int64(generator.Intn(128))
 
-			buf = make([]byte, size.Int64()+int64(n))
-			_, err = rand.Read(buf)
+			buf = make([]byte, size+n)
+			_, err = generator.Read(buf)
 			require.NoError(t, err)
 
 			test.value = buf

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1131,7 +1131,7 @@ func TestNextKey_Random(t *testing.T) {
 	}
 }
 
-func Benchmark_RootHashParallel(b *testing.B) {
+func Benchmark_Trie_Hash(b *testing.B) {
 	rt := GenerateRandomTests(b, 1000000)
 	trie := NewEmptyTrie()
 	for i := range rt {

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1131,39 +1131,43 @@ func TestNextKey_Random(t *testing.T) {
 	}
 }
 
-func TestRootHashNonParallel(t *testing.T) {
-	rt := GenerateRandomTests(t, 1000000)
+func Benchmark_RootHashParallel(b *testing.B) {
+	rt := GenerateRandomTests(b, 1000000)
 	trie := NewEmptyTrie()
 	for i := range rt {
 		test := &rt[i]
 		trie.Put(test.key, test.value)
 	}
 
-	t.Run("Non Parallel Hash", func(t *testing.T) {
+	trieTwo, err := trie.DeepCopy()
+	require.NoError(b, err)
+
+	b.Run("Sequential hash", func(b *testing.B) {
 		trie.parallel = false
+
+		b.StartTimer()
 		_, err := trie.Hash()
-		require.NoError(t, err)
-		PrintMemUsage()
+		b.StopTimer()
+
+		require.NoError(b, err)
+
+		printMemUsage()
+	})
+
+	b.Run("Parallel hash", func(b *testing.B) {
+		trieTwo.parallel = true
+
+		b.StartTimer()
+		_, err := trieTwo.Hash()
+		b.StopTimer()
+
+		require.NoError(b, err)
+
+		printMemUsage()
 	})
 }
 
-func TestRootHashParallel(t *testing.T) {
-	rt := GenerateRandomTests(t, 1000000)
-	trie := NewEmptyTrie()
-	for i := range rt {
-		test := &rt[i]
-		trie.Put(test.key, test.value)
-	}
-
-	t.Run("Parallel Hash", func(t *testing.T) {
-		trie.parallel = true
-		_, err := trie.Hash()
-		require.NoError(t, err)
-		PrintMemUsage()
-	})
-}
-
-func PrintMemUsage() {
+func printMemUsage() {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	// For info on each, see: https://golang.org/pkg/runtime/#MemStats


### PR DESCRIPTION
## Changes

- Why?
  - This must be slowing down the CI quite badly
  - This makes my CPU melt when running them and forgetting to `t.Skip()` them
  - These are really benchmarks, and not unit testing anything really as far as i know
- Change unit tests to a merged Go benchmark (you can run them with `go test -bench`)
- Use deepcopy to copy the trie instead of re-generating one, which takes time
- Use math/rand instead of crypto/rand to generate trie values faster. I don't think we care about crypto secured randomness in most unit tests, and especially not in a benchmark

## Tests

```
go test -bench -run ^Benchmark_Trie_Hash$ github.com/ChainSafe/gossamer/lib/trie
```

## Issues

## Primary Reviewer

- @arijitAD 