### PR TITLE
fix(lib/trie): remove map deletion at `loadProof`

### DIFF
--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -133,13 +133,13 @@ func (t *Trie) loadProof(proofHashToNode map[string]Node, n Node) {
 		}
 
 		proofHash := common.BytesToHex(child.GetHash())
-		childOnMap, ok := proofHashToNode[proofHash]
+		node, ok := proofHashToNode[proofHash]
 		if !ok {
 			continue
 		}
 
-		branch.Children[i] = childOnMap
-		t.loadProof(proofHashToNode, childOnMap)
+		branch.Children[i] = node
+		t.loadProof(proofHashToNode, node)
 	}
 }
 

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -133,14 +133,13 @@ func (t *Trie) loadProof(proofHashToNode map[string]Node, n Node) {
 		}
 
 		proofHash := common.BytesToHex(child.GetHash())
-		node, ok := proofHashToNode[proofHash]
+		childOnMap, ok := proofHashToNode[proofHash]
 		if !ok {
 			continue
 		}
-		delete(proofHashToNode, proofHash)
 
-		branch.Children[i] = node
-		t.loadProof(proofHashToNode, node)
+		branch.Children[i] = childOnMap
+		t.loadProof(proofHashToNode, childOnMap)
 	}
 }
 

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -78,11 +78,10 @@ func testGenerateProof(t *testing.T, entries []Pair, keys [][]byte) ([]byte, [][
 		value := trie.Get(key)
 		require.NotNil(t, value)
 
-		itemFromDB := Pair{
+		items[idx] = Pair{
 			Key:   key,
 			Value: value,
 		}
-		items[idx] = itemFromDB
 	}
 
 	return root, proof, items
@@ -95,23 +94,23 @@ func TestVerifyProof_ShouldReturnTrue(t *testing.T) {
 		{Key: []byte("alpha"), Value: make([]byte, 32)},
 		{Key: []byte("bravo"), Value: []byte("bravo")},
 		{Key: []byte("do"), Value: []byte("verb")},
-		{Key: []byte("dog"), Value: []byte("puppy")},
-		{Key: []byte("doge"), Value: make([]byte, 32)},
+		{Key: []byte("dogea"), Value: []byte("puppy")},
+		{Key: []byte("dogeb"), Value: []byte("puppy")},
 		{Key: []byte("horse"), Value: []byte("stallion")},
 		{Key: []byte("house"), Value: []byte("building")},
 	}
 
 	keys := [][]byte{
 		[]byte("do"),
-		[]byte("dog"),
-		[]byte("doge"),
+		[]byte("dogea"),
+		[]byte("dogeb"),
 	}
 
-	root, proof, pl := testGenerateProof(t, entries, keys)
+	root, proof, pairs := testGenerateProof(t, entries, keys)
+	v, err := VerifyProof(proof, root, pairs)
 
-	v, err := VerifyProof(proof, root, pl)
-	require.True(t, v)
 	require.NoError(t, err)
+	require.True(t, v)
 }
 
 func TestVerifyProof_ShouldReturnDuplicateKeysError(t *testing.T) {
@@ -157,4 +156,72 @@ func TestVerifyProof_ShouldReturnTrueWithouCompareValues(t *testing.T) {
 	v, err := VerifyProof(proof, root, pl)
 	require.True(t, v)
 	require.NoError(t, err)
+}
+
+func TestDiferentPathsSameKeys_GenerateAndVerifyProof(t *testing.T) {
+	value := []byte("somevalue")
+	entries := []Pair{
+		{Key: []byte("d"), Value: value},
+		{Key: []byte("b"), Value: value},
+		{Key: []byte("dxyz"), Value: value},
+		{Key: []byte("bxyz"), Value: value},
+		{Key: []byte("dxyzi"), Value: value},
+		{Key: []byte("bxyzi"), Value: value},
+	}
+
+	keys := [][]byte{
+		[]byte("d"),
+		[]byte("b"),
+		[]byte("dxyz"),
+		[]byte("bxyz"),
+		[]byte("dxyzi"),
+		[]byte("bxyzi"),
+	}
+
+	root, proof, pairs := testGenerateProof(t, entries, keys)
+
+	ok, err := VerifyProof(proof, root, pairs)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestKeysWithSameValue_GenerateAndVerifyProof(t *testing.T) {
+	tmp := t.TempDir()
+
+	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
+		InMemory: true,
+		DataDir:  tmp,
+	})
+	require.NoError(t, err)
+
+	var (
+		value = []byte("somevalue")
+		key1  = []byte("worlda")
+		key2  = []byte("worldb")
+		key3  = []byte("worldc")
+	)
+
+	tt := NewEmptyTrie()
+	tt.Put(key1, value)
+	tt.Put(key2, value)
+	tt.Put(key3, nil)
+
+	err = tt.Store(memdb)
+	require.NoError(t, err)
+
+	hash, err := tt.Hash()
+	require.NoError(t, err)
+
+	proof, err := GenerateProof(hash.ToBytes(), [][]byte{key1, key2, key3}, memdb)
+	require.NoError(t, err)
+
+	pairs := []Pair{
+		{Key: key1, Value: value},
+		{Key: key2, Value: value},
+		{Key: key3, Value: nil},
+	}
+
+	ok, err := VerifyProof(proof, hash.ToBytes(), pairs)
+	require.NoError(t, err)
+	require.True(t, ok)
 }

--- a/lib/trie/proof_test.go
+++ b/lib/trie/proof_test.go
@@ -158,7 +158,7 @@ func TestVerifyProof_ShouldReturnTrueWithouCompareValues(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDiferentPathsSameKeys_GenerateAndVerifyProof(t *testing.T) {
+func TestBranchNodes_SameHash_DiferentPaths_GenerateAndVerifyProof(t *testing.T) {
 	value := []byte("somevalue")
 	entries := []Pair{
 		{Key: []byte("d"), Value: value},
@@ -185,7 +185,7 @@ func TestDiferentPathsSameKeys_GenerateAndVerifyProof(t *testing.T) {
 	require.True(t, ok)
 }
 
-func TestKeysWithSameValue_GenerateAndVerifyProof(t *testing.T) {
+func TestLeafNodes_SameHash_DifferentPaths_GenerateAndVerifyProof(t *testing.T) {
 	tmp := t.TempDir()
 
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
@@ -198,13 +198,11 @@ func TestKeysWithSameValue_GenerateAndVerifyProof(t *testing.T) {
 		value = []byte("somevalue")
 		key1  = []byte("worlda")
 		key2  = []byte("worldb")
-		key3  = []byte("worldc")
 	)
 
 	tt := NewEmptyTrie()
 	tt.Put(key1, value)
 	tt.Put(key2, value)
-	tt.Put(key3, nil)
 
 	err = tt.Store(memdb)
 	require.NoError(t, err)
@@ -212,13 +210,12 @@ func TestKeysWithSameValue_GenerateAndVerifyProof(t *testing.T) {
 	hash, err := tt.Hash()
 	require.NoError(t, err)
 
-	proof, err := GenerateProof(hash.ToBytes(), [][]byte{key1, key2, key3}, memdb)
+	proof, err := GenerateProof(hash.ToBytes(), [][]byte{key1, key2}, memdb)
 	require.NoError(t, err)
 
 	pairs := []Pair{
 		{Key: key1, Value: value},
 		{Key: key2, Value: value},
-		{Key: key3, Value: nil},
 	}
 
 	ok, err := VerifyProof(proof, hash.ToBytes(), pairs)


### PR DESCRIPTION
## Changes

- Remove `delete(proofHashesMap, hash)` from the `loadProof` function, this was creating problems when nodes were in different paths however with the same hash not being loaded into the trie.

## Tests

I added two more test inside `./lib/trie/proof_test.go`
- Test leaf nodes in different paths with the same hash
```
go test -run ^TestLeafNodes_SameHash_DifferentPaths_GenerateAndVerifyProof$ github.com/ChainSafe/gossamer/lib/trie
```

- Test branch nodes in different paths with the same hash
```
go test -run ^TestBranchNodes_SameHash_DiferentPaths_GenerateAndVerifyProof$ github.com/ChainSafe/gossamer/lib/trie
```

## Issues

- Closes #2240

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @noot 
