### PR TITLE
fix(dot): fix `TestNewNode`

### DIFF
--- a/devnet/cmd/update-dd-agent-confd/main.go
+++ b/devnet/cmd/update-dd-agent-confd/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 type options struct {
-	Namespace string   `short:"n" long:"namespace" description:"namespace that is prepended to all metrics" required:"true"`
+	Namespace string   `short:"n" long:"namespace" description:"namespace that is prepended to all metrics" required:"true"` //nolint:lll
 	Tags      []string `short:"t" long:"tags" description:"tags that are added to all metrics"`
 }
 

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -153,6 +153,7 @@ func TestStartNode(t *testing.T) {
 
 	cfg.Init.Genesis = genFile.Name()
 	cfg.Core.GrandpaAuthority = false
+	cfg.Core.BABELead = true
 
 	err := InitNode(cfg)
 	require.NoError(t, err)

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -1388,7 +1388,11 @@ func addBlocksToState(t *testing.T, blockState *state.BlockState, depth int) {
 	}
 }
 
-func addBlocksAndReturnTheLastOne(t *testing.T, blockState *state.BlockState, depth int, lastBlockArrivalTime time.Time) *types.Block {
+func addBlocksAndReturnTheLastOne(
+	t *testing.T, blockState *state.BlockState,
+	depth int,
+	lastBlockArrivalTime time.Time,
+) *types.Block {
 	t.Helper()
 	addBlocksToState(t, blockState, depth)
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Sets the `BABELead` attribute to true which should avoid waiting for the first block.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot -v -run TestStartNode   
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @noot 
