### PR TITLE
fix(levels-logged): Fix log levels logging at start

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -123,7 +123,7 @@ func createDotConfig(ctx *cli.Context) (*dot.Config, error) {
 
 	// TODO: log this better.
 	// See https://github.com/ChainSafe/gossamer/issues/1945
-	logger.Infof("loaded package log configuration: %#v", cfg.Log)
+	logger.Infof("loaded package log configuration: %s", cfg.Log)
 
 	// set global configuration values
 	if err := setDotGlobalConfig(ctx, tomlCfg, &cfg.Global); err != nil {

--- a/dot/config.go
+++ b/dot/config.go
@@ -63,6 +63,21 @@ type LogConfig struct {
 	FinalityGadgetLvl log.Level
 }
 
+func (l LogConfig) String() string {
+	entries := []string{
+		fmt.Sprintf("core: %s", l.CoreLvl),
+		fmt.Sprintf("digest: %s", l.DigestLvl),
+		fmt.Sprintf("sync: %s", l.SyncLvl),
+		fmt.Sprintf("network: %s", l.NetworkLvl),
+		fmt.Sprintf("rpc: %s", l.RPCLvl),
+		fmt.Sprintf("state: %s", l.StateLvl),
+		fmt.Sprintf("runtime: %s", l.RuntimeLvl),
+		fmt.Sprintf("block producer: %s", l.BlockProducerLvl),
+		fmt.Sprintf("finality gadget: %s", l.FinalityGadgetLvl),
+	}
+	return strings.Join(entries, ", ")
+}
+
 // InitConfig is the configuration for the node initialization
 type InitConfig struct {
 	Genesis string


### PR DESCRIPTION
Just some tiny PR since this bothered me more than it should 😄

## Changes

- [x] Add `String() string` method to `LogConfig`
- [x] Format the log config with `%s`

Before:

```
2022-01-26T14:32:47Z INFO loaded package log configuration: dot.LogConfig{CoreLvl:0x3, DigestLvl:0x3, SyncLvl:0x3, NetworkLvl:0x3, RPCLvl:0x3, StateLvl:0x3, RuntimeLvl:0x3, BlockProducerLvl:0x3, FinalityGadgetLvl:0x3}     config.go:L126  pkg=cmd
```

After:

```
2022-01-26T14:32:19Z INFO loaded package log configuration: core: INFO, digest: INFO, sync: INFO, network: INFO, rpc: INFO, state: INFO, runtime: INFO, block producer: INFO, finality gadget: INFO   config.go:L126  pkg=cmd
```

## Tests

## Issues

- #1945 

## Primary Reviewer
