### PR TITLE
chore(githooks): Makefile `githooks` target and document it

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,19 +1,9 @@
 #!/bin/bash
 
-echo "Executing pre push hook. To disable do 'git push --no-verify'"
+STAGED_GO_FILES=$(git diff --cached --name-only | grep ".go$")
 
-make lint 
-if [ $? -ne 0 ]
-then
-    echo "***ERROR*** 'make lint' failed. Fix errors before proceeding to push."
-    exit 1
+if [[ "$STAGED_GO_FILES" = "" ]]; then
+  exit 0
 fi
 
-# Note: this won't detect unneeded `// indirect` commented dependencies
-go mod tidy
-git diff --exit-code -- go.mod go.sum >/dev/null
-if [ $? -ne 0 ]
-then
-    echo "***ERROR*** 'go.mod' file is updated. Add the file before proceeding to push."
-    exit 1
-fi
+make lint

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,13 +42,14 @@ For coding style, you may refer to the [code style](CODE_STYLE.md) document whic
     git remote -v (you should see myrepo and gossamer in the list of remotes)
     ```
 
-5. **Find something to work on.**
+5. You can optionally setup Git hooks defined in this repository with `make githooks`.
+6. **Find something to work on.**
 
     To start, check out our open issues. We recommend starting with an [issue labeled `Good First Issue`](https://github.com/ChainSafe/gossamer/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22). Leave a comment to let us know that you would like to work on it.
 
     Another option is to improve gossamer where you see fit based on your evaluation of our code. In order to best facilitate collaboration, please create an issue before you start working on it.
 
-6. **Make improvements to the code.**
+7. **Make improvements to the code.**
 
     Each time you work on the code be sure that you are working on the branch that you have created as opposed to your local copy of the gossamer repo. Keeping your changes segregated in this branch will make it easier to merge your changes into the repo later.
 
@@ -56,7 +57,7 @@ For coding style, you may refer to the [code style](CODE_STYLE.md) document whic
     git checkout -b feature-in-progress-branch
     ```
 
-7. **Test your changes.**
+8. **Test your changes.**
 
     Changes that only affect a single file can be tested with
 
@@ -81,7 +82,7 @@ For coding style, you may refer to the [code style](CODE_STYLE.md) document whic
 
     Generate the mock code with `go generate -run "mockery" ./...` from your working directory. This will also update existing mocks. You can update all mocks by running `go generate -run "mockery" ./...` from the repository root.
 
-8. **Lint your changes.**
+9. **Lint your changes.**
 
     Before opening a pull request be sure to run the linter
 
@@ -89,11 +90,11 @@ For coding style, you may refer to the [code style](CODE_STYLE.md) document whic
     make lint
     ```
 
-9. **Add licenses to new Go and Proto files**
+10. **Add licenses to new Go and Proto files**
 
     If you added any new file, run `make license` to setup all licenses on relevant files.
     If you do not have `make` available, you can copy paste the command from the Makefile's `license:` block and run that instead.
-10. **Create a pull request.**
+11. **Create a pull request.**
 
     Navigate your browser to [https://github.com/ChainSafe/gossamer](https://github.com/ChainSafe/gossamer) and click on the new pull request button. In the “base” box on the left, change the branch to “**base development**”, the branch that you want your changes to be applied to. In the “compare” box on the right, select feature-in-progress-branch, the branch containing the changes you want to apply. You will then be asked to answer a few questions about your pull request. After you complete the questionnaire, the pull request will appear in the list of pull requests at [https://github.com/ChainSafe/gossamer/pulls](https://github.com/ChainSafe/gossamer/pulls).
 

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,7 @@ build-debug: clean
 init:
 	./bin/gossamer init --force
 
-## init-repo: Set initial configuration for the repo
-init-repo:
+githooks:
 	git config core.hooksPath .githooks
 
 ## start: Starts application from binary executable in `./bin/gossamer` with built-in key alice


### PR DESCRIPTION
## Changes

- Rename `repo-init` target to `githooks`
- Simplify lint part of the pre-push git hook
- Remove script go mod diff part since Go 1.17 works differently
- Only trigger lint if a go file is staged
- Resource: https://tutorialedge.net/golang/improving-go-workflow-with-git-hooks/

## Tests

Modify a .go file and run

```sh
./.githooks/pre-push
```

## Issues

## Primary Reviewer

- @jimjbrettj 
