### PR TITLE
fix(dot/state): actually prune finalized tries from memory

### DIFF
--- a/dot/network/helpers_test.go
+++ b/dot/network/helpers_test.go
@@ -19,16 +19,14 @@ import (
 
 type testStreamHandler struct {
 	messages map[peer.ID][]Message
-	//handshakes map[peer.ID][]Message
-	decoder messageDecoder
-	exit    bool
+	decoder  messageDecoder
+	exit     bool
 }
 
 func newTestStreamHandler(decoder messageDecoder) *testStreamHandler {
 	return &testStreamHandler{
 		messages: make(map[peer.ID][]Message),
-		//handshakes: make(map[peer.ID][]Message),
-		decoder: decoder,
+		decoder:  decoder,
 	}
 }
 

--- a/dot/network/helpers_test.go
+++ b/dot/network/helpers_test.go
@@ -19,14 +19,16 @@ import (
 
 type testStreamHandler struct {
 	messages map[peer.ID][]Message
-	decoder  messageDecoder
-	exit     bool
+	//handshakes map[peer.ID][]Message
+	decoder messageDecoder
+	exit    bool
 }
 
 func newTestStreamHandler(decoder messageDecoder) *testStreamHandler {
 	return &testStreamHandler{
 		messages: make(map[peer.ID][]Message),
-		decoder:  decoder,
+		//handshakes: make(map[peer.ID][]Message),
+		decoder: decoder,
 	}
 }
 
@@ -44,6 +46,7 @@ func (s *testStreamHandler) handleStream(stream libp2pnetwork.Stream) {
 func (s *testStreamHandler) handleMessage(stream libp2pnetwork.Stream, msg Message) error {
 	msgs := s.messages[stream.Conn().RemotePeer()]
 	s.messages[stream.Conn().RemotePeer()] = append(msgs, msg)
+
 	announceHandshake := &BlockAnnounceHandshake{
 		BestBlockNumber: 0,
 	}

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -290,6 +290,7 @@ func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtoc
 
 	if s.host.messageCache != nil && s.host.messageCache.exists(peer, msg) {
 		// message has already been sent
+		logger.Tracef("not sending message, already sent: peer=%s msg=%s", peer, msg)
 		return
 	}
 

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -289,8 +289,7 @@ func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtoc
 	}
 
 	if s.host.messageCache != nil && s.host.messageCache.exists(peer, msg) {
-		// message has already been sent
-		logger.Tracef("not sending message, already sent: peer=%s msg=%s", peer, msg)
+		logger.Tracef("message has already been sent, ignoring: peer=%s msg=%s", peer, msg)
 		return
 	}
 

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -274,13 +274,20 @@ func Test_HandshakeTimeout(t *testing.T) {
 	}
 	require.NoError(t, err)
 
+	// clear handshake data from connection handler
+	time.Sleep(time.Millisecond * 100)
+	info.outboundHandshakeData.Delete(nodeB.host.id())
+	connAToB := nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
+	for _, stream := range connAToB[0].GetStreams() {
+		_ = stream.Close()
+	}
+
 	testHandshakeMsg := &BlockAnnounceHandshake{
 		Roles:           4,
 		BestBlockNumber: 77,
 		BestBlockHash:   common.Hash{1},
 		GenesisHash:     common.Hash{2},
 	}
-	nodeA.GossipMessage(testHandshakeMsg)
 
 	info.outboundHandshakeMutexes.Store(nodeB.host.id(), new(sync.Mutex))
 	go nodeA.sendData(nodeB.host.id(), testHandshakeMsg, info, nil)
@@ -292,7 +299,7 @@ func Test_HandshakeTimeout(t *testing.T) {
 	require.False(t, ok)
 
 	// a stream should be open until timeout
-	connAToB := nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
+	connAToB = nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
 	require.Len(t, connAToB, 1)
 	require.Len(t, connAToB[0].GetStreams(), 1)
 

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -443,12 +443,12 @@ func (s *Service) handleConn(conn libp2pnetwork.Conn) {
 		return
 	}
 
-	stream, err := s.sendHandshake(conn.RemotePeer(), hs, prtl)
+	_, err = s.sendHandshake(conn.RemotePeer(), hs, prtl)
 	if err != nil {
 		return
 	}
 
-	_ = stream.Close()
+	// leave stream open if there's no error
 }
 
 // Stop closes running instances of the host and network services as well as

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -440,11 +440,19 @@ func (s *Service) handleConn(conn libp2pnetwork.Conn) {
 
 	hs, err := prtl.getHandshake()
 	if err != nil {
+		logger.Warnf("failed to get handshake for protocol %s: %s",
+			prtl.protocolID,
+			err,
+		)
 		return
 	}
 
 	_, err = s.sendHandshake(conn.RemotePeer(), hs, prtl)
 	if err != nil {
+		logger.Debugf("failed to send handshake to peer on connection, peer=%s: %s",
+			conn.RemotePeer(),
+			err,
+		)
 		return
 	}
 

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -449,7 +449,7 @@ func (s *Service) handleConn(conn libp2pnetwork.Conn) {
 
 	_, err = s.sendHandshake(conn.RemotePeer(), hs, prtl)
 	if err != nil {
-		logger.Debugf("failed to send handshake to peer on connection, peer=%s: %s",
+		logger.Debugf("failed to send handshake to peer %s on connection: %s",
 			conn.RemotePeer(),
 			err,
 		)

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -430,6 +430,25 @@ func (s *Service) sentBlockIntervalTelemetry() {
 func (s *Service) handleConn(conn libp2pnetwork.Conn) {
 	// TODO: currently we only have one set so setID is 0, change this once we have more set in peerSet.
 	s.host.cm.peerSetHandler.Incoming(0, conn.RemotePeer())
+
+	// exchange BlockAnnounceHandshake with peer so we can start to
+	// sync if necessary.
+	prtl, has := s.notificationsProtocols[BlockAnnounceMsgType]
+	if !has {
+		return
+	}
+
+	hs, err := prtl.getHandshake()
+	if err != nil {
+		return
+	}
+
+	stream, err := s.sendHandshake(conn.RemotePeer(), hs, prtl)
+	if err != nil {
+		return
+	}
+
+	_ = stream.Close()
 }
 
 // Stop closes running instances of the host and network services as well as

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/utils"
 )
@@ -100,7 +101,7 @@ func createTestService(t *testing.T, cfg *Config) (srvc *Service) {
 			Port:         availablePort(t),
 			NoBootstrap:  true,
 			NoMDNS:       true,
-			LogLvl:       5,
+			LogLvl:       log.Warn,
 			SlotDuration: time.Second,
 		}
 	}

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -239,10 +239,7 @@ func (bs *BlockState) handleFinalisedBlock(curr common.Hash) error {
 		}
 
 		logger.Tracef("cleaned out finalised block from memory; block number %s with hash %s", block.Header.Number, hash)
-
-		go func(header *types.Header) {
-			bs.pruneKeyCh <- header
-		}(&block.Header)
+		bs.pruneKeyCh <- header
 	}
 
 	return batch.Flush()

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -239,7 +239,7 @@ func (bs *BlockState) handleFinalisedBlock(curr common.Hash) error {
 		}
 
 		logger.Tracef("cleaned out finalised block from memory; block number %s with hash %s", block.Header.Number, hash)
-		bs.pruneKeyCh <- header
+		bs.pruneKeyCh <- &block.Header
 	}
 
 	return batch.Flush()

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -152,10 +152,7 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 		}
 
 		logger.Tracef("pruned block number %s with hash %s", block.Header.Number, hash)
-
-		go func(header *types.Header) {
-			bs.pruneKeyCh <- header
-		}(&block.Header)
+		bs.pruneKeyCh <- &block.Header
 	}
 
 	// if nothing was previously finalised, set the first slot of the network to the

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -84,6 +84,7 @@ func (s *StorageState) SetSyncing(syncing bool) {
 }
 
 func (s *StorageState) pruneKey(keyHeader *types.Header) {
+	logger.Tracef("pruning trie, number=%d hash=%s", keyHeader.Number, keyHeader.Hash())
 	s.tries.Delete(keyHeader.StateRoot)
 }
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -133,20 +133,20 @@ func (bt *BlockTree) getNode(h Hash) (ret *node) {
 // Prune sets the given hash as the new blocktree root,
 // removing all nodes that are not the new root node or its descendant
 // It returns an array of hashes that have been pruned
-func (bt *BlockTree) Prune(finalised Hash) (pruned []Hash) {
+func (bt *BlockTree) Prune(finalised Hash) []Hash {
 	bt.Lock()
 	defer bt.Unlock()
 
 	if finalised == bt.root.hash {
-		return pruned
+		return []Hash{}
 	}
 
 	n := bt.getNode(finalised)
 	if n == nil {
-		return pruned
+		return []Hash{}
 	}
 
-	pruned = bt.root.prune(n, nil)
+	pruned := bt.root.prune(n, nil)
 	bt.root = n
 	bt.root.parent = nil
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -133,20 +133,20 @@ func (bt *BlockTree) getNode(h Hash) (ret *node) {
 // Prune sets the given hash as the new blocktree root,
 // removing all nodes that are not the new root node or its descendant
 // It returns an array of hashes that have been pruned
-func (bt *BlockTree) Prune(finalised Hash) []Hash {
+func (bt *BlockTree) Prune(finalised Hash) (pruned []Hash) {
 	bt.Lock()
 	defer bt.Unlock()
 
 	if finalised == bt.root.hash {
-		return []Hash{}
+		return pruned
 	}
 
 	n := bt.getNode(finalised)
 	if n == nil {
-		return []Hash{}
+		return pruned
 	}
 
-	pruned := bt.root.prune(n, nil)
+	pruned = bt.root.prune(n, nil)
 	bt.root = n
 	bt.root.parent = nil
 


### PR DESCRIPTION

## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- fix removal of tries older than current finalized from memory
- exchange `BlockAnnounceHandshake` with peer on connect, previously it would sometimes take many minutes for the node to start bootstrap syncing. this makes it start basically as soon as we get peers.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
run gossamer for many hours and see better memory usage (hopefully)?
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- #1973 

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @qdm12 
