### PR TITLE
chore(lib/trie): node `Type() Type` method

### DIFF
--- a/internal/trie/node/branch.go
+++ b/internal/trie/node/branch.go
@@ -40,6 +40,15 @@ func NewBranch(key, value []byte, dirty bool, generation uint64) *Branch {
 	}
 }
 
+// Type returns BranchType if the branch value
+// is nil, and BranchWithValueType otherwise.
+func (b *Branch) Type() Type {
+	if b.Value == nil {
+		return BranchType
+	}
+	return BranchWithValueType
+}
+
 func (b *Branch) String() string {
 	if len(b.Value) > 1024 {
 		return fmt.Sprintf("branch key=0x%x childrenBitmap=%b value (hashed)=0x%x dirty=%t",

--- a/internal/trie/node/branch_test.go
+++ b/internal/trie/node/branch_test.go
@@ -33,6 +33,41 @@ func Test_NewBranch(t *testing.T) {
 	assert.Equal(t, expectedBranch, branch)
 }
 
+func Test_Branch_Type(t *testing.T) {
+	testCases := map[string]struct {
+		branch *Branch
+		Type   Type
+	}{
+		"nil value": {
+			branch: &Branch{},
+			Type:   BranchType,
+		},
+		"empty value": {
+			branch: &Branch{
+				Value: []byte{},
+			},
+			Type: BranchWithValueType,
+		},
+		"non empty value": {
+			branch: &Branch{
+				Value: []byte{1},
+			},
+			Type: BranchWithValueType,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			Type := testCase.branch.Type()
+
+			assert.Equal(t, testCase.Type, Type)
+		})
+	}
+}
+
 func Test_Branch_String(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -62,7 +62,9 @@ func Decode(reader io.Reader) (n Node, err error) {
 // find other values using the persistent database.
 func decodeBranch(reader io.Reader, header byte) (branch *Branch, err error) {
 	nodeType := Type(header >> 6)
-	if nodeType != BranchType && nodeType != BranchWithValueType {
+	switch nodeType {
+	case BranchType, BranchWithValueType:
+	default:
 		return nil, fmt.Errorf("%w: %d", ErrNodeTypeIsNotABranch, nodeType)
 	}
 

--- a/internal/trie/node/header.go
+++ b/internal/trie/node/header.go
@@ -15,9 +15,9 @@ const (
 func (b *Branch) encodeHeader(writer io.Writer) (err error) {
 	var header byte
 	if b.Value == nil {
-		header = 2 << 6
+		header = byte(BranchType) << 6
 	} else {
-		header = 3 << 6
+		header = byte(BranchWithValueType) << 6
 	}
 
 	if len(b.Key) >= keyLenOffset {
@@ -44,7 +44,7 @@ func (b *Branch) encodeHeader(writer io.Writer) (err error) {
 
 // encodeHeader creates the encoded header for the leaf.
 func (l *Leaf) encodeHeader(writer io.Writer) (err error) {
-	var header byte = 1 << 6
+	header := byte(LeafType) << 6
 
 	if len(l.Key) < 63 {
 		header |= byte(len(l.Key))

--- a/internal/trie/node/header.go
+++ b/internal/trie/node/header.go
@@ -14,10 +14,11 @@ const (
 // encodeHeader creates the encoded header for the branch.
 func (b *Branch) encodeHeader(writer io.Writer) (err error) {
 	var header byte
+	const nodeHeaderShift = 6
 	if b.Value == nil {
-		header = byte(BranchType) << 6
+		header = byte(BranchType) << nodeHeaderShift
 	} else {
-		header = byte(BranchWithValueType) << 6
+		header = byte(BranchWithValueType) << nodeHeaderShift
 	}
 
 	if len(b.Key) >= keyLenOffset {
@@ -44,7 +45,8 @@ func (b *Branch) encodeHeader(writer io.Writer) (err error) {
 
 // encodeHeader creates the encoded header for the leaf.
 func (l *Leaf) encodeHeader(writer io.Writer) (err error) {
-	header := byte(LeafType) << 6
+	const nodeHeaderShift = 6
+	header := byte(LeafType) << nodeHeaderShift
 
 	if len(l.Key) < 63 {
 		header |= byte(len(l.Key))

--- a/internal/trie/node/header.go
+++ b/internal/trie/node/header.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	keyLenOffset = 0x3f
+	keyLenOffset    = 0x3f
+	nodeHeaderShift = 6
 )
 
 // encodeHeader creates the encoded header for the branch.
 func (b *Branch) encodeHeader(writer io.Writer) (err error) {
 	var header byte
-	const nodeHeaderShift = 6
 	if b.Value == nil {
 		header = byte(BranchType) << nodeHeaderShift
 	} else {
@@ -45,7 +45,6 @@ func (b *Branch) encodeHeader(writer io.Writer) (err error) {
 
 // encodeHeader creates the encoded header for the leaf.
 func (l *Leaf) encodeHeader(writer io.Writer) (err error) {
-	const nodeHeaderShift = 6
 	header := byte(LeafType) << nodeHeaderShift
 
 	if len(l.Key) < 63 {

--- a/internal/trie/node/leaf.go
+++ b/internal/trie/node/leaf.go
@@ -40,6 +40,11 @@ func NewLeaf(key, value []byte, dirty bool, generation uint64) *Leaf {
 	}
 }
 
+// Type returns LeafType.
+func (l *Leaf) Type() Type {
+	return LeafType
+}
+
 func (l *Leaf) String() string {
 	if len(l.Value) > 1024 {
 		return fmt.Sprintf("leaf key=0x%x value (hashed)=0x%x dirty=%t", l.Key, common.MustBlake2bHash(l.Value), l.dirty)

--- a/internal/trie/node/leaf_test.go
+++ b/internal/trie/node/leaf_test.go
@@ -33,6 +33,16 @@ func Test_NewLeaf(t *testing.T) {
 	assert.Equal(t, expectedLeaf, leaf)
 }
 
+func Test_Leaf_Type(t *testing.T) {
+	t.Parallel()
+
+	leaf := new(Leaf)
+
+	Type := leaf.Type()
+
+	assert.Equal(t, LeafType, Type)
+}
+
 func Test_Leaf_String(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trie/node/node.go
+++ b/internal/trie/node/node.go
@@ -19,4 +19,5 @@ type Node interface {
 	GetGeneration() (generation uint64)
 	SetGeneration(generation uint64)
 	Copy() Node
+	Type() Type
 }

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -374,11 +374,10 @@ func (t *Trie) writeDirty(db chaindb.Batch, n Node) error {
 			hash, err)
 	}
 
-	n.SetDirty(false)
-
 	switch n.Type() {
 	case node.BranchType, node.BranchWithValueType:
 	default: // not a branch
+		n.SetDirty(false)
 		return nil
 	}
 
@@ -395,6 +394,8 @@ func (t *Trie) writeDirty(db chaindb.Batch, n Node) error {
 			return err
 		}
 	}
+
+	branch.SetDirty(false)
 
 	return nil
 }

--- a/lib/trie/lookup.go
+++ b/lib/trie/lookup.go
@@ -29,10 +29,13 @@ func find(parent Node, key []byte, recorder recorder) error {
 
 	recorder.Record(hash, enc)
 
-	b, ok := parent.(*node.Branch)
-	if !ok {
+	switch parent.Type() {
+	case node.BranchType, node.BranchWithValueType:
+	default: // not a branch
 		return nil
 	}
+
+	b := parent.(*node.Branch)
 
 	length := lenCommonPrefix(b.Key, key)
 

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -263,18 +263,23 @@ func (t *Trie) tryPut(key, value []byte) {
 
 // insert attempts to insert a key with value into the trie
 func (t *Trie) insert(parent Node, key []byte, value Node) Node {
-	switch p := t.maybeUpdateGeneration(parent).(type) {
-	case *node.Branch:
+	newParent := t.maybeUpdateGeneration(parent)
+	if newParent == nil {
+		value.SetKey(key)
+		return value
+	}
+
+	switch newParent.Type() {
+	case node.BranchType, node.BranchWithValueType:
+		p := newParent.(*node.Branch)
 		n := t.updateBranch(p, key, value)
 
 		if p != nil && n != nil && n.IsDirty() {
 			p.SetDirty(true)
 		}
 		return n
-	case nil:
-		value.SetKey(key)
-		return value
-	case *node.Leaf:
+	case node.LeafType:
+		p := newParent.(*node.Leaf)
 		// if a value already exists in the trie at this key, overwrite it with the new value
 		// if the values are the same, don't mark node dirty
 		if p.Value != nil && bytes.Equal(p.Key, key) {
@@ -324,9 +329,9 @@ func (t *Trie) insert(parent Node, key []byte, value Node) Node {
 		}
 
 		return br
+	default:
+		panic("unknown node type: " + fmt.Sprint(newParent.Type()))
 	}
-	// This will never happen.
-	return nil
 }
 
 // updateBranch attempts to add the value node to a branch


### PR DESCRIPTION
## Changes

- [x] Add node `Type() Type` method
- [x] Implement `Type() Type` method for branches (`2` or `3` type)
- [x] Implement `Type() Type` method for leaves (`1`)
- [x] Update existing code to use `Type()` on nodes
- [x] Update existing code to use node type constants (1, 2, 3)
- [x] Use `Type()` methods instead of type switches, with the aim of getting rid of type assertions in the future

## Tests

```
go test -race ./lib/trie/...
```

## Issues

- #2085 

## Primary Reviewer