### PR TITLE
chore(trie): improve `String()` methods for `trie.Trie` and `node.Node`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/nanobox-io/golang-scribble v0.0.0-20190309225732-aa3e7c118975
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/perlin-network/life v0.0.0-20191203030451-05c0e0f7eaea
+	github.com/qdm12/gotree v0.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.5
 	github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec

--- a/go.sum
+++ b/go.sum
@@ -1156,6 +1156,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/qdm12/gotree v0.2.0 h1:+58ltxkNLUyHtATFereAcOjBVfY6ETqRex8XK90Fb/c=
+github.com/qdm12/gotree v0.2.0/go.mod h1:1SdFaqKZuI46U1apbXIf25pDMNnrPuYLEqMF/qL4lY4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=

--- a/internal/trie/node/branch.go
+++ b/internal/trie/node/branch.go
@@ -4,10 +4,9 @@
 package node
 
 import (
-	"fmt"
 	"sync"
 
-	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/qdm12/gotree"
 )
 
 var _ Node = (*Branch)(nil)
@@ -51,10 +50,26 @@ func (b *Branch) Type() Type {
 }
 
 func (b *Branch) String() string {
-	if len(b.Value) > 1024 {
-		return fmt.Sprintf("branch key=0x%x childrenBitmap=%b value (hashed)=0x%x dirty=%t",
-			b.Key, b.ChildrenBitmap(), common.MustBlake2bHash(b.Value), b.Dirty)
+	return b.StringNode().String()
+}
+
+// StringNode returns a gotree compatible node for String methods.
+func (b *Branch) StringNode() (stringNode *gotree.Node) {
+	stringNode = gotree.New("Branch")
+	stringNode.Appendf("Generation: %d", b.Generation)
+	stringNode.Appendf("Dirty: %t", b.Dirty)
+	stringNode.Appendf("Key: " + bytesToString(b.Key))
+	stringNode.Appendf("Value: " + bytesToString(b.Value))
+	stringNode.Appendf("Calculated encoding: " + bytesToString(b.Encoding))
+	stringNode.Appendf("Calculated digest: " + bytesToString(b.hashDigest))
+
+	for i, child := range b.Children {
+		if child == nil {
+			continue
+		}
+		childNode := stringNode.Appendf("Child %d", i)
+		childNode.AppendNode(child.StringNode())
 	}
-	return fmt.Sprintf("branch key=0x%x childrenBitmap=%b value=0x%x dirty=%t",
-		b.Key, b.ChildrenBitmap(), b.Value, b.Dirty)
+
+	return stringNode
 }

--- a/internal/trie/node/branch_test.go
+++ b/internal/trie/node/branch_test.go
@@ -77,7 +77,13 @@ func Test_Branch_String(t *testing.T) {
 	}{
 		"empty branch": {
 			branch: &Branch{},
-			s:      "branch key=0x childrenBitmap=0 value=0x dirty=false",
+			s: `Branch
+├── Generation: 0
+├── Dirty: false
+├── Key: nil
+├── Value: nil
+├── Calculated encoding: nil
+└── Calculated digest: nil`,
 		},
 		"branch with value smaller than 1024": {
 			branch: &Branch{
@@ -94,7 +100,37 @@ func Test_Branch_String(t *testing.T) {
 					nil, nil, nil, nil,
 				},
 			},
-			s: "branch key=0x0102 childrenBitmap=100010001000 value=0x0304 dirty=true",
+			s: `Branch
+├── Generation: 0
+├── Dirty: true
+├── Key: 0x0102
+├── Value: 0x0304
+├── Calculated encoding: nil
+├── Calculated digest: nil
+├── Child 3
+|   └── Leaf
+|       ├── Generation: 0
+|       ├── Dirty: false
+|       ├── Key: nil
+|       ├── Value: nil
+|       ├── Calculated encoding: nil
+|       └── Calculated digest: nil
+├── Child 7
+|   └── Branch
+|       ├── Generation: 0
+|       ├── Dirty: false
+|       ├── Key: nil
+|       ├── Value: nil
+|       ├── Calculated encoding: nil
+|       └── Calculated digest: nil
+└── Child 11
+    └── Leaf
+        ├── Generation: 0
+        ├── Dirty: false
+        ├── Key: nil
+        ├── Value: nil
+        ├── Calculated encoding: nil
+        └── Calculated digest: nil`,
 		},
 		"branch with value higher than 1024": {
 			branch: &Branch{
@@ -111,9 +147,37 @@ func Test_Branch_String(t *testing.T) {
 					nil, nil, nil, nil,
 				},
 			},
-			s: "branch key=0x0102 childrenBitmap=100010001000 " +
-				"value (hashed)=0x307861663233363133353361303538646238383034626337353735323831663131663735313265326331346336373032393864306232336630396538386266333066 " + //nolint:lll
-				"dirty=true",
+			s: `Branch
+├── Generation: 0
+├── Dirty: true
+├── Key: 0x0102
+├── Value: 0x0000000000000000...0000000000000000
+├── Calculated encoding: nil
+├── Calculated digest: nil
+├── Child 3
+|   └── Leaf
+|       ├── Generation: 0
+|       ├── Dirty: false
+|       ├── Key: nil
+|       ├── Value: nil
+|       ├── Calculated encoding: nil
+|       └── Calculated digest: nil
+├── Child 7
+|   └── Branch
+|       ├── Generation: 0
+|       ├── Dirty: false
+|       ├── Key: nil
+|       ├── Value: nil
+|       ├── Calculated encoding: nil
+|       └── Calculated digest: nil
+└── Child 11
+    └── Leaf
+        ├── Generation: 0
+        ├── Dirty: false
+        ├── Key: nil
+        ├── Value: nil
+        ├── Calculated encoding: nil
+        └── Calculated digest: nil`,
 		},
 	}
 

--- a/internal/trie/node/leaf.go
+++ b/internal/trie/node/leaf.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/qdm12/gotree"
 )
 
 var _ Node = (*Leaf)(nil)
@@ -47,8 +47,29 @@ func (l *Leaf) Type() Type {
 }
 
 func (l *Leaf) String() string {
-	if len(l.Value) > 1024 {
-		return fmt.Sprintf("leaf key=0x%x value (hashed)=0x%x dirty=%t", l.Key, common.MustBlake2bHash(l.Value), l.Dirty)
+	return l.StringNode().String()
+}
+
+// StringNode returns a gotree compatible node for String methods.
+func (l *Leaf) StringNode() (stringNode *gotree.Node) {
+	stringNode = gotree.New("Leaf")
+	stringNode.Appendf("Generation: %d", l.Generation)
+	stringNode.Appendf("Dirty: %t", l.Dirty)
+	stringNode.Appendf("Key: " + bytesToString(l.Key))
+	stringNode.Appendf("Value: " + bytesToString(l.Value))
+	stringNode.Appendf("Calculated encoding: " + bytesToString(l.Encoding))
+	stringNode.Appendf("Calculated digest: " + bytesToString(l.hashDigest))
+	return stringNode
+}
+
+func bytesToString(b []byte) (s string) {
+	switch {
+	case b == nil:
+		return "nil"
+	case len(b) <= 20:
+		return fmt.Sprintf("0x%x", b)
+	default:
+		return fmt.Sprintf("0x%x...%x", b[:8], b[len(b)-8:])
 	}
-	return fmt.Sprintf("leaf key=0x%x value=0x%x dirty=%t", l.Key, l.Value, l.Dirty)
+
 }

--- a/internal/trie/node/leaf_test.go
+++ b/internal/trie/node/leaf_test.go
@@ -52,7 +52,13 @@ func Test_Leaf_String(t *testing.T) {
 	}{
 		"empty leaf": {
 			leaf: &Leaf{},
-			s:    "leaf key=0x value=0x dirty=false",
+			s: `Leaf
+├── Generation: 0
+├── Dirty: false
+├── Key: nil
+├── Value: nil
+├── Calculated encoding: nil
+└── Calculated digest: nil`,
 		},
 		"leaf with value smaller than 1024": {
 			leaf: &Leaf{
@@ -60,7 +66,13 @@ func Test_Leaf_String(t *testing.T) {
 				Value: []byte{3, 4},
 				Dirty: true,
 			},
-			s: "leaf key=0x0102 value=0x0304 dirty=true",
+			s: `Leaf
+├── Generation: 0
+├── Dirty: true
+├── Key: 0x0102
+├── Value: 0x0304
+├── Calculated encoding: nil
+└── Calculated digest: nil`,
 		},
 		"leaf with value higher than 1024": {
 			leaf: &Leaf{
@@ -68,9 +80,13 @@ func Test_Leaf_String(t *testing.T) {
 				Value: make([]byte, 1025),
 				Dirty: true,
 			},
-			s: "leaf key=0x0102 " +
-				"value (hashed)=0x307861663233363133353361303538646238383034626337353735323831663131663735313265326331346336373032393864306232336630396538386266333066 " + //nolint:lll
-				"dirty=true",
+			s: `Leaf
+├── Generation: 0
+├── Dirty: true
+├── Key: 0x0102
+├── Value: 0x0000000000000000...0000000000000000
+├── Calculated encoding: nil
+└── Calculated digest: nil`,
 		},
 	}
 

--- a/internal/trie/node/node.go
+++ b/internal/trie/node/node.go
@@ -3,6 +3,8 @@
 
 package node
 
+import "github.com/qdm12/gotree"
+
 // Node is a node in the trie and can be a leaf or a branch.
 type Node interface {
 	Encode(buffer Buffer) (err error) // TODO change to io.Writer
@@ -20,4 +22,5 @@ type Node interface {
 	SetGeneration(generation uint64)
 	Copy(copyChildren bool) Node
 	Type() Type
+	StringNode() (stringNode *gotree.Node)
 }

--- a/lib/trie/print.go
+++ b/lib/trie/print.go
@@ -3,73 +3,11 @@
 
 package trie
 
-import (
-	"bytes"
-	"fmt"
-
-	"github.com/ChainSafe/gossamer/internal/trie/node"
-	"github.com/ChainSafe/gossamer/internal/trie/pools"
-	"github.com/ChainSafe/gossamer/lib/common"
-
-	"github.com/disiqueira/gotree"
-)
-
 // String returns the trie stringified through pre-order traversal
 func (t *Trie) String() string {
 	if t.root == nil {
 		return "empty"
 	}
 
-	tree := gotree.New(fmt.Sprintf("Trie root=0x%x", t.root.GetHash()))
-	t.string(tree, t.root, 0)
-	return fmt.Sprintf("\n%s", tree.Print())
-}
-
-func (t *Trie) string(tree gotree.Tree, curr Node, idx int) {
-	switch c := curr.(type) {
-	case *node.Branch:
-		buffer := pools.EncodingBuffers.Get().(*bytes.Buffer)
-		buffer.Reset()
-
-		_ = c.Encode(buffer)
-		encoding := buffer.Bytes()
-
-		var bstr string
-		if len(encoding) > 1024 {
-			bstr = fmt.Sprintf("idx=%d %s hash=%x gen=%d",
-				idx, c, common.MustBlake2bHash(encoding), c.GetGeneration())
-		} else {
-			bstr = fmt.Sprintf("idx=%d %s encode=%x gen=%d", idx, c.String(), encoding, c.GetGeneration())
-		}
-
-		pools.EncodingBuffers.Put(buffer)
-
-		sub := tree.Add(bstr)
-		for i, child := range c.Children {
-			if child != nil {
-				t.string(sub, child, i)
-			}
-		}
-	case *node.Leaf:
-		buffer := pools.EncodingBuffers.Get().(*bytes.Buffer)
-		buffer.Reset()
-
-		_ = c.Encode(buffer)
-
-		encoding := buffer.Bytes()
-
-		var bstr string
-		if len(encoding) > 1024 {
-			bstr = fmt.Sprintf("idx=%d %s hash=%x gen=%d",
-				idx, c.String(), common.MustBlake2bHash(encoding), c.GetGeneration())
-		} else {
-			bstr = fmt.Sprintf("idx=%d %s encode=%x gen=%d", idx, c.String(), encoding, c.GetGeneration())
-		}
-
-		pools.EncodingBuffers.Put(buffer)
-
-		tree.Add(bstr)
-	default:
-		return
-	}
+	return t.root.String()
 }

--- a/lib/trie/print_test.go
+++ b/lib/trie/print_test.go
@@ -1,3 +1,6 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package trie
 
 import (

--- a/lib/trie/print_test.go
+++ b/lib/trie/print_test.go
@@ -1,0 +1,92 @@
+package trie
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/trie/node"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Trie_String(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		trie Trie
+		s    string
+	}{
+		"empty trie": {
+			s: "empty",
+		},
+		"leaf root": {
+			trie: Trie{
+				root: &node.Leaf{
+					Key:        []byte{1, 2, 3},
+					Value:      []byte{3, 4, 5},
+					Generation: 1,
+				},
+			},
+			s: `Leaf
+├── Generation: 1
+├── Dirty: false
+├── Key: 0x010203
+├── Value: 0x030405
+├── Calculated encoding: nil
+└── Calculated digest: nil`,
+		},
+		"branch root": {
+			trie: Trie{
+				root: &node.Branch{
+					Key:   nil,
+					Value: []byte{1, 2},
+					Children: [16]node.Node{
+						&node.Leaf{
+							Key:        []byte{1, 2, 3},
+							Value:      []byte{3, 4, 5},
+							Generation: 2,
+						},
+						nil, nil,
+						&node.Leaf{
+							Key:        []byte{1, 2, 3},
+							Value:      []byte{3, 4, 5},
+							Generation: 3,
+						},
+					},
+				},
+			},
+			s: `Branch
+├── Generation: 0
+├── Dirty: false
+├── Key: nil
+├── Value: 0x0102
+├── Calculated encoding: nil
+├── Calculated digest: nil
+├── Child 0
+|   └── Leaf
+|       ├── Generation: 2
+|       ├── Dirty: false
+|       ├── Key: 0x010203
+|       ├── Value: 0x030405
+|       ├── Calculated encoding: nil
+|       └── Calculated digest: nil
+└── Child 3
+    └── Leaf
+        ├── Generation: 3
+        ├── Dirty: false
+        ├── Key: 0x010203
+        ├── Value: 0x030405
+        ├── Calculated encoding: nil
+        └── Calculated digest: nil`,
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			s := testCase.trie.String()
+
+			assert.Equal(t, testCase.s, s)
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Why? Because I'm going crazy trying to print a nice trie or nodes when debugging tests

- Use github.com/qdm12/gotree to have a tree string structure
- Add `StringNode` methods to node implementations
- Update node's `String` methods and `Trie`'s `String` method

## Tests

```
go test ./internal/trie/... ./lib/trie/...
```

## Issues


## Primary Reviewer
