### PR TITLE
Noot/fix chain select

### DIFF
--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -475,7 +475,7 @@ func (bs *BlockState) BestBlockHash() common.Hash {
 		return common.Hash{}
 	}
 
-	return bs.bt.DeepestBlockHash()
+	return bs.bt.BestBlockHash()
 }
 
 // BestBlockHeader returns the block header of the current head of the chain

--- a/dot/types/babe.go
+++ b/dot/types/babe.go
@@ -114,3 +114,27 @@ func GetSlotFromHeader(header *Header) (uint64, error) {
 
 	return slotNumber, nil
 }
+
+// IsPrimary returns true if the block was authored in a primary slot, false otherwise.
+func IsPrimary(header *Header) (bool, error) {
+	if len(header.Digest.Types) == 0 {
+		return false, fmt.Errorf("chain head missing digest")
+	}
+
+	preDigest, ok := header.Digest.Types[0].Value().(PreRuntimeDigest)
+	if !ok {
+		return false, fmt.Errorf("first digest item is not pre-digest")
+	}
+
+	digest, err := DecodeBabePreDigest(preDigest.Data)
+	if err != nil {
+		return false, fmt.Errorf("cannot decode BabePreDigest from pre-digest: %s", err)
+	}
+
+	switch digest.(type) {
+	case BabePrimaryPreDigest:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -194,18 +194,6 @@ func (bt *BlockTree) String() string {
 	return fmt.Sprintf("%s\n%s\n", metadata, tree.Print())
 }
 
-// // longestPath returns the path from the root to the deepest leaf in the blocktree
-// func (bt *BlockTree) longestPath() []*node {
-// 	dl := bt.deepestLeaf()
-// 	var path []*node
-// 	for curr := dl; ; curr = curr.parent {
-// 		path = append([]*node{curr}, path...)
-// 		if curr.parent == nil {
-// 			return path
-// 		}
-// 	}
-// }
-
 // subChain returns the path from the node with Hash start to the node with Hash end
 func (bt *BlockTree) subChain(start, end Hash) ([]*node, error) {
 	sn := bt.getNode(start)

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -256,15 +256,11 @@ func (bt *BlockTree) BestBlockHash() Hash {
 		return Hash{}
 	}
 
-	best := bt.leaves.bestBlock()
-	return best.hash
+	if len(bt.root.children) == 0 {
+		return bt.root.hash
+	}
 
-	// deepest := bt.leaves.deepestLeaf()
-	// if deepest == nil {
-	// 	return Hash{}
-	// }
-
-	// return deepest.hash
+	return bt.best().hash
 }
 
 // IsDescendantOf returns true if the child is a descendant of parent, false otherwise.

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -76,12 +76,18 @@ func (bt *BlockTree) AddBlock(header *types.Header, arrivalTime time.Time) error
 		return errUnexpectedNumber
 	}
 
+	isPrimary, err := types.IsPrimary(header)
+	if err != nil {
+		return fmt.Errorf("failed to check if block was primary: %w", err)
+	}
+
 	n := &node{
 		hash:        header.Hash(),
 		parent:      parent,
 		children:    []*node{},
 		number:      number,
 		arrivalTime: arrivalTime,
+		isPrimary:   isPrimary,
 	}
 
 	parent.addChild(n)
@@ -188,17 +194,17 @@ func (bt *BlockTree) String() string {
 	return fmt.Sprintf("%s\n%s\n", metadata, tree.Print())
 }
 
-// longestPath returns the path from the root to the deepest leaf in the blocktree
-func (bt *BlockTree) longestPath() []*node {
-	dl := bt.deepestLeaf()
-	var path []*node
-	for curr := dl; ; curr = curr.parent {
-		path = append([]*node{curr}, path...)
-		if curr.parent == nil {
-			return path
-		}
-	}
-}
+// // longestPath returns the path from the root to the deepest leaf in the blocktree
+// func (bt *BlockTree) longestPath() []*node {
+// 	dl := bt.deepestLeaf()
+// 	var path []*node
+// 	for curr := dl; ; curr = curr.parent {
+// 		path = append([]*node{curr}, path...)
+// 		if curr.parent == nil {
+// 			return path
+// 		}
+// 	}
+// }
 
 // subChain returns the path from the node with Hash start to the node with Hash end
 func (bt *BlockTree) subChain(start, end Hash) ([]*node, error) {
@@ -230,27 +236,35 @@ func (bt *BlockTree) SubBlockchain(start, end Hash) ([]Hash, error) {
 
 }
 
-// deepestLeaf returns the deepest leaf in the block tree.
-func (bt *BlockTree) deepestLeaf() *node {
-	return bt.leaves.deepestLeaf()
-}
+// // deepestLeaf returns the deepest leaf in the block tree.
+// func (bt *BlockTree) deepestLeaf() *node {
+// 	return bt.leaves.deepestLeaf()
+// }
 
-// DeepestBlockHash returns the hash of the deepest block in the blocktree
-// If there is multiple deepest blocks, it returns the one with the earliest arrival time.
-func (bt *BlockTree) DeepestBlockHash() Hash {
+// BestBlockHash returns the hash of the block that is considered "best" based on the
+// fork-choice rule. It returns the head of the chain with the most primary blocks.
+// If there are multiple chains with the same number of primaries, it returns the one
+// with the highest head number.
+// If there are multiple chains with the same number of primaries and the same height,
+// it returns the one with the head block that arrived the earliest.
+func (bt *BlockTree) BestBlockHash() Hash {
 	bt.RLock()
 	defer bt.RUnlock()
 
 	if bt.leaves == nil {
+		// this shouldn't happen
 		return Hash{}
 	}
 
-	deepest := bt.leaves.deepestLeaf()
-	if deepest == nil {
-		return Hash{}
-	}
+	best := bt.leaves.bestBlock()
+	return best.hash
 
-	return deepest.hash
+	// deepest := bt.leaves.deepestLeaf()
+	// if deepest == nil {
+	// 	return Hash{}
+	// }
+
+	// return deepest.hash
 }
 
 // IsDescendantOf returns true if the child is a descendant of parent, false otherwise.
@@ -326,13 +340,13 @@ func (bt *BlockTree) GetHashByNumber(num *big.Int) (common.Hash, error) {
 	bt.RLock()
 	defer bt.RUnlock()
 
-	deepest := bt.leaves.deepestLeaf()
-	if deepest.number.Cmp(num) == -1 {
+	best := bt.leaves.bestBlock()
+	if best.number.Cmp(num) == -1 {
 		return common.Hash{}, ErrNumGreaterThanHighest
 	}
 
-	if deepest.number.Cmp(num) == 0 {
-		return deepest.hash, nil
+	if best.number.Cmp(num) == 0 {
+		return best.hash, nil
 	}
 
 	if bt.root.number.Cmp(num) == 1 {
@@ -343,7 +357,7 @@ func (bt *BlockTree) GetHashByNumber(num *big.Int) (common.Hash, error) {
 		return bt.root.hash, nil
 	}
 
-	curr := deepest.parent
+	curr := best.parent
 	for {
 		if curr == nil {
 			return common.Hash{}, ErrNodeNotFound

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -236,10 +236,10 @@ func (bt *BlockTree) SubBlockchain(start, end Hash) ([]Hash, error) {
 
 }
 
-// // deepestLeaf returns the deepest leaf in the block tree.
-// func (bt *BlockTree) deepestLeaf() *node {
-// 	return bt.leaves.deepestLeaf()
-// }
+// best returns the best node in the block tree using the fork choice rule.
+func (bt *BlockTree) best() *node {
+	return bt.leaves.bestBlock()
+}
 
 // BestBlockHash returns the hash of the block that is considered "best" based on the
 // fork-choice rule. It returns the head of the chain with the most primary blocks.

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -477,7 +477,7 @@ func TestBlockTree_GetHashByNumber(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestBlockTree_AllLeavesHasSameNumberAndArrivalTime_BestBlockHash(t *testing.T) {
+func TestBlockTree_BestBlockHash_AllChainsEqual(t *testing.T) {
 	bt := NewBlockTreeFromRoot(testHeader)
 	previousHash := testHeader.Hash()
 
@@ -627,4 +627,30 @@ func equalLeaves(lm *leafMap, lmCopy *leafMap) bool {
 		return equalNodeValue(val, lmCopyVal)
 	}
 	return true
+}
+
+func TestBlockTree_best(t *testing.T) {
+	bt := NewEmptyBlockTree()
+	bt.root = &node{
+		hash: common.Hash{0},
+	}
+
+	bt.root.children = []*node{
+		{
+			hash:      common.Hash{1},
+			parent:    bt.root,
+			isPrimary: true,
+		},
+		{
+			hash:      common.Hash{2},
+			parent:    bt.root,
+			isPrimary: false,
+		},
+	}
+
+	bt.leaves = newEmptyLeafMap()
+	bt.leaves.store(bt.root.children[0].hash, bt.root.children[0])
+	bt.leaves.store(bt.root.children[1].hash, bt.root.children[1])
+
+	require.Equal(t, bt.root.children[0].hash, bt.BestBlockHash())
 }

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"sync"
 
+	"fmt"
+
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
@@ -145,6 +147,7 @@ func (lm *leafMap) bestBlock() *node {
 		n := nn.(*node)
 		count := n.primaryAncestorCount(0)
 
+		fmt.Println(n, count)
 		nodesWithCount, has := counts[count]
 		if !has {
 			counts[count] = []*node{n}

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -66,11 +66,11 @@ func (lm *leafMap) highestLeaf() *node {
 
 	var deepest *node
 	lm.smap.Range(func(h, n interface{}) bool {
-		if n == nil {
+		node := n.(*node)
+		if node == nil {
+			// this should never happen
 			return true
 		}
-
-		node := n.(*node)
 
 		if max.Cmp(node.number) < 0 {
 			max = node.number

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -13,7 +13,7 @@ import (
 
 // leafMap provides quick lookup for existing leaves
 type leafMap struct {
-	currentDeepestLeaf *node
+	currHighestLeaf *node
 	sync.RWMutex
 	smap *sync.Map // map[common.Hash]*node
 }
@@ -56,9 +56,9 @@ func (lm *leafMap) replace(oldNode, newNode *node) {
 	lm.store(newNode.hash, newNode)
 }
 
-// DeepestLeaf searches the stored leaves to the find the one with the greatest number.
+// highestLeaf searches the stored leaves to the find the one with the greatest number.
 // If there are two leaves with the same number, choose the one with the earliest arrival time.
-func (lm *leafMap) deepestLeaf() *node {
+func (lm *leafMap) highestLeaf() *node {
 	lm.RLock()
 	defer lm.RUnlock()
 
@@ -82,25 +82,25 @@ func (lm *leafMap) deepestLeaf() *node {
 		return true
 	})
 
-	if lm.currentDeepestLeaf != nil {
-		if lm.currentDeepestLeaf.hash == deepest.hash {
-			return lm.currentDeepestLeaf
+	if lm.currHighestLeaf != nil {
+		if lm.currHighestLeaf.hash == deepest.hash {
+			return lm.currHighestLeaf
 		}
 
 		// update the current deepest leaf if the found deepest has a greater number or
 		// if the current and the found deepest has the same number however the current
 		// arrived later then the found deepest
-		if deepest.number.Cmp(lm.currentDeepestLeaf.number) == 1 {
-			lm.currentDeepestLeaf = deepest
-		} else if deepest.number.Cmp(lm.currentDeepestLeaf.number) == 0 &&
-			deepest.arrivalTime.Before(lm.currentDeepestLeaf.arrivalTime) {
-			lm.currentDeepestLeaf = deepest
+		if deepest.number.Cmp(lm.currHighestLeaf.number) == 1 {
+			lm.currHighestLeaf = deepest
+		} else if deepest.number.Cmp(lm.currHighestLeaf.number) == 0 &&
+			deepest.arrivalTime.Before(lm.currHighestLeaf.arrivalTime) {
+			lm.currHighestLeaf = deepest
 		}
 	} else {
-		lm.currentDeepestLeaf = deepest
+		lm.currHighestLeaf = deepest
 	}
 
-	return lm.currentDeepestLeaf
+	return lm.currHighestLeaf
 }
 
 func (lm *leafMap) toMap() map[common.Hash]*node {
@@ -132,4 +132,48 @@ func (lm *leafMap) nodes() []*node {
 	})
 
 	return nodes
+}
+
+func (lm *leafMap) bestBlock() *node {
+	lm.RLock()
+	defer lm.RUnlock()
+
+	// map of primary ancestor count -> *node
+	counts := make(map[int][]*node)
+
+	lm.smap.Range(func(_, nn interface{}) bool {
+		n := nn.(*node)
+		count := n.primaryAncestorCount(0)
+
+		nodesWithCount, has := counts[count]
+		if !has {
+			counts[count] = []*node{n}
+		} else {
+			counts[count] = append(nodesWithCount, n)
+		}
+
+		return true
+	})
+
+	// get highest count
+	highest := 0
+	for count := range counts {
+		if count > highest {
+			highest = count
+		}
+	}
+
+	// there's just one node with the highest amount of primary ancestors,
+	// so let's return it
+	if len(counts[highest]) == 1 {
+		return counts[highest][0]
+	}
+
+	// there are multple with the highest count, run them through `highestLeaf`
+	lm2 := newEmptyLeafMap()
+	for _, node := range counts[highest] {
+		lm2.store(node.hash, node)
+	}
+
+	return lm2.highestLeaf()
 }

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -243,7 +243,9 @@ func (n *node) primaryAncestorCount(count int) int {
 		return count
 	}
 
-	if n.isPrimary {
+	if n.isPrimary && n.parent != nil {
+		// if parent is nil, we're at the root node
+		// we don't need to count it, as all blocks have the root as an ancestor
 		count++
 	}
 

--- a/lib/blocktree/node.go
+++ b/lib/blocktree/node.go
@@ -19,6 +19,7 @@ type node struct {
 	children    []*node     // Nodes of children blocks
 	number      *big.Int    // block number
 	arrivalTime time.Time   // Arrival time of the block
+	isPrimary   bool        // whether the block was authored in a primary slot or not
 }
 
 // addChild appends Node to n's list of children
@@ -235,4 +236,16 @@ func (n *node) deleteChild(toDelete *node) {
 			return
 		}
 	}
+}
+
+func (n *node) primaryAncestorCount(count int) int {
+	if n == nil {
+		return count
+	}
+
+	if n.isPrimary {
+		count++
+	}
+
+	return n.parent.primaryAncestorCount(count)
 }

--- a/lib/blocktree/node_test.go
+++ b/lib/blocktree/node_test.go
@@ -61,3 +61,18 @@ func TestNode_Prune(t *testing.T) {
 		}
 	}
 }
+
+func TestNode_primaryAncestorCount(t *testing.T) {
+	bt, hashes := createFlatTree(t, 16)
+	require.Equal(t, 0, bt.root.primaryAncestorCount(0))
+	require.Equal(t, 15, bt.getNode(hashes[15]).primaryAncestorCount(0))
+
+	for i, hash := range hashes {
+		n := bt.getNode(hash)
+		if i%2 == 0 {
+			n.isPrimary = false
+		}
+	}
+
+	require.Equal(t, 8, bt.getNode(hashes[15]).primaryAncestorCount(0))
+}


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- reimplement `BlockTree.BestBlockHash()` to implement fork choice rule that prefers chain with the most amount of primary authored blocks
- if there are multple chains with the same amount of primaries, it uses the same fork choice rule as previously (ie. pick chain with highest head number, if there are multiple with same head number then pick one with lowest arrival time)

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./lib/blocktree
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #2249

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @kishansagathiya 
