### PR TITLE
chore(test-skip-logs): Use `t.Log` + `fmt.Println` instead of `_, _ = fmt.Fprintln`

### DIFF
--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -4,7 +4,6 @@
 package polkadotjs_test
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -19,7 +18,7 @@ var polkadotSuite = "polkadot"
 
 func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 	if utils.MODE != polkadotSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip polkadot.js/api suite tests")
+		t.Log("Going to skip polkadot.js/api suite tests")
 		return
 	}
 	t.Log("starting gossamer for polkadot.js/api tests...")

--- a/tests/rpc/rpc_00_test.go
+++ b/tests/rpc/rpc_00_test.go
@@ -20,7 +20,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	_, _ = fmt.Fprintln(os.Stdout, "Going to start RPC suite test")
+	fmt.Println("Going to start RPC suite test")
 
 	utils.CreateDefaultConfig()
 	defer os.Remove(utils.ConfigDefault)

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -4,8 +4,6 @@
 package rpc
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -16,7 +14,7 @@ import (
 
 func TestSystemRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -6,7 +6,6 @@ package rpc
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -21,7 +20,7 @@ import (
 
 func TestAuthorSubmitExtrinsic(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 
@@ -90,7 +89,7 @@ func TestAuthorSubmitExtrinsic(t *testing.T) {
 
 func TestAuthorRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -4,9 +4,7 @@
 package rpc
 
 import (
-	"fmt"
 	"log"
-	"os"
 	"testing"
 	"time"
 
@@ -18,7 +16,7 @@ import (
 
 func TestChainRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 
@@ -124,7 +122,7 @@ func TestChainRPC(t *testing.T) {
 
 func TestChainSubscriptionRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -4,8 +4,6 @@
 package rpc
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +13,7 @@ import (
 
 func TestOffchainRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -5,7 +5,6 @@ package rpc
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -16,7 +15,7 @@ import (
 
 func TestStateRPCResponseValidation(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 
@@ -126,7 +125,7 @@ func TestStateRPCResponseValidation(t *testing.T) {
 
 func TestStateRPCAPI(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 
@@ -328,7 +327,7 @@ func TestStateRPCAPI(t *testing.T) {
 
 func TestRPCStructParamUnmarshal(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -4,8 +4,6 @@
 package rpc
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +13,7 @@ import (
 
 func TestEngineRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -4,8 +4,6 @@
 package rpc
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +13,7 @@ import (
 
 func TestPaymentRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -4,8 +4,6 @@
 package rpc
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +13,7 @@ import (
 
 func TestContractsRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -4,8 +4,6 @@
 package rpc
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +13,7 @@ import (
 
 func TestBabeRPC(t *testing.T) {
 	if utils.MODE != rpcSuite {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip RPC suite tests")
+		t.Log("Going to skip RPC suite tests")
 		return
 	}
 

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestMain(m *testing.M) {
 	if utils.MODE != "stress" {
-		_, _ = fmt.Fprintln(os.Stdout, "Skipping stress test")
+		fmt.Println("Skipping stress test")
 		return
 	}
 

--- a/tests/sync/sync_test.go
+++ b/tests/sync/sync_test.go
@@ -47,7 +47,7 @@ var checks = []checkDBCall{
 
 func TestMain(m *testing.M) {
 	if utils.MODE != "sync" {
-		_, _ = fmt.Fprintln(os.Stdout, "Going to skip stress test")
+		fmt.Println("Going to skip stress test")
 		return
 	}
 	fw, err := utils.InitFramework(3)


### PR DESCRIPTION
## Changes

- Replace (just why) `_, _ = fmt.Fprintln(os.Stdout` with `t.Log(` or `fmt.Println(` (for TestMain) for test skipping logs

## Tests

## Issues

## Primary Reviewer
