### PR TITLE
fix(ci): add missing go-version matrix to fix development branch CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
         run: make build
 
   publish-code-coverage:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths


### PR DESCRIPTION
## Changes

- See title

## Tests

CI passing on development branch

## Issues

## Primary Reviewer

- Anyone, this is trivial