### PR TITLE
chore(tests): remove unneeded `gomock.Eq` in tests

### DIFF
--- a/lib/babe/epoch_test.go
+++ b/lib/babe/epoch_test.go
@@ -23,9 +23,9 @@ func TestBabeService_checkAndSetFirstSlot(t *testing.T) {
 	mockEpochState0 := NewMockEpochState(ctrl)
 	mockEpochState1 := NewMockEpochState(ctrl)
 
-	mockEpochState0.EXPECT().GetStartSlotForEpoch(gomock.Eq(uint64(0))).Return(uint64(1), nil)
-	mockEpochState1.EXPECT().GetStartSlotForEpoch(gomock.Eq(uint64(0))).Return(uint64(99), nil)
-	mockEpochState1.EXPECT().SetFirstSlot(gomock.Eq(uint64(1))).Return(nil)
+	mockEpochState0.EXPECT().GetStartSlotForEpoch(uint64(0)).Return(uint64(1), nil)
+	mockEpochState1.EXPECT().GetStartSlotForEpoch(uint64(0)).Return(uint64(99), nil)
+	mockEpochState1.EXPECT().SetFirstSlot(uint64(1)).Return(nil)
 
 	testBabeSecondaryPlainPreDigest := types.BabeSecondaryPlainPreDigest{
 		SlotNumber: 1,
@@ -38,8 +38,8 @@ func TestBabeService_checkAndSetFirstSlot(t *testing.T) {
 		Header: *header,
 	}
 
-	mockBlockState.EXPECT().GetBlockByNumber(gomock.Eq(big.NewInt(1))).Return(block, nil)
-	mockBlockState.EXPECT().GetBlockByNumber(gomock.Eq(big.NewInt(1))).Return(block, nil)
+	mockBlockState.EXPECT().GetBlockByNumber(big.NewInt(1)).Return(block, nil)
+	mockBlockState.EXPECT().GetBlockByNumber(big.NewInt(1)).Return(block, nil)
 
 	bs0 := &Service{
 		epochState: mockEpochState0,
@@ -78,12 +78,12 @@ func TestBabeService_getEpochDataAndStartSlot(t *testing.T) {
 	mockEpochState1 := NewMockEpochState(ctrl)
 	mockEpochState2 := NewMockEpochState(ctrl)
 
-	mockEpochState0.EXPECT().GetStartSlotForEpoch(gomock.Eq(uint64(0))).Return(uint64(1), nil)
-	mockEpochState1.EXPECT().GetStartSlotForEpoch(gomock.Eq(uint64(1))).Return(uint64(201), nil)
-	mockEpochState2.EXPECT().GetStartSlotForEpoch(gomock.Eq(uint64(1))).Return(uint64(201), nil)
+	mockEpochState0.EXPECT().GetStartSlotForEpoch(uint64(0)).Return(uint64(1), nil)
+	mockEpochState1.EXPECT().GetStartSlotForEpoch(uint64(1)).Return(uint64(201), nil)
+	mockEpochState2.EXPECT().GetStartSlotForEpoch(uint64(1)).Return(uint64(201), nil)
 
-	mockEpochState1.EXPECT().HasEpochData(gomock.Eq(uint64(1))).Return(true, nil)
-	mockEpochState2.EXPECT().HasEpochData(gomock.Eq(uint64(1))).Return(true, nil)
+	mockEpochState1.EXPECT().HasEpochData(uint64(1)).Return(true, nil)
+	mockEpochState2.EXPECT().HasEpochData(uint64(1)).Return(true, nil)
 
 	kp := keyring.Alice().(*sr25519.Keypair)
 	authority := types.NewAuthority(kp.Public(), uint64(1))
@@ -92,18 +92,18 @@ func TestBabeService_getEpochDataAndStartSlot(t *testing.T) {
 		Authorities: []types.Authority{*authority},
 	}
 
-	mockEpochState1.EXPECT().GetEpochData(gomock.Eq(uint64(1))).Return(testEpochData, nil)
-	mockEpochState2.EXPECT().GetEpochData(gomock.Eq(uint64(1))).Return(testEpochData, nil)
+	mockEpochState1.EXPECT().GetEpochData(uint64(1)).Return(testEpochData, nil)
+	mockEpochState2.EXPECT().GetEpochData(uint64(1)).Return(testEpochData, nil)
 
-	mockEpochState1.EXPECT().HasConfigData(gomock.Eq(uint64(1))).Return(true, nil)
-	mockEpochState2.EXPECT().HasConfigData(gomock.Eq(uint64(1))).Return(false, nil)
+	mockEpochState1.EXPECT().HasConfigData(uint64(1)).Return(true, nil)
+	mockEpochState2.EXPECT().HasConfigData(uint64(1)).Return(false, nil)
 
 	testConfigData := &types.ConfigData{
 		C1: 1,
 		C2: 1,
 	}
 
-	mockEpochState1.EXPECT().GetConfigData(gomock.Eq(uint64(1))).Return(testConfigData, nil)
+	mockEpochState1.EXPECT().GetConfigData(uint64(1)).Return(testConfigData, nil)
 
 	testLatestConfigData := &types.ConfigData{
 		C1: 1,

--- a/lib/babe/verify_test.go
+++ b/lib/babe/verify_test.go
@@ -738,10 +738,10 @@ func TestVerificationManager_getConfigData(t *testing.T) {
 	mockEpochStateHasErr := NewMockEpochState(ctrl)
 	mockEpochStateGetErr := NewMockEpochState(ctrl)
 
-	mockEpochStateEmpty.EXPECT().HasConfigData(gomock.Eq(uint64(0))).Return(false, nil)
-	mockEpochStateHasErr.EXPECT().HasConfigData(gomock.Eq(uint64(0))).Return(false, errNoConfigData)
-	mockEpochStateGetErr.EXPECT().HasConfigData(gomock.Eq(uint64(0))).Return(true, nil)
-	mockEpochStateGetErr.EXPECT().GetConfigData(gomock.Eq(uint64(0))).Return(nil, errNoConfigData)
+	mockEpochStateEmpty.EXPECT().HasConfigData(uint64(0)).Return(false, nil)
+	mockEpochStateHasErr.EXPECT().HasConfigData(uint64(0)).Return(false, errNoConfigData)
+	mockEpochStateGetErr.EXPECT().HasConfigData(uint64(0)).Return(true, nil)
+	mockEpochStateGetErr.EXPECT().GetConfigData(uint64(0)).Return(nil, errNoConfigData)
 
 	vm0, err := NewVerificationManager(mockBlockState, mockEpochStateEmpty)
 	assert.NoError(t, err)
@@ -794,22 +794,22 @@ func TestVerificationManager_getVerifierInfo(t *testing.T) {
 	mockEpochStateThresholdErr := NewMockEpochState(ctrl)
 	mockEpochStateOk := NewMockEpochState(ctrl)
 
-	mockEpochStateGetErr.EXPECT().GetEpochData(gomock.Eq(uint64(0))).Return(nil, errNoConfigData)
+	mockEpochStateGetErr.EXPECT().GetEpochData(uint64(0)).Return(nil, errNoConfigData)
 
-	mockEpochStateHasErr.EXPECT().GetEpochData(gomock.Eq(uint64(0))).Return(&types.EpochData{}, nil)
-	mockEpochStateHasErr.EXPECT().HasConfigData(gomock.Eq(uint64(0))).Return(false, errNoConfigData)
+	mockEpochStateHasErr.EXPECT().GetEpochData(uint64(0)).Return(&types.EpochData{}, nil)
+	mockEpochStateHasErr.EXPECT().HasConfigData(uint64(0)).Return(false, errNoConfigData)
 
-	mockEpochStateThresholdErr.EXPECT().GetEpochData(gomock.Eq(uint64(0))).Return(&types.EpochData{}, nil)
-	mockEpochStateThresholdErr.EXPECT().HasConfigData(gomock.Eq(uint64(0))).Return(true, nil)
-	mockEpochStateThresholdErr.EXPECT().GetConfigData(gomock.Eq(uint64(0))).
+	mockEpochStateThresholdErr.EXPECT().GetEpochData(uint64(0)).Return(&types.EpochData{}, nil)
+	mockEpochStateThresholdErr.EXPECT().HasConfigData(uint64(0)).Return(true, nil)
+	mockEpochStateThresholdErr.EXPECT().GetConfigData(uint64(0)).
 		Return(&types.ConfigData{
 			C1: 3,
 			C2: 1,
 		}, nil)
 
-	mockEpochStateOk.EXPECT().GetEpochData(gomock.Eq(uint64(0))).Return(&types.EpochData{}, nil)
-	mockEpochStateOk.EXPECT().HasConfigData(gomock.Eq(uint64(0))).Return(true, nil)
-	mockEpochStateOk.EXPECT().GetConfigData(gomock.Eq(uint64(0))).
+	mockEpochStateOk.EXPECT().GetEpochData(uint64(0)).Return(&types.EpochData{}, nil)
+	mockEpochStateOk.EXPECT().HasConfigData(uint64(0)).Return(true, nil)
+	mockEpochStateOk.EXPECT().GetConfigData(uint64(0)).
 		Return(&types.ConfigData{
 			C1: 1,
 			C2: 3,
@@ -895,31 +895,31 @@ func TestVerificationManager_VerifyBlock(t *testing.T) {
 	mockEpochStateNilBlockStateErr := NewMockEpochState(ctrl)
 	mockEpochStateVerifyAuthorshipErr := NewMockEpochState(ctrl)
 
-	mockBlockStateCheckFinErr.EXPECT().NumberIsFinalised(gomock.Eq(big.NewInt(1))).Return(false, errFailedFinalisation)
+	mockBlockStateCheckFinErr.EXPECT().NumberIsFinalised(big.NewInt(1)).Return(false, errFailedFinalisation)
 
-	mockBlockStateNotFinal.EXPECT().NumberIsFinalised(gomock.Eq(big.NewInt(1))).Return(false, nil)
+	mockBlockStateNotFinal.EXPECT().NumberIsFinalised(big.NewInt(1)).Return(false, nil)
 
-	mockBlockStateNotFinal2.EXPECT().NumberIsFinalised(gomock.Eq(big.NewInt(1))).Return(false, nil)
-	mockEpochStateSetSlotErr.EXPECT().SetFirstSlot(gomock.Eq(uint64(1))).Return(errSetFirstSlot)
+	mockBlockStateNotFinal2.EXPECT().NumberIsFinalised(big.NewInt(1)).Return(false, nil)
+	mockEpochStateSetSlotErr.EXPECT().SetFirstSlot(uint64(1)).Return(errSetFirstSlot)
 
-	mockEpochStateGetEpochErr.EXPECT().GetEpochForBlock(gomock.Eq(testBlockHeaderEmpty)).
+	mockEpochStateGetEpochErr.EXPECT().GetEpochForBlock(testBlockHeaderEmpty).
 		Return(uint64(0), errGetEpoch)
 
-	mockEpochStateSkipVerifyErr.EXPECT().GetEpochForBlock(gomock.Eq(testBlockHeaderEmpty)).Return(uint64(1), nil)
-	mockEpochStateSkipVerifyErr.EXPECT().GetEpochData(gomock.Eq(uint64(1))).Return(nil, errGetEpochData)
-	mockEpochStateSkipVerifyErr.EXPECT().SkipVerify(gomock.Eq(testBlockHeaderEmpty)).Return(false, errSkipVerify)
+	mockEpochStateSkipVerifyErr.EXPECT().GetEpochForBlock(testBlockHeaderEmpty).Return(uint64(1), nil)
+	mockEpochStateSkipVerifyErr.EXPECT().GetEpochData(uint64(1)).Return(nil, errGetEpochData)
+	mockEpochStateSkipVerifyErr.EXPECT().SkipVerify(testBlockHeaderEmpty).Return(false, errSkipVerify)
 
-	mockEpochStateSkipVerifyTrue.EXPECT().GetEpochForBlock(gomock.Eq(testBlockHeaderEmpty)).Return(uint64(1), nil)
-	mockEpochStateSkipVerifyTrue.EXPECT().GetEpochData(gomock.Eq(uint64(1))).Return(nil, errGetEpochData)
-	mockEpochStateSkipVerifyTrue.EXPECT().SkipVerify(gomock.Eq(testBlockHeaderEmpty)).Return(true, nil)
+	mockEpochStateSkipVerifyTrue.EXPECT().GetEpochForBlock(testBlockHeaderEmpty).Return(uint64(1), nil)
+	mockEpochStateSkipVerifyTrue.EXPECT().GetEpochData(uint64(1)).Return(nil, errGetEpochData)
+	mockEpochStateSkipVerifyTrue.EXPECT().SkipVerify(testBlockHeaderEmpty).Return(true, nil)
 
-	mockEpochStateGetVerifierInfoErr.EXPECT().GetEpochForBlock(gomock.Eq(testBlockHeaderEmpty)).Return(uint64(1), nil)
-	mockEpochStateGetVerifierInfoErr.EXPECT().GetEpochData(gomock.Eq(uint64(1))).
+	mockEpochStateGetVerifierInfoErr.EXPECT().GetEpochForBlock(testBlockHeaderEmpty).Return(uint64(1), nil)
+	mockEpochStateGetVerifierInfoErr.EXPECT().GetEpochData(uint64(1)).
 		Return(nil, errGetEpochData)
-	mockEpochStateGetVerifierInfoErr.EXPECT().SkipVerify(gomock.Eq(testBlockHeaderEmpty)).Return(false, nil)
+	mockEpochStateGetVerifierInfoErr.EXPECT().SkipVerify(testBlockHeaderEmpty).Return(false, nil)
 
-	mockEpochStateNilBlockStateErr.EXPECT().GetEpochForBlock(gomock.Eq(testBlockHeaderEmpty)).Return(uint64(1), nil)
-	mockEpochStateVerifyAuthorshipErr.EXPECT().GetEpochForBlock(gomock.Eq(testBlockHeaderEmpty)).Return(uint64(1), nil)
+	mockEpochStateNilBlockStateErr.EXPECT().GetEpochForBlock(testBlockHeaderEmpty).Return(uint64(1), nil)
+	mockEpochStateVerifyAuthorshipErr.EXPECT().GetEpochForBlock(testBlockHeaderEmpty).Return(uint64(1), nil)
 
 	block1Header := types.NewEmptyHeader()
 	block1Header.Number = big.NewInt(1)
@@ -1063,22 +1063,22 @@ func TestVerificationManager_SetOnDisabled(t *testing.T) {
 	mockEpochStateOk2 := NewMockEpochState(ctrl)
 	mockEpochStateOk3 := NewMockEpochState(ctrl)
 
-	mockEpochStateGetEpochErr.EXPECT().GetEpochForBlock(gomock.Eq(types.NewEmptyHeader())).Return(uint64(0), errGetEpoch)
+	mockEpochStateGetEpochErr.EXPECT().GetEpochForBlock(types.NewEmptyHeader()).Return(uint64(0), errGetEpoch)
 
-	mockEpochStateGetEpochDataErr.EXPECT().GetEpochForBlock(gomock.Eq(types.NewEmptyHeader())).Return(uint64(0), nil)
-	mockEpochStateGetEpochDataErr.EXPECT().GetEpochData(gomock.Eq(uint64(0))).Return(nil, errGetEpochData)
+	mockEpochStateGetEpochDataErr.EXPECT().GetEpochForBlock(types.NewEmptyHeader()).Return(uint64(0), nil)
+	mockEpochStateGetEpochDataErr.EXPECT().GetEpochData(uint64(0)).Return(nil, errGetEpochData)
 
-	mockEpochStateIndexLenErr.EXPECT().GetEpochForBlock(gomock.Eq(types.NewEmptyHeader())).Return(uint64(2), nil)
+	mockEpochStateIndexLenErr.EXPECT().GetEpochForBlock(types.NewEmptyHeader()).Return(uint64(2), nil)
 
-	mockEpochStateSetDisabledProd.EXPECT().GetEpochForBlock(gomock.Eq(types.NewEmptyHeader())).Return(uint64(2), nil)
+	mockEpochStateSetDisabledProd.EXPECT().GetEpochForBlock(types.NewEmptyHeader()).Return(uint64(2), nil)
 
-	mockEpochStateOk.EXPECT().GetEpochForBlock(gomock.Eq(types.NewEmptyHeader())).Return(uint64(2), nil)
+	mockEpochStateOk.EXPECT().GetEpochForBlock(types.NewEmptyHeader()).Return(uint64(2), nil)
 	mockBlockStateIsDescendantErr.EXPECT().IsDescendantOf(gomock.Any(), gomock.Any()).Return(false, errDescendant)
 
-	mockEpochStateOk2.EXPECT().GetEpochForBlock(gomock.Eq(testHeader)).Return(uint64(2), nil)
+	mockEpochStateOk2.EXPECT().GetEpochForBlock(testHeader).Return(uint64(2), nil)
 	mockBlockStateAuthorityDisabled.EXPECT().IsDescendantOf(gomock.Any(), gomock.Any()).Return(true, nil)
 
-	mockEpochStateOk3.EXPECT().GetEpochForBlock(gomock.Eq(testHeader)).Return(uint64(2), nil)
+	mockEpochStateOk3.EXPECT().GetEpochForBlock(testHeader).Return(uint64(2), nil)
 	mockBlockStateOk.EXPECT().IsDescendantOf(gomock.Any(), gomock.Any()).Return(false, nil)
 
 	authority := types.NewAuthority(kp.Public(), uint64(1))


### PR DESCRIPTION
## Changes

Dumb `gomock.Eq` removal since it's not needed.
Found whilst doing #2330 and took under 1 minute.

## Tests

## Issues

## Primary Reviewer