### PR TITLE
chore(all): use `errors.Is` instead of `err ==`

### DIFF
--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"math/big"
 	"sync"
 
@@ -204,9 +205,9 @@ func (s *Service) handleBlock(block *types.Block, state *rtstorage.TrieState) er
 
 	// store block in database
 	if err = s.blockState.AddBlock(block); err != nil {
-		if err == blocktree.ErrParentNotFound && block.Header.Number.Cmp(big.NewInt(0)) != 0 {
+		if errors.Is(err, blocktree.ErrParentNotFound) && block.Header.Number.Cmp(big.NewInt(0)) != 0 {
 			return err
-		} else if err == blocktree.ErrBlockExists || block.Header.Number.Cmp(big.NewInt(0)) == 0 {
+		} else if errors.Is(err, blocktree.ErrBlockExists) || block.Header.Number.Cmp(big.NewInt(0)) == 0 {
 			// this is fine
 		} else {
 			return err

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -194,7 +194,7 @@ func (s *GrandpaState) GetSetIDByBlockNumber(num *big.Int) (uint64, error) {
 
 	for {
 		changeUpper, err := s.GetSetIDChange(curr + 1)
-		if err == chaindb.ErrKeyNotFound {
+		if errors.Is(err, chaindb.ErrKeyNotFound) {
 			if curr == 0 {
 				return 0, nil
 			}

--- a/dot/state/pruner/pruner.go
+++ b/dot/state/pruner/pruner.go
@@ -4,6 +4,7 @@
 package pruner
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -355,7 +356,7 @@ func (p *FullNode) storeLastPrunedIndex(blockNum int64) error {
 
 func (p *FullNode) getLastPrunedIndex() (int64, error) {
 	val, err := p.journalDB.Get([]byte(lastPrunedKey))
-	if err == chaindb.ErrKeyNotFound {
+	if errors.Is(err, chaindb.ErrKeyNotFound) {
 		return 0, nil
 	}
 

--- a/dot/types/body.go
+++ b/dot/types/body.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -62,7 +63,7 @@ func NewBodyFromExtrinsicStrings(ss []string) (*Body, error) {
 	exts := []Extrinsic{}
 	for _, s := range ss {
 		b, err := common.HexToBytes(s)
-		if err == common.ErrNoPrefix {
+		if errors.Is(err, common.ErrNoPrefix) {
 			b = []byte(s)
 		} else if err != nil {
 			return nil, err

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -377,7 +377,7 @@ func (s *Service) initiate() error {
 		}
 
 		err = s.playGrandpaRound()
-		if err == ErrServicePaused {
+		if errors.Is(err, ErrServicePaused) {
 			logger.Info("service paused")
 			// wait for service to un-pause
 			<-s.resumed
@@ -1163,7 +1163,7 @@ func (s *Service) getPossibleSelectedAncestors(votes []Vote, curr common.Hash,
 
 		// find common ancestor, check if votes for it is >threshold or not
 		pred, err := s.blockState.HighestCommonAncestor(v.Hash, curr)
-		if err == blocktree.ErrNodeNotFound {
+		if errors.Is(err, blocktree.ErrNodeNotFound) {
 			continue
 		} else if err != nil {
 			return nil, err

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -4,6 +4,7 @@
 package stress
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -194,7 +195,7 @@ func compareFinalizedHeadsWithRetry(t *testing.T, nodes []*utils.Node, round uin
 			break
 		}
 
-		if err == errFinalizedBlockMismatch {
+		if errors.Is(err, errFinalizedBlockMismatch) {
 			return common.Hash{}, fmt.Errorf("%w: round=%d hashes=%v", err, round, hashes)
 		}
 


### PR DESCRIPTION
## Changes

Dumb replacement of `err == someSentinelError` by `errors.Is(err, someSentinelError)`
Found whilst doing #2330 and took under 3 minutes.

## Tests

## Issues

## Primary Reviewer
