### PR TITLE
fix(dot/sync): sync benchmark

### DIFF
--- a/dot/sync/benchmark.go
+++ b/dot/sync/benchmark.go
@@ -11,31 +11,35 @@ type syncBenchmarker struct {
 	start           time.Time
 	startBlock      uint64
 	blocksPerSecond []float64
+	samplesToKeep   int
 }
 
-func newSyncBenchmarker() *syncBenchmarker {
+func newSyncBenchmarker(samplesToKeep int) *syncBenchmarker {
 	return &syncBenchmarker{
-		blocksPerSecond: []float64{},
+		blocksPerSecond: make([]float64, 0, samplesToKeep),
+		samplesToKeep:   samplesToKeep,
 	}
 }
 
-func (b *syncBenchmarker) begin(block uint64) {
-	b.start = time.Now()
+func (b *syncBenchmarker) begin(now time.Time, block uint64) {
+	b.start = now
 	b.startBlock = block
 }
 
-func (b *syncBenchmarker) end(block uint64) {
-	duration := time.Since(b.start)
+func (b *syncBenchmarker) end(now time.Time, block uint64) {
+	duration := now.Sub(b.start)
 	blocks := block - b.startBlock
-	if blocks == 0 {
-		blocks = 1
-	}
 	bps := float64(blocks) / duration.Seconds()
+
+	if len(b.blocksPerSecond) == b.samplesToKeep {
+		b.blocksPerSecond = b.blocksPerSecond[1:]
+	}
+
 	b.blocksPerSecond = append(b.blocksPerSecond, bps)
 }
 
 func (b *syncBenchmarker) average() float64 {
-	sum := float64(0)
+	var sum float64
 	for _, bps := range b.blocksPerSecond {
 		sum += bps
 	}

--- a/dot/sync/benchmark_test.go
+++ b/dot/sync/benchmark_test.go
@@ -1,0 +1,234 @@
+package sync
+
+import (
+	"container/ring"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newSyncBenchmarker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("10 samples to keep", func(t *testing.T) {
+		const samplesToKeep = 10
+		actual := newSyncBenchmarker(samplesToKeep)
+
+		expected := &syncBenchmarker{
+			blocksPerSecond: ring.New(samplesToKeep),
+			samplesToKeep:   samplesToKeep,
+		}
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("panics on 0 sample to keep", func(t *testing.T) {
+		const samplesToKeep = 0
+		assert.PanicsWithValue(t, "cannot have 0 samples to keep", func() {
+			newSyncBenchmarker(samplesToKeep)
+		})
+	})
+}
+
+func Test_syncBenchmarker_begin(t *testing.T) {
+	t.Parallel()
+
+	const startSec = 1000
+	start := time.Unix(startSec, 0)
+	const startBlock = 10
+
+	b := syncBenchmarker{}
+	b.begin(start, startBlock)
+
+	expected := syncBenchmarker{
+		start:      start,
+		startBlock: startBlock,
+	}
+
+	assert.Equal(t, expected, b)
+}
+
+func Test_syncBenchmarker_end(t *testing.T) {
+	t.Parallel()
+
+	const startSec = 1000
+	start := time.Unix(startSec, 0)
+
+	const nowSec = 1010
+	now := time.Unix(nowSec, 0)
+
+	const (
+		startBlock = 10
+		endBlock   = 12
+	)
+
+	const ringCap = 3
+
+	blocksPerSecond := ring.New(ringCap)
+	blocksPerSecond.Value = 1.00
+	blocksPerSecond = blocksPerSecond.Next()
+
+	b := syncBenchmarker{
+		start:           start,
+		startBlock:      startBlock,
+		blocksPerSecond: blocksPerSecond,
+	}
+	b.end(now, endBlock)
+
+	expectedBlocksPerSecond := ring.New(ringCap)
+	expectedBlocksPerSecond.Value = 1.00
+	expectedBlocksPerSecond = expectedBlocksPerSecond.Next()
+	expectedBlocksPerSecond.Value = 0.2
+	expectedBlocksPerSecond = expectedBlocksPerSecond.Next()
+
+	expected := syncBenchmarker{
+		start:           start,
+		startBlock:      startBlock,
+		blocksPerSecond: expectedBlocksPerSecond,
+	}
+
+	assert.Equal(t, expected, b)
+}
+
+func Test_syncBenchmarker_average(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		values  []float64
+		ringCap int
+		average float64
+	}{
+		// zero size ring is not possible due to constructor check
+		"empty ring": {
+			ringCap: 1,
+		},
+		"single element in one-size ring": {
+			values:  []float64{1.1},
+			ringCap: 1,
+			average: 1.1,
+		},
+		"single element in two-size ring": {
+			values:  []float64{1.1},
+			ringCap: 2,
+			average: 1.1,
+		},
+		"two elements in two-size ring": {
+			values:  []float64{1.0, 2.0},
+			ringCap: 2,
+			average: 1.5,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			blocksPerSecond := ring.New(testCase.ringCap)
+			for _, value := range testCase.values {
+				blocksPerSecond.Value = value
+				blocksPerSecond = blocksPerSecond.Next()
+			}
+
+			benchmarker := syncBenchmarker{
+				blocksPerSecond: blocksPerSecond,
+				samplesToKeep:   testCase.ringCap,
+			}
+
+			avg := benchmarker.average()
+
+			assert.Equal(t, testCase.average, avg)
+		})
+	}
+}
+
+func Test_syncBenchmarker_mostRecentAverage(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		values  []float64
+		ringCap int
+		average float64
+	}{
+		// zero size ring is not possible due to constructor check
+		"empty ring": {
+			ringCap: 1,
+		},
+		"single element in one-size ring": {
+			values:  []float64{1.1},
+			ringCap: 1,
+			average: 1.1,
+		},
+		"single element in two-size ring": {
+			values:  []float64{1.1},
+			ringCap: 2,
+			average: 1.1,
+		},
+		"two elements in two-size ring": {
+			values:  []float64{1.0, 2.0},
+			ringCap: 2,
+			average: 2.0,
+		},
+		"three elements in two-size ring": {
+			values:  []float64{1.0, 2.0, 3.0},
+			ringCap: 2,
+			average: 3.0,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			blocksPerSecond := ring.New(testCase.ringCap)
+			for _, value := range testCase.values {
+				blocksPerSecond.Value = value
+				blocksPerSecond = blocksPerSecond.Next()
+			}
+
+			benchmarker := syncBenchmarker{
+				blocksPerSecond: blocksPerSecond,
+			}
+
+			avg := benchmarker.mostRecentAverage()
+
+			assert.Equal(t, testCase.average, avg)
+		})
+	}
+}
+
+func Test_syncBenchmarker(t *testing.T) {
+	t.Parallel()
+
+	const samplesToKeep = 5
+	benchmarker := newSyncBenchmarker(samplesToKeep)
+
+	const initialBlock = 10
+	timeZero := time.Unix(0, 0)
+	const timeIncrement = time.Second
+	const baseBlocksIncrement uint64 = 1
+
+	startTime := timeZero
+	endTime := startTime.Add(timeIncrement)
+	var block uint64 = initialBlock
+
+	const samples = 10
+	for i := 0; i < samples; i++ {
+		benchmarker.begin(startTime, block)
+		block += baseBlocksIncrement + uint64(i)
+		benchmarker.end(endTime, block)
+
+		startTime = startTime.Add(timeIncrement)
+		endTime = startTime.Add(timeIncrement)
+	}
+
+	avg := benchmarker.average()
+	const expectedAvg = 8.0
+	assert.Equal(t, expectedAvg, avg)
+
+	mostRecentAvg := benchmarker.mostRecentAverage()
+	const expectedMostRecentAvg = 10.0
+	assert.Equal(t, expectedMostRecentAvg, mostRecentAvg)
+}

--- a/dot/sync/benchmark_test.go
+++ b/dot/sync/benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package sync
 
 import (


### PR DESCRIPTION
## Changes

- [x] only keep 30 latest samples with a ring buffer
- [x] Inject time to benchmark functions
- [x] Remove force setting blocks to `1` when `0` so we don't have 0.2 bps when it's actually 0
- [x] Unit tests
- [x] Ran Gossamer with it

## Tests

## Issues

## Primary Reviewer
