### PR TITLE
feat(dot/network): add mismatched genesis peer reporting

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/pkg/scale"
@@ -176,6 +177,10 @@ func (s *Service) validateBlockAnnounceHandshake(from peer.ID, hs Handshake) err
 	}
 
 	if bhs.GenesisHash != s.blockState.GenesisHash() {
+		s.host.cm.peerSetHandler.ReportPeer(peerset.ReputationChange{
+			Value:  peerset.GenesisMismatch,
+			Reason: peerset.GenesisMismatchReason,
+		}, from)
 		return errors.New("genesis hash mismatch")
 	}
 

--- a/dot/peerset/constants.go
+++ b/dot/peerset/constants.go
@@ -62,4 +62,9 @@ const (
 	BadJustificationValue Reputation = -(1 << 16)
 	// BadJustificationReason is used when peer send invalid justification.
 	BadJustificationReason = "Bad justification"
+
+	// GenesisMismatch is used when peer has a different genesis
+	GenesisMismatch Reputation = math.MinInt32
+	// GenesisMismatchReason used when a peer has a different genesis
+	GenesisMismatchReason = "Genesis mismatch"
 )


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Matches substrate to apply reputation change for a given peer if their genesis hash doesn't match node genesis hash.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/network
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- #1887 

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @EclesioMeloJunior 
