### PR TITLE
chore(dot): remove trie related memory test

### DIFF
--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -4,11 +4,8 @@
 package dot
 
 import (
-	"log"
 	"os"
-	"runtime"
 	"testing"
-	"time"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/trie"
@@ -63,60 +60,6 @@ func TestNewTestGenesisFile(t *testing.T) {
 
 	// values from raw genesis file should equal values generated from human readable genesis file
 	require.Equal(t, genRaw.Genesis.Raw["top"], genHR.Genesis.Raw["top"])
-}
-
-func TestDeepCopyVsSnapshot(t *testing.T) {
-	cfg := NewTestConfig(t)
-	require.NotNil(t, cfg)
-
-	genRawFile := NewTestGenesisRawFile(t, cfg)
-	require.NotNil(t, genRawFile)
-
-	defer os.Remove(genRawFile.Name())
-
-	genRaw, err := genesis.NewGenesisFromJSONRaw(genRawFile.Name())
-	require.NoError(t, err)
-
-	tri := trie.NewEmptyTrie()
-	var ttlLenght int
-	for k, v := range genRaw.Genesis.Raw["top"] {
-		val := []byte(v)
-		ttlLenght += len(val)
-		tri.Put([]byte(k), val)
-	}
-
-	testCases := []struct {
-		name string
-		fn   func(tri *trie.Trie) (*trie.Trie, error)
-	}{
-		{"DeepCopy", func(tri *trie.Trie) (*trie.Trie, error) {
-			return tri.DeepCopy()
-		}},
-		{"Snapshot", func(tri *trie.Trie) (*trie.Trie, error) {
-			return tri.Snapshot(), nil
-		}},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			trieMap := make(map[int]*trie.Trie)
-			start := time.Now()
-			var m runtime.MemStats
-			for i := 0; i <= 200; i++ {
-				newTrie, err := tc.fn(tri)
-				require.NoError(t, err)
-
-				runtime.ReadMemStats(&m)
-				trieMap[i] = newTrie
-			}
-
-			log.Printf("\nAlloc = %v MB \nTotalAlloc = %v MB \nSys = %v MB \nNumGC = %v \n\n",
-				m.Alloc/(1024*1024), m.TotalAlloc/(1024*1024), m.Sys/(1024*1024), m.NumGC)
-			elapsed := time.Since(start)
-			log.Printf("DeepCopy to trie took %s", elapsed)
-			runtime.GC()
-		})
-	}
 }
 
 func TestTrieSnapshot(t *testing.T) {


### PR DESCRIPTION
## Changes

- [x] Remove a test that measures memory usage for trie Snapshot vs DeepCopy. This is clearly not a test and I'm not sure what it does. There is similar benchmark in the trie package, so I removed that one.

## Tests


## Issues

## Primary Reviewer
