### PR TITLE
chore(lib/trie): refactor `ClearPrefixLimit`

### DIFF
--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -640,19 +640,16 @@ func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (deleted uint32, 
 	prefix := codec.KeyLEToNibbles(prefixLE)
 	prefix = bytes.TrimSuffix(prefix, []byte{0})
 
-	initialLimit := limit
-	t.root, _, allDeleted = t.clearPrefixLimit(t.root, prefix, &limit)
-	deleted = initialLimit - limit
+	t.root, deleted, allDeleted = t.clearPrefixLimit(t.root, prefix, limit)
 	return deleted, allDeleted
 }
 
 // clearPrefixLimit deletes the keys having the prefix till limit reached and returns updated trie root node,
 // true if any node in the trie got updated, and next bool returns true if there is no keys left with prefix.
-// TODO return deleted count and deduce updated from deleted count, do not pass limit as pointer.
-func (t *Trie) clearPrefixLimit(parent Node, prefix []byte, limit *uint32) (
-	newParent Node, updated bool, allDeleted bool) {
+func (t *Trie) clearPrefixLimit(parent Node, prefix []byte, limit uint32) (
+	newParent Node, valuesDeleted uint32, allDeleted bool) {
 	if parent == nil {
-		return nil, false, true
+		return nil, 0, true
 	}
 
 	newParent = parent
@@ -666,38 +663,36 @@ func (t *Trie) clearPrefixLimit(parent Node, prefix []byte, limit *uint32) (
 		// TODO check this is the same behaviour as in substrate
 		const allDeleted = true
 		if bytes.HasPrefix(leaf.Key, prefix) {
-			*limit--
-			return nil, true, allDeleted
+			valuesDeleted = 1
+			return nil, valuesDeleted, allDeleted
 		}
 		// not modified so return the leaf of the original
 		// trie generation. The copied leaf newParent will be
 		// garbage collected.
-		return parent, false, allDeleted
+		return parent, 0, allDeleted
 	}
 
 	branch := newParent.(*node.Branch)
-	newParent, updated, allDeleted = t.clearPrefixLimitBranch(branch, prefix, limit)
-	if !updated {
+	newParent, valuesDeleted, allDeleted = t.clearPrefixLimitBranch(branch, prefix, limit)
+	if valuesDeleted == 0 {
 		// not modified so return the node of the original
 		// trie generation. The copied newParent will be
 		// garbage collected.
 		newParent = parent
 	}
 
-	return newParent, updated, allDeleted
+	return newParent, valuesDeleted, allDeleted
 }
 
-func (t *Trie) clearPrefixLimitBranch(branch *node.Branch, prefix []byte, limit *uint32) (
-	newParent Node, updated, allDeleted bool) {
+func (t *Trie) clearPrefixLimitBranch(branch *node.Branch, prefix []byte, limit uint32) (
+	newParent Node, valuesDeleted uint32, allDeleted bool) {
 	newParent = branch
 
 	if bytes.HasPrefix(branch.Key, prefix) {
-		updated = true // at least one node will be deleted
 		nilPrefix := ([]byte)(nil)
-		// TODO return deleted count to replace updated boolean and update limit
-		newParent = t.deleteNodesLimit(branch, nilPrefix, limit)
+		newParent, valuesDeleted = t.deleteNodesLimit(branch, nilPrefix, limit)
 		allDeleted = newParent == nil
-		return newParent, updated, allDeleted
+		return newParent, valuesDeleted, allDeleted
 	}
 
 	if len(prefix) == len(branch.Key)+1 &&
@@ -709,8 +704,9 @@ func (t *Trie) clearPrefixLimitBranch(branch *node.Branch, prefix []byte, limit 
 	noPrefixForNode := len(prefix) <= len(branch.Key) ||
 		lenCommonPrefix(branch.Key, prefix) < len(branch.Key)
 	if noPrefixForNode {
-		updated, allDeleted = false, true
-		return newParent, updated, allDeleted
+		valuesDeleted = 0
+		allDeleted = true
+		return newParent, valuesDeleted, allDeleted
 	}
 
 	childIndex := prefix[len(branch.Key)]
@@ -718,17 +714,17 @@ func (t *Trie) clearPrefixLimitBranch(branch *node.Branch, prefix []byte, limit 
 	child := branch.Children[childIndex]
 
 	newParent = branch // mostly just a reminder for the reader
-	branch.Children[childIndex], updated, allDeleted = t.clearPrefixLimit(child, childPrefix, limit)
-	if updated {
+	branch.Children[childIndex], valuesDeleted, allDeleted = t.clearPrefixLimit(child, childPrefix, limit)
+	if valuesDeleted > 0 {
 		branch.SetDirty(true)
 		newParent = handleDeletion(branch, prefix)
 	}
 
-	return newParent, newParent.IsDirty(), allDeleted
+	return newParent, valuesDeleted, allDeleted
 }
 
-func (t *Trie) clearPrefixLimitChild(branch *node.Branch, prefix []byte, limit *uint32) (
-	newParent Node, updated, allDeleted bool) {
+func (t *Trie) clearPrefixLimitChild(branch *node.Branch, prefix []byte, limit uint32) (
+	newParent Node, valuesDeleted uint32, allDeleted bool) {
 	newParent = branch
 
 	childIndex := prefix[len(branch.Key)]
@@ -736,28 +732,28 @@ func (t *Trie) clearPrefixLimitChild(branch *node.Branch, prefix []byte, limit *
 
 	if child == nil {
 		// TODO ensure this is the same behaviour as in substrate
-		updated, allDeleted = false, true
-		return newParent, updated, allDeleted
+		allDeleted = true
+		return newParent, 0, allDeleted
 	}
 
 	nilPrefix := ([]byte)(nil)
-	branch.Children[childIndex] = t.deleteNodesLimit(child, nilPrefix, limit)
+	branch.Children[childIndex], valuesDeleted = t.deleteNodesLimit(child, nilPrefix, limit)
 	branch.SetDirty(true)
 
 	newParent = handleDeletion(branch, prefix)
 
-	updated = true
 	allDeleted = branch.Children[childIndex] == nil
-	return newParent, updated, allDeleted
+	return newParent, valuesDeleted, allDeleted
 }
 
-func (t *Trie) deleteNodesLimit(parent Node, prefix []byte, limit *uint32) (newParent Node) {
-	if *limit == 0 {
-		return parent
+func (t *Trie) deleteNodesLimit(parent Node, prefix []byte, limit uint32) (
+	newParent Node, valuesDeleted uint32) {
+	if limit == 0 {
+		return parent, 0
 	}
 
 	if parent == nil {
-		return nil
+		return nil, 0
 	}
 
 	newParent = parent
@@ -766,8 +762,8 @@ func (t *Trie) deleteNodesLimit(parent Node, prefix []byte, limit *uint32) (newP
 	}
 
 	if newParent.Type() == node.LeafType {
-		*limit--
-		return nil
+		valuesDeleted = 1
+		return nil, valuesDeleted
 	}
 
 	branch := newParent.(*node.Branch)
@@ -776,33 +772,36 @@ func (t *Trie) deleteNodesLimit(parent Node, prefix []byte, limit *uint32) (newP
 
 	nilChildren := node.ChildrenCapacity - branch.NumChildren()
 
+	var newDeleted uint32
 	for i, child := range branch.Children {
 		if child == nil {
 			continue
 		}
 
-		branch.Children[i] = t.deleteNodesLimit(child, fullKey, limit)
+		branch.Children[i], newDeleted = t.deleteNodesLimit(child, fullKey, limit)
 		if branch.Children[i] == nil {
 			nilChildren++
 		}
+		limit -= newDeleted
+		valuesDeleted += newDeleted
 
 		branch.SetDirty(true)
 		newParent = handleDeletion(branch, fullKey)
 		if nilChildren == node.ChildrenCapacity &&
 			branch.Value == nil {
-			return nil
+			return nil, valuesDeleted
 		}
 
-		if *limit == 0 {
-			return newParent
+		if limit == 0 {
+			return newParent, valuesDeleted
 		}
 	}
 
 	if branch.Value != nil {
-		*limit--
+		valuesDeleted++
 	}
 
-	return nil
+	return nil, valuesDeleted
 }
 
 // ClearPrefix deletes all nodes in the trie for which the key contains the

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -644,8 +644,9 @@ func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (deleted uint32, 
 	return deleted, allDeleted
 }
 
-// clearPrefixLimit deletes the keys having the prefix till limit reached and returns updated trie root node,
-// true if any node in the trie got updated, and next bool returns true if there is no keys left with prefix.
+// clearPrefixLimit deletes the keys having the prefix until the value deletion limit is reached.
+// It returns the updated node newParent, the number of deleted values valuesDeleted and the
+// allDeleted boolean indicating if there is no key left with the prefix.
 func (t *Trie) clearPrefixLimit(parent Node, prefix []byte, limit uint32) (
 	newParent Node, valuesDeleted uint32, allDeleted bool) {
 	if parent == nil {

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -2016,36 +2016,34 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 		parent        Node
 		prefix        []byte
 		limit         uint32
-		expectedLimit uint32
 		newParent     Node
-		updated       bool
+		valuesDeleted uint32
 		allDeleted    bool
 	}{
 		"limit is zero": {
 			allDeleted: true,
 		},
 		"nil parent": {
-			limit:         1,
-			expectedLimit: 1,
-			allDeleted:    true,
+			limit:      1,
+			allDeleted: true,
 		},
 		"leaf parent with common prefix": {
 			parent: &node.Leaf{
 				Key: []byte{1, 2},
 			},
-			prefix:     []byte{1},
-			limit:      1,
-			updated:    true,
-			allDeleted: true,
+			prefix:        []byte{1},
+			limit:         1,
+			valuesDeleted: 1,
+			allDeleted:    true,
 		},
 		"leaf parent with key equal prefix": {
 			parent: &node.Leaf{
 				Key: []byte{1},
 			},
-			prefix:     []byte{1},
-			limit:      1,
-			updated:    true,
-			allDeleted: true,
+			prefix:        []byte{1},
+			limit:         1,
+			valuesDeleted: 1,
+			allDeleted:    true,
 		},
 		"leaf parent with key no common prefix": {
 			trie: Trie{
@@ -2054,9 +2052,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 			parent: &node.Leaf{
 				Key: []byte{1, 2},
 			},
-			prefix:        []byte{1, 3},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 3},
+			limit:  1,
 			newParent: &node.Leaf{
 				Key: []byte{1, 2},
 			},
@@ -2069,9 +2066,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 			parent: &node.Leaf{
 				Key: []byte{1},
 			},
-			prefix:        []byte{1, 2},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 2},
+			limit:  1,
 			newParent: &node.Leaf{
 				Key: []byte{1},
 			},
@@ -2087,8 +2083,7 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 			},
 			prefix:        []byte{1},
 			limit:         3,
-			expectedLimit: 1,
-			updated:       true,
+			valuesDeleted: 2,
 			allDeleted:    true,
 		},
 		"branch without value with key equal prefix": {
@@ -2101,8 +2096,7 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 			},
 			prefix:        []byte{1, 2},
 			limit:         3,
-			expectedLimit: 1,
-			updated:       true,
+			valuesDeleted: 2,
 			allDeleted:    true,
 		},
 		"branch without value with no common prefix": {
@@ -2116,9 +2110,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{2}},
 				},
 			},
-			prefix:        []byte{1, 3},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 3},
+			limit:  1,
 			newParent: &node.Branch{
 				Key: []byte{1, 2},
 				Children: [16]node.Node{
@@ -2139,9 +2132,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{2}},
 				},
 			},
-			prefix:        []byte{1, 2, 3},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 2, 3},
+			limit:  1,
 			newParent: &node.Branch{
 				Key: []byte{1},
 				Children: [16]node.Node{
@@ -2162,9 +2154,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{2}},
 				},
 			},
-			prefix:        []byte{1, 2},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 2},
+			limit:  1,
 			newParent: &node.Branch{
 				Key: []byte{1},
 				Children: [16]node.Node{
@@ -2182,10 +2173,10 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{1}},
 				},
 			},
-			prefix:     []byte{1},
-			limit:      2,
-			updated:    true,
-			allDeleted: true,
+			prefix:        []byte{1},
+			limit:         2,
+			valuesDeleted: 2,
+			allDeleted:    true,
 		},
 		"branch with value with key equal prefix": {
 			parent: &node.Branch{
@@ -2195,10 +2186,10 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{1}},
 				},
 			},
-			prefix:     []byte{1, 2},
-			limit:      2,
-			updated:    true,
-			allDeleted: true,
+			prefix:        []byte{1, 2},
+			limit:         2,
+			valuesDeleted: 2,
+			allDeleted:    true,
 		},
 		"branch with value with no common prefix": {
 			trie: Trie{
@@ -2211,9 +2202,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{1}},
 				},
 			},
-			prefix:        []byte{1, 3},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 3},
+			limit:  1,
 			newParent: &node.Branch{
 				Key:   []byte{1, 2},
 				Value: []byte{1},
@@ -2234,9 +2224,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{1}},
 				},
 			},
-			prefix:        []byte{1, 2, 3},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 2, 3},
+			limit:  1,
 			newParent: &node.Branch{
 				Key:   []byte{1},
 				Value: []byte{1},
@@ -2257,9 +2246,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{1}},
 				},
 			},
-			prefix:        []byte{1, 2},
-			limit:         1,
-			expectedLimit: 1,
+			prefix: []byte{1, 2},
+			limit:  1,
 			newParent: &node.Branch{
 				Key:   []byte{1},
 				Value: []byte{1},
@@ -2293,7 +2281,7 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{4}},
 				},
 			},
-			updated: true,
+			valuesDeleted: 1,
 		},
 		"delete only child of branch": {
 			parent: &node.Branch{
@@ -2310,8 +2298,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 				Value: []byte{1},
 				Dirty: true,
 			},
-			updated:    true,
-			allDeleted: true,
+			valuesDeleted: 1,
+			allDeleted:    true,
 		},
 		"fully delete children of branch with value": {
 			trie: Trie{
@@ -2333,7 +2321,7 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 				Dirty:      true,
 				Generation: 1,
 			},
-			updated: true,
+			valuesDeleted: 2,
 		},
 		"fully delete children of branch without value": {
 			parent: &node.Branch{
@@ -2343,10 +2331,10 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					&node.Leaf{Key: []byte{4}},
 				},
 			},
-			prefix:     []byte{1},
-			limit:      2,
-			updated:    true,
-			allDeleted: true,
+			prefix:        []byte{1},
+			limit:         2,
+			valuesDeleted: 2,
+			allDeleted:    true,
 		},
 		"partially delete child of branch": {
 			trie: Trie{
@@ -2390,7 +2378,7 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 					},
 				},
 			},
-			updated: true,
+			valuesDeleted: 1,
 		},
 		"update child of branch": {
 			trie: Trie{
@@ -2417,8 +2405,8 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 				Dirty:      true,
 				Generation: 1,
 			},
-			updated:    true,
-			allDeleted: true,
+			valuesDeleted: 2,
+			allDeleted:    true,
 		},
 	}
 
@@ -2430,29 +2418,27 @@ func Test_Trie_clearPrefixLimit(t *testing.T) {
 			trie := testCase.trie
 			expectedTrie := *trie.DeepCopy()
 
-			newParent, updated, allDeleted := trie.clearPrefixLimit(testCase.parent,
-				testCase.prefix, &testCase.limit)
+			newParent, valuesDeleted, allDeleted := trie.clearPrefixLimit(testCase.parent,
+				testCase.prefix, testCase.limit)
 
 			assert.Equal(t, testCase.newParent, newParent)
-			assert.Equal(t, testCase.expectedLimit, testCase.limit)
-			assert.Equal(t, testCase.updated, updated)
+			assert.Equal(t, testCase.valuesDeleted, valuesDeleted)
 			assert.Equal(t, testCase.allDeleted, allDeleted)
 			assert.Equal(t, expectedTrie, trie)
 		})
 	}
 }
 
-func Test_Trie_deleteNodes(t *testing.T) {
+func Test_Trie_deleteNodesLimit(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie        Trie
-		parent      Node
-		prefix      []byte
-		limit       uint32
-		newLimit    uint32
-		newNode     Node
-		oneDeletion bool
+		trie          Trie
+		parent        Node
+		prefix        []byte
+		limit         uint32
+		newNode       Node
+		valuesDeleted uint32
 	}{
 		"zero limit": {
 			trie: Trie{
@@ -2466,13 +2452,12 @@ func Test_Trie_deleteNodes(t *testing.T) {
 			},
 		},
 		"nil parent": {
-			limit:    1,
-			newLimit: 1,
+			limit: 1,
 		},
 		"delete leaf": {
-			parent:   &node.Leaf{},
-			limit:    2,
-			newLimit: 1,
+			parent:        &node.Leaf{},
+			limit:         2,
+			valuesDeleted: 1,
 		},
 		"delete branch without value": {
 			parent: &node.Branch{
@@ -2481,8 +2466,8 @@ func Test_Trie_deleteNodes(t *testing.T) {
 					&node.Leaf{},
 				},
 			},
-			limit:    3,
-			newLimit: 1,
+			limit:         3,
+			valuesDeleted: 2,
 		},
 		"delete branch with value": {
 			parent: &node.Branch{
@@ -2492,8 +2477,8 @@ func Test_Trie_deleteNodes(t *testing.T) {
 					&node.Leaf{},
 				},
 			},
-			limit:    3,
-			newLimit: 1,
+			limit:         3,
+			valuesDeleted: 2,
 		},
 		"delete branch and all children": {
 			parent: &node.Branch{
@@ -2503,8 +2488,8 @@ func Test_Trie_deleteNodes(t *testing.T) {
 					&node.Leaf{Key: []byte{2}},
 				},
 			},
-			limit:    10,
-			newLimit: 8,
+			limit:         10,
+			valuesDeleted: 2,
 		},
 		"delete branch one child only": {
 			trie: Trie{
@@ -2529,6 +2514,7 @@ func Test_Trie_deleteNodes(t *testing.T) {
 					&node.Leaf{Key: []byte{2}},
 				},
 			},
+			valuesDeleted: 1,
 		},
 		"delete branch children only": {
 			trie: Trie{
@@ -2542,14 +2528,14 @@ func Test_Trie_deleteNodes(t *testing.T) {
 					&node.Leaf{Key: []byte{2}},
 				},
 			},
-			limit:    2,
-			newLimit: 0,
+			limit: 2,
 			newNode: &node.Leaf{
 				Key:        []byte{3},
 				Value:      []byte{1, 2, 3},
 				Dirty:      true,
 				Generation: 1,
 			},
+			valuesDeleted: 2,
 		},
 		"delete branch all children except one": {
 			trie: Trie{
@@ -2566,14 +2552,14 @@ func Test_Trie_deleteNodes(t *testing.T) {
 					&node.Leaf{Key: []byte{3}},
 				},
 			},
-			prefix:   []byte{1, 2},
-			limit:    2,
-			newLimit: 0,
+			prefix: []byte{1, 2},
+			limit:  2,
 			newNode: &node.Leaf{
 				Key:        []byte{3, 5, 3},
 				Generation: 1,
 				Dirty:      true,
 			},
+			valuesDeleted: 2,
 		},
 	}
 
@@ -2585,10 +2571,10 @@ func Test_Trie_deleteNodes(t *testing.T) {
 			trie := testCase.trie
 			expectedTrie := *trie.DeepCopy()
 
-			newNode := trie.deleteNodesLimit(testCase.parent, testCase.prefix, &testCase.limit)
+			newNode, valuesDeleted := trie.deleteNodesLimit(testCase.parent, testCase.prefix, testCase.limit)
 
-			assert.Equal(t, testCase.limit, testCase.limit)
 			assert.Equal(t, testCase.newNode, newNode)
+			assert.Equal(t, testCase.valuesDeleted, valuesDeleted)
 			assert.Equal(t, expectedTrie, trie)
 		})
 	}


### PR DESCRIPTION
## Changes

- Pass limit and return values deleted count, do not pass limit as pointer downstream
- Simpler code more appropriate for end goal (return number of deleted values)
- Helps #2229 

## Tests


```
go test ./internal/trie/... ./lib/trie/...
```

## Issues

- #2229 

## Primary Reviewer