### PR TITLE
fix(cmd/cfg): Use  Babe Lead value from toml config

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -581,7 +581,11 @@ func setDotCoreConfig(ctx *cli.Context, tomlCfg ctoml.CoreConfig, cfg *dot.CoreC
 	cfg.BabeAuthority = tomlCfg.Roles == types.AuthorityRole
 	cfg.GrandpaAuthority = tomlCfg.Roles == types.AuthorityRole
 	cfg.GrandpaInterval = time.Second * time.Duration(tomlCfg.GrandpaInterval)
-	cfg.BABELead = ctx.GlobalBool(BABELeadFlag.Name)
+
+	cfg.BABELead = tomlCfg.BABELead
+	if ctx.IsSet(BABELeadFlag.Name) {
+		cfg.BABELead = ctx.GlobalBool(BABELeadFlag.Name)
+	}
 
 	// check --roles flag and update node configuration
 	if roles := ctx.GlobalString(RolesFlag.Name); roles != "" {

--- a/dot/config.go
+++ b/dot/config.go
@@ -333,6 +333,7 @@ func DevConfig() *Config {
 			BabeAuthority:    dev.DefaultBabeAuthority,
 			GrandpaAuthority: dev.DefaultGrandpaAuthority,
 			WasmInterpreter:  dev.DefaultWasmInterpreter,
+			BABELead:         dev.DefaultBabeAuthority,
 		},
 		Network: NetworkConfig{
 			Port:        dev.DefaultNetworkPort,


### PR DESCRIPTION


## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Earlier, babe lead value was read only from "babe-lead" cli flag.
cfg.BABELead was being set to false in case this flag was not provided.

This commit sets cfg.BABELead from toml config and uses "babe-lead" cli
flag only when it is set.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->
Run 
```
./bin/gossamer --chain dev
```

If we are lead not, we would not wait for first block, otherwise babe service would fail throwing a timeout error.
## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @arijitAD 
