### PR TITLE
chore(internal/trie/node): remove all mutexes

### DIFF
--- a/internal/trie/node/branch.go
+++ b/internal/trie/node/branch.go
@@ -4,8 +4,6 @@
 package node
 
 import (
-	"sync"
-
 	"github.com/qdm12/gotree"
 )
 
@@ -27,7 +25,6 @@ type Branch struct {
 	// which is updated to match the trie Generation once they are
 	// inserted, moved or iterated over.
 	Generation uint64
-	sync.RWMutex
 }
 
 // NewBranch creates a new branch using the arguments given.

--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -7,9 +7,6 @@ package node
 // Setting copyChildren to true will deep copy
 // children as well.
 func (b *Branch) Copy(copyChildren bool) Node {
-	b.RLock()
-	defer b.RUnlock()
-
 	cpy := &Branch{
 		Dirty:      b.Dirty,
 		Generation: b.Generation,
@@ -52,12 +49,6 @@ func (b *Branch) Copy(copyChildren bool) Node {
 
 // Copy deep copies the leaf.
 func (l *Leaf) Copy(_ bool) Node {
-	l.RLock()
-	defer l.RUnlock()
-
-	l.encodingMu.RLock()
-	defer l.encodingMu.RUnlock()
-
 	cpy := &Leaf{
 		Dirty:      l.Dirty,
 		Generation: l.Generation,

--- a/internal/trie/node/hash.go
+++ b/internal/trie/node/hash.go
@@ -70,9 +70,7 @@ func (b *Branch) EncodeAndHash() (encoding, hash []byte, err error) {
 // SetEncodingAndHash sets the encoding and hash slices
 // given to the branch. Note it does not copy them, so beware.
 func (l *Leaf) SetEncodingAndHash(enc, hash []byte) {
-	l.encodingMu.Lock()
 	l.Encoding = enc
-	l.encodingMu.Unlock()
 	l.HashDigest = hash
 }
 
@@ -89,12 +87,9 @@ func (l *Leaf) GetHash() []byte {
 // If the encoding is less than 32 bytes, the hash returned
 // is the encoding and not the hash of the encoding.
 func (l *Leaf) EncodeAndHash() (encoding, hash []byte, err error) {
-	l.encodingMu.RLock()
 	if !l.IsDirty() && l.Encoding != nil && l.HashDigest != nil {
-		l.encodingMu.RUnlock()
 		return l.Encoding, l.HashDigest, nil
 	}
-	l.encodingMu.RUnlock()
 
 	buffer := pools.EncodingBuffers.Get().(*bytes.Buffer)
 	buffer.Reset()
@@ -107,12 +102,10 @@ func (l *Leaf) EncodeAndHash() (encoding, hash []byte, err error) {
 
 	bufferBytes := buffer.Bytes()
 
-	l.encodingMu.Lock()
 	// TODO remove this copying since it defeats the purpose of `buffer`
 	// and the sync.Pool.
 	l.Encoding = make([]byte, len(bufferBytes))
 	copy(l.Encoding, bufferBytes)
-	l.encodingMu.Unlock()
 	encoding = l.Encoding // no need to copy
 
 	if len(bufferBytes) < 32 {

--- a/internal/trie/node/leaf.go
+++ b/internal/trie/node/leaf.go
@@ -5,7 +5,6 @@ package node
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/qdm12/gotree"
 )
@@ -22,13 +21,11 @@ type Leaf struct {
 	Dirty      bool
 	HashDigest []byte
 	Encoding   []byte
-	encodingMu sync.RWMutex
 	// Generation is incremented on every trie Snapshot() call.
 	// Each node also contain a certain Generation number,
 	// which is updated to match the trie Generation once they are
 	// inserted, moved or iterated over.
 	Generation uint64
-	sync.RWMutex
 }
 
 // NewLeaf creates a new leaf using the arguments given.

--- a/internal/trie/node/leaf_encode.go
+++ b/internal/trie/node/leaf_encode.go
@@ -18,16 +18,13 @@ import (
 // The encoding has the following format:
 // NodeHeader | Extra partial key length | Partial Key | Value
 func (l *Leaf) Encode(buffer Buffer) (err error) {
-	l.encodingMu.RLock()
 	if !l.Dirty && l.Encoding != nil {
 		_, err = buffer.Write(l.Encoding)
-		l.encodingMu.RUnlock()
 		if err != nil {
 			return fmt.Errorf("cannot write stored encoding to buffer: %w", err)
 		}
 		return nil
 	}
-	l.encodingMu.RUnlock()
 
 	err = l.encodeHeader(buffer)
 	if err != nil {
@@ -52,8 +49,6 @@ func (l *Leaf) Encode(buffer Buffer) (err error) {
 
 	// TODO remove this copying since it defeats the purpose of `buffer`
 	// and the sync.Pool.
-	l.encodingMu.Lock()
-	defer l.encodingMu.Unlock()
 	l.Encoding = make([]byte, buffer.Len())
 	copy(l.Encoding, buffer.Bytes())
 	return nil


### PR DESCRIPTION
## Changes

- Remove leaf's `encodingMu` since it was a temporary fix I forgot to remove in #2009 as far as I recall
- Remove leaf and branch rw mutex since it's not needed (all code is pretty much synchronous and called synchronously through mutexes etc.)

## Tests

```
go test -count 1 -race ./internal/trie/... ./lib/trie/...
```

## Issues

Done to test a comment after discussion with sigmap on Slack

## Primary Reviewer
