### PR TITLE
chore(lint): upgrade `golangci-lint` to `v1.44.x`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: Makefile
 
 .PHONY: lint
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44
 	golangci-lint run --build-tags integration --timeout 10m
 
 clean:

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -108,7 +108,7 @@ func makeDir(fp string) error {
 // saveKey attempts to save a private key to the provided filepath
 func saveKey(priv crypto.PrivKey, fp string) (err error) {
 	pth := path.Join(filepath.Clean(fp), DefaultKeyFile)
-	f, err := os.Create(pth)
+	f, err := os.Create(filepath.Clean(pth))
 	if err != nil {
 		return err
 	}

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/system"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,10 +94,14 @@ func TestHTTPServer_ServeHTTP(t *testing.T) {
 	u := url.URL{Scheme: "ws", Host: *addr, Path: "/"}
 	log.Printf("connecting to %s", u.String())
 
-	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	c, response, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
 		log.Fatal("dial:", err)
 	}
+	defer func() {
+		err := response.Body.Close()
+		assert.NoError(t, err)
+	}()
 	defer c.Close()
 
 	for _, item := range testCalls {

--- a/dot/telemetry/mailer.go
+++ b/dot/telemetry/mailer.go
@@ -57,7 +57,7 @@ func BootstrapMailer(ctx context.Context, conns []*genesis.TelemetryEndpoint, en
 		const maxRetries = 5
 
 		for connAttempts := 0; connAttempts < maxRetries; connAttempts++ {
-			conn, _, err := websocket.DefaultDialer.Dial(v.Endpoint, nil)
+			conn, response, err := websocket.DefaultDialer.Dial(v.Endpoint, nil)
 			if err != nil {
 				mailer.logger.Debugf("cannot dial telemetry endpoint %s (try %d of %d): %s",
 					v.Endpoint, connAttempts+1, maxRetries, err)
@@ -76,6 +76,11 @@ func BootstrapMailer(ctx context.Context, conns []*genesis.TelemetryEndpoint, en
 
 					return nil, ctx.Err()
 				}
+			}
+
+			err = response.Body.Close()
+			if err != nil {
+				mailer.logger.Errorf("cannot close body of response from %s: %s", v.Endpoint, err)
 			}
 
 			mailer.connections = append(mailer.connections, &telemetryConnection{

--- a/dot/telemetry/mailer.go
+++ b/dot/telemetry/mailer.go
@@ -80,7 +80,7 @@ func BootstrapMailer(ctx context.Context, conns []*genesis.TelemetryEndpoint, en
 
 			err = response.Body.Close()
 			if err != nil {
-				mailer.logger.Errorf("cannot close body of response from %s: %s", v.Endpoint, err)
+				mailer.logger.Warnf("cannot close body of response from %s: %s", v.Endpoint, err)
 			}
 
 			mailer.connections = append(mailer.connections, &telemetryConnection{


### PR DESCRIPTION
## Changes

- [x] Upgrade from `v1.43.0` to `v1.44`
- [x] Downloads and installs the latest feature release instead of pinning to a certain bug fix version
- [x] Fix newly detected errors

(Got sick of these 3 errors always showing up on my linter v1.44.x and that took under 5 minutes 😉)

## Tests

```
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44
golangci-lint run
```

## Issues

## Primary Reviewer
