### PR TITLE
bug(dot/state): delete previous previous finalised trie from `BlockState.tries`

### DIFF
--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -176,6 +176,17 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 		),
 	)
 
+	lastFinalisedHeader, err := bs.GetHeader(bs.lastFinalised)
+	if err != nil {
+		return fmt.Errorf("unable to retrieve header for last finalised block, hash: %s, err: %s", bs.lastFinalised, err)
+	}
+	stateRootTrie := bs.tries.get(lastFinalisedHeader.StateRoot)
+	if stateRootTrie != nil {
+		bs.tries.delete(lastFinalisedHeader.StateRoot)
+	} else {
+		return fmt.Errorf("unable to find trie with stateroot hash: %s", lastFinalisedHeader.StateRoot)
+	}
+
 	bs.lastFinalised = hash
 	return nil
 }
@@ -243,7 +254,6 @@ func (bs *BlockState) handleFinalisedBlock(curr common.Hash) error {
 
 		logger.Tracef("cleaned out finalised block from memory; block number %s with hash %s", block.Header.Number, hash)
 	}
-
 	return batch.Flush()
 }
 

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -136,9 +136,9 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 		return fmt.Errorf("failed to set highest round and set ID: %w", err)
 	}
 
-	if err := bs.handleFinalisedBlock(hash); err != nil {
-		return fmt.Errorf("failed to set number->hash mapping on finalisation: %w", err)
-	}
+	// if err := bs.handleFinalisedBlock(hash); err != nil {
+	// 	return fmt.Errorf("failed to set number->hash mapping on finalisation: %w", err)
+	// }
 
 	if round > 0 {
 		bs.notifyFinalized(hash, round, setID)
@@ -176,15 +176,17 @@ func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) er
 		),
 	)
 
-	lastFinalisedHeader, err := bs.GetHeader(bs.lastFinalised)
-	if err != nil {
-		return fmt.Errorf("unable to retrieve header for last finalised block, hash: %s, err: %s", bs.lastFinalised, err)
-	}
-	stateRootTrie := bs.tries.get(lastFinalisedHeader.StateRoot)
-	if stateRootTrie != nil {
-		bs.tries.delete(lastFinalisedHeader.StateRoot)
-	} else {
-		return fmt.Errorf("unable to find trie with stateroot hash: %s", lastFinalisedHeader.StateRoot)
+	if !bs.lastFinalised.Equal(hash) {
+		lastFinalisedHeader, err := bs.GetHeader(bs.lastFinalised)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve header for last finalised block, hash: %s, err: %s", bs.lastFinalised, err)
+		}
+		stateRootTrie := bs.tries.get(lastFinalisedHeader.StateRoot)
+		if stateRootTrie != nil {
+			bs.tries.delete(lastFinalisedHeader.StateRoot)
+		} else {
+			return fmt.Errorf("unable to find trie with stateroot hash: %s", lastFinalisedHeader.StateRoot)
+		}
 	}
 
 	bs.lastFinalised = hash

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -10,11 +10,8 @@ import (
 	"time"
 
 	"github.com/ChainSafe/gossamer/dot/types"
-	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	runtimemocks "github.com/ChainSafe/gossamer/lib/runtime/mocks"
-	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,16 +44,7 @@ func TestFreeImportedBlockNotifierChannel(t *testing.T) {
 }
 
 func TestFinalizedChannel(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Set(0.00).Times(3)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	bs := newTestBlockState(t, testGenesisHeader, tries)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	ch := bs.GetFinalisedNotifierChannel()
 
@@ -111,16 +99,7 @@ func TestImportChannel_Multi(t *testing.T) {
 }
 
 func TestFinalizedChannel_Multi(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Set(0.00)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	bs := newTestBlockState(t, testGenesisHeader, tries)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
 
 	num := 5
 	chs := make([]chan *types.FinalisationInfo, num)

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -28,7 +28,7 @@ func TestConcurrencySetHeader(t *testing.T) {
 		dbs[i] = NewInMemoryDB(t)
 	}
 
-	tries := (*Tries)(nil) // not used in this test
+	tries := newTriesEmpty() // not used in this test
 
 	pend := new(sync.WaitGroup)
 	pend.Add(threads)

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -37,6 +37,12 @@ func newTestBlockState(t *testing.T, header *types.Header, tries *Tries) *BlockS
 
 	bs, err := NewBlockStateFromGenesis(db, tries, header, telemetryMock)
 	require.NoError(t, err)
+
+	tr := trie.NewEmptyTrie()
+	err = tr.Load(bs.db, header.StateRoot)
+	require.NoError(t, err)
+	bs.tries.softSet(header.StateRoot, tr)
+
 	return bs
 }
 
@@ -262,17 +268,8 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 }
 
 func TestFinalization_DeleteBlock(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Set(0.00).Times(5)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	bs := newTestBlockState(t, testGenesisHeader, tries)
-	AddBlocksToState(t, bs, 5, false)
+	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	AddBlocksToState(t, bs, 5, false, true)
 
 	btBefore := bs.bt.DeepCopy()
 	before := bs.bt.GetAllBlocks()
@@ -482,14 +479,7 @@ func TestAddBlockToBlockTree(t *testing.T) {
 }
 
 func TestNumberIsFinalised(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Set(0.00).Times(2)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
+	tries := newTriesEmpty()
 
 	bs := newTestBlockState(t, testGenesisHeader, tries)
 	fin, err := bs.NumberIsFinalised(big.NewInt(0))

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -15,7 +15,10 @@ import (
 
 func newTriesEmpty() *Tries {
 	return &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
+		rootToTrie:    make(map[common.Hash]*trie.Trie),
+		triesGauge:    triesGauge,
+		setCounter:    setCounter,
+		deleteCounter: deleteCounter,
 	}
 }
 

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -13,23 +13,12 @@ import (
 
 	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStorageState_RegisterStorageObserver(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(2)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	ss := newTestStorageState(t, tries)
+	ss := newTestStorageState(t, newTriesEmpty())
 
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
@@ -64,16 +53,7 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 }
 
 func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(2)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	ss := newTestStorageState(t, tries)
+	ss := newTestStorageState(t, newTriesEmpty())
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
 
@@ -125,18 +105,7 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 
 func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 	t.Skip() // this seems to fail often on CI
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	// TODO restrict those mock calls once test is fixed.
-	triesGauge.EXPECT().Inc().AnyTimes()
-	triesGauge.EXPECT().Set(gomock.Any()).AnyTimes()
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	ss := newTestStorageState(t, tries)
+	ss := newTestStorageState(t, newTriesEmpty())
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
 

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -32,16 +32,7 @@ func newTestStorageState(t *testing.T, tries *Tries) *StorageState {
 }
 
 func TestStorage_StoreAndLoadTrie(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc()
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	storage := newTestStorageState(t, tries)
+	storage := newTestStorageState(t, newTriesEmpty())
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -61,16 +52,16 @@ func TestStorage_StoreAndLoadTrie(t *testing.T) {
 }
 
 func TestStorage_GetStorageByBlockHash(t *testing.T) {
-	ctrl := gomock.NewController(t)
+	// ctrl := gomock.NewController(t)
 
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(2)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
+	// triesGauge := NewMockGauge(ctrl)
+	// triesGauge.EXPECT().Inc().Times(2)
+	// tries := &Tries{
+	// 	rootToTrie: make(map[common.Hash]*trie.Trie),
+	// 	triesGauge: triesGauge,
+	// }
 
-	storage := newTestStorageState(t, tries)
+	storage := newTestStorageState(t, newTriesEmpty())
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -105,17 +96,7 @@ func TestStorage_GetStorageByBlockHash(t *testing.T) {
 }
 
 func TestStorage_TrieState(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(3)
-	triesGauge.EXPECT().Set(1.00).Times(1)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	storage := newTestStorageState(t, tries)
+	storage := newTestStorageState(t, newTriesEmpty())
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 	ts.Set([]byte("noot"), []byte("washere"))
@@ -135,17 +116,7 @@ func TestStorage_TrieState(t *testing.T) {
 }
 
 func TestStorage_LoadFromDB(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(4)
-	triesGauge.EXPECT().Set(1.00).Times(3)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	storage := newTestStorageState(t, tries)
+	storage := newTestStorageState(t, newTriesEmpty())
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -190,16 +161,7 @@ func TestStorage_LoadFromDB(t *testing.T) {
 }
 
 func TestStorage_StoreTrie_NotSyncing(t *testing.T) {
-	ctrl := gomock.NewController(t)
-
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(2)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
-
-	storage := newTestStorageState(t, tries)
+	storage := newTestStorageState(t, newTriesEmpty())
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -233,13 +195,7 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	err = genTrie.PutChild([]byte("keyToChild"), testChildTrie)
 	require.NoError(t, err)
 
-	triesGauge := NewMockGauge(ctrl)
-	triesGauge.EXPECT().Inc().Times(2)
-	triesGauge.EXPECT().Set(0.00)
-	tries := &Tries{
-		rootToTrie: make(map[common.Hash]*trie.Trie),
-		triesGauge: triesGauge,
-	}
+	tries := newTriesEmpty()
 
 	blockState, err := NewBlockStateFromGenesis(db, tries, genHeader, telemetryMock)
 	require.NoError(t, err)

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"testing"
@@ -61,7 +62,7 @@ type testBranch struct {
 
 // AddBlocksToState adds `depth` number of blocks to the BlockState, optionally with random branches
 func AddBlocksToState(t *testing.T, blockState *BlockState, depth int,
-	withBranches bool) ([]*types.Header, []*types.Header) {
+	withBranches bool, withFakeStateRoots ...interface{}) ([]*types.Header, []*types.Header) {
 	var (
 		currentChain, branchChains []*types.Header
 		branches                   []testBranch
@@ -82,15 +83,29 @@ func AddBlocksToState(t *testing.T, blockState *BlockState, depth int,
 		err = digest.Add(*prd)
 		require.NoError(t, err)
 
+		var stateRoot common.Hash
+
+		if len(withFakeStateRoots) > 0 {
+			// generate some dummy state root based on block number
+			bs := make([]byte, 4)
+			binary.LittleEndian.PutUint32(bs, uint32(i))
+			stateRoot = common.Hash{bs[0], bs[1], bs[2], bs[3]}
+		} else {
+			stateRoot = trie.EmptyHash
+		}
+
 		block := &types.Block{
 			Header: types.Header{
 				ParentHash: previousHash,
 				Number:     big.NewInt(int64(i)),
-				StateRoot:  trie.EmptyHash,
+				StateRoot:  stateRoot,
 				Digest:     digest,
 			},
 			Body: types.Body{},
 		}
+
+		// write to tries, since this will need to be deleted
+		blockState.tries.softSet(stateRoot, trie.NewEmptyTrie())
 
 		currentChain = append(currentChain, &block.Header)
 


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Deletes the previous trie after a block is finalised from `BlockState.tries`.
- Significantly reduces memory usage over time
- Added a tries set/delete gauge
- Removed gauge mocks from `dot/state` tests.

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
go test ./dot/state
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- closes #2340 

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @noot 
