### PR TITLE
fix(dot/network): add nil checks in `connManager`

### DIFF
--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -130,7 +130,9 @@ func (cm *ConnManager) unprotectedPeers(peers []peer.ID) []peer.ID {
 func (cm *ConnManager) Connected(n network.Network, c network.Conn) {
 	logger.Tracef(
 		"Host %s connected to peer %s", n.LocalPeer(), c.RemotePeer())
-	cm.connectHandler(c.RemotePeer())
+	if cm.connectHandler != nil {
+		cm.connectHandler(c.RemotePeer())
+	}
 
 	cm.Lock()
 	defer cm.Unlock()
@@ -169,7 +171,9 @@ func (cm *ConnManager) Disconnected(_ network.Network, c network.Conn) {
 	logger.Tracef("Host %s disconnected from peer %s", c.LocalPeer(), c.RemotePeer())
 
 	cm.Unprotect(c.RemotePeer(), "")
-	cm.disconnectHandler(c.RemotePeer())
+	if cm.disconnectHandler != nil {
+		cm.disconnectHandler(c.RemotePeer())
+	}
 }
 
 // OpenedStream is called when a stream is opened


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- add nil checks for `connectHandler` and `disconnectHandler`
- saw this error:

```
nohup: ignoring input
2021-11-23T16:41:55Z INFO loaded package log configuration: {INFO INFO INFO INFO INFO INFO INFO INFO}	config.go:L124	pkg=cmd
2021-11-23T16:41:55Z INFO 🕸️ initialising node services with global configuration name step-enroll-54633, id gssmr and base path /home/ubuntu/.gossamer/gssmr...	node.go:L189	pkg=dot
2021-11-23T16:41:56Z INFO created state service with head 0xa1f12cdab91ed4c6693fda20c8485c1c53be2f2af18dc87c9943b4bdc282fc11, highest number 9854 and genesis hash 0x4a72cc0b6687ad404e1ba7388d0411fbf3545eb278aab044110767d3f14b57fa	service.go:L161	pkg=state
2021-11-23T16:41:59Z INFO creating runtime with interpreter wasmer...	services.go:L84	pkg=dot
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xda71c9]

goroutine 286 [running]:
github.com/ChainSfae/gossamer/dot/network.(*ConnManager).Connected(0xc0025f31d0, {0x156afd0, 0xc0017b2780}, {0x15631a0, 0xc003900a20})
	github.com/ChainSafe/gossamer/dot/network/connmgr.go:133 +0x169
github.com/libp2p/go-libp2p-core/network.(*NotifyBundle).Connected(0xc0017ea7a0, {0x156afd0, 0xc0017b2780}, {0x15631a0, 0xc003900a20})
	github.com/libp2p/go-libp2p-core@v0.9.0/network/notifee.go:55 +0x43
github.com/libp2p/go-libp2p-swarm.(*Swarm).addConn.func1({0x154e100, 0xc002fdb650})
	github.com/libp2p/go-libp2p-swarm@v0.5.3/swarm.go:275 +0x3d
github.com/libp2p/go-libp2p-swarm.(*Swarm).notifyAll.func1({0x154e100, 0xc002fdb650})
	github.com/libp2p/go-libp2p-swarm@v0.5.3/swarm.go:549 +0x69
created by github.com/libp2p/go-libp2p-swarm.(*Swarm).notifyAll
	github.com/libp2p/go-libp2p-swarm@v0.5.3/swarm.go:547 +0xf1

```

this is because as soon as the libp2p host is created, other nodes can connect to it. but the handlers are set in `*Service.Start()` as the functions depend on the service existing. 

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network -short
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- n/a

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @EclesioMeloJunior 
