### PR TITLE
chore(ci): Update staging Kusama and Polkadot validator task definitions

### DIFF
--- a/.github/workflows/staging/kusama-taskdef.json
+++ b/.github/workflows/staging/kusama-taskdef.json
@@ -35,11 +35,11 @@
             "expression": "attribute:ecs.availability-zone==us-east-2a"
         }
     ],
-    "memory": "3945",
+    "memory": "16041",
     "family": "gossamer-kusama",
     "networkMode": "host",
     "requiresCompatibilities": [
         "EC2"
     ],
-    "cpu": "2048"
+    "cpu": "4096"
 }

--- a/.github/workflows/staging/polkadot-taskdef.json
+++ b/.github/workflows/staging/polkadot-taskdef.json
@@ -35,11 +35,11 @@
             "expression": "attribute:ecs.availability-zone==us-east-2a"
         }
     ],
-    "memory": "3945",
+    "memory": "16041",
     "family": "gossamer-polkadot",
     "networkMode": "host",
     "requiresCompatibilities": [
         "EC2"
     ],
-    "cpu": "2048"
+    "cpu": "4096"
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Increases memory usage to 16GB and to 4096 CPU units of the staging validator nodes.
- Upgrade cluster to larger size instances manually.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

Push to `staging` branch and ensure task definitions reflect new CPU and memory requirements.

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

-

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @noot 
