### PR TITLE
fix(pprof): only run pprof service if enabled

### DIFF
--- a/dot/node.go
+++ b/dot/node.go
@@ -195,7 +195,9 @@ func NewNode(cfg *Config, ks *keystore.GlobalKeystore) (*Node, error) {
 		networkSrvc *network.Service
 	)
 
-	nodeSrvcs = append(nodeSrvcs, createPprofService(cfg.Pprof.Settings))
+	if cfg.Pprof.Enabled {
+		nodeSrvcs = append(nodeSrvcs, createPprofService(cfg.Pprof.Settings))
+	}
 
 	stateSrvc, err := createStateService(cfg)
 	if err != nil {


### PR DESCRIPTION
## Changes

- Only add pprof service to services list if it is enabled

## Tests

## Issues

## Primary Reviewer

- @noot 