### PR TITLE
fix(internal/log): fix logger mutex locking in `.New` method

### DIFF
--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -34,6 +34,9 @@ func New(options ...Option) *Logger {
 // It can use a different writer, but it is expected to use the
 // same writer since it is thread safe.
 func (l *Logger) New(options ...Option) *Logger {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	var childSettings settings
 	childSettings.mergeWith(l.settings)
 	childSettings.mergeWith(newSettings(options))


### PR DESCRIPTION
## Changes

- This looks like it's fixing the trace logs appearing when the runtime changes
- Credits to @EclesioMeloJunior who found it using the race detector

## Tests

## Issues

## Primary Reviewer

- @EclesioMeloJunior 