### PR TITLE
fix(dot/network): remove `defer cancel()` inside loop

### DIFF
--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -82,8 +82,8 @@ func (d *discovery) waitForPeers() (peers []peer.AddrInfo, err error) {
 	}
 
 	peers = make([]peer.AddrInfo, len(currentPeers))
-	for idx, p := range currentPeers {
-		peers[idx] = d.h.Peerstore().PeerInfo(p)
+	for idx, peer := range currentPeers {
+		peers[idx] = d.h.Peerstore().PeerInfo(peer)
 	}
 
 	return peers, nil
@@ -151,15 +151,15 @@ func (d *discovery) advertise() {
 	ttl := initialAdvertisementTimeout
 
 	for {
-		wait := time.NewTimer(ttl)
+		timer := time.NewTimer(ttl)
 
 		select {
 		case <-d.ctx.Done():
-			if !wait.Stop() {
-				<-wait.C
+			if !timer.Stop() {
+				<-timer.C
 			}
 			return
-		case <-wait.C:
+		case <-timer.C:
 			logger.Debug("advertising ourselves in the DHT...")
 			err := d.dht.Bootstrap(d.ctx)
 			if err != nil {
@@ -177,14 +177,14 @@ func (d *discovery) advertise() {
 }
 
 func (d *discovery) checkPeerCount() {
-	t := time.NewTicker(connectToPeersTimeout)
-	defer t.Stop()
+	timer := time.NewTicker(connectToPeersTimeout)
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-d.ctx.Done():
 			return
-		case <-t.C:
+		case <-timer.C:
 			if len(d.h.Network().Peers()) > d.minPeers {
 				continue
 			}
@@ -202,12 +202,12 @@ func (d *discovery) findPeers() {
 		return
 	}
 
-	timeout := time.NewTimer(findPeersTimeout)
-	defer timeout.Stop()
+	timer := time.NewTimer(findPeersTimeout)
+	defer timer.Stop()
 
 	for {
 		select {
-		case <-timeout.C:
+		case <-timer.C:
 			return
 		case peer := <-peerCh:
 			if peer.ID == d.h.ID() || peer.ID == "" {

--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -60,34 +60,42 @@ func newDiscovery(ctx context.Context, h libp2phost.Host,
 	}
 }
 
+func (d *discovery) waitForPeers() (peers []peer.AddrInfo, err error) {
+	// get all currently connected peers and use them to bootstrap the DHT
+	currentPeers := d.h.Network().Peers()
+	t := time.NewTicker(startDHTTimeout)
+
+	defer t.Stop()
+	for len(currentPeers) > 0 {
+		select {
+		case <-t.C:
+			logger.Debug("no peers yet, waiting to start DHT...")
+			// wait for peers to connect before starting DHT, otherwise DHT bootstrap nodes
+			// will be empty and we will fail to fill the routing table
+		case <-d.ctx.Done():
+			return nil, d.ctx.Err()
+		}
+
+		currentPeers = d.h.Network().Peers()
+	}
+
+	peers = make([]peer.AddrInfo, 0)
+	for _, p := range currentPeers {
+		peers = append(d.bootnodes, d.h.Peerstore().PeerInfo(p))
+	}
+
+	return peers, nil
+}
+
 // start creates the DHT.
 func (d *discovery) start() error {
 	if len(d.bootnodes) == 0 {
-		// get all currently connected peers and use them to bootstrap the DHT
-		peers := d.h.Network().Peers()
-
-		t := time.NewTicker(startDHTTimeout)
-		defer t.Stop()
-		for {
-			if len(peers) > 0 {
-				break
-			}
-
-			select {
-			case <-t.C:
-				logger.Debug("no peers yet, waiting to start DHT...")
-				// wait for peers to connect before starting DHT, otherwise DHT bootstrap nodes
-				// will be empty and we will fail to fill the routing table
-			case <-d.ctx.Done():
-				return nil
-			}
-
-			peers = d.h.Network().Peers()
+		peers, err := d.waitForPeers()
+		if err != nil {
+			return fmt.Errorf("failed while waiting for peers: %w", err)
 		}
 
-		for _, p := range peers {
-			d.bootnodes = append(d.bootnodes, d.h.Peerstore().PeerInfo(p))
-		}
+		d.bootnodes = peers
 	}
 
 	logger.Debugf("starting DHT with bootnodes %v...", d.bootnodes)
@@ -142,7 +150,12 @@ func (d *discovery) advertise() {
 
 	for {
 		select {
-		case <-time.After(ttl):
+		case <-d.ctx.Done():
+			return
+		default:
+			wait := time.NewTimer(ttl)
+			<-wait.C
+
 			logger.Debug("advertising ourselves in the DHT...")
 			err := d.dht.Bootstrap(d.ctx)
 			if err != nil {
@@ -155,8 +168,6 @@ func (d *discovery) advertise() {
 				logger.Warnf("failed to advertise in the DHT: %s", err)
 				ttl = tryAdvertiseTimeout
 			}
-		case <-d.ctx.Done():
-			return
 		}
 	}
 }
@@ -164,6 +175,7 @@ func (d *discovery) advertise() {
 func (d *discovery) checkPeerCount() {
 	t := time.NewTicker(connectToPeersTimeout)
 	defer t.Stop()
+
 	for {
 		select {
 		case <-d.ctx.Done():
@@ -173,14 +185,12 @@ func (d *discovery) checkPeerCount() {
 				continue
 			}
 
-			ctx, cancel := context.WithTimeout(d.ctx, findPeersTimeout)
-			defer cancel()
-			d.findPeers(ctx)
+			d.findPeers()
 		}
 	}
 }
 
-func (d *discovery) findPeers(ctx context.Context) {
+func (d *discovery) findPeers() {
 	logger.Debug("attempting to find DHT peers...")
 	peerCh, err := d.rd.FindPeers(d.ctx, string(d.pid))
 	if err != nil {
@@ -188,20 +198,24 @@ func (d *discovery) findPeers(ctx context.Context) {
 		return
 	}
 
+	timeout := time.NewTimer(findPeersTimeout)
+	defer timeout.Stop()
+
 	for {
 		select {
-		case <-ctx.Done():
+		case <-timeout.C:
 			return
 		case peer := <-peerCh:
 			if peer.ID == d.h.ID() || peer.ID == "" {
 				continue
 			}
 
-			logger.Tracef("found new peer %s via DHT", peer.ID)
-
-			d.h.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
-			d.handler.AddPeer(0, peer.ID)
-
+			// d.handler.AddPeer can be blocked while writing to the action queue channel
+			go func() {
+				logger.Tracef("found new peer %s via DHT", peer.ID)
+				d.h.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
+				d.handler.AddPeer(0, peer.ID)
+			}()
 		}
 	}
 }

--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -217,6 +217,10 @@ func (d *discovery) findPeers() {
 			logger.Tracef("found new peer %s via DHT", peer.ID)
 			d.h.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
 			d.handler.AddPeer(0, peer.ID)
+
+			if !timer.Stop() {
+				<-timer.C
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Remove unnecessary context creation inside a infinity for loop

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network/... -v -short -timeout 5m
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- Closes #2247

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @noot 
