### PR TITLE
fix(dot/sync): remove max size limit from ascending block requests

### DIFF
--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -972,8 +972,17 @@ func workerToRequests(w *worker) ([]*network.BlockRequestMessage, error) {
 	reqs := make([]*network.BlockRequestMessage, numRequests)
 
 	for i := 0; i < numRequests; i++ {
+		// check if we want to specify a size
 		max := uint32(maxResponseSize)
-		
+
+		if w.direction == network.Descending && i == numRequests-1 {
+			size := numBlocks % maxResponseSize
+			if size == 0 {
+				size = maxResponseSize
+			}
+			max = uint32(size)
+		}
+
 		var start *variadic.Uint64OrHash
 		if w.startHash.IsEmpty() {
 			// worker startHash is unspecified if we are in bootstrap mode

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -972,16 +972,8 @@ func workerToRequests(w *worker) ([]*network.BlockRequestMessage, error) {
 	reqs := make([]*network.BlockRequestMessage, numRequests)
 
 	for i := 0; i < numRequests; i++ {
-		// check if we want to specify a size
-		var max uint32 = maxResponseSize
-		if i == numRequests-1 {
-			size := numBlocks % maxResponseSize
-			if size == 0 {
-				size = maxResponseSize
-			}
-			max = uint32(size)
-		}
-
+		max := uint32(maxResponseSize)
+		
 		var start *variadic.Uint64OrHash
 		if w.startHash.IsEmpty() {
 			// worker startHash is unspecified if we are in bootstrap mode

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -275,7 +275,6 @@ func TestWorkerToRequests(t *testing.T) {
 		max128 = uint32(128)
 		max9   = uint32(9)
 		max64  = uint32(64)
-		max1   = uint32(1)
 	)
 
 	testCases := []testCase{
@@ -333,7 +332,7 @@ func TestWorkerToRequests(t *testing.T) {
 					StartingBlock: *variadic.MustNewUint64OrHash(1),
 					EndBlockHash:  nil,
 					Direction:     network.Ascending,
-					Max:           &max9,
+					Max:           &max128,
 				},
 			},
 		},
@@ -374,7 +373,7 @@ func TestWorkerToRequests(t *testing.T) {
 					StartingBlock: *variadic.MustNewUint64OrHash(1 + maxResponseSize),
 					EndBlockHash:  nil,
 					Direction:     network.Ascending,
-					Max:           &max64,
+					Max:           &max128,
 				},
 			},
 		},
@@ -392,7 +391,7 @@ func TestWorkerToRequests(t *testing.T) {
 					StartingBlock: *variadic.MustNewUint64OrHash(1),
 					EndBlockHash:  &(common.Hash{0xa}),
 					Direction:     network.Ascending,
-					Max:           &max9,
+					Max:           &max128,
 				},
 			},
 		},
@@ -411,7 +410,7 @@ func TestWorkerToRequests(t *testing.T) {
 					StartingBlock: *variadic.MustNewUint64OrHash(common.Hash{0xb}),
 					EndBlockHash:  &(common.Hash{0xc}),
 					Direction:     network.Ascending,
-					Max:           &max9,
+					Max:           &max128,
 				},
 			},
 		},
@@ -427,7 +426,7 @@ func TestWorkerToRequests(t *testing.T) {
 					RequestedData: bootstrapRequestData,
 					StartingBlock: *variadic.MustNewUint64OrHash(10),
 					Direction:     network.Ascending,
-					Max:           &max1,
+					Max:           &max128,
 				},
 			},
 		},


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- remove `max` size limit on ascending block requests we send out, it isn't really needed as if there aren't any more blocks to return, the remote node just won't send them (eg. if we're at the head)
- there was also a case where we send the request with some limit, but the remote node actually had another block just past the limit (just built for example), then we'd have to send out another request after for that block

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/sync
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- #1356 

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @jimjbrettj 
