### PR TITLE
feat(all): detect chain directory dynamically

### DIFF
--- a/cmd/gossamer/import_runtime.go
+++ b/cmd/gossamer/import_runtime.go
@@ -10,9 +10,8 @@ import (
 	"path/filepath"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/utils"
 )
-
-var defaultGenesisSpecPath = "./chain/gssmr/genesis-spec.json"
 
 func createGenesisWithRuntime(fp string) (string, error) {
 	runtime, err := os.ReadFile(filepath.Clean(fp))
@@ -20,7 +19,12 @@ func createGenesisWithRuntime(fp string) (string, error) {
 		return "", err
 	}
 
-	genesis, err := genesis.NewGenesisSpecFromJSON(defaultGenesisSpecPath)
+	genesisPath, err := utils.GetGssmrGenesisPath()
+	if err != nil {
+		return "", fmt.Errorf("cannot find gssmr genesis path: %w", err)
+	}
+
+	genesis, err := genesis.NewGenesisSpecFromJSON(genesisPath)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/gossamer/import_runtime_test.go
+++ b/cmd/gossamer/import_runtime_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestCreateGenesisWithRuntime(t *testing.T) {
-	defaultGenesisSpecPath = "../../chain/gssmr/genesis-spec.json"
-
 	testCode := []byte("somecode")
 	testHex := common.BytesToHex(testCode)
 

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"syscall"
 	"testing"
@@ -195,10 +196,17 @@ func TestMain(m *testing.M) {
 	if reexec.Init() {
 		return
 	}
-	defaultGssmrConfigPath = "../../chain/gssmr/config.toml"
-	defaultKusamaConfigPath = "../../chain/kusama/config.toml"
-	defaultPolkadotConfigPath = "../../chain/polkadot/config.toml"
-	defaultDevConfigPath = "../../chain/dev/config.toml"
+
+	rootPath, err := utils.GetProjectRootPath()
+	if err != nil {
+		panic(err)
+	}
+
+	defaultGssmrConfigPath = filepath.Join(rootPath, "./chain/gssmr/config.toml")
+	defaultKusamaConfigPath = filepath.Join(rootPath, "./chain/kusama/config.toml")
+	defaultPolkadotConfigPath = filepath.Join(rootPath, "./chain/polkadot/config.toml")
+	defaultDevConfigPath = filepath.Join(rootPath, "./chain/dev/config.toml")
+
 	os.Exit(m.Run())
 }
 
@@ -217,7 +225,7 @@ func TestInvalidCommand(t *testing.T) {
 }
 
 func TestInitCommand_RenameNodeWhenCalled(t *testing.T) {
-	genesisPath := utils.GetGssmrGenesisRawPath()
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
 
 	tempDir := t.TempDir()
 
@@ -255,11 +263,12 @@ func TestInitCommand_RenameNodeWhenCalled(t *testing.T) {
 }
 
 func TestBuildSpecCommandWithOutput(t *testing.T) {
-	tmpOutputfile := "/tmp/raw-genesis-spec-output.json"
+	const tmpOutputfile = "/tmp/raw-genesis-spec-output.json"
+
 	buildSpecCommand := runTestGossamer(t,
 		"build-spec",
 		"--raw",
-		"--genesis-spec", "../../chain/gssmr/genesis-spec.json",
+		"--genesis-spec", utils.GetGssmrGenesisPathTest(t),
 		"--output", tmpOutputfile)
 
 	time.Sleep(5 * time.Second)

--- a/cmd/gossamer/toml_config_test.go
+++ b/cmd/gossamer/toml_config_test.go
@@ -4,18 +4,14 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot"
+	"github.com/ChainSafe/gossamer/lib/utils"
 
 	"github.com/stretchr/testify/require"
 )
-
-const GssmrConfigPath = "../../chain/gssmr/config.toml"
-const GssmrGenesisPath = "../../chain/gssmr/genesis.json"
-
-const KusamaConfigPath = "../../chain/kusama/config.toml"
-const KusamaGenesisPath = "../../chain/kusama/genesis.json"
 
 // TestLoadConfig tests loading a toml configuration file
 func TestLoadConfig(t *testing.T) {
@@ -40,12 +36,15 @@ func TestLoadConfigGssmr(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	cfg.Global.BasePath = t.TempDir()
-	cfg.Init.Genesis = GssmrGenesisPath
+	cfg.Init.Genesis = utils.GetGssmrGenesisPathTest(t)
 
 	err := dot.InitNode(cfg)
 	require.Nil(t, err)
 
-	err = loadConfig(dotConfigToToml(cfg), GssmrConfigPath)
+	projectRootPath := utils.GetProjectRootPathTest(t)
+	gssmrConfigPath := filepath.Join(projectRootPath, "./chain/gssmr/config.toml")
+
+	err = loadConfig(dotConfigToToml(cfg), gssmrConfigPath)
 	require.Nil(t, err)
 	require.NotNil(t, cfg)
 }
@@ -55,11 +54,14 @@ func TestLoadConfigKusama(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	cfg.Global.BasePath = t.TempDir()
-	cfg.Init.Genesis = KusamaGenesisPath
+	cfg.Init.Genesis = utils.GetKusamaGenesisPath(t)
 
 	err := dot.InitNode(cfg)
 	require.Nil(t, err)
 
-	err = loadConfig(dotConfigToToml(cfg), KusamaConfigPath)
+	projectRootPath := utils.GetProjectRootPathTest(t)
+	kusamaConfigPath := filepath.Join(projectRootPath, "./chain/kusama/config.toml")
+
+	err = loadConfig(dotConfigToToml(cfg), kusamaConfigPath)
 	require.Nil(t, err)
 }

--- a/dot/build_spec_integration_test.go
+++ b/dot/build_spec_integration_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
-	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,7 +85,7 @@ func TestWriteGenesisSpecFile(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewTestConfig(t)
-	cfg.Init.Genesis = runtime.GetAbsolutePath("../chain/gssmr/genesis.json")
+	cfg.Init.Genesis = utils.GetGssmrGenesisRawPathTest(t)
 
 	expected, err := genesis.NewGenesisFromJSONRaw(cfg.Init.Genesis)
 	require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestBuildFromDB(t *testing.T) {
 
 	// setup expected
 	cfg := NewTestConfig(t)
-	cfg.Init.Genesis = runtime.GetAbsolutePath("../chain/gssmr/genesis.json")
+	cfg.Init.Genesis = utils.GetGssmrGenesisRawPathTest(t)
 	expected, err := genesis.NewGenesisFromJSONRaw(cfg.Init.Genesis)
 	require.NoError(t, err)
 	// initialise node (initialise state database and load genesis data)

--- a/dot/rpc/modules/sync_state_integration_test.go
+++ b/dot/rpc/modules/sync_state_integration_test.go
@@ -13,14 +13,12 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/require"
 )
 
-const GssmrGenesisPath = "../../../chain/gssmr/genesis.json"
-
 func TestSyncStateModule(t *testing.T) {
-	fp, err := filepath.Abs(GssmrGenesisPath)
-	require.NoError(t, err)
+	fp := utils.GetGssmrGenesisRawPathTest(t)
 
 	data, err := ioutil.ReadFile(filepath.Clean(fp))
 	require.NoError(t, err)

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -156,7 +156,7 @@ func newTestSyncer(t *testing.T) *Service {
 }
 
 func newTestGenesisWithTrieAndHeader(t *testing.T) (*genesis.Genesis, *trie.Trie, *types.Header) {
-	fp := "../../chain/gssmr/genesis.json"
+	fp := utils.GetGssmrGenesisRawPathTest(t)
 	gen, err := genesis.NewGenesisFromJSONRaw(fp)
 	require.NoError(t, err)
 

--- a/dot/utils.go
+++ b/dot/utils.go
@@ -26,7 +26,7 @@ import (
 
 // newTestGenesis returns a test genesis instance using "gssmr" raw data
 func newTestGenesis(t *testing.T) *genesis.Genesis {
-	fp := utils.GetGssmrGenesisRawPath()
+	fp := utils.GetGssmrGenesisRawPathTest(t)
 
 	gssmrGen, err := genesis.NewGenesisFromJSONRaw(fp)
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func newTestGenesis(t *testing.T) *genesis.Genesis {
 func NewTestGenesisRawFile(t *testing.T, cfg *Config) (filename string) {
 	filename = filepath.Join(t.TempDir(), "genesis.json")
 
-	fp := utils.GetGssmrGenesisRawPath()
+	fp := utils.GetGssmrGenesisRawPathTest(t)
 
 	gssmrGen, err := genesis.NewGenesisFromJSONRaw(fp)
 	require.Nil(t, err)
@@ -68,7 +68,7 @@ func NewTestGenesisRawFile(t *testing.T, cfg *Config) (filename string) {
 
 // newTestGenesisFile returns a human-readable test genesis file using "gssmr" human readable data
 func newTestGenesisFile(t *testing.T, cfg *Config) (filename string) {
-	fp := utils.GetGssmrGenesisPath()
+	fp := utils.GetGssmrGenesisPathTest(t)
 
 	gssmrGen, err := genesis.NewGenesisFromJSON(fp, 0)
 	require.Nil(t, err)

--- a/lib/genesis/test_utils.go
+++ b/lib/genesis/test_utils.go
@@ -5,17 +5,15 @@ package genesis
 
 import (
 	"encoding/json"
-	"errors"
 	"math/big"
 	"os"
-	"path"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/trie"
+	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,40 +99,9 @@ func CreateTestGenesisJSONFile(t *testing.T, asRaw bool) (filename string) {
 	return filename
 }
 
-// getAbsolutePath returns the absolute path concatenated with pathFromRoot
-func getAbsolutePath(t *testing.T, pathFromRoot string) string {
-	t.Helper()
-
-	_, fullpath, _, _ := runtime.Caller(0)
-	finderPath := path.Dir(fullpath)
-
-	const searchingFor = "go.mod"
-	for {
-		filepathToCheck := path.Join(finderPath, searchingFor)
-		_, err := os.Stat(filepathToCheck)
-
-		fileNotFound := errors.Is(err, os.ErrNotExist)
-		if fileNotFound {
-			previousFinderPath := finderPath
-			finderPath = path.Dir(finderPath)
-
-			if finderPath == previousFinderPath {
-				t.Fatal(t, "cannot find project root")
-			}
-
-			continue
-		}
-
-		require.NoError(t, err)
-		break
-	}
-
-	return filepath.Join(finderPath, pathFromRoot)
-}
-
 // NewTestGenesisWithTrieAndHeader generates genesis, genesis trie and genesis header
 func NewTestGenesisWithTrieAndHeader(t *testing.T) (*Genesis, *trie.Trie, *types.Header) {
-	genesisPath := getAbsolutePath(t, "chain/gssmr/genesis.json")
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
 	gen, err := NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
@@ -144,7 +111,7 @@ func NewTestGenesisWithTrieAndHeader(t *testing.T) (*Genesis, *trie.Trie, *types
 
 // NewDevGenesisWithTrieAndHeader generates test dev genesis, genesis trie and genesis header
 func NewDevGenesisWithTrieAndHeader(t *testing.T) (*Genesis, *trie.Trie, *types.Header) {
-	genesisPath := getAbsolutePath(t, "chain/dev/genesis.json")
+	genesisPath := utils.GetDevGenesisPath(t)
 
 	gen, err := NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)

--- a/lib/runtime/life/exports_test.go
+++ b/lib/runtime/life/exports_test.go
@@ -15,12 +15,14 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/trie"
+	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/stretchr/testify/require"
 )
 
 func newInstanceFromGenesis(t *testing.T) runtime.Instance {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/gssmr/genesis.json")
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -209,7 +211,8 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 	block := buildBlock(t, instance)
 
 	// reset state back to parent state before executing
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/gssmr/genesis.json")
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
@@ -222,7 +225,8 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/kusama/genesis.json")
+	genesisPath := utils.GetKusamaGenesisPath(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -272,7 +276,8 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/polkadot/genesis.json")
+	genesisPath := utils.GetPolkadotGenesisPath(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer/testdata"
 	"github.com/ChainSafe/gossamer/lib/trie"
+	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
 	"github.com/stretchr/testify/require"
@@ -120,7 +121,8 @@ func TestInstance_Version_PolkadotRuntime(t *testing.T) {
 }
 
 func TestInstance_Version_KusamaRuntime(t *testing.T) {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/kusama/genesis.json")
+	genesisPath := utils.GetKusamaGenesisPath(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -244,7 +246,8 @@ func balanceKey(t *testing.T, pub []byte) []byte {
 }
 
 func TestNodeRuntime_ValidateTransaction(t *testing.T) {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/gssmr/genesis.json")
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -478,7 +481,8 @@ func TestInstance_ExecuteBlock_NodeRuntime(t *testing.T) {
 
 func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 	t.Skip() // TODO: this fails with "syscall frame is no longer valid" (#1026)
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/gssmr/genesis.json")
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -508,7 +512,8 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 
 func TestInstance_ApplyExtrinsic_GossamerRuntime(t *testing.T) {
 	t.Skip() // TODO: this fails with "syscall frame is no longer valid" (#1026)
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/gssmr/genesis.json")
+	genesisPath := utils.GetGssmrGenesisRawPathTest(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -566,7 +571,8 @@ func TestInstance_ExecuteBlock_PolkadotRuntime(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/polkadot/genesis.json")
+	genesisPath := utils.GetPolkadotGenesisPath(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
@@ -617,7 +623,8 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
-	gen, err := genesis.NewGenesisFromJSONRaw("../../../chain/kusama/genesis.json")
+	genesisPath := utils.GetKusamaGenesisPath(t)
+	gen, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 
 	genTrie, err := genesis.NewTrieFromGenesis(gen)

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -58,7 +58,7 @@ func TestStress_Grandpa_ThreeAuthorities(t *testing.T) {
 
 func TestStress_Grandpa_SixAuthorities(t *testing.T) {
 	t.Skip()
-	utils.GenerateGenesisSixAuth()
+	utils.GenerateGenesisSixAuth(t)
 	defer os.Remove(utils.GenesisSixAuths)
 
 	numNodes := 6
@@ -108,7 +108,7 @@ func TestStress_Grandpa_CatchUp(t *testing.T) {
 		t.Skip("skipping TestStress_Grandpa_CatchUp")
 	}
 
-	utils.GenerateGenesisSixAuth()
+	utils.GenerateGenesisSixAuth(t)
 	defer os.Remove(utils.GenesisSixAuths)
 
 	numNodes := 6

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -396,7 +396,12 @@ func TestDir(t *testing.T, name string) string {
 
 // GenerateGenesisThreeAuth generates Genesis file with three authority.
 func GenerateGenesisThreeAuth() {
-	bs, err := dot.BuildFromGenesis(utils.GetGssmrGenesisPath(), 3)
+	genesisPath, err := utils.GetGssmrGenesisPath()
+	if err != nil {
+		panic(err)
+	}
+
+	bs, err := dot.BuildFromGenesis(genesisPath, 3)
 	if err != nil {
 		Logger.Errorf("genesis file not found: %s", err)
 		os.Exit(1)
@@ -405,8 +410,8 @@ func GenerateGenesisThreeAuth() {
 }
 
 // GenerateGenesisSixAuth generates Genesis file with six authority.
-func GenerateGenesisSixAuth() {
-	bs, err := dot.BuildFromGenesis(utils.GetGssmrGenesisPath(), 6)
+func GenerateGenesisSixAuth(t *testing.T) {
+	bs, err := dot.BuildFromGenesis(utils.GetGssmrGenesisPathTest(t), 6)
 	if err != nil {
 		Logger.Errorf("genesis file not found: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
💁 as the branch name suggests, that was me having some friday night fun and killing the 2022 new year PR #2139 to move everything to `internal/` for now.

## Changes

- Detect project root based on `chain` directory (and its subdirectories)
- Better detection of chain directory location for tests and production code
- Allow to move source files more easily
- Note this is just a takeaway from now defunct #2139 

## Tests


## Issues

- Helping for #1527

## Primary Reviewer
