### PR TITLE
chore(dot/network): replace `sync.Map` with map+mutex

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -190,10 +190,10 @@ func (s *Service) validateBlockAnnounceHandshake(from peer.ID, hs Handshake) err
 
 	// don't need to lock here, since function is always called inside the func returned by
 	// `createNotificationsMessageHandler` which locks the map beforehand.
-	data, ok := np.getInboundHandshakeData(from)
-	if ok {
+	data := np.peersData.getInbound(from)
+	if data != nil {
 		data.handshake = hs
-		np.inboundHandshakeData.Store(from, data)
+		np.peersData.setInbound(from, data)
 	}
 
 	// if peer has higher best block than us, begin syncing

--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -190,10 +190,10 @@ func (s *Service) validateBlockAnnounceHandshake(from peer.ID, hs Handshake) err
 
 	// don't need to lock here, since function is always called inside the func returned by
 	// `createNotificationsMessageHandler` which locks the map beforehand.
-	data := np.peersData.getInbound(from)
+	data := np.peersData.getInboundHandshakeData(from)
 	if data != nil {
 		data.handshake = hs
-		np.peersData.setInbound(from, data)
+		np.peersData.setInboundHandshakeData(from, data)
 	}
 
 	// if peer has higher best block than us, begin syncing

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -162,7 +162,7 @@ func TestValidateBlockAnnounceHandshake(t *testing.T) {
 		peersData: newPeersData(),
 	}
 	testPeerID := peer.ID("noot")
-	nodeA.notificationsProtocols[BlockAnnounceMsgType].peersData.setInbound(testPeerID, &handshakeData{})
+	nodeA.notificationsProtocols[BlockAnnounceMsgType].peersData.setInboundHandshakeData(testPeerID, &handshakeData{})
 
 	err := nodeA.validateBlockAnnounceHandshake(testPeerID, &BlockAnnounceHandshake{
 		BestBlockNumber: 100,

--- a/dot/network/block_announce_test.go
+++ b/dot/network/block_announce_test.go
@@ -4,7 +4,6 @@
 package network
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -160,10 +159,10 @@ func TestValidateBlockAnnounceHandshake(t *testing.T) {
 	nodeA := createTestService(t, configA)
 	nodeA.noGossip = true
 	nodeA.notificationsProtocols[BlockAnnounceMsgType] = &notificationsProtocol{
-		inboundHandshakeData: new(sync.Map),
+		peersData: newPeersData(),
 	}
 	testPeerID := peer.ID("noot")
-	nodeA.notificationsProtocols[BlockAnnounceMsgType].inboundHandshakeData.Store(testPeerID, &handshakeData{})
+	nodeA.notificationsProtocols[BlockAnnounceMsgType].peersData.setInbound(testPeerID, &handshakeData{})
 
 	err := nodeA.validateBlockAnnounceHandshake(testPeerID, &BlockAnnounceHandshake{
 		BestBlockNumber: 100,

--- a/dot/network/errors.go
+++ b/dot/network/errors.go
@@ -11,7 +11,6 @@ var (
 	errCannotValidateHandshake = errors.New("failed to validate handshake")
 	errMessageTypeNotValid     = errors.New("message type is not valid")
 	errMessageIsNotHandshake   = errors.New("failed to convert message to Handshake")
-	errMissingHandshakeMutex   = errors.New("outboundHandshakeMutex does not exist")
 	errInvalidHandshakeForPeer = errors.New("peer previously sent invalid handshake")
 	errHandshakeTimeout        = errors.New("handshake timeout reached")
 )

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -348,19 +348,19 @@ func TestStreamCloseMetadataCleanup(t *testing.T) {
 	info := nodeA.notificationsProtocols[BlockAnnounceMsgType]
 
 	// Set handshake data to received
-	info.peersData.setInbound(nodeB.host.id(), &handshakeData{
+	info.peersData.setInboundHandshakeData(nodeB.host.id(), &handshakeData{
 		received:  true,
 		validated: true,
 	})
 
 	// Verify that handshake data exists.
-	data := info.peersData.getInbound(nodeB.host.id())
+	data := info.peersData.getInboundHandshakeData(nodeB.host.id())
 	require.NotNil(t, data)
 
 	nodeB.host.close()
 
 	// Verify that handshake data is cleared.
-	data = info.peersData.getInbound(nodeB.host.id())
+	data = info.peersData.getInboundHandshakeData(nodeB.host.id())
 	require.Nil(t, data)
 }
 

--- a/dot/network/host_test.go
+++ b/dot/network/host_test.go
@@ -348,24 +348,20 @@ func TestStreamCloseMetadataCleanup(t *testing.T) {
 	info := nodeA.notificationsProtocols[BlockAnnounceMsgType]
 
 	// Set handshake data to received
-	info.inboundHandshakeData.Store(nodeB.host.id(), &handshakeData{
+	info.peersData.setInbound(nodeB.host.id(), &handshakeData{
 		received:  true,
 		validated: true,
 	})
 
 	// Verify that handshake data exists.
-	_, ok := info.getInboundHandshakeData(nodeB.host.id())
-	require.True(t, ok)
+	data := info.peersData.getInbound(nodeB.host.id())
+	require.NotNil(t, data)
 
-	time.Sleep(time.Second)
 	nodeB.host.close()
 
-	// Wait for cleanup
-	time.Sleep(time.Second)
-
 	// Verify that handshake data is cleared.
-	_, ok = info.getInboundHandshakeData(nodeB.host.id())
-	require.False(t, ok)
+	data = info.peersData.getInbound(nodeB.host.id())
+	require.Nil(t, data)
 }
 
 func Test_PeerSupportsProtocol(t *testing.T) {

--- a/dot/network/inbound.go
+++ b/dot/network/inbound.go
@@ -64,7 +64,7 @@ func (s *Service) resetInboundStream(stream libp2pnetwork.Stream) {
 			continue
 		}
 
-		prtl.peersData.deleteInbound(peerID)
+		prtl.peersData.deleteInboundHandshakeData(peerID)
 		break
 	}
 

--- a/dot/network/inbound.go
+++ b/dot/network/inbound.go
@@ -64,7 +64,7 @@ func (s *Service) resetInboundStream(stream libp2pnetwork.Stream) {
 			continue
 		}
 
-		prtl.inboundHandshakeData.Delete(peerID)
+		prtl.peersData.deleteInbound(peerID)
 		break
 	}
 

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -6,7 +6,6 @@ package network
 import (
 	"errors"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -33,17 +32,16 @@ func TestCreateDecoder_BlockAnnounce(t *testing.T) {
 
 	// create info and decoder
 	info := &notificationsProtocol{
-		protocolID:            s.host.protocolID + blockAnnounceID,
-		getHandshake:          s.getBlockAnnounceHandshake,
-		handshakeValidator:    s.validateBlockAnnounceHandshake,
-		inboundHandshakeData:  new(sync.Map),
-		outboundHandshakeData: new(sync.Map),
+		protocolID:         s.host.protocolID + blockAnnounceID,
+		getHandshake:       s.getBlockAnnounceHandshake,
+		handshakeValidator: s.validateBlockAnnounceHandshake,
+		peersData:          newPeersData(),
 	}
 	decoder := createDecoder(info, decodeBlockAnnounceHandshake, decodeBlockAnnounceMessage)
 
 	// haven't received handshake from peer
 	testPeerID := peer.ID("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ")
-	info.inboundHandshakeData.Store(testPeerID, &handshakeData{
+	info.peersData.setInbound(testPeerID, &handshakeData{
 		received: false,
 	})
 
@@ -73,9 +71,9 @@ func TestCreateDecoder_BlockAnnounce(t *testing.T) {
 	require.NoError(t, err)
 
 	// set handshake data to received
-	hsData, _ := info.getInboundHandshakeData(testPeerID)
+	hsData := info.peersData.getInbound(testPeerID)
 	hsData.received = true
-	info.inboundHandshakeData.Store(testPeerID, hsData)
+	info.peersData.setInbound(testPeerID, hsData)
 	msg, err = decoder(enc, testPeerID, true)
 	require.NoError(t, err)
 	require.Equal(t, testBlockAnnounce, msg)
@@ -119,16 +117,15 @@ func TestCreateNotificationsMessageHandler_BlockAnnounce(t *testing.T) {
 
 	// create info and handler
 	info := &notificationsProtocol{
-		protocolID:            s.host.protocolID + blockAnnounceID,
-		getHandshake:          s.getBlockAnnounceHandshake,
-		handshakeValidator:    s.validateBlockAnnounceHandshake,
-		inboundHandshakeData:  new(sync.Map),
-		outboundHandshakeData: new(sync.Map),
+		protocolID:         s.host.protocolID + blockAnnounceID,
+		getHandshake:       s.getBlockAnnounceHandshake,
+		handshakeValidator: s.validateBlockAnnounceHandshake,
+		peersData:          newPeersData(),
 	}
 	handler := s.createNotificationsMessageHandler(info, s.handleBlockAnnounceMessage, nil)
 
 	// set handshake data to received
-	info.inboundHandshakeData.Store(testPeerID, &handshakeData{
+	info.peersData.setInbound(testPeerID, &handshakeData{
 		received:  true,
 		validated: true,
 	})
@@ -156,11 +153,10 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 
 	// create info and handler
 	info := &notificationsProtocol{
-		protocolID:            s.host.protocolID + blockAnnounceID,
-		getHandshake:          s.getBlockAnnounceHandshake,
-		handshakeValidator:    s.validateBlockAnnounceHandshake,
-		inboundHandshakeData:  new(sync.Map),
-		outboundHandshakeData: new(sync.Map),
+		protocolID:         s.host.protocolID + blockAnnounceID,
+		getHandshake:       s.getBlockAnnounceHandshake,
+		handshakeValidator: s.validateBlockAnnounceHandshake,
+		peersData:          newPeersData(),
 	}
 	handler := s.createNotificationsMessageHandler(info, s.handleBlockAnnounceMessage, nil)
 
@@ -198,8 +194,8 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 
 	err = handler(stream, testHandshake)
 	require.Equal(t, errCannotValidateHandshake, err)
-	data, has := info.getInboundHandshakeData(testPeerID)
-	require.True(t, has)
+	data := info.peersData.getInbound(testPeerID)
+	require.NotNil(t, data)
 	require.True(t, data.received)
 	require.False(t, data.validated)
 
@@ -211,12 +207,12 @@ func TestCreateNotificationsMessageHandler_BlockAnnounceHandshake(t *testing.T) 
 		GenesisHash:     s.blockState.GenesisHash(),
 	}
 
-	info.inboundHandshakeData.Delete(testPeerID)
+	info.peersData.deleteInbound(testPeerID)
 
 	err = handler(stream, testHandshake)
 	require.NoError(t, err)
-	data, has = info.getInboundHandshakeData(testPeerID)
-	require.True(t, has)
+	data = info.peersData.getInbound(testPeerID)
+	require.NotNil(t, data)
 	require.True(t, data.received)
 	require.True(t, data.validated)
 }
@@ -268,7 +264,7 @@ func Test_HandshakeTimeout(t *testing.T) {
 
 	// clear handshake data from connection handler
 	time.Sleep(time.Millisecond * 100)
-	info.outboundHandshakeData.Delete(nodeB.host.id())
+	info.peersData.deleteOutbound(nodeB.host.id())
 	connAToB := nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
 	for _, stream := range connAToB[0].GetStreams() {
 		_ = stream.Close()
@@ -281,14 +277,14 @@ func Test_HandshakeTimeout(t *testing.T) {
 		GenesisHash:     common.Hash{2},
 	}
 
-	info.outboundHandshakeMutexes.Store(nodeB.host.id(), new(sync.Mutex))
+	info.peersData.setMutex(nodeB.host.id())
 	go nodeA.sendData(nodeB.host.id(), testHandshakeMsg, info, nil)
 
 	time.Sleep(time.Second)
 
 	// handshake data shouldn't exist, as nodeB hasn't responded yet
-	_, ok := info.getOutboundHandshakeData(nodeB.host.id())
-	require.False(t, ok)
+	data := info.peersData.getOutbound(nodeB.host.id())
+	require.Nil(t, data)
 
 	// a stream should be open until timeout
 	connAToB = nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
@@ -299,8 +295,8 @@ func Test_HandshakeTimeout(t *testing.T) {
 	time.Sleep(handshakeTimeout)
 
 	// handshake data shouldn't exist still
-	_, ok = info.getOutboundHandshakeData(nodeB.host.id())
-	require.False(t, ok)
+	data = info.peersData.getOutbound(nodeB.host.id())
+	require.Nil(t, data)
 
 	// stream should be closed
 	connAToB = nodeA.host.h.Network().ConnsToPeer(nodeB.host.id())
@@ -350,16 +346,15 @@ func TestCreateNotificationsMessageHandler_HandleTransaction(t *testing.T) {
 
 	// create info and handler
 	info := &notificationsProtocol{
-		protocolID:            txnProtocolID,
-		getHandshake:          srvc1.getTransactionHandshake,
-		handshakeValidator:    validateTransactionHandshake,
-		inboundHandshakeData:  new(sync.Map),
-		outboundHandshakeData: new(sync.Map),
+		protocolID:         txnProtocolID,
+		getHandshake:       srvc1.getTransactionHandshake,
+		handshakeValidator: validateTransactionHandshake,
+		peersData:          newPeersData(),
 	}
 	handler := srvc1.createNotificationsMessageHandler(info, srvc1.handleTransactionMessage, txnBatchHandler)
 
 	// set handshake data to received
-	info.inboundHandshakeData.Store(srvc2.host.id(), handshakeData{
+	info.peersData.setInbound(srvc2.host.id(), &handshakeData{
 		received:  true,
 		validated: true,
 	})

--- a/dot/network/peersdata.go
+++ b/dot/network/peersdata.go
@@ -44,19 +44,19 @@ func (p *peersData) deleteMutex(peerID peer.ID) {
 	delete(p.mutexes, peerID)
 }
 
-func (p *peersData) getInbound(peerID peer.ID) (data *handshakeData) {
+func (p *peersData) getInboundHandshakeData(peerID peer.ID) (data *handshakeData) {
 	p.inboundMu.RLock()
 	defer p.inboundMu.RUnlock()
 	return p.inbound[peerID]
 }
 
-func (p *peersData) setInbound(peerID peer.ID, data *handshakeData) {
+func (p *peersData) setInboundHandshakeData(peerID peer.ID, data *handshakeData) {
 	p.inboundMu.Lock()
 	defer p.inboundMu.Unlock()
 	p.inbound[peerID] = data
 }
 
-func (p *peersData) deleteInbound(peerID peer.ID) {
+func (p *peersData) deleteInboundHandshakeData(peerID peer.ID) {
 	p.inboundMu.Lock()
 	defer p.inboundMu.Unlock()
 	delete(p.inbound, peerID)
@@ -73,19 +73,19 @@ func (p *peersData) countInboundStreams() (count int64) {
 	return count
 }
 
-func (p *peersData) getOutbound(peerID peer.ID) (data *handshakeData) {
+func (p *peersData) getOutboundHandshakeData(peerID peer.ID) (data *handshakeData) {
 	p.outboundMu.RLock()
 	defer p.outboundMu.RUnlock()
 	return p.outbound[peerID]
 }
 
-func (p *peersData) setOutbound(peerID peer.ID, data *handshakeData) {
+func (p *peersData) setOutboundHandshakeData(peerID peer.ID, data *handshakeData) {
 	p.outboundMu.Lock()
 	defer p.outboundMu.Unlock()
 	p.outbound[peerID] = data
 }
 
-func (p *peersData) deleteOutbound(peerID peer.ID) {
+func (p *peersData) deleteOutboundHandshakeData(peerID peer.ID) {
 	p.outboundMu.Lock()
 	defer p.outboundMu.Unlock()
 	delete(p.outbound, peerID)

--- a/dot/network/peersdata.go
+++ b/dot/network/peersdata.go
@@ -1,0 +1,103 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package network
+
+import (
+	"sync"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type peersData struct {
+	mutexesMu  sync.RWMutex
+	mutexes    map[peer.ID]*sync.Mutex
+	inboundMu  sync.RWMutex
+	inbound    map[peer.ID]*handshakeData
+	outboundMu sync.RWMutex
+	outbound   map[peer.ID]*handshakeData
+}
+
+func newPeersData() *peersData {
+	return &peersData{
+		mutexes:  make(map[peer.ID]*sync.Mutex),
+		inbound:  make(map[peer.ID]*handshakeData),
+		outbound: make(map[peer.ID]*handshakeData),
+	}
+}
+
+func (p *peersData) setMutex(peerID peer.ID) {
+	p.mutexesMu.Lock()
+	defer p.mutexesMu.Unlock()
+	p.mutexes[peerID] = new(sync.Mutex)
+}
+
+func (p *peersData) getMutex(peerID peer.ID) *sync.Mutex {
+	p.mutexesMu.RLock()
+	defer p.mutexesMu.RUnlock()
+	return p.mutexes[peerID]
+}
+
+func (p *peersData) deleteMutex(peerID peer.ID) {
+	p.mutexesMu.Lock()
+	defer p.mutexesMu.Unlock()
+	delete(p.mutexes, peerID)
+}
+
+func (p *peersData) getInbound(peerID peer.ID) (data *handshakeData) {
+	p.inboundMu.RLock()
+	defer p.inboundMu.RUnlock()
+	return p.inbound[peerID]
+}
+
+func (p *peersData) setInbound(peerID peer.ID, data *handshakeData) {
+	p.inboundMu.Lock()
+	defer p.inboundMu.Unlock()
+	p.inbound[peerID] = data
+}
+
+func (p *peersData) deleteInbound(peerID peer.ID) {
+	p.inboundMu.Lock()
+	defer p.inboundMu.Unlock()
+	delete(p.inbound, peerID)
+}
+
+func (p *peersData) countInboundStreams() (count int64) {
+	p.inboundMu.RLock()
+	defer p.inboundMu.RUnlock()
+	for _, data := range p.inbound {
+		if data.stream != nil {
+			count++
+		}
+	}
+	return count
+}
+
+func (p *peersData) getOutbound(peerID peer.ID) (data *handshakeData) {
+	p.outboundMu.RLock()
+	defer p.outboundMu.RUnlock()
+	return p.outbound[peerID]
+}
+
+func (p *peersData) setOutbound(peerID peer.ID, data *handshakeData) {
+	p.outboundMu.Lock()
+	defer p.outboundMu.Unlock()
+	p.outbound[peerID] = data
+}
+
+func (p *peersData) deleteOutbound(peerID peer.ID) {
+	p.outboundMu.Lock()
+	defer p.outboundMu.Unlock()
+	delete(p.outbound, peerID)
+}
+
+func (p *peersData) countOutboundStreams() (count int64) {
+	p.outboundMu.RLock()
+	defer p.outboundMu.RUnlock()
+	for _, data := range p.outbound {
+		if data.stream != nil {
+			count++
+		}
+	}
+	return count
+}

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -283,16 +283,16 @@ func (s *Service) Start() error {
 	// it creates a per-protocol mutex for sending outbound handshakes to the peer
 	s.host.cm.connectHandler = func(peerID peer.ID) {
 		for _, prtl := range s.notificationsProtocols {
-			prtl.outboundHandshakeMutexes.Store(peerID, new(sync.Mutex))
+			prtl.peersData.setMutex(peerID)
 		}
 	}
 
 	// when a peer gets disconnected, we should clear all handshake data we have for it.
 	s.host.cm.disconnectHandler = func(peerID peer.ID) {
 		for _, prtl := range s.notificationsProtocols {
-			prtl.outboundHandshakeMutexes.Delete(peerID)
-			prtl.inboundHandshakeData.Delete(peerID)
-			prtl.outboundHandshakeData.Delete(peerID)
+			prtl.peersData.deleteMutex(peerID)
+			prtl.peersData.deleteInbound(peerID)
+			prtl.peersData.deleteOutbound(peerID)
 		}
 	}
 
@@ -374,26 +374,10 @@ func (s *Service) getNumStreams(protocolID byte, inbound bool) (count int64) {
 		return 0
 	}
 
-	var hsData *sync.Map
 	if inbound {
-		hsData = np.inboundHandshakeData
-	} else {
-		hsData = np.outboundHandshakeData
+		return np.peersData.countInboundStreams()
 	}
-
-	hsData.Range(func(_, data interface{}) bool {
-		if data == nil {
-			return true
-		}
-
-		if data.(*handshakeData).stream != nil {
-			count++
-		}
-
-		return true
-	})
-
-	return count
+	return np.peersData.countOutboundStreams()
 }
 
 func (s *Service) logPeerCount() {
@@ -632,8 +616,8 @@ func (s *Service) Peers() []common.PeerInfo {
 	s.notificationsMu.RUnlock()
 
 	for _, p := range s.host.peers() {
-		data, has := np.getInboundHandshakeData(p)
-		if !has || data.handshake == nil {
+		data := np.peersData.getInbound(p)
+		if data == nil || data.handshake == nil {
 			peers = append(peers, common.PeerInfo{
 				PeerID: p.String(),
 			})

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -291,8 +291,8 @@ func (s *Service) Start() error {
 	s.host.cm.disconnectHandler = func(peerID peer.ID) {
 		for _, prtl := range s.notificationsProtocols {
 			prtl.peersData.deleteMutex(peerID)
-			prtl.peersData.deleteInbound(peerID)
-			prtl.peersData.deleteOutbound(peerID)
+			prtl.peersData.deleteInboundHandshakeData(peerID)
+			prtl.peersData.deleteOutboundHandshakeData(peerID)
 		}
 	}
 
@@ -616,7 +616,7 @@ func (s *Service) Peers() []common.PeerInfo {
 	s.notificationsMu.RUnlock()
 
 	for _, p := range s.host.peers() {
-		data := np.peersData.getInbound(p)
+		data := np.peersData.getInboundHandshakeData(p)
 		if data == nil || data.handshake == nil {
 			peers = append(peers, common.PeerInfo{
 				PeerID: p.String(),

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -274,7 +274,7 @@ func TestBroadcastDuplicateMessage(t *testing.T) {
 	require.NotNil(t, stream)
 
 	protocol := nodeA.notificationsProtocols[BlockAnnounceMsgType]
-	protocol.outboundHandshakeData.Store(nodeB.host.id(), &handshakeData{
+	protocol.peersData.setOutbound(nodeB.host.id(), &handshakeData{
 		received:  true,
 		validated: true,
 		stream:    stream,

--- a/dot/network/service_test.go
+++ b/dot/network/service_test.go
@@ -274,7 +274,7 @@ func TestBroadcastDuplicateMessage(t *testing.T) {
 	require.NotNil(t, stream)
 
 	protocol := nodeA.notificationsProtocols[BlockAnnounceMsgType]
-	protocol.peersData.setOutbound(nodeB.host.id(), &handshakeData{
+	protocol.peersData.setOutboundHandshakeData(nodeB.host.id(), &handshakeData{
 		received:  true,
 		validated: true,
 		stream:    stream,


### PR DESCRIPTION
## Changes

- Add `peersData` struct holding 3 mutex protected maps:
    - inbound
    - outbound
    - mutexes
- Add helping methods on `peersData`:
    - `countOutboundStreams`
    - `countInboundStreams`

## Tests


## Issues

- #2281 

## Primary Reviewer