### PR TITLE
fix(dot/sync): fix "block with unknown header is ready" error

### DIFF
--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -700,8 +700,10 @@ func (cs *chainSync) doSync(req *network.BlockRequestMessage, peersTried map[pee
 }
 
 func handleReadyBlock(bd *types.BlockData, pendingBlocks DisjointBlockSet, readyBlocks *blockQueue) {
-	// see if there are any descendents in the pending queue that are now ready to be processed,
-	// as we have just become aware of their parent block
+	// first check that the block isn't already in the ready queue
+	if readyBlocks.has(bd.Hash) {
+		return
+	}
 
 	// if header was not requested, get it from the pending set
 	// if we're expecting headers, validate should ensure we have a header
@@ -722,6 +724,8 @@ func handleReadyBlock(bd *types.BlockData, pendingBlocks DisjointBlockSet, ready
 
 	logger.Tracef("new ready block number %s with hash %s", bd.Header.Number, bd.Hash)
 
+	// see if there are any descendents in the pending queue that are now ready to be processed,
+	// as we have just become aware of their parent block
 	ready := []*types.BlockData{bd}
 	ready = pendingBlocks.getReadyDescendants(bd.Hash, ready)
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -703,7 +703,7 @@ func (cs *chainSync) doSync(req *network.BlockRequestMessage, peersTried map[pee
 func (cs *chainSync) handleReadyBlock(bd *types.BlockData) {
 	// first check that the block isn't already in the ready queue
 	if cs.readyBlocks.has(bd.Hash) {
-		logger.Tracef("ignoring block %s, already in ready queue", bd.Hash)
+		logger.Tracef("ignoring block %s in response, already in ready queue", bd.Hash)
 		return
 	}
 
@@ -722,7 +722,7 @@ func (cs *chainSync) handleReadyBlock(bd *types.BlockData) {
 
 			if has {
 				// seems we already processed the block, so let's just return
-				logger.Tracef("ignoring block we already have, hash=%s", bd.Hash)
+				logger.Tracef("ignoring block we've already processed, hash=%s", bd.Hash)
 				return
 			}
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -700,7 +700,6 @@ func (cs *chainSync) doSync(req *network.BlockRequestMessage, peersTried map[pee
 }
 
 func (cs *chainSync) handleReadyBlock(bd *types.BlockData) {
-	// first check that the block isn't already in the ready queue
 	if cs.readyBlocks.has(bd.Hash) {
 		logger.Tracef("ignoring block %s in response, already in ready queue", bd.Hash)
 		return
@@ -715,12 +714,11 @@ func (cs *chainSync) handleReadyBlock(bd *types.BlockData) {
 			// let's check the db as maybe we already processed it
 			has, err := cs.blockState.HasHeader(bd.Hash)
 			if err != nil && !errors.Is(err, chaindb.ErrKeyNotFound) {
-				logger.Debugf("failed to check if header is known for hash %s: err=%s", bd.Hash, err)
+				logger.Debugf("failed to check if header is known for hash %s: %s", bd.Hash, err)
 				return
 			}
 
 			if has {
-				// seems we already processed the block, so let's just return
 				logger.Tracef("ignoring block we've already processed, hash=%s", bd.Hash)
 				return
 			}

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -692,6 +692,7 @@ func (cs *chainSync) doSync(req *network.BlockRequestMessage, peersTried map[pee
 	// response was validated! place into ready block queue
 	for _, bd := range resp.BlockData {
 		// block is ready to be processed!
+		logger.Infof("handling block response block %v", bd)
 		handleReadyBlock(bd, cs.pendingBlocks, cs.readyBlocks)
 	}
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -693,7 +693,6 @@ func (cs *chainSync) doSync(req *network.BlockRequestMessage, peersTried map[pee
 	// response was validated! place into ready block queue
 	for _, bd := range resp.BlockData {
 		// block is ready to be processed!
-		logger.Infof("handling block response block %v", bd)
 		cs.handleReadyBlock(bd)
 	}
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -13,10 +13,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ChainSafe/gossamer/dot/peerset"
+	"github.com/ChainSafe/chaindb"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/variadic"
@@ -522,7 +523,7 @@ func (cs *chainSync) setMode(mode chainSyncState) {
 	case bootstrap:
 		cs.handler = newBootstrapSyncer(cs.blockState)
 	case tip:
-		cs.handler = newTipSyncer(cs.blockState, cs.pendingBlocks, cs.readyBlocks)
+		cs.handler = newTipSyncer(cs.blockState, cs.pendingBlocks, cs.readyBlocks, cs.handleReadyBlock)
 	}
 
 	cs.state = mode
@@ -693,24 +694,40 @@ func (cs *chainSync) doSync(req *network.BlockRequestMessage, peersTried map[pee
 	for _, bd := range resp.BlockData {
 		// block is ready to be processed!
 		logger.Infof("handling block response block %v", bd)
-		handleReadyBlock(bd, cs.pendingBlocks, cs.readyBlocks)
+		cs.handleReadyBlock(bd)
 	}
 
 	return nil
 }
 
-func handleReadyBlock(bd *types.BlockData, pendingBlocks DisjointBlockSet, readyBlocks *blockQueue) {
+func (cs *chainSync) handleReadyBlock(bd *types.BlockData) {
 	// first check that the block isn't already in the ready queue
-	if readyBlocks.has(bd.Hash) {
+	if cs.readyBlocks.has(bd.Hash) {
+		logger.Tracef("ignoring block %s, already in ready queue", bd.Hash)
 		return
 	}
 
 	// if header was not requested, get it from the pending set
 	// if we're expecting headers, validate should ensure we have a header
 	if bd.Header == nil {
-		block := pendingBlocks.getBlock(bd.Hash)
+		block := cs.pendingBlocks.getBlock(bd.Hash)
 		if block == nil {
-			logger.Criticalf("block with unknown header is ready: hash=%s", bd.Hash)
+			// block wasn't in the pending set!
+			// let's check the db as maybe we already processed it
+			has, err := cs.blockState.HasHeader(bd.Hash)
+			if err != nil && !errors.Is(err, chaindb.ErrKeyNotFound) {
+				logger.Debugf("failed to check if header is known for hash %s: err=%s", bd.Hash, err)
+				return
+			}
+
+			if has {
+				// seems we already processed the block, so let's just return
+				logger.Tracef("ignoring block we already have, hash=%s", bd.Hash)
+				return
+			}
+
+			// this is bad and shouldn't happen
+			logger.Errorf("block with unknown header is ready: hash=%s", bd.Hash)
 			return
 		}
 
@@ -718,7 +735,7 @@ func handleReadyBlock(bd *types.BlockData, pendingBlocks DisjointBlockSet, ready
 	}
 
 	if bd.Header == nil {
-		logger.Criticalf("new ready block number (unknown) with hash %s", bd.Hash)
+		logger.Errorf("new ready block number (unknown) with hash %s", bd.Hash)
 		return
 	}
 
@@ -727,11 +744,11 @@ func handleReadyBlock(bd *types.BlockData, pendingBlocks DisjointBlockSet, ready
 	// see if there are any descendents in the pending queue that are now ready to be processed,
 	// as we have just become aware of their parent block
 	ready := []*types.BlockData{bd}
-	ready = pendingBlocks.getReadyDescendants(bd.Hash, ready)
+	ready = cs.pendingBlocks.getReadyDescendants(bd.Hash, ready)
 
 	for _, rb := range ready {
-		pendingBlocks.removeBlock(rb.Hash)
-		readyBlocks.push(rb)
+		cs.pendingBlocks.removeBlock(rb.Hash)
+		cs.readyBlocks.push(rb)
 	}
 }
 

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/network"
 	syncmocks "github.com/ChainSafe/gossamer/dot/sync/mocks"
 	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/variadic"
 	"github.com/ChainSafe/gossamer/lib/trie"
@@ -46,6 +47,8 @@ func newTestChainSync(t *testing.T) (*chainSync, *blockQueue) {
 	net.On("ReportPeer", mock.AnythingOfType("peerset.ReputationChange"), mock.AnythingOfType("peer.ID"))
 
 	readyBlocks := newBlockQueue(maxResponseSize)
+
+	logger.Patch(log.SetLevel(log.Trace))
 
 	cfg := &chainSyncConfig{
 		bs:            bs,
@@ -662,6 +665,7 @@ func TestChainSync_doSync(t *testing.T) {
 	resp := &network.BlockResponseMessage{
 		BlockData: []*types.BlockData{
 			{
+				Hash: common.Hash{0x1},
 				Header: &types.Header{
 					Number: big.NewInt(1),
 				},
@@ -687,6 +691,7 @@ func TestChainSync_doSync(t *testing.T) {
 	resp = &network.BlockResponseMessage{
 		BlockData: []*types.BlockData{
 			{
+				Hash: common.Hash{0x3},
 				Header: &types.Header{
 					ParentHash: parent,
 					Number:     big.NewInt(3),
@@ -694,6 +699,7 @@ func TestChainSync_doSync(t *testing.T) {
 				Body: &types.Body{},
 			},
 			{
+				Hash: common.Hash{0x2},
 				Header: &types.Header{
 					Number: big.NewInt(2),
 				},
@@ -762,7 +768,7 @@ func TestHandleReadyBlock(t *testing.T) {
 	}
 	cs.pendingBlocks.addBlock(block2NotDescendant)
 
-	handleReadyBlock(block1.ToBlockData(), cs.pendingBlocks, cs.readyBlocks)
+	cs.handleReadyBlock(block1.ToBlockData())
 
 	require.False(t, cs.pendingBlocks.hasBlock(header1.Hash()))
 	require.False(t, cs.pendingBlocks.hasBlock(header2.Hash()))

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/network"
 	syncmocks "github.com/ChainSafe/gossamer/dot/sync/mocks"
 	"github.com/ChainSafe/gossamer/dot/types"
-	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/variadic"
 	"github.com/ChainSafe/gossamer/lib/trie"
@@ -47,8 +46,6 @@ func newTestChainSync(t *testing.T) (*chainSync, *blockQueue) {
 	net.On("ReportPeer", mock.AnythingOfType("peerset.ReputationChange"), mock.AnythingOfType("peer.ID"))
 
 	readyBlocks := newBlockQueue(maxResponseSize)
-
-	logger.Patch(log.SetLevel(log.Trace))
 
 	cfg := &chainSyncConfig{
 		bs:            bs,

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -14,7 +14,7 @@ import (
 
 var _ workHandler = &tipSyncer{}
 
-type handleReadyBlockFunc = func(*types.BlockData)
+type handleReadyBlockFunc func(*types.BlockData)
 
 // tipSyncer handles workers when syncing at the tip of the chain
 type tipSyncer struct {

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -215,7 +215,6 @@ func (s *tipSyncer) handleTick() ([]*worker, error) {
 		if has || s.readyBlocks.has(block.header.ParentHash) {
 			// block is ready, as parent is known!
 			// also, move any pendingBlocks that are descendants of this block to the ready blocks queue
-			logger.Infof("moving block from pending to ready: block=%v", block.toBlockData())
 			s.handleReadyBlock(block.toBlockData())
 			continue
 		}

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -24,7 +24,8 @@ type tipSyncer struct {
 	handleReadyBlock handleReadyBlockFunc
 }
 
-func newTipSyncer(blockState BlockState, pendingBlocks DisjointBlockSet, readyBlocks *blockQueue, handleReadyBlock handleReadyBlockFunc) *tipSyncer {
+func newTipSyncer(blockState BlockState, pendingBlocks DisjointBlockSet, readyBlocks *blockQueue,
+	handleReadyBlock handleReadyBlockFunc) *tipSyncer {
 	return &tipSyncer{
 		blockState:       blockState,
 		pendingBlocks:    pendingBlocks,

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -210,6 +210,7 @@ func (s *tipSyncer) handleTick() ([]*worker, error) {
 		if has || s.readyBlocks.has(block.header.ParentHash) {
 			// block is ready, as parent is known!
 			// also, move any pendingBlocks that are descendants of this block to the ready blocks queue
+			logger.Infof("moving block from pending to ready: block=%v", block.toBlockData())
 			handleReadyBlock(block.toBlockData(), s.pendingBlocks, s.readyBlocks)
 			continue
 		}

--- a/dot/sync/tip_syncer.go
+++ b/dot/sync/tip_syncer.go
@@ -8,23 +8,28 @@ import (
 	"math/big"
 
 	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
 var _ workHandler = &tipSyncer{}
 
+type handleReadyBlockFunc = func(*types.BlockData)
+
 // tipSyncer handles workers when syncing at the tip of the chain
 type tipSyncer struct {
-	blockState    BlockState
-	pendingBlocks DisjointBlockSet
-	readyBlocks   *blockQueue
+	blockState       BlockState
+	pendingBlocks    DisjointBlockSet
+	readyBlocks      *blockQueue
+	handleReadyBlock handleReadyBlockFunc
 }
 
-func newTipSyncer(blockState BlockState, pendingBlocks DisjointBlockSet, readyBlocks *blockQueue) *tipSyncer {
+func newTipSyncer(blockState BlockState, pendingBlocks DisjointBlockSet, readyBlocks *blockQueue, handleReadyBlock handleReadyBlockFunc) *tipSyncer {
 	return &tipSyncer{
-		blockState:    blockState,
-		pendingBlocks: pendingBlocks,
-		readyBlocks:   readyBlocks,
+		blockState:       blockState,
+		pendingBlocks:    pendingBlocks,
+		readyBlocks:      readyBlocks,
+		handleReadyBlock: handleReadyBlock,
 	}
 }
 
@@ -211,7 +216,7 @@ func (s *tipSyncer) handleTick() ([]*worker, error) {
 			// block is ready, as parent is known!
 			// also, move any pendingBlocks that are descendants of this block to the ready blocks queue
 			logger.Infof("moving block from pending to ready: block=%v", block.toBlockData())
-			handleReadyBlock(block.toBlockData(), s.pendingBlocks, s.readyBlocks)
+			s.handleReadyBlock(block.toBlockData())
 			continue
 		}
 

--- a/dot/sync/tip_syncer_test.go
+++ b/dot/sync/tip_syncer_test.go
@@ -28,7 +28,13 @@ func newTestTipSyncer(t *testing.T) *tipSyncer {
 
 	readyBlocks := newBlockQueue(maxResponseSize)
 	pendingBlocks := newDisjointBlockSet(pendingBlocksLimit)
-	return newTipSyncer(bs, pendingBlocks, readyBlocks)
+	cs := &chainSync{
+		blockState:    bs,
+		readyBlocks:   readyBlocks,
+		pendingBlocks: pendingBlocks,
+	}
+
+	return newTipSyncer(bs, pendingBlocks, readyBlocks, cs.handleReadyBlock)
 }
 
 func TestTipSyncer_handleNewPeerState(t *testing.T) {


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix "block with unknown header is ready" error which was caused by already having the block in the ready queue or processed, so it was deleted from the pending set already (which is why we couldn't find the header in the pending set)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/sync
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #2189

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @EclesioMeloJunior 
