### PR TITLE
fix(dot/state): inject mutex protected tries to states

### DIFF
--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -42,8 +42,8 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 
 	db := state.NewInMemoryDB(t)
 
-	_, _, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
-	bs, err := state.NewBlockStateFromGenesis(db, genesisHeader, telemetryMock)
+	_, genesisTrie, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
+	bs, err := state.NewBlockStateFromGenesis(db, genesisTrie, genesisHeader, telemetryMock)
 	require.NoError(t, err)
 	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)
 	require.NoError(t, err)

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -43,7 +43,8 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 	db := state.NewInMemoryDB(t)
 
 	_, genesisTrie, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
-	bs, err := state.NewBlockStateFromGenesis(db, genesisTrie, genesisHeader, telemetryMock)
+	tries := state.NewTries(genesisTrie)
+	bs, err := state.NewBlockStateFromGenesis(db, tries, genesisHeader, telemetryMock)
 	require.NoError(t, err)
 	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)
 	require.NoError(t, err)

--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestGetSet_ReceiptMessageQueue_Justification(t *testing.T) {
-	s := newTestBlockState(t, nil)
+	s := newTestBlockState(t, nil, newTriesEmpty())
 	require.NotNil(t, s)
 
 	var genesisHeader = &types.Header{

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -144,7 +144,7 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 		bs.notifyFinalized(hash, round, setID)
 	}
 
-	pruned := bs.bt.Prune(hash) // TODO this is always 0
+	pruned := bs.bt.Prune(hash)
 	for _, hash := range pruned {
 		block, has := bs.getAndDeleteUnfinalisedBlock(hash)
 		if !has {

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestHighestRoundAndSetID(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	round, setID, err := bs.GetHighestRoundAndSetID()
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), round)
@@ -61,7 +61,7 @@ func TestHighestRoundAndSetID(t *testing.T) {
 }
 
 func TestBlockState_SetFinalisedHash(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	h, err := bs.GetFinalisedHash(0, 0)
 	require.NoError(t, err)
 	require.Equal(t, testGenesisHeader.Hash(), h)
@@ -97,7 +97,7 @@ func TestBlockState_SetFinalisedHash(t *testing.T) {
 }
 
 func TestSetFinalisedHash_setFirstSlotOnFinalisation(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	firstSlot := uint64(42069)
 
 	digest := types.NewDigest()

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -12,13 +12,14 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	runtimemocks "github.com/ChainSafe/gossamer/lib/runtime/mocks"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/stretchr/testify/require"
 )
 
 var testMessageTimeout = time.Second * 3
 
 func TestImportChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 	ch := bs.GetImportedBlockNotifierChannel()
 
 	defer bs.FreeImportedBlockNotifierChannel(ch)
@@ -35,7 +36,7 @@ func TestImportChannel(t *testing.T) {
 }
 
 func TestFreeImportedBlockNotifierChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 	ch := bs.GetImportedBlockNotifierChannel()
 	require.Equal(t, 1, len(bs.imported))
 
@@ -44,7 +45,7 @@ func TestFreeImportedBlockNotifierChannel(t *testing.T) {
 }
 
 func TestFinalizedChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 
 	ch := bs.GetFinalisedNotifierChannel()
 
@@ -66,7 +67,7 @@ func TestFinalizedChannel(t *testing.T) {
 }
 
 func TestImportChannel_Multi(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 
 	num := 5
 	chs := make([]chan *types.Block, num)
@@ -99,7 +100,7 @@ func TestImportChannel_Multi(t *testing.T) {
 }
 
 func TestFinalizedChannel_Multi(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 
 	num := 5
 	chs := make([]chan *types.FinalisationInfo, num)
@@ -136,7 +137,7 @@ func TestFinalizedChannel_Multi(t *testing.T) {
 }
 
 func TestService_RegisterUnRegisterRuntimeUpdatedChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 	ch := make(chan<- runtime.Version)
 	chID, err := bs.RegisterRuntimeUpdatedChannel(ch)
 	require.NoError(t, err)
@@ -147,7 +148,7 @@ func TestService_RegisterUnRegisterRuntimeUpdatedChannel(t *testing.T) {
 }
 
 func TestService_RegisterUnRegisterConcurrentCalls(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 
 	go func() {
 		for i := 0; i < 100; i++ {

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -28,13 +28,15 @@ func TestConcurrencySetHeader(t *testing.T) {
 		dbs[i] = NewInMemoryDB(t)
 	}
 
+	someTrie := trie.NewEmptyTrie() // not used in this test
+
 	pend := new(sync.WaitGroup)
 	pend.Add(threads)
 	for i := 0; i < threads; i++ {
 		go func(index int) {
 			defer pend.Done()
 
-			bs, err := NewBlockStateFromGenesis(dbs[index], testGenesisHeader, telemetryMock)
+			bs, err := NewBlockStateFromGenesis(dbs[index], someTrie, testGenesisHeader, telemetryMock)
 			require.NoError(t, err)
 
 			header := &types.Header{

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -28,7 +28,7 @@ func TestConcurrencySetHeader(t *testing.T) {
 		dbs[i] = NewInMemoryDB(t)
 	}
 
-	someTrie := trie.NewEmptyTrie() // not used in this test
+	tries := NewTries(trie.NewEmptyTrie()) // not used in this test
 
 	pend := new(sync.WaitGroup)
 	pend.Add(threads)
@@ -36,7 +36,7 @@ func TestConcurrencySetHeader(t *testing.T) {
 		go func(index int) {
 			defer pend.Done()
 
-			bs, err := NewBlockStateFromGenesis(dbs[index], someTrie, testGenesisHeader, telemetryMock)
+			bs, err := NewBlockStateFromGenesis(dbs[index], tries, testGenesisHeader, telemetryMock)
 			require.NoError(t, err)
 
 			header := &types.Header{

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -25,7 +25,7 @@ var testGenesisHeader = &types.Header{
 	Digest:    types.NewDigest(),
 }
 
-func newTestBlockState(t *testing.T, header *types.Header) *BlockState {
+func newTestBlockState(t *testing.T, header *types.Header, tries *Tries) *BlockState {
 	ctrl := gomock.NewController(t)
 	telemetryMock := NewMockClient(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
@@ -35,13 +35,13 @@ func newTestBlockState(t *testing.T, header *types.Header) *BlockState {
 		header = testGenesisHeader
 	}
 
-	bs, err := NewBlockStateFromGenesis(db, trie.NewEmptyTrie(), header, telemetryMock)
+	bs, err := NewBlockStateFromGenesis(db, tries, header, telemetryMock)
 	require.NoError(t, err)
 	return bs
 }
 
 func TestSetAndGetHeader(t *testing.T) {
-	bs := newTestBlockState(t, nil)
+	bs := newTestBlockState(t, nil, newTriesEmpty())
 
 	header := &types.Header{
 		Number:    big.NewInt(0),
@@ -58,7 +58,7 @@ func TestSetAndGetHeader(t *testing.T) {
 }
 
 func TestHasHeader(t *testing.T) {
-	bs := newTestBlockState(t, nil)
+	bs := newTestBlockState(t, nil, newTriesEmpty())
 
 	header := &types.Header{
 		Number:    big.NewInt(0),
@@ -75,7 +75,7 @@ func TestHasHeader(t *testing.T) {
 }
 
 func TestGetBlockByNumber(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	blockHeader := &types.Header{
 		ParentHash: testGenesisHeader.Hash(),
@@ -97,7 +97,7 @@ func TestGetBlockByNumber(t *testing.T) {
 }
 
 func TestAddBlock(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	// Create header
 	header0 := &types.Header{
@@ -160,7 +160,7 @@ func TestAddBlock(t *testing.T) {
 }
 
 func TestGetSlotForBlock(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	expectedSlot := uint64(77)
 
 	babeHeader := types.NewBabeDigest()
@@ -191,7 +191,7 @@ func TestGetSlotForBlock(t *testing.T) {
 }
 
 func TestIsBlockOnCurrentChain(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	currChain, branchChains := AddBlocksToState(t, bs, 3, false)
 
 	for _, header := range currChain {
@@ -214,7 +214,7 @@ func TestIsBlockOnCurrentChain(t *testing.T) {
 }
 
 func TestAddBlock_BlockNumberToHash(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	currChain, branchChains := AddBlocksToState(t, bs, 8, false)
 
 	bestHash := bs.BestBlockHash()
@@ -262,7 +262,7 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 }
 
 func TestFinalization_DeleteBlock(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	AddBlocksToState(t, bs, 5, false)
 
 	btBefore := bs.bt.DeepCopy()
@@ -317,7 +317,7 @@ func TestFinalization_DeleteBlock(t *testing.T) {
 }
 
 func TestGetHashByNumber(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	res, err := bs.GetHashByNumber(big.NewInt(0))
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestGetHashByNumber(t *testing.T) {
 
 func TestAddBlock_WithReOrg(t *testing.T) {
 	t.Skip() // TODO: this should be fixed after state refactor PR
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	header1a := &types.Header{
 		Number:     big.NewInt(1),
@@ -453,7 +453,7 @@ func TestAddBlock_WithReOrg(t *testing.T) {
 }
 
 func TestAddBlockToBlockTree(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	header := &types.Header{
 		Number:     big.NewInt(1),
@@ -473,7 +473,7 @@ func TestAddBlockToBlockTree(t *testing.T) {
 }
 
 func TestNumberIsFinalised(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 	fin, err := bs.NumberIsFinalised(big.NewInt(0))
 	require.NoError(t, err)
 	require.True(t, fin)

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -35,7 +35,7 @@ func newTestBlockState(t *testing.T, header *types.Header) *BlockState {
 		header = testGenesisHeader
 	}
 
-	bs, err := NewBlockStateFromGenesis(db, header, telemetryMock)
+	bs, err := NewBlockStateFromGenesis(db, trie.NewEmptyTrie(), header, telemetryMock)
 	require.NoError(t, err)
 	return bs
 }

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,8 @@ var genesisBABEConfig = &types.BabeConfiguration{
 
 func newEpochStateFromGenesis(t *testing.T) *EpochState {
 	db := NewInMemoryDB(t)
-	s, err := NewEpochStateFromGenesis(db, newTestBlockState(t, nil), genesisBABEConfig)
+	blockState := newTestBlockState(t, nil, NewTries(trie.NewEmptyTrie()))
+	s, err := NewEpochStateFromGenesis(db, blockState, genesisBABEConfig)
 	require.NoError(t, err)
 	return s
 }
@@ -184,7 +186,7 @@ func TestEpochState_SetAndGetSlotDuration(t *testing.T) {
 
 func TestEpochState_GetEpochFromTime(t *testing.T) {
 	s := newEpochStateFromGenesis(t)
-	s.blockState = newTestBlockState(t, testGenesisHeader)
+	s.blockState = newTestBlockState(t, testGenesisHeader, NewTries(trie.NewEmptyTrie()))
 
 	epochDuration, err := time.ParseDuration(
 		fmt.Sprintf("%dms",

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -8,8 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/stretchr/testify/require"
 )
+
+func newTriesEmpty() *Tries {
+	return &Tries{
+		rootToTrie: make(map[common.Hash]*trie.Trie),
+	}
+}
 
 // newGenerator creates a new PRNG seeded with the
 // unix nanoseconds value of the current time.

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -63,13 +63,13 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 	}
 
 	// create block state from genesis block
-	blockState, err := NewBlockStateFromGenesis(db, header, s.Telemetry)
+	blockState, err := NewBlockStateFromGenesis(db, t, header, s.Telemetry)
 	if err != nil {
 		return fmt.Errorf("failed to create block state from genesis: %s", err)
 	}
 
 	// create storage state from genesis trie
-	storageState, err := NewStorageState(db, blockState, t, pruner.Config{})
+	storageState, err := NewStorageState(db, blockState, pruner.Config{})
 	if err != nil {
 		return fmt.Errorf("failed to create storage state from trie: %s", err)
 	}

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -62,14 +62,16 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to write genesis values to database: %s", err)
 	}
 
+	tries := NewTries(t)
+
 	// create block state from genesis block
-	blockState, err := NewBlockStateFromGenesis(db, t, header, s.Telemetry)
+	blockState, err := NewBlockStateFromGenesis(db, tries, header, s.Telemetry)
 	if err != nil {
 		return fmt.Errorf("failed to create block state from genesis: %s", err)
 	}
 
 	// create storage state from genesis trie
-	storageState, err := NewStorageState(db, blockState, pruner.Config{})
+	storageState, err := NewStorageState(db, blockState, tries, pruner.Config{})
 	if err != nil {
 		return fmt.Errorf("failed to create storage state from trie: %s", err)
 	}

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -41,7 +41,7 @@ func NewOfflinePruner(inputDBPath, prunedDBPath string, bloomSize uint64,
 		return nil, fmt.Errorf("failed to load DB %w", err)
 	}
 
-	tries := newTries(trie.NewEmptyTrie())
+	tries := NewTries(trie.NewEmptyTrie())
 
 	// create blockState state
 	// NewBlockState on pruner execution does not use telemetry
@@ -62,7 +62,7 @@ func NewOfflinePruner(inputDBPath, prunedDBPath string, bloomSize uint64,
 	}
 
 	// load storage state
-	storageState, err := NewStorageState(db, blockState, pruner.Config{})
+	storageState, err := NewStorageState(db, blockState, tries, pruner.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new storage state %w", err)
 	}

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -41,9 +41,11 @@ func NewOfflinePruner(inputDBPath, prunedDBPath string, bloomSize uint64,
 		return nil, fmt.Errorf("failed to load DB %w", err)
 	}
 
+	tries := newTries(trie.NewEmptyTrie())
+
 	// create blockState state
 	// NewBlockState on pruner execution does not use telemetry
-	blockState, err := NewBlockState(db, nil)
+	blockState, err := NewBlockState(db, tries, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block state: %w", err)
 	}
@@ -60,7 +62,7 @@ func NewOfflinePruner(inputDBPath, prunedDBPath string, bloomSize uint64,
 	}
 
 	// load storage state
-	storageState, err := NewStorageState(db, blockState, trie.NewEmptyTrie(), pruner.Config{})
+	storageState, err := NewStorageState(db, blockState, pruner.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new storage state %w", err)
 	}

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -114,7 +114,7 @@ func (s *Service) Start() error {
 		return nil
 	}
 
-	tries := newTries(trie.NewEmptyTrie())
+	tries := NewTries(trie.NewEmptyTrie())
 
 	var err error
 	// create block state
@@ -138,7 +138,7 @@ func (s *Service) Start() error {
 	}
 
 	// create storage state
-	s.Storage, err = NewStorageState(s.db, s.Block, pr)
+	s.Storage, err = NewStorageState(s.db, s.Block, tries, pr)
 	if err != nil {
 		return fmt.Errorf("failed to create storage state: %w", err)
 	}

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -114,9 +114,11 @@ func (s *Service) Start() error {
 		return nil
 	}
 
+	tries := newTries(trie.NewEmptyTrie())
+
 	var err error
 	// create block state
-	s.Block, err = NewBlockState(s.db, s.Telemetry)
+	s.Block, err = NewBlockState(s.db, tries, s.Telemetry)
 	if err != nil {
 		return fmt.Errorf("failed to create block state: %w", err)
 	}
@@ -136,7 +138,7 @@ func (s *Service) Start() error {
 	}
 
 	// create storage state
-	s.Storage, err = NewStorageState(s.db, s.Block, trie.NewEmptyTrie(), pr)
+	s.Storage, err = NewStorageState(s.db, s.Block, pr)
 	if err != nil {
 		return fmt.Errorf("failed to create storage state: %w", err)
 	}
@@ -166,9 +168,6 @@ func (s *Service) Start() error {
 		s.Block.BestBlockHash().String() +
 		", highest number " + num.String() +
 		" and genesis hash " + s.Block.genesisHash.String())
-
-	// Start background goroutine to GC pruned keys.
-	go s.Storage.pruneStorage(s.closeCh)
 
 	return nil
 }

--- a/dot/state/service_test.go
+++ b/dot/state/service_test.go
@@ -289,7 +289,7 @@ func TestService_PruneStorage(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	for _, v := range prunedArr {
-		tr := serv.Storage.tries.get(v.hash)
+		tr := serv.Storage.blockState.tries.get(v.hash)
 		require.Nil(t, tr)
 	}
 }

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -23,9 +23,11 @@ import (
 
 func newTestStorageState(t *testing.T) *StorageState {
 	db := NewInMemoryDB(t)
-	bs := newTestBlockState(t, testGenesisHeader)
+	tries := newTriesEmpty()
 
-	s, err := NewStorageState(db, bs, pruner.Config{})
+	bs := newTestBlockState(t, testGenesisHeader, tries)
+
+	s, err := NewStorageState(db, bs, tries, pruner.Config{})
 	require.NoError(t, err)
 	return s
 }
@@ -185,10 +187,12 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	err = genTrie.PutChild([]byte("keyToChild"), testChildTrie)
 	require.NoError(t, err)
 
-	blockState, err := NewBlockStateFromGenesis(db, genTrie, genHeader, telemetryMock)
+	tries := NewTries(genTrie)
+
+	blockState, err := NewBlockStateFromGenesis(db, tries, genHeader, telemetryMock)
 	require.NoError(t, err)
 
-	storage, err := NewStorageState(db, blockState, pruner.Config{})
+	storage, err := NewStorageState(db, blockState, tries, pruner.Config{})
 	require.NoError(t, err)
 
 	trieState, err := runtime.NewTrieState(genTrie)

--- a/dot/state/tries.go
+++ b/dot/state/tries.go
@@ -10,13 +10,17 @@ import (
 	"github.com/ChainSafe/gossamer/lib/trie"
 )
 
-type tries struct {
+// Tries is a thread safe map of root hash
+// to trie.
+type Tries struct {
 	rootToTrie map[common.Hash]*trie.Trie
 	mapMutex   sync.RWMutex
 }
 
-func newTries(t *trie.Trie) *tries {
-	return &tries{
+// NewTries creates a new thread safe map of root hash
+// to trie using the trie given as a first trie.
+func NewTries(t *trie.Trie) *Tries {
+	return &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{
 			t.MustHash(): t,
 		},
@@ -25,7 +29,7 @@ func newTries(t *trie.Trie) *tries {
 
 // softSet sets the given trie at the given root hash
 // in the memory map only if it is not already set.
-func (t *tries) softSet(root common.Hash, trie *trie.Trie) {
+func (t *Tries) softSet(root common.Hash, trie *trie.Trie) {
 	t.mapMutex.Lock()
 	defer t.mapMutex.Unlock()
 
@@ -37,7 +41,7 @@ func (t *tries) softSet(root common.Hash, trie *trie.Trie) {
 	t.rootToTrie[root] = trie
 }
 
-func (t *tries) delete(root common.Hash) {
+func (t *Tries) delete(root common.Hash) {
 	t.mapMutex.Lock()
 	defer t.mapMutex.Unlock()
 	delete(t.rootToTrie, root)
@@ -45,7 +49,7 @@ func (t *tries) delete(root common.Hash) {
 
 // get retrieves the trie corresponding to the root hash given
 // from the in-memory thread safe map.
-func (t *tries) get(root common.Hash) (tr *trie.Trie) {
+func (t *Tries) get(root common.Hash) (tr *trie.Trie) {
 	t.mapMutex.RLock()
 	defer t.mapMutex.RUnlock()
 	return t.rootToTrie[root]
@@ -53,7 +57,7 @@ func (t *tries) get(root common.Hash) (tr *trie.Trie) {
 
 // len returns the current numbers of tries
 // stored in the in-memory map.
-func (t *tries) len() int {
+func (t *Tries) len() int {
 	t.mapMutex.RLock()
 	defer t.mapMutex.RUnlock()
 	return len(t.rootToTrie)

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_newTries(t *testing.T) {
+func Test_NewTries(t *testing.T) {
 	t.Parallel()
 
 	tr := trie.NewEmptyTrie()
 
-	rootToTrie := newTries(tr)
+	rootToTrie := NewTries(tr)
 
-	expectedTries := &tries{
+	expectedTries := &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{
 			tr.MustHash(): tr,
 		},
@@ -28,36 +28,36 @@ func Test_newTries(t *testing.T) {
 	assert.Equal(t, expectedTries, rootToTrie)
 }
 
-func Test_tries_softSet(t *testing.T) {
+func Test_Tries_softSet(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		tries         *tries
+		tries         *Tries
 		root          common.Hash
 		trie          *trie.Trie
-		expectedTries *tries
+		expectedTries *Tries
 	}{
 		"set new in map": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{},
 			},
 			root: common.Hash{1, 2, 3},
 			trie: trie.NewEmptyTrie(),
-			expectedTries: &tries{
+			expectedTries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: trie.NewEmptyTrie(),
 				},
 			},
 		},
 		"do not override in map": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: {},
 				},
 			},
 			root: common.Hash{1, 2, 3},
 			trie: trie.NewEmptyTrie(),
-			expectedTries: &tries{
+			expectedTries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: {},
 				},
@@ -77,31 +77,31 @@ func Test_tries_softSet(t *testing.T) {
 	}
 }
 
-func Test_tries_delete(t *testing.T) {
+func Test_Tries_delete(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		tries         *tries
+		tries         *Tries
 		root          common.Hash
-		expectedTries *tries
+		expectedTries *Tries
 	}{
 		"not found": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{},
 			},
 			root: common.Hash{1, 2, 3},
-			expectedTries: &tries{
+			expectedTries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{},
 			},
 		},
 		"deleted": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: {},
 				},
 			},
 			root: common.Hash{1, 2, 3},
-			expectedTries: &tries{
+			expectedTries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{},
 			},
 		},
@@ -118,16 +118,16 @@ func Test_tries_delete(t *testing.T) {
 		})
 	}
 }
-func Test_tries_get(t *testing.T) {
+func Test_Tries_get(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		tries *tries
+		tries *Tries
 		root  common.Hash
 		trie  *trie.Trie
 	}{
 		"found in map": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: trie.NewTrie(&node.Leaf{
 						Key: []byte{1, 2, 3},
@@ -141,7 +141,7 @@ func Test_tries_get(t *testing.T) {
 		},
 		"not found in map": {
 			// similar to not found in database
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{},
 			},
 			root: common.Hash{1, 2, 3},
@@ -160,20 +160,20 @@ func Test_tries_get(t *testing.T) {
 	}
 }
 
-func Test_tries_len(t *testing.T) {
+func Test_Tries_len(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		tries  *tries
+		tries  *Tries
 		length int
 	}{
 		"empty map": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{},
 			},
 		},
 		"non empty map": {
-			tries: &tries{
+			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: {},
 				},

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -60,7 +60,7 @@ func newTestState(t *testing.T) *state.Service {
 	t.Cleanup(func() { db.Close() })
 
 	_, genTrie, _ := genesis.NewTestGenesisWithTrieAndHeader(t)
-	block, err := state.NewBlockStateFromGenesis(db, testGenesisHeader, telemetryMock)
+	block, err := state.NewBlockStateFromGenesis(db, genTrie, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 
 	rtCfg := &wasmer.Config{}
@@ -862,7 +862,6 @@ func TestFindParentWithNumber(t *testing.T) {
 
 	p, err := gs.findParentWithNumber(v, 1)
 	require.NoError(t, err)
-	t.Log(st.Block.BlocktreeAsString())
 
 	expected, err := st.Block.GetBlockByNumber(big.NewInt(1))
 	require.NoError(t, err)

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -60,7 +60,8 @@ func newTestState(t *testing.T) *state.Service {
 	t.Cleanup(func() { db.Close() })
 
 	_, genTrie, _ := genesis.NewTestGenesisWithTrieAndHeader(t)
-	block, err := state.NewBlockStateFromGenesis(db, genTrie, testGenesisHeader, telemetryMock)
+	tries := state.NewTries(genTrie)
+	block, err := state.NewBlockStateFromGenesis(db, tries, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 
 	rtCfg := &wasmer.Config{}


### PR DESCRIPTION
## Changes

Previously after each finalized block, a trie would not be found from memory and would be loaded from the database.
You can print it out at [this code line](https://github.com/ChainSafe/gossamer/blob/3ae34011ee4d00bc0c439d21e93c121ba7701294/dot/state/storage.go#L131). This caused some memory bloat in the long run.

I initially tried to refactor a bit by injecting the tries (mutex protected already) instead of relying on channels and a goroutine to send hashes to the state, and this has been fixed. I think it was a race condition introduced by the buffered channel + goroutine, where `TrieState` was called too late after the trie got deleted from memory.

## Tests

## Issues

- #1973 

## Primary Reviewer

- @timwu20 