### PR TITLE
chore(staging): update staging task definitions, and expose pprof server

### DIFF
--- a/.github/workflows/staging/kusama-taskdef.json
+++ b/.github/workflows/staging/kusama-taskdef.json
@@ -21,6 +21,10 @@
                 {
                     "containerPort": 8540,
                     "protocol": "tcp"
+                },
+                {
+                    "containerPort": 6060,
+                    "protocol": "tcp"
                 }
             ],
             "environment": [],
@@ -35,7 +39,7 @@
             "expression": "attribute:ecs.availability-zone==us-east-2a"
         }
     ],
-    "memory": "16041",
+    "memory": "12000",
     "family": "gossamer-kusama",
     "networkMode": "host",
     "requiresCompatibilities": [

--- a/.github/workflows/staging/kusama-taskdef.json
+++ b/.github/workflows/staging/kusama-taskdef.json
@@ -39,7 +39,7 @@
             "expression": "attribute:ecs.availability-zone==us-east-2a"
         }
     ],
-    "memory": "12000",
+    "memory": "12288",
     "family": "gossamer-kusama",
     "networkMode": "host",
     "requiresCompatibilities": [

--- a/.github/workflows/staging/openmetrics.d/kusama-conf.yaml
+++ b/.github/workflows/staging/openmetrics.d/kusama-conf.yaml
@@ -61,9 +61,7 @@ instances:
     #
     metrics:
       - gossamer_*
-      - network_*
-      - service_*
-      - system_*
+      - go_*
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.

--- a/.github/workflows/staging/openmetrics.d/polkadot-conf.yaml
+++ b/.github/workflows/staging/openmetrics.d/polkadot-conf.yaml
@@ -61,9 +61,7 @@ instances:
     #
     metrics:
       - gossamer_*
-      - network_*
-      - service_*
-      - system_*
+      - go_*
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.

--- a/.github/workflows/staging/polkadot-taskdef.json
+++ b/.github/workflows/staging/polkadot-taskdef.json
@@ -21,6 +21,10 @@
                 {
                     "containerPort": 8540,
                     "protocol": "tcp"
+                },
+                {
+                    "containerPort": 6060,
+                    "protocol": "tcp"
                 }
             ],
             "environment": [],
@@ -35,7 +39,7 @@
             "expression": "attribute:ecs.availability-zone==us-east-2a"
         }
     ],
-    "memory": "16041",
+    "memory": "12000",
     "family": "gossamer-polkadot",
     "networkMode": "host",
     "requiresCompatibilities": [

--- a/.github/workflows/staging/polkadot-taskdef.json
+++ b/.github/workflows/staging/polkadot-taskdef.json
@@ -39,7 +39,7 @@
             "expression": "attribute:ecs.availability-zone==us-east-2a"
         }
     ],
-    "memory": "12000",
+    "memory": "12288",
     "family": "gossamer-polkadot",
     "networkMode": "host",
     "requiresCompatibilities": [

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -23,5 +23,5 @@ RUN go get ./...
 RUN go build github.com/ChainSafe/gossamer/cmd/gossamer
 
 RUN ["sh", "-c", "gossamer init --chain=${chain}"]
-ENTRYPOINT ["sh", "-c", "service datadog-agent restart && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics"]
-EXPOSE 7001 8546 8540 9876
+ENTRYPOINT ["sh", "-c", "service datadog-agent restart && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --pprofserver --pprofaddress=\":6060\""]
+EXPOSE 7001 8546 8540 9876 6060

--- a/devnet/cmd/update-dd-agent-confd/confd.yml
+++ b/devnet/cmd/update-dd-agent-confd/confd.yml
@@ -61,9 +61,7 @@ instances:
     #
     metrics:
       - gossamer_*
-      - network_*
-      - service_*
-      - system_*
+      - go_*
 
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Modify staging container sizes to use 12GB instead of the full 16GB per instance.
- Update datadog metrics harvester to include new metrics from #2220 

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./...
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- #1973 

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @qdm12 
