### PR TITLE
fix(lib/blocktree): removes the inconsistency to choose a deepest leaf

### DIFF
--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -494,13 +494,13 @@ func TestBlockTree_AllLeavesHasSameNumberAndArrivalTime_DeepestBlockHash_ShouldH
 	the leaves has the same number (8) the numbers in the right represents the order
 	the nodes are inserted into the blocktree.
 
-		a -> b -> c -> d -> e -> f -> g -> h (1)
-			 |    |    |    |    |    |->  h (7)
-			 |    |    |    |    |->  g -> h (6)
-		     |    |    |    |->  f -> g -> h (5)
-	         |    |    |->  e -> f -> g -> h (4)
-		     |    |->  d -> e -> f -> g -> h (3)
-		     |->  c -> d -> e -> f -> g -> h (2)
+	a -> b -> c -> d -> e -> f -> g -> h (1)
+		|    |    |    |    |    |> h (7)
+		|    |    |    |    |> g -> h (6)
+		|    |    |    |> f -> g -> h (5)
+		|    |    |> e -> f -> g -> h (4)
+		|    |> d -> e -> f -> g -> h (3)
+		|> c -> d -> e -> f -> g -> h (2)
 	**/
 
 	for i := 1; i <= deep; i++ {

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -38,7 +38,6 @@ func newBlockTreeFromNode(root *node) *BlockTree {
 }
 
 func createTestBlockTree(t *testing.T, header *types.Header, number int) (*BlockTree, []testBranch) {
-	fmt.Printf("Building the block tree\n")
 	bt := NewBlockTreeFromRoot(header)
 	previousHash := header.Hash()
 
@@ -59,8 +58,6 @@ func createTestBlockTree(t *testing.T, header *types.Header, number int) (*Block
 		hash := header.Hash()
 		err := bt.AddBlock(header, time.Unix(0, at))
 		require.NoError(t, err)
-
-		fmt.Printf("BUILDING #%v (%v) => %s\n", i, at, hash)
 
 		previousHash = hash
 
@@ -92,8 +89,6 @@ func createTestBlockTree(t *testing.T, header *types.Header, number int) (*Block
 			hash := header.Hash()
 			err := bt.AddBlock(header, time.Unix(0, at))
 			require.NoError(t, err)
-
-			fmt.Printf("BRANCHING #%v (%v) => %s\n", branch.number.Uint64(), at, hash)
 
 			previousHash = hash
 			at += int64(r.Intn(8))
@@ -466,16 +461,11 @@ func TestBlockTree_GetHashByNumber(t *testing.T) {
 	best := bt.DeepestBlockHash()
 	bn := bt.getNode(best)
 
-	fmt.Printf("Assert the descendents\n")
 	for i := int64(0); i < bn.number.Int64(); i++ {
-		deepest := bt.leaves.deepestLeaf()
-
 		hash, err := bt.GetHashByNumber(big.NewInt(i))
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(i), bt.getNode(hash).number)
 		desc, err := bt.IsDescendantOf(hash, best)
-		fmt.Printf("%s -> %s\n", hash, deepest.hash)
-
 		require.NoError(t, err)
 		require.True(t, desc, fmt.Sprintf("index %d failed, got hash=%s", i, hash))
 	}

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -490,7 +490,7 @@ func TestBlockTree_AllLeavesHasSameNumberAndArrivalTime_DeepestBlockHash_ShouldH
 	// and all block with the same arrival time
 
 	/**
-	base tree and nodes representation, all with the same arraival time and all
+	base tree and nodes representation, all with the same arrival time and all
 	the leaves has the same number (8) the numbers in the right represents the order
 	the nodes are inserted into the blocktree.
 
@@ -526,7 +526,7 @@ func TestBlockTree_AllLeavesHasSameNumberAndArrivalTime_DeepestBlockHash_ShouldH
 		}
 	}
 
-	// create all the branch nodes with the same arraival time
+	// create all the branch nodes with the same arrival time
 	for _, branch := range branches {
 		previousHash = branch.hash
 

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -487,6 +487,111 @@ func TestBlockTree_GetHashByNumber(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestBlockTree_AllLeavesHasSameNumberAndArrivalTime_DeepestBlockHash_ShouldHasConsistentOutput(t *testing.T) {
+	bt := NewBlockTreeFromRoot(testHeader)
+	previousHash := testHeader.Hash()
+
+	branches := []testBranch{}
+
+	const fixedArrivalTime = 99
+	const deep = 8
+
+	// create a base tree with a fixed amount of blocks
+	// and all block with the same arrival time
+
+	/**
+	base tree and nodes representation, all with the same arraival time and all
+	the leaves has the same number (8) the numbers in the right represents the order
+	the nodes are inserted into the blocktree.
+
+		a -> b -> c -> d -> e -> f -> g -> h (1)
+			 |    |    |    |    |    |->  h (7)
+			 |    |    |    |    |->  g -> h (6)
+		     |    |    |    |->  f -> g -> h (5)
+	         |    |    |->  e -> f -> g -> h (4)
+		     |    |->  d -> e -> f -> g -> h (3)
+		     |->  c -> d -> e -> f -> g -> h (2)
+	**/
+
+	for i := 1; i <= deep; i++ {
+		header := &types.Header{
+			ParentHash: previousHash,
+			Number:     big.NewInt(int64(i)),
+			Digest:     types.NewDigest(),
+		}
+
+		hash := header.Hash()
+
+		err := bt.AddBlock(header, time.Unix(0, fixedArrivalTime))
+		require.NoError(t, err)
+
+		previousHash = hash
+
+		// the last block on the base tree should not generates a branch
+		if i < deep {
+			branches = append(branches, testBranch{
+				hash:   hash,
+				number: bt.getNode(hash).number,
+			})
+		}
+	}
+
+	// create all the branch nodes with the same arraival time
+	for _, branch := range branches {
+		previousHash = branch.hash
+
+		for i := int(branch.number.Uint64()); i < deep; i++ {
+			header := &types.Header{
+				ParentHash: previousHash,
+				Number:     big.NewInt(int64(i) + 1),
+				StateRoot:  common.Hash{0x1},
+				Digest:     types.NewDigest(),
+			}
+
+			hash := header.Hash()
+			err := bt.AddBlock(header, time.Unix(0, fixedArrivalTime))
+			require.NoError(t, err)
+
+			previousHash = hash
+		}
+	}
+
+	// check all leaves has the same number and timestamps
+	leaves := bt.leaves.nodes()
+	for idx := 0; idx < len(leaves)-2; idx++ {
+		curr := leaves[idx]
+		next := leaves[idx+1]
+
+		require.Equal(t, curr.number, next.number)
+		require.Equal(t, curr.arrivalTime, next.arrivalTime)
+	}
+
+	require.Len(t, leaves, deep)
+
+	// expects currentDeepestLeaf nil till call deepestLeaf() function
+	require.Nil(t, bt.leaves.currentDeepestLeaf)
+	deepestLeaf := bt.deepestLeaf()
+
+	require.Equal(t, deepestLeaf, bt.leaves.currentDeepestLeaf)
+	require.Contains(t, leaves, deepestLeaf)
+
+	// adding a new node with a greater number, should update the currentDeepestLeaf
+	header := &types.Header{
+		ParentHash: previousHash,
+		Number:     big.NewInt(int64(deepestLeaf.number.Uint64() + 1)),
+		StateRoot:  common.Hash{0x1},
+		Digest:     types.NewDigest(),
+	}
+
+	hash := header.Hash()
+	err := bt.AddBlock(header, time.Unix(0, fixedArrivalTime))
+	require.NoError(t, err)
+
+	deepestLeaf = bt.deepestLeaf()
+	require.Equal(t, hash, deepestLeaf.hash)
+	require.Equal(t, hash, bt.leaves.currentDeepestLeaf.hash)
+}
+
 func TestBlockTree_DeepCopy(t *testing.T) {
 	bt, _ := createFlatTree(t, 8)
 

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -38,6 +38,7 @@ func newBlockTreeFromNode(root *node) *BlockTree {
 }
 
 func createTestBlockTree(t *testing.T, header *types.Header, number int) (*BlockTree, []testBranch) {
+	fmt.Printf("Building the block tree\n")
 	bt := NewBlockTreeFromRoot(header)
 	previousHash := header.Hash()
 
@@ -58,6 +59,9 @@ func createTestBlockTree(t *testing.T, header *types.Header, number int) (*Block
 		hash := header.Hash()
 		err := bt.AddBlock(header, time.Unix(0, at))
 		require.NoError(t, err)
+
+		fmt.Printf("BUILDING #%v (%v) => %s\n", i, at, hash)
+
 		previousHash = hash
 
 		isBranch := r.Intn(2)
@@ -88,8 +92,12 @@ func createTestBlockTree(t *testing.T, header *types.Header, number int) (*Block
 			hash := header.Hash()
 			err := bt.AddBlock(header, time.Unix(0, at))
 			require.NoError(t, err)
+
+			fmt.Printf("BRANCHING #%v (%v) => %s\n", branch.number.Uint64(), at, hash)
+
 			previousHash = hash
 			at += int64(r.Intn(8))
+
 		}
 	}
 
@@ -458,11 +466,16 @@ func TestBlockTree_GetHashByNumber(t *testing.T) {
 	best := bt.DeepestBlockHash()
 	bn := bt.getNode(best)
 
+	fmt.Printf("Assert the descendents\n")
 	for i := int64(0); i < bn.number.Int64(); i++ {
+		deepest := bt.leaves.deepestLeaf()
+
 		hash, err := bt.GetHashByNumber(big.NewInt(i))
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(i), bt.getNode(hash).number)
 		desc, err := bt.IsDescendantOf(hash, best)
+		fmt.Printf("%s -> %s\n", hash, deepest.hash)
+
 		require.NoError(t, err)
 		require.True(t, desc, fmt.Sprintf("index %d failed, got hash=%s", i, hash))
 	}

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -64,7 +64,7 @@ func (lm *leafMap) deepestLeaf() *node {
 
 	max := big.NewInt(-1)
 
-	var foundDeepest *node
+	var deepest *node
 	lm.smap.Range(func(h, n interface{}) bool {
 		if n == nil {
 			return true
@@ -74,30 +74,30 @@ func (lm *leafMap) deepestLeaf() *node {
 
 		if max.Cmp(node.number) < 0 {
 			max = node.number
-			foundDeepest = node
-		} else if max.Cmp(node.number) == 0 && node.arrivalTime.Before(foundDeepest.arrivalTime) {
-			foundDeepest = node
+			deepest = node
+		} else if max.Cmp(node.number) == 0 && node.arrivalTime.Before(deepest.arrivalTime) {
+			deepest = node
 		}
 
 		return true
 	})
 
 	if lm.currentDeepestLeaf != nil {
-		if lm.currentDeepestLeaf.hash == foundDeepest.hash {
+		if lm.currentDeepestLeaf.hash == deepest.hash {
 			return lm.currentDeepestLeaf
 		}
 
-		// update the current deepest leaf if the foundDeepest has a greater number or
+		// update the current deepest leaf if the found deepest has a greater number or
 		// if the current and the found deepest has the same number however the current
 		// arrived later then the found deepest
-		if foundDeepest.number.Cmp(lm.currentDeepestLeaf.number) == 1 {
-			lm.currentDeepestLeaf = foundDeepest
-		} else if foundDeepest.number.Cmp(lm.currentDeepestLeaf.number) == 0 &&
-			foundDeepest.arrivalTime.Before(lm.currentDeepestLeaf.arrivalTime) {
-			lm.currentDeepestLeaf = foundDeepest
+		if deepest.number.Cmp(lm.currentDeepestLeaf.number) == 1 {
+			lm.currentDeepestLeaf = deepest
+		} else if deepest.number.Cmp(lm.currentDeepestLeaf.number) == 0 &&
+			deepest.arrivalTime.Before(lm.currentDeepestLeaf.arrivalTime) {
+			lm.currentDeepestLeaf = deepest
 		}
 	} else {
-		lm.currentDeepestLeaf = foundDeepest
+		lm.currentDeepestLeaf = deepest
 	}
 
 	return lm.currentDeepestLeaf


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->
### Quick explanation

Given the following block tree representation

```
           /-> d -> f
a -> b -> c -> d
      \-> c -> d -> f
```

considering the upper `f` and lower `f` have the same number and arrival time, the function `blocktree.leaves. deepestLeaf()` can return inconsistent output since `sync.Map` doesn't guarantee the same sequence every time.

So this inconsistency causes the problem in the test `TestBlockTree_GetHashByNumber` for the following reasons:
1. If the function `blocktree.GetHashByNumber` needs to find the block with number `c` and takes the upper `f` as its deepest leaf then the output will be the middle `c` block
2. However, the function `blocktree.IsDescendantOf` receives the lower `f` and middle `c` as parameters to check if `f` is descendant of `c` which is false because lower `f` is descendant of **lower `c`**

### Updates
- This PR adds a field called `currentDeepestLeaf` at `leafMap` struct which holds the deepest node and ignores the others one whose have the same number and arrival time

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
WIP
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Related #1975

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @qdm12 
