### PR TITLE
chore(tests/stress): refactor `compareBlocksByNumber`

### DIFF
--- a/tests/stress/empty.go
+++ b/tests/stress/empty.go
@@ -1,4 +1,0 @@
-// Copyright 2021 ChainSafe Systems (ON)
-// SPDX-License-Identifier: LGPL-3.0-only
-
-package stress

--- a/tests/stress/errors.go
+++ b/tests/stress/errors.go
@@ -10,7 +10,5 @@ import (
 var (
 	errFinalizedBlockMismatch = errors.New("node finalised head hashes don't match")
 	errNoFinalizedBlock       = errors.New("did not finalise block for round")
-	errNoBlockAtNumber        = errors.New("no blocks found for given number")
-	errBlocksAtNumberMismatch = errors.New("different blocks found for given number")
 	errChainHeadMismatch      = errors.New("node chain head hashes don't match")
 )


### PR DESCRIPTION
## Changes

*First in a serie of `tests/` refactor PRs*
The end goal is to move timeouts responsibility to the test instead of hidden in helpers.

- Takes in context
- Retry as long as context is not canceled
- Assert errors and common values

## Tests

```
make it-stress
```

## Issues

- #2326 

## Primary Reviewer

- Anyone it's just a single function changed.