### PR TITLE
feat(trie): finer deep copy of nodes

### DIFF
--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -3,76 +3,107 @@
 
 package node
 
+// CopySettings contains settings to configure the deep copy
+// of a node. By default, it:
+// - does not deep copy children recrursively
+// - does not copy cached fields HashDigest and Encoding
+// - deep copies the key field
+// - deep copies the value field
+type CopySettings struct {
+	// CopyChildren can be set to true to recursively deep copy the eventual
+	// children of the node. This is false by default and should only be used
+	// in tests since it is quite inefficient.
+	CopyChildren bool
+	// CopyCached can be set to true to deep copy the cached digest
+	// and encoding fields on the current node copied.
+	// This is false by default because in production, a node is copied
+	// when it is about to be mutated, hence making its cached fields
+	// no longer valid.
+	CopyCached bool
+	// LeaveKeyEmpty can be set to true to not deep copy the key field of
+	// the node. This is useful if the key is about to be assigned after the
+	// Copy operation, to save a memory operation.
+	LeaveKeyEmpty bool
+	// LeaveValueEmpty can be set to true to not deep copy the value field of
+	// the node. This is useful if the value is about to be assigned after the
+	// Copy operation, to save a memory operation.
+	LeaveValueEmpty bool
+}
+
 // Copy deep copies the branch.
 // Setting copyChildren to true will deep copy
 // children as well.
-func (b *Branch) Copy(copyChildren bool) Node {
+func (b *Branch) Copy(settings CopySettings) Node {
 	cpy := &Branch{
 		Dirty:      b.Dirty,
 		Generation: b.Generation,
 	}
 
-	if copyChildren {
+	if settings.CopyChildren {
 		for i, child := range b.Children {
 			if child == nil {
 				continue
 			}
-			cpy.Children[i] = child.Copy(copyChildren)
+			cpy.Children[i] = child.Copy(settings)
 		}
 	} else {
 		cpy.Children = b.Children // copy interface pointers only
 	}
 
-	if b.Key != nil {
+	if !settings.LeaveKeyEmpty && b.Key != nil {
 		cpy.Key = make([]byte, len(b.Key))
 		copy(cpy.Key, b.Key)
 	}
 
 	// nil and []byte{} are encoded differently, watch out!
-	if b.Value != nil {
+	if !settings.LeaveValueEmpty && b.Value != nil {
 		cpy.Value = make([]byte, len(b.Value))
 		copy(cpy.Value, b.Value)
 	}
 
-	if b.HashDigest != nil {
-		cpy.HashDigest = make([]byte, len(b.HashDigest))
-		copy(cpy.HashDigest, b.HashDigest)
-	}
+	if settings.CopyCached {
+		if b.HashDigest != nil {
+			cpy.HashDigest = make([]byte, len(b.HashDigest))
+			copy(cpy.HashDigest, b.HashDigest)
+		}
 
-	if b.Encoding != nil {
-		cpy.Encoding = make([]byte, len(b.Encoding))
-		copy(cpy.Encoding, b.Encoding)
+		if b.Encoding != nil {
+			cpy.Encoding = make([]byte, len(b.Encoding))
+			copy(cpy.Encoding, b.Encoding)
+		}
 	}
 
 	return cpy
 }
 
 // Copy deep copies the leaf.
-func (l *Leaf) Copy(_ bool) Node {
+func (l *Leaf) Copy(settings CopySettings) Node {
 	cpy := &Leaf{
 		Dirty:      l.Dirty,
 		Generation: l.Generation,
 	}
 
-	if l.Key != nil {
+	if !settings.LeaveKeyEmpty && l.Key != nil {
 		cpy.Key = make([]byte, len(l.Key))
 		copy(cpy.Key, l.Key)
 	}
 
 	// nil and []byte{} are encoded differently, watch out!
-	if l.Value != nil {
+	if !settings.LeaveValueEmpty && l.Value != nil {
 		cpy.Value = make([]byte, len(l.Value))
 		copy(cpy.Value, l.Value)
 	}
 
-	if l.HashDigest != nil {
-		cpy.HashDigest = make([]byte, len(l.HashDigest))
-		copy(cpy.HashDigest, l.HashDigest)
-	}
+	if settings.CopyCached {
+		if l.HashDigest != nil {
+			cpy.HashDigest = make([]byte, len(l.HashDigest))
+			copy(cpy.HashDigest, l.HashDigest)
+		}
 
-	if l.Encoding != nil {
-		cpy.Encoding = make([]byte, len(l.Encoding))
-		copy(cpy.Encoding, l.Encoding)
+		if l.Encoding != nil {
+			cpy.Encoding = make([]byte, len(l.Encoding))
+			copy(cpy.Encoding, l.Encoding)
+		}
 	}
 
 	return cpy

--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -3,33 +3,31 @@
 
 package node
 
-// DefaultCopySettings returns the following copy settings:
-// - children are NOT deep copied recursively
-// - the HashDigest field is left empty on the copy
-// - the Encoding field is left empty on the copy
-// - the key field is deep copied
-// - the value field is deep copied
-func DefaultCopySettings() CopySettings {
-	return CopySettings{
+var (
+	// DefaultCopySettings contains the following copy settings:
+	// - children are NOT deep copied recursively
+	// - the HashDigest field is left empty on the copy
+	// - the Encoding field is left empty on the copy
+	// - the key field is deep copied
+	// - the value field is deep copied
+	DefaultCopySettings = CopySettings{
 		CopyKey:   true,
 		CopyValue: true,
 	}
-}
 
-// DeepCopySettings returns the following copy settings:
-// - children are deep copied recursively
-// - the HashDigest field is deep copied
-// - the Encoding field is deep copied
-// - the key field is deep copied
-// - the value field is deep copied
-func DeepCopySettings() CopySettings {
-	return CopySettings{
+	// DeepCopySettings returns the following copy settings:
+	// - children are deep copied recursively
+	// - the HashDigest field is deep copied
+	// - the Encoding field is deep copied
+	// - the key field is deep copied
+	// - the value field is deep copied
+	DeepCopySettings = CopySettings{
 		CopyChildren: true,
 		CopyCached:   true,
 		CopyKey:      true,
 		CopyValue:    true,
 	}
-}
+)
 
 // CopySettings contains settings to configure the deep copy
 // of a node.

--- a/internal/trie/node/copy_test.go
+++ b/internal/trie/node/copy_test.go
@@ -44,6 +44,7 @@ func Test_Branch_Copy(t *testing.T) {
 				HashDigest: []byte{5},
 				Encoding:   []byte{6},
 			},
+			settings: DefaultCopySettings(),
 			expectedBranch: &Branch{
 				Key:   []byte{1, 2},
 				Value: []byte{3, 4},
@@ -66,6 +67,29 @@ func Test_Branch_Copy(t *testing.T) {
 				Children: [16]Node{
 					nil, nil, &Leaf{Key: []byte{9}},
 				},
+			},
+		},
+		"deep copy": {
+			branch: &Branch{
+				Key:   []byte{1, 2},
+				Value: []byte{3, 4},
+				Children: [16]Node{
+					nil, nil, &Leaf{Key: []byte{9}},
+				},
+				Dirty:      true,
+				HashDigest: []byte{5},
+				Encoding:   []byte{6},
+			},
+			settings: DeepCopySettings(),
+			expectedBranch: &Branch{
+				Key:   []byte{1, 2},
+				Value: []byte{3, 4},
+				Children: [16]Node{
+					nil, nil, &Leaf{Key: []byte{9}},
+				},
+				Dirty:      true,
+				HashDigest: []byte{5},
+				Encoding:   []byte{6},
 			},
 		},
 	}
@@ -102,6 +126,7 @@ func Test_Leaf_Copy(t *testing.T) {
 	}{
 		"empty leaf": {
 			leaf:         &Leaf{},
+			settings:     DefaultCopySettings(),
 			expectedLeaf: &Leaf{},
 		},
 		"non empty leaf": {
@@ -112,10 +137,28 @@ func Test_Leaf_Copy(t *testing.T) {
 				HashDigest: []byte{5},
 				Encoding:   []byte{6},
 			},
+			settings: DefaultCopySettings(),
 			expectedLeaf: &Leaf{
 				Key:   []byte{1, 2},
 				Value: []byte{3, 4},
 				Dirty: true,
+			},
+		},
+		"deep copy": {
+			leaf: &Leaf{
+				Key:        []byte{1, 2},
+				Value:      []byte{3, 4},
+				Dirty:      true,
+				HashDigest: []byte{5},
+				Encoding:   []byte{6},
+			},
+			settings: DeepCopySettings(),
+			expectedLeaf: &Leaf{
+				Key:        []byte{1, 2},
+				Value:      []byte{3, 4},
+				Dirty:      true,
+				HashDigest: []byte{5},
+				Encoding:   []byte{6},
 			},
 		},
 	}

--- a/internal/trie/node/copy_test.go
+++ b/internal/trie/node/copy_test.go
@@ -44,7 +44,7 @@ func Test_Branch_Copy(t *testing.T) {
 				HashDigest: []byte{5},
 				Encoding:   []byte{6},
 			},
-			settings: DefaultCopySettings(),
+			settings: DefaultCopySettings,
 			expectedBranch: &Branch{
 				Key:   []byte{1, 2},
 				Value: []byte{3, 4},
@@ -80,7 +80,7 @@ func Test_Branch_Copy(t *testing.T) {
 				HashDigest: []byte{5},
 				Encoding:   []byte{6},
 			},
-			settings: DeepCopySettings(),
+			settings: DeepCopySettings,
 			expectedBranch: &Branch{
 				Key:   []byte{1, 2},
 				Value: []byte{3, 4},
@@ -126,7 +126,7 @@ func Test_Leaf_Copy(t *testing.T) {
 	}{
 		"empty leaf": {
 			leaf:         &Leaf{},
-			settings:     DefaultCopySettings(),
+			settings:     DefaultCopySettings,
 			expectedLeaf: &Leaf{},
 		},
 		"non empty leaf": {
@@ -137,7 +137,7 @@ func Test_Leaf_Copy(t *testing.T) {
 				HashDigest: []byte{5},
 				Encoding:   []byte{6},
 			},
-			settings: DefaultCopySettings(),
+			settings: DefaultCopySettings,
 			expectedLeaf: &Leaf{
 				Key:   []byte{1, 2},
 				Value: []byte{3, 4},
@@ -152,7 +152,7 @@ func Test_Leaf_Copy(t *testing.T) {
 				HashDigest: []byte{5},
 				Encoding:   []byte{6},
 			},
-			settings: DeepCopySettings(),
+			settings: DeepCopySettings,
 			expectedLeaf: &Leaf{
 				Key:        []byte{1, 2},
 				Value:      []byte{3, 4},

--- a/internal/trie/node/node.go
+++ b/internal/trie/node/node.go
@@ -20,7 +20,7 @@ type Node interface {
 	GetValue() (value []byte)
 	GetGeneration() (generation uint64)
 	SetGeneration(generation uint64)
-	Copy(copyChildren bool) Node
+	Copy(settings CopySettings) (cpy Node)
 	Type() Type
 	StringNode() (stringNode *gotree.Node)
 }

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -46,7 +46,7 @@ func NewTrie(root Node) *Trie {
 // the set of deleted hashes.
 func (t *Trie) Snapshot() (newTrie *Trie) {
 	childTries := make(map[common.Hash]*Trie, len(t.childTries))
-	rootCopySettings := node.DefaultCopySettings()
+	rootCopySettings := node.DefaultCopySettings
 	rootCopySettings.CopyCached = true
 	for rootHash, childTrie := range t.childTries {
 		childTries[rootHash] = &Trie{
@@ -141,7 +141,7 @@ func (t *Trie) DeepCopy() (trieCopy *Trie) {
 	}
 
 	if t.root != nil {
-		copySettings := node.DeepCopySettings()
+		copySettings := node.DeepCopySettings
 		trieCopy.root = t.root.Copy(copySettings)
 	}
 
@@ -150,7 +150,7 @@ func (t *Trie) DeepCopy() (trieCopy *Trie) {
 
 // RootNode returns a copy of the root node of the trie.
 func (t *Trie) RootNode() Node {
-	copySettings := node.DefaultCopySettings()
+	copySettings := node.DefaultCopySettings
 	copySettings.CopyCached = true
 	return t.root.Copy(copySettings)
 }
@@ -365,7 +365,7 @@ func (t *Trie) insertInLeaf(parentLeaf *node.Leaf, key,
 			return parentLeaf
 		}
 
-		copySettings := node.DefaultCopySettings()
+		copySettings := node.DefaultCopySettings
 		copySettings.CopyValue = false
 		parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings)
 		parentLeaf.Value = value
@@ -388,7 +388,7 @@ func (t *Trie) insertInLeaf(parentLeaf *node.Leaf, key,
 
 		if len(key) < len(parentLeafKey) {
 			// Move the current leaf parent as a child to the new branch.
-			copySettings := node.DefaultCopySettings()
+			copySettings := node.DefaultCopySettings
 			parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings)
 			childIndex := parentLeafKey[commonPrefixLength]
 			parentLeaf.Key = parentLeaf.Key[commonPrefixLength+1:]
@@ -403,7 +403,7 @@ func (t *Trie) insertInLeaf(parentLeaf *node.Leaf, key,
 		newBranchParent.Value = parentLeaf.Value
 	} else {
 		// make the leaf a child of the new branch
-		copySettings := node.DefaultCopySettings()
+		copySettings := node.DefaultCopySettings
 		parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings)
 		childIndex := parentLeafKey[commonPrefixLength]
 		parentLeaf.Key = parentLeaf.Key[commonPrefixLength+1:]
@@ -421,7 +421,7 @@ func (t *Trie) insertInLeaf(parentLeaf *node.Leaf, key,
 }
 
 func (t *Trie) insertInBranch(parentBranch *node.Branch, key, value []byte) (newParent Node) {
-	copySettings := node.DefaultCopySettings()
+	copySettings := node.DefaultCopySettings
 	parentBranch = t.prepBranchForMutation(parentBranch, copySettings)
 
 	if bytes.Equal(key, parentBranch.Key) {
@@ -725,7 +725,7 @@ func (t *Trie) clearPrefixLimitBranch(branch *node.Branch, prefix []byte, limit 
 		return branch, valuesDeleted, allDeleted
 	}
 
-	copySettings := node.DefaultCopySettings()
+	copySettings := node.DefaultCopySettings
 	branch = t.prepBranchForMutation(branch, copySettings)
 	branch.Children[childIndex] = child
 	newParent = handleDeletion(branch, prefix)
@@ -752,7 +752,7 @@ func (t *Trie) clearPrefixLimitChild(branch *node.Branch, prefix []byte, limit u
 		return branch, valuesDeleted, allDeleted
 	}
 
-	copySettings := node.DefaultCopySettings()
+	copySettings := node.DefaultCopySettings
 	branch = t.prepBranchForMutation(branch, copySettings)
 	branch.Children[childIndex] = child
 
@@ -788,7 +788,7 @@ func (t *Trie) deleteNodesLimit(parent Node, prefix []byte, limit uint32) (
 			continue
 		}
 
-		copySettings := node.DefaultCopySettings()
+		copySettings := node.DefaultCopySettings
 		branch = t.prepBranchForMutation(branch, copySettings)
 		branch.Children[i], newDeleted = t.deleteNodesLimit(child, fullKey, limit)
 		if branch.Children[i] == nil {
@@ -855,7 +855,7 @@ func (t *Trie) clearPrefix(parent Node, prefix []byte) (
 			return parent, false
 		}
 
-		copySettings := node.DefaultCopySettings()
+		copySettings := node.DefaultCopySettings
 		branch = t.prepBranchForMutation(branch, copySettings)
 		branch.Children[childIndex] = nil
 		newParent = handleDeletion(branch, prefix)
@@ -877,7 +877,7 @@ func (t *Trie) clearPrefix(parent Node, prefix []byte) (
 		return parent, false
 	}
 
-	copySettings := node.DefaultCopySettings()
+	copySettings := node.DefaultCopySettings
 	branch = t.prepBranchForMutation(branch, copySettings)
 	branch.Children[childIndex] = child
 	newParent = handleDeletion(branch, prefix)
@@ -917,7 +917,7 @@ func deleteLeaf(parent Node, key []byte) (newParent Node) {
 
 func (t *Trie) deleteBranch(branch *node.Branch, key []byte) (newParent Node, deleted bool) {
 	if len(key) == 0 || bytes.Equal(branch.Key, key) {
-		copySettings := node.DefaultCopySettings()
+		copySettings := node.DefaultCopySettings
 		copySettings.CopyValue = false
 		branch = t.prepBranchForMutation(branch, copySettings)
 		// we need to set to nil if the branch has the same generation
@@ -936,7 +936,7 @@ func (t *Trie) deleteBranch(branch *node.Branch, key []byte) (newParent Node, de
 		return branch, false
 	}
 
-	copySettings := node.DefaultCopySettings()
+	copySettings := node.DefaultCopySettings
 	branch = t.prepBranchForMutation(branch, copySettings)
 	branch.Children[childIndex] = newChild
 	newParent = handleDeletion(branch, key)

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -110,6 +110,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				Generation: 1,
 				Key:        []byte{1},
 			},
+			copySettings: node.DefaultCopySettings(),
 			newNode: &node.Leaf{
 				Generation: 2,
 				Key:        []byte{1},
@@ -124,6 +125,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				Key:        []byte{1},
 				HashDigest: []byte{1, 2, 3},
 			},
+			copySettings: node.DefaultCopySettings(),
 			newNode: &node.Leaf{
 				Generation: 2,
 				Key:        []byte{1},
@@ -2043,10 +2045,7 @@ func Test_retrieve(t *testing.T) {
 			t.Parallel()
 
 			// Check no mutation was done
-			copySettings := node.CopySettings{
-				CopyChildren: true,
-				CopyCached:   true,
-			}
+			copySettings := node.DeepCopySettings()
 			var expectedParent Node
 			if testCase.parent != nil {
 				expectedParent = testCase.parent.Copy(copySettings)

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -110,7 +110,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				Generation: 1,
 				Key:        []byte{1},
 			},
-			copySettings: node.DefaultCopySettings(),
+			copySettings: node.DefaultCopySettings,
 			newNode: &node.Leaf{
 				Generation: 2,
 				Key:        []byte{1},
@@ -125,7 +125,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				Key:        []byte{1},
 				HashDigest: []byte{1, 2, 3},
 			},
-			copySettings: node.DefaultCopySettings(),
+			copySettings: node.DefaultCopySettings,
 			newNode: &node.Leaf{
 				Generation: 2,
 				Key:        []byte{1},
@@ -2045,7 +2045,7 @@ func Test_retrieve(t *testing.T) {
 			t.Parallel()
 
 			// Check no mutation was done
-			copySettings := node.DeepCopySettings()
+			copySettings := node.DeepCopySettings
 			var expectedParent Node
 			if testCase.parent != nil {
 				expectedParent = testCase.parent.Copy(copySettings)

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -99,6 +99,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 	testCases := map[string]struct {
 		trieGeneration        uint64
 		node                  Node
+		copySettings          node.CopySettings
 		newNode               Node
 		copied                bool
 		expectedDeletedHashes map[common.Hash]struct{}
@@ -126,7 +127,6 @@ func Test_Trie_updateGeneration(t *testing.T) {
 			newNode: &node.Leaf{
 				Generation: 2,
 				Key:        []byte{1},
-				HashDigest: []byte{1, 2, 3},
 			},
 			copied: true,
 			expectedDeletedHashes: map[common.Hash]struct{}{
@@ -147,7 +147,8 @@ func Test_Trie_updateGeneration(t *testing.T) {
 
 			deletedHashes := make(map[common.Hash]struct{})
 
-			newNode := updateGeneration(testCase.node, testCase.trieGeneration, deletedHashes)
+			newNode := updateGeneration(testCase.node, testCase.trieGeneration,
+				deletedHashes, testCase.copySettings)
 
 			assert.Equal(t, testCase.newNode, newNode)
 			assert.Equal(t, testCase.expectedDeletedHashes, deletedHashes)
@@ -2042,10 +2043,13 @@ func Test_retrieve(t *testing.T) {
 			t.Parallel()
 
 			// Check no mutation was done
-			const copyChildren = true
+			copySettings := node.CopySettings{
+				CopyChildren: true,
+				CopyCached:   true,
+			}
 			var expectedParent Node
 			if testCase.parent != nil {
-				expectedParent = testCase.parent.Copy(copyChildren)
+				expectedParent = testCase.parent.Copy(copySettings)
 			}
 
 			value := retrieve(testCase.parent, testCase.key)


### PR DESCRIPTION
## Changes

- Do not copy cached fields when not needed
- Do not copy key field when not needed
- Do not copy value field when not needed

## Tests

```
go test -race ./internal/trie/... ./lib/trie/...
```

## Issues

- #2351 - already done but this is finer to save a few extra operations

## Primary Reviewer

- Anyone :tada: 