### PR TITLE
chore(go1.18beta1): upgrade from Go 1.17 to Go 1.18beta1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        go-version: [1.17.x]
         platform: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -35,7 +34,9 @@ jobs:
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          stable: false
+          go-version: 1.18.0-beta1
+
       - uses: actions/checkout@v2
 
       # cache go build cache
@@ -59,9 +60,6 @@ jobs:
 
   publish-code-coverage:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        go-version: [1.17.x]
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
@@ -70,7 +68,9 @@ jobs:
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          stable: false
+          go-version: 1.18.0-beta1
+
       - uses: actions/checkout@v2
 
       # cache go build cache

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.x"
+          stable: false
+          go-version: 1.18.0-beta1
+
       - uses: actions/checkout@v2
 
       - name: Run go vet
@@ -45,7 +47,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.x"
+          stable: false
+          go-version: 1.18.0-beta1
+
       - uses: actions/checkout@v2
       - name: Checks PR has title and body description
         run: |

--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -20,9 +20,6 @@ env:
 jobs:
   publish-code-coverage:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        go-version: [1.17.x]
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
@@ -31,7 +28,9 @@ jobs:
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          stable: false
+          go-version: 1.18.0-beta1
+
       - uses: actions/checkout@v2
 
       # cache go build cache

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -3,15 +3,17 @@ on:
   push:
     branches:
       - devnet
-      
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.0'
+          stable: false
+          go-version: 1.18.0-beta1
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -65,7 +67,7 @@ jobs:
           docker build --progress=plain \
           -t=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t=$ECR_REGISTRY/$ECR_REPOSITORY:latest \
           --build-arg key=charlie --build-arg DD_API_KEY=$DD_API_KEY --build-arg METRICS_NAMESPACE=gossamer.ecs.devnet \
-          -f=devnet/bob.Dockerfile . 
+          -f=devnet/bob.Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
@@ -74,7 +76,7 @@ jobs:
         working-directory: ./devnet/cmd/scale-down-ecs-service
         run: |
           go run . -c gssmr-ecs -s="gssmr-ecs-(Charlie|Bob)Service-.+$"
-      
+
       - name: docker compose up
         id: docker-compose-up
         working-directory: ./devnet/gssmr-ecs

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,11 +20,7 @@ env:
 jobs:
   unit-tests:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
         run: |
@@ -33,7 +29,9 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          stable: false
+          go-version: 1.18.0-beta1
+
       - uses: actions/checkout@v2
 
       # cache go build cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_VERSION=bullseye-slim
-ARG GO_VERSION=1.17-buster
+ARG GO_VERSION=1.18beta1-buster
 
 FROM golang:${GO_VERSION} AS builder
 

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18beta1
 
 ARG chain="polkadot"
 ARG basepath="~/.gossamer"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For more information about Gossamer, the Polkadot ecosystem, and how to use Goss
 
 ### Prerequisites
 
-install go version `>=1.17`
+Install Go version [`>=1.18beta1`](https://go.dev/dl/#go1.18beta1)
 
 ### Installation
 

--- a/devnet/alice.Dockerfile
+++ b/devnet/alice.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM golang:1.17
+FROM golang:1.18beta1
 
 ARG DD_API_KEY=somekey
 ENV DD_API_KEY=${DD_API_KEY}
@@ -12,7 +12,7 @@ WORKDIR /gossamer
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . . 
+COPY . .
 
 RUN go install -trimpath github.com/ChainSafe/gossamer/cmd/gossamer
 

--- a/devnet/bob.Dockerfile
+++ b/devnet/bob.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM golang:1.17
+FROM golang:1.18beta1
 
 ARG DD_API_KEY=somekey
 ENV DD_API_KEY=${DD_API_KEY}

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ permalink: /getting-started/installation
 
 ## Prerequisites
 
-Install <a target="_blank" rel="noopener noreferrer" href="https://golang.org/">Go</a> version `>=1.17`
+Install [Go](https://go.dev/doc/install) version [`>=1.18beta1`](https://go.dev/dl/#go1.18beta1)
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -182,4 +182,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
-go 1.17
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -187,7 +187,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -616,7 +615,6 @@ github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.3 h1:G5AfA94pHPysR56qqrkO2pxEexdDzrpFJ6yt/VqWxVU=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
-github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDKIzp7y4voR9CX/nvcfymLmg2UiOio=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
@@ -865,7 +863,6 @@ github.com/libp2p/go-yamux v1.3.3/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZ
 github.com/libp2p/go-yamux v1.3.5/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/libp2p/go-yamux v1.3.7/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
 github.com/libp2p/go-yamux v1.4.0/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
-github.com/libp2p/go-yamux v1.4.1 h1:P1Fe9vF4th5JOxxgQvfbOHkrGqIZniTLf+ddhZp8YTI=
 github.com/libp2p/go-yamux v1.4.1/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
 github.com/libp2p/go-yamux/v2 v2.2.0 h1:RwtpYZ2/wVviZ5+3pjC8qdQ4TKnrak0/E01N1UWoAFU=
 github.com/libp2p/go-yamux/v2 v2.2.0/go.mod h1:3So6P6TV6r75R9jiBpiIKgU/66lOarCZjqROGxzPpPQ=
@@ -1168,7 +1165,6 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9Ac
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
## Changes

Reason: play with generics and fuzzing

- [x] Install `1.18.0-beta1` for CI
- [x] Use `1.18beta1` for Docker images
- [x] Update go.mod to use go `1.18`
- [x] Update documentation and add links for Go 1.18-beta1
- [x] Remove unnecessary matrixes
- [ ] Get rid of mockery since it doesn't work with Go 1.18 beta 1 (in another PR(s))
- [ ] Wait for golangci-lint to work with Go 1.18beta-1

## Tests

## Issues

- Fix #2120

## Primary Reviewer

- @timwu20 