### PR TITLE
feat(go): upgrade Go from 1.17 to 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        go-version: [1.17.x]
         platform: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -37,7 +36,10 @@ jobs:
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
       - uses: actions/checkout@v3
 
       # cache go build cache
@@ -61,9 +63,6 @@ jobs:
 
   publish-code-coverage:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        go-version: [1.17.x]
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
@@ -72,7 +71,10 @@ jobs:
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
       - uses: actions/checkout@v3
 
       # cache go build cache

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,9 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.x"
+          go-version: 1.18
+          stable: true
+          check-latest: true
 
       - name: Lint
         run: make lint
@@ -36,7 +38,10 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17.x"
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
       - uses: actions/checkout@v3
       - name: Checks PR has title and body description
         run: |

--- a/.github/workflows/code-cov.yml
+++ b/.github/workflows/code-cov.yml
@@ -22,9 +22,6 @@ env:
 jobs:
   publish-code-coverage:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        go-version: [1.17.x]
     runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
@@ -33,7 +30,10 @@ jobs:
           echo "::set-output name=go-mod::$(go env GOMODCACHE)"
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
       - uses: actions/checkout@v3
 
       # cache go build cache

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -18,7 +18,9 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.17"
+          go-version: 1.18
+          stable: true
+          check-latest: true
 
       - run: go install github.com/google/addlicense@v1.0.0
 

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -3,15 +3,18 @@ on:
   push:
     branches:
       - devnet
-      
+
 jobs:
   update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.0'
+          go-version: 1.18
+          stable: true
+          check-latest: true
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -65,7 +68,7 @@ jobs:
           docker build --progress=plain \
           -t=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t=$ECR_REGISTRY/$ECR_REPOSITORY:latest \
           --build-arg key=charlie --build-arg DD_API_KEY=$DD_API_KEY --build-arg METRICS_NAMESPACE=gossamer.ecs.devnet \
-          -f=devnet/bob.Dockerfile . 
+          -f=devnet/bob.Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
@@ -74,7 +77,7 @@ jobs:
         working-directory: ./devnet/cmd/scale-down-ecs-service
         run: |
           go run . -c gssmr-ecs -s="gssmr-ecs-(Charlie|Bob)Service-.+$"
-      
+
       - name: docker compose up
         id: docker-compose-up
         working-directory: ./devnet/gssmr-ecs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,10 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17.x
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
       - uses: actions/checkout@v3
 
       # cache go build cache

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Check devnet module
         run: |
           cd devnet && \
+          go mod download && \
           go generate -run "mockery" -tags integration ./... && \
           go generate -run "mockgen" -tags integration ./... && \
           git diff --exit-code && \
@@ -35,6 +36,7 @@ jobs:
 
       - name: Check Gossamer module
         run: |
+          go mod download && \
           go generate -run "mockery" -tags integration ./... && \
           go generate -run "mockgen" -tags integration ./... && \
           git diff --exit-code

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -17,7 +17,9 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.17"
+          go-version: 1.18
+          stable: true
+          check-latest: true
 
       - run: go install github.com/vektra/mockery/v2@v2.10.0
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,11 +22,7 @@ env:
 jobs:
   unit-tests:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - id: go-cache-paths
         run: |
@@ -35,7 +31,10 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
       - uses: actions/checkout@v3
 
       # cache go build cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_VERSION=bullseye-slim
-ARG GO_VERSION=1.17-buster
+ARG GO_VERSION=1.18-buster
 
 FROM golang:${GO_VERSION} AS builder
 

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 ARG chain="polkadot"
 ARG basepath="~/.gossamer"

--- a/README.md
+++ b/README.md
@@ -43,28 +43,33 @@ For more information about Gossamer, the Polkadot ecosystem, and how to use Goss
 
 ### Prerequisites
 
-install go version `>=1.17`
+Install Go version [`>=1.18`](https://go.dev/dl/#go1.18)
 
 ### Installation
 
 get the [ChainSafe/gossamer](https://github.com/ChainSafe/gossamer) repository:
+
 ```
 git clone git@github.com:ChainSafe/gossamer
 cd gossamer
 ```
 
 build gossamer command:
+
 ```
 make gossamer
 ```
+
 ### Troubleshooting for Apple Silicon users
 
 If you are facing the following problem with the `wasmer`:
+
 ```
 undefined: cWasmerImportObjectT
 undefined: cWasmerImportFuncT
 undefined: cWasmerValueTag
 ```
+
 Make sure you have the following Golang enviroment variables:
 
 - GOARCH="amd64"
@@ -73,8 +78,6 @@ Make sure you have the following Golang enviroment variables:
 > use _go env_ to see all the Golang enviroment variables
 
 > use _go env -w **ENV_NAME**=**ENV_VALUE**_ to set the new value
-
-
 
 ### Run Development Node
 
@@ -85,22 +88,25 @@ To initialise a development node:
 ```
 
 To start the development node:
+
 ```
 ./bin/gossamer --chain dev
 ```
 
-The development node is configured to produce a block every slot and to finalise a block every round (as there is only one authority, `alice`.) 
+The development node is configured to produce a block every slot and to finalise a block every round (as there is only one authority, `alice`.)
 
 ### Run Gossamer Node
 
 The gossamer node runs by default as an authority with 9 authorites set at genesis. The built-in keys, corresponding to the authorities, that are available for the node are `alice`, `bob`, `charlie`, `dave`, `eve`, `ferdie`, `george`, and `ian`.
 
 To initialise a gossamer node:
+
 ```
 ./bin/gossamer --chain gssmr init
 ```
 
 To start the gossamer node:
+
 ```
 ./bin/gossamer --chain gssmr --key alice
 ```
@@ -112,11 +118,13 @@ Note: If you only run one gossamer node, the node will not build blocks every sl
 Kusama is currently supported as a **full node**, ie. it can sync the chain but not act as an authority.
 
 To initialise a kusama node:
+
 ```
 ./bin/gossamer --chain kusama init
 ```
 
 To start the kusama node:
+
 ```
 ./bin/gossamer --chain kusama
 ```
@@ -128,18 +136,20 @@ The node may not appear to do anything for the first minute or so (it's bootstra
 network = "debug"
 ```
 
-After it's finished bootstrapping, the node should begin to sync. 
+After it's finished bootstrapping, the node should begin to sync.
 
 ### Run Polkadot Node
 
 Polkadot is currently supported as a **full node**, ie. it can sync the chain but not act as an authority.
 
 To initialise a polkadot node:
+
 ```
 ./bin/gossamer --chain polkadot init
 ```
 
 To start the polkadot node:
+
 ```
 ./bin/gossamer --chain polkadot
 ```
@@ -159,12 +169,11 @@ Our work on gossamer is funded by grants. If you'd like to donate, you can send 
 ### Reporting a Security Bug
 
 We take all security issues seriously, if you believe you have found a security issue within a ChainSafe
-project please notify us immediately. If an issue is confirmed, we will take all necessary precautions 
+project please notify us immediately. If an issue is confirmed, we will take all necessary precautions
 to ensure a statement and patch release is made in a timely manner.
 
 Please email us a description of the flaw and any related information (e.g. reproduction steps, version) to
 [security at chainsafe dot io](mailto:security@chainsafe.io).
-
 
 ## License
 
@@ -172,6 +181,5 @@ _GNU Lesser General Public License v3.0_
 
 <br />
 <p align="center">
-	<img src="/docs/docs/assets/img/chainsafe_gopher.png">
+ <img src="/docs/docs/assets/img/chainsafe_gopher.png">
 </p>
-

--- a/devnet/alice.Dockerfile
+++ b/devnet/alice.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM golang:1.17
+FROM golang:1.18
 
 ARG POLKADOT_VERSION=v0.9.10
 
@@ -18,7 +18,7 @@ WORKDIR /gossamer
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . . 
+COPY . .
 
 RUN go install -trimpath github.com/ChainSafe/gossamer/cmd/gossamer
 

--- a/devnet/bob.Dockerfile
+++ b/devnet/bob.Dockerfile
@@ -1,8 +1,7 @@
 # Copyright 2021 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 
-
-FROM golang:1.17
+FROM golang:1.18
 
 ARG POLKADOT_VERSION=v0.9.10
 

--- a/devnet/go.mod
+++ b/devnet/go.mod
@@ -1,6 +1,6 @@
 module github.com/ChainSafe/gossamer/devnet
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.42.22

--- a/devnet/substrate_alice.Dockerfile
+++ b/devnet/substrate_alice.Dockerfile
@@ -3,7 +3,7 @@
 
 ARG POLKADOT_VERSION=v0.9.10
 
-FROM golang:1.17 as openmetrics
+FROM golang:1.18 as openmetrics
 ARG METRICS_NAMESPACE=substrate.local.devnet
 
 WORKDIR /devnet

--- a/devnet/substrate_bob.Dockerfile
+++ b/devnet/substrate_bob.Dockerfile
@@ -1,7 +1,8 @@
 # Copyright 2022 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 ARG POLKADOT_VERSION=v0.9.10
-FROM golang:1.17 as openmetrics
+
+FROM golang:1.18 as openmetrics
 
 ARG METRICS_NAMESPACE=substrate.local.devnet
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -8,17 +8,19 @@ permalink: /getting-started/installation
 
 ## Prerequisites
 
-Install <a target="_blank" rel="noopener noreferrer" href="https://golang.org/">Go</a> version `>=1.17`
+Install [Go](https://go.dev/doc/install) version [`>=1.18`](https://go.dev/dl/#go1.18)
 
 ## Installation
 
 Get the <a target="_blank" rel="noopener noreferrer" href="https://github.com/ChainSafe/gossamer">ChainSafe/gossamer</a> repository:
+
 ```
 git clone git@github.com:ChainSafe/gossamer
 cd gossamer
 ```
 
 Run the following command to build the Gossamer binary:
+
 ```
 make gossamer
 ```
@@ -32,22 +34,25 @@ To initialise a development node:
 ```
 
 To start the development node:
+
 ```
 ./bin/gossamer --chain dev
 ```
 
-The development node is configured to produce a block every slot and to finalise a block every round (as there is only one authority, `alice`.) 
+The development node is configured to produce a block every slot and to finalise a block every round (as there is only one authority, `alice`.)
 
 ### Run Gossamer Node
 
 The gossamer node runs by default as an authority with 9 authorites set at genesis. The built-in keys, corresponding to the authorities, that are available for the node are `alice`, `bob`, `charlie`, `dave`, `eve`, `ferdie`, `george`, and `ian`.
 
 To initialise a gossamer node:
+
 ```
 ./bin/gossamer --chain gssmr init
 ```
 
 To start the gossamer node:
+
 ```
 ./bin/gossamer --chain gssmr --key alice
 ```
@@ -55,6 +60,7 @@ To start the gossamer node:
 Note: If you only run one gossamer node, the node will not build blocks every slot or finalize blocks; it will appear that the node is doing nothing, but it is actually waiting for a slot to build a block. This is because there are 9 authorities set, so at least 6 of the authorities should be run for a functional network. If you wish to reduce the number of authorities, you can modify the genesis file in `chain/gssmr/genesis-spec.json`.
 
 If you wish to run the default node as a non-authority, you can specify `roles=1`:
+
 ```
 ./bin/gossamer --chain gssmr --roles 1
 ```
@@ -62,11 +68,13 @@ If you wish to run the default node as a non-authority, you can specify `roles=1
 ## Run Kusama Node
 
 To run a Kusama node, first initialise the node:
+
 ```
 ./bin/gossamer --chain kusama init
 ```
 
 Then run the node selecting the Kusama chain:
+
 ```
 ./bin/gossamer --chain kusama
 ```
@@ -78,35 +86,37 @@ The node may not appear to do anything for the first minute or so (it's bootstra
 network = "debug"
 ```
 
-After it's finished bootstrapping, the node should begin to sync. 
+After it's finished bootstrapping, the node should begin to sync.
 
-## Run Polkadot Node 
+## Run Polkadot Node
 
 Initialise polkadot node:
+
 ```
 ./bin/gossamer --chain polkadot init
 ```
 
 Start polkadot node:
+
 ```
 ./bin/gossamer --chain polkadot
 ```
 
 ## Run Gossamer Node with Docker
 
-Gossamer can also be installed on GNU/Linux, MacOS systems with Docker. 
+Gossamer can also be installed on GNU/Linux, MacOS systems with Docker.
 
 ### Dependencies
 
 - Install the latest release of [Docker](https://docs.docker.com/get-docker/)
 
-Ensure you are running the most recent version of Docker by issuing the command: 
+Ensure you are running the most recent version of Docker by issuing the command:
 
 ```
 docker -v
 ```
 
-Pull the latest Gossamer images from DockerHub Registry: 
+Pull the latest Gossamer images from DockerHub Registry:
 
 ```
 docker pull chainsafe/gossamer:latest
@@ -121,6 +131,7 @@ docker run -it --entrypoint /bin/bash chainsafe/gossamer:latest
 ```
 
 The built-in authorities are `alice`, `bob`, `charlie`, `dave`, `eve`, `ferdie`, `george`, and `ian`. To start the node as an authority, provide it with a built-in key:
+
 ```
 ./bin/gossamer --chain gssmr --key alice
 ```

--- a/dot/build_spec_integration_test.go
+++ b/dot/build_spec_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package dot
 

--- a/dot/config_integration_test.go
+++ b/dot/config_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package dot
 

--- a/dot/core/messages_integration_test.go
+++ b/dot/core/messages_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package core
 

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package core
 

--- a/dot/import_integration_test.go
+++ b/dot/import_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package dot
 

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package dot
 

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/childstate_integration_test.go
+++ b/dot/rpc/modules/childstate_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/grandpa_integration_test.go
+++ b/dot/rpc/modules/grandpa_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/offchain_integration_test.go
+++ b/dot/rpc/modules/offchain_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/payment_integration_test.go
+++ b/dot/rpc/modules/payment_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/sync_state_integration_test.go
+++ b/dot/rpc/modules/sync_state_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/rpc/modules/system_integration_test.go
+++ b/dot/rpc/modules/system_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package modules
 

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package dot
 

--- a/dot/utils_integration_test.go
+++ b/dot/utils_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package dot
 

--- a/go.mod
+++ b/go.mod
@@ -187,4 +187,4 @@ require (
 	gotest.tools/v3 v3.0.3 // indirect
 )
 
-go 1.17
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -188,7 +188,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
-github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -622,7 +621,6 @@ github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
 github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
-github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDKIzp7y4voR9CX/nvcfymLmg2UiOio=
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
@@ -871,7 +869,6 @@ github.com/libp2p/go-yamux v1.3.3/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZ
 github.com/libp2p/go-yamux v1.3.5/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/libp2p/go-yamux v1.3.7/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
 github.com/libp2p/go-yamux v1.4.0/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
-github.com/libp2p/go-yamux v1.4.1 h1:P1Fe9vF4th5JOxxgQvfbOHkrGqIZniTLf+ddhZp8YTI=
 github.com/libp2p/go-yamux v1.4.1/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
 github.com/libp2p/go-yamux/v2 v2.2.0 h1:RwtpYZ2/wVviZ5+3pjC8qdQ4TKnrak0/E01N1UWoAFU=
 github.com/libp2p/go-yamux/v2 v2.2.0/go.mod h1:3So6P6TV6r75R9jiBpiIKgU/66lOarCZjqROGxzPpPQ=
@@ -1179,7 +1176,6 @@ github.com/rs/cors v0.0.0-20160617231935-a62a804a8a00/go.mod h1:gFx+x8UowdsKA9Ac
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -1832,7 +1828,6 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package babe
 

--- a/lib/babe/build_integration_test.go
+++ b/lib/babe/build_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package babe
 

--- a/lib/babe/epoch_integration_test.go
+++ b/lib/babe/epoch_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package babe
 

--- a/lib/babe/secondary_integration_test.go
+++ b/lib/babe/secondary_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package babe
 

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 //go:build integration
-// +build integration
 
 package babe
 


### PR DESCRIPTION
## Changes

- CI Workflows
    - change from Go 1.17.x Go 1.18 with `check-latest: true`
    - remove Go version matrices (because we don't use them)
    - Add `stable: true` since I took me a while to find `stable: false` to try with the beta Go 1.18
- Change all Dockerfiles to use Go 1.18 
- Change `go.mod` to specify `go 1.18`
- Update readme.md and docs/docs/getting-started/installation.md to specify to use Go 1.18
- Collateral changes:
    - Auto-formatting for markdown files
    - Auto-formatting of yml files

## Tests

- All workflows passing

## Issues

## Primary Reviewer

- @EclesioMeloJunior 