### PR TITLE
chore(ci): set 60 minutes timeout on some jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   builds:
+    timeout-minutes: 60
     strategy:
       matrix:
         go-version: [1.17.x]
@@ -41,6 +42,7 @@ jobs:
         run: make build
 
   publish-code-coverage:
+    timeout-minutes: 60
     strategy:
       matrix:
         go-version: [1.17.x]

--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -5,6 +5,7 @@ env:
 
 jobs:
   publish-code-coverage:
+    timeout-minutes: 60
     strategy:
       matrix:
         go-version: [1.17.x]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ env:
 
 jobs:
   unit-tests:
+    timeout-minutes: 60
     strategy:
       matrix:
         go-version: [1.17.x]


### PR DESCRIPTION
## Changes

- Set 60min timeout on CI jobs that often get canceled after 360minutes.

## Tests

## Issues

## Primary Reviewer

- @timwu20 