### PR TITLE
fix(ci): run golangci-lint with integration build tag

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,14 +25,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17.x"
-      - uses: actions/checkout@v2
 
-      - name: setup golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh |
-          sh -s -- -b $(go env GOPATH)/bin v1.43.0
-
-      - run: golangci-lint run --timeout 10m
+      - name: Lint
+        run: make lint
 
   check-description:
     name: Checks PR has title and body description

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help: Makefile
 .PHONY: lint
 lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
-	golangci-lint run
+	golangci-lint run --build-tags integration --timeout 10m
 
 clean:
 	rm -fr ./bin


### PR DESCRIPTION
## Changes

- Use `Makefile` lint target
- Add `--build-tags integration` to Makefile lint command
- Add ` --timeout 10m` to Makefile lint command.

## Tests

checks workflow passing

## Issues


## Primary Reviewer
