### PR TITLE
fix(lib/grandpa): fix vote message switch 

### DIFF
--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -39,7 +39,7 @@ func (s *Service) receiveMessages(ctx context.Context) {
 			vm := msg.msg
 
 			switch vm.Message.Stage {
-			case prevote:
+			case prevote, primaryProposal:
 				err := telemetry.GetInstance().SendMessage(
 					telemetry.NewAfgReceivedPrevoteTM(
 						vm.Message.Hash,


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- primaryProposal were not being counted as valid vote messages although they are, they are simply a pre-vote message issued by the round's primary 

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/grandpa 
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- n/a

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @timwu20 
