### PR TITLE
fix(dot/sync): cleanup logs; don't log case where we fail to get parent while processing

### DIFF
--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -169,7 +169,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		}
 
 		if err := s.handleBlock(block); err != nil {
-			logger.Errorf("failed to handle block number %s: %s", block.Header.Number, err)
+			logger.Debugf("failed to handle block number %s: %s", block.Header.Number, err)
 			return err
 		}
 

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -83,17 +83,19 @@ func (s *chainProcessor) processReadyBlocks() {
 		}
 
 		if err := s.processBlockData(bd); err != nil {
-			logger.Errorf("block data processing for block with hash %s failed: %s", bd.Hash, err)
-
 			// depending on the error, we might want to save this block for later
 			if errors.Is(err, errFailedToGetParent) {
+				logger.Tracef("block data processing for block with hash %s failed: %s", bd.Hash, err)
 				if err := s.pendingBlocks.addBlock(&types.Block{
 					Header: *bd.Header,
 					Body:   *bd.Body,
 				}); err != nil {
 					logger.Debugf("failed to re-add block to pending blocks: %s", err)
 				}
+				continue
 			}
+
+			logger.Errorf("block data processing for block with hash %s failed: %s", bd.Hash, err)
 		}
 	}
 }

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -84,18 +84,18 @@ func (s *chainProcessor) processReadyBlocks() {
 
 		if err := s.processBlockData(bd); err != nil {
 			// depending on the error, we might want to save this block for later
-			if errors.Is(err, errFailedToGetParent) {
-				logger.Tracef("block data processing for block with hash %s failed: %s", bd.Hash, err)
-				if err := s.pendingBlocks.addBlock(&types.Block{
-					Header: *bd.Header,
-					Body:   *bd.Body,
-				}); err != nil {
-					logger.Debugf("failed to re-add block to pending blocks: %s", err)
-				}
+			if !errors.Is(err, errFailedToGetParent) {
+				logger.Errorf("block data processing for block with hash %s failed: %s", bd.Hash, err)
 				continue
 			}
 
-			logger.Errorf("block data processing for block with hash %s failed: %s", bd.Hash, err)
+			logger.Tracef("block data processing for block with hash %s failed: %s", bd.Hash, err)
+			if err := s.pendingBlocks.addBlock(&types.Block{
+				Header: *bd.Header,
+				Body:   *bd.Body,
+			}); err != nil {
+				logger.Debugf("failed to re-add block to pending blocks: %s", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- don't log case where we fail to get parent while processing (except as a trace log)
- this doesn't explicitly track the first block that fails (and its whole descendant chain), but I think it's ok as the processing of the block will fail almost immediately if we don't have the parent (ie line 214)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
./bin/gossamer --chain polkadot
```

ensure that logs don't get spammed anymore

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #2154

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @qdm12 
