### PR TITLE
chore(tests): refactor tests/utils/request_utils.go

### DIFF
--- a/tests/rpc/rpc_00_test.go
+++ b/tests/rpc/rpc_00_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -38,13 +39,14 @@ type testCase struct {
 	skip        bool
 }
 
-func getResponse(t *testing.T, test *testCase) interface{} {
+func getResponse(ctx context.Context, t *testing.T, test *testCase) interface{} {
 	if test.skip {
 		t.Skip("RPC endpoint not yet implemented")
 		return nil
 	}
 
-	respBody, err := utils.PostRPC(test.method, utils.NewEndpoint(currentPort), test.params)
+	endpoint := utils.NewEndpoint(currentPort)
+	respBody, err := utils.PostRPC(ctx, endpoint, test.method, test.params)
 	require.NoError(t, err)
 
 	target := reflect.New(reflect.TypeOf(test.expected)).Interface()

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -100,8 +100,8 @@ func TestSystemRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			target := getResponse(getResponseCtx, t, test)
-			cancel()
 
 			switch v := target.(type) {
 			case *modules.SystemHealthResponse:

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -97,7 +98,10 @@ func TestSystemRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			target := getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			target := getResponse(getResponseCtx, t, test)
+			cancel()
 
 			switch v := target.(type) {
 			case *modules.SystemHealthResponse:

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -5,6 +5,7 @@ package rpc
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -139,7 +140,10 @@ func TestAuthorRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -142,8 +142,8 @@ func TestAuthorRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
-			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"log"
 	"testing"
 	"time"
@@ -72,7 +73,11 @@ func TestChainRPC(t *testing.T) {
 				test.params = "[\"" + chainBlockHeaderHash + "\"]"
 			}
 
-			target := getResponse(t, test)
+			ctx := context.Background()
+
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			target := getResponse(getResponseCtx, t, test)
+			cancel()
 
 			switch v := target.(type) {
 			case *modules.ChainBlockHeaderResponse:

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -76,8 +76,8 @@ func TestChainRPC(t *testing.T) {
 			ctx := context.Background()
 
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			target := getResponse(getResponseCtx, t, test)
-			cancel()
 
 			switch v := target.(type) {
 			case *modules.ChainBlockHeaderResponse:

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -46,8 +46,8 @@ func TestOffchainRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
-			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -43,7 +44,10 @@ func TestOffchainRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -125,8 +125,8 @@ func TestStateRPCResponseValidation(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
-			_ = getResponse(getResponseCtx, t, test)
 			cancel()
+			_ = getResponse(getResponseCtx, t, test)
 		})
 	}
 

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -125,7 +125,7 @@ func TestStateRPCResponseValidation(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
-			cancel()
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
 		})
 	}

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -33,7 +34,11 @@ func TestStateRPCResponseValidation(t *testing.T) {
 
 	time.Sleep(time.Second) // give server a second to start
 
-	blockHash, err := utils.GetBlockHash(t, nodes[0], "")
+	ctx := context.Background()
+
+	getBlockHashCtx, cancel := context.WithTimeout(ctx, time.Second)
+	blockHash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0], "")
+	cancel()
 	require.NoError(t, err)
 
 	testCases := []*testCase{
@@ -118,7 +123,10 @@ func TestStateRPCResponseValidation(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 
@@ -142,7 +150,11 @@ func TestStateRPCAPI(t *testing.T) {
 
 	time.Sleep(5 * time.Second) // Wait for block production
 
-	blockHash, err := utils.GetBlockHash(t, nodes[0], "")
+	ctx := context.Background()
+
+	getBlockHashCtx, cancel := context.WithTimeout(ctx, time.Second)
+	blockHash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0], "")
+	cancel()
 	require.NoError(t, err)
 
 	const (
@@ -319,7 +331,11 @@ func TestStateRPCAPI(t *testing.T) {
 	// Cases for valid block hash in RPC params
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			respBody, err := utils.PostRPC(test.method, utils.NewEndpoint(nodes[0].RPCPort), test.params)
+			ctx := context.Background()
+			postRPCCtx, cancel := context.WithTimeout(ctx, time.Second)
+			endpoint := utils.NewEndpoint(nodes[0].RPCPort)
+			respBody, err := utils.PostRPC(postRPCCtx, endpoint, test.method, test.params)
+			cancel()
 			require.NoError(t, err)
 
 			require.Contains(t, string(respBody), test.expected)
@@ -351,7 +367,12 @@ func TestRPCStructParamUnmarshal(t *testing.T) {
 		params:      `[["0xf2794c22e353e9a839f12faab03a911bf68967d635641a7087e53f2bff1ecad3c6756fee45ec79ead60347fffb770bcdf0ec74da701ab3d6495986fe1ecc3027"],"0xa32c60dee8647b07435ae7583eb35cee606209a595718562dd4a486a07b6de15", null]`, //nolint:lll
 	}
 	t.Run(test.description, func(t *testing.T) {
-		respBody, err := utils.PostRPC(test.method, utils.NewEndpoint(nodes[0].RPCPort), test.params)
+		ctx := context.Background()
+
+		postRPCCtx, cancel := context.WithTimeout(ctx, time.Second)
+		endpoint := utils.NewEndpoint(nodes[0].RPCPort)
+		respBody, err := utils.PostRPC(postRPCCtx, endpoint, test.method, test.params)
+		cancel()
 		require.NoError(t, err)
 		require.NotContains(t, string(respBody), "json: cannot unmarshal")
 		fmt.Println(string(respBody))

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,7 +39,10 @@ func TestEngineRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -41,8 +41,8 @@ func TestEngineRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
-			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,10 @@ func TestPaymentRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -36,8 +36,8 @@ func TestPaymentRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
-			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -41,8 +41,8 @@ func TestContractsRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
-			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,7 +39,10 @@ func TestContractsRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,7 +34,10 @@ func TestBabeRPC(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			_ = getResponse(t, test)
+			ctx := context.Background()
+			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			_ = getResponse(getResponseCtx, t, test)
+			cancel()
 		})
 	}
 

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -36,8 +36,8 @@ func TestBabeRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 			getResponseCtx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			_ = getResponse(getResponseCtx, t, test)
-			cancel()
 		})
 	}
 

--- a/tests/rpc/system_integration_test.go
+++ b/tests/rpc/system_integration_test.go
@@ -5,6 +5,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 	"testing"
@@ -56,7 +57,7 @@ func TestStableNetworkRPC(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
 
-			endpoint := "http://" + utils.HOSTNAME + ":" + utils.PORT
+			endpoint := fmt.Sprintf("http://%s:%s", utils.HOSTNAME, utils.PORT)
 			const params = "{}"
 			respBody, err := utils.PostRPC(ctx, endpoint, test.method, params)
 			require.NoError(t, err)

--- a/tests/rpc/system_integration_test.go
+++ b/tests/rpc/system_integration_test.go
@@ -4,6 +4,7 @@
 package rpc
 
 import (
+	"context"
 	"reflect"
 	"strconv"
 	"testing"
@@ -53,7 +54,11 @@ func TestStableNetworkRPC(t *testing.T) {
 
 	for _, test := range testsCases {
 		t.Run(test.description, func(t *testing.T) {
-			respBody, err := utils.PostRPC(test.method, "http://"+utils.HOSTNAME+":"+utils.PORT, "{}")
+			ctx := context.Background()
+
+			endpoint := "http://" + utils.HOSTNAME + ":" + utils.PORT
+			const params = "{}"
+			respBody, err := utils.PostRPC(ctx, endpoint, test.method, params)
 			require.NoError(t, err)
 
 			target := reflect.New(reflect.TypeOf(test.expected)).Interface()

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -4,6 +4,7 @@
 package stress
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -25,11 +26,16 @@ func TestStress_Grandpa_OneAuthority(t *testing.T) {
 
 	time.Sleep(time.Second * 10)
 
-	compareChainHeadsWithRetry(t, nodes)
-	prev, _ := compareFinalizedHeads(t, nodes)
+	ctx := context.Background()
+
+	const getChainHeadTimeout = time.Second
+	compareChainHeadsWithRetry(ctx, t, nodes, getChainHeadTimeout)
+
+	const getFinalizedHeadTimeout = time.Second
+	prev, _ := compareFinalizedHeads(ctx, t, nodes, getFinalizedHeadTimeout)
 
 	time.Sleep(time.Second * 10)
-	curr, _ := compareFinalizedHeads(t, nodes)
+	curr, _ := compareFinalizedHeads(ctx, t, nodes, getFinalizedHeadTimeout)
 	require.NotEqual(t, prev, curr)
 }
 
@@ -48,9 +54,13 @@ func TestStress_Grandpa_ThreeAuthorities(t *testing.T) {
 		require.Len(t, errList, 0)
 	}()
 
+	ctx := context.Background()
+
 	numRounds := 5
 	for i := 1; i < numRounds+1; i++ {
-		fin, err := compareFinalizedHeadsWithRetry(t, nodes, uint64(i))
+		const getFinalizedHeadByRoundTimeout = time.Second
+		fin, err := compareFinalizedHeadsWithRetry(ctx, t,
+			nodes, uint64(i), getFinalizedHeadByRoundTimeout)
 		require.NoError(t, err)
 		t.Logf("finalised hash in round %d: %s", i, fin)
 	}
@@ -70,9 +80,13 @@ func TestStress_Grandpa_SixAuthorities(t *testing.T) {
 		require.Len(t, errList, 0)
 	}()
 
+	ctx := context.Background()
+
 	numRounds := 10
 	for i := 1; i < numRounds+1; i++ {
-		fin, err := compareFinalizedHeadsWithRetry(t, nodes, uint64(i))
+		const getFinalizedHeadByRoundTimeout = time.Second
+		fin, err := compareFinalizedHeadsWithRetry(ctx, t, nodes,
+			uint64(i), getFinalizedHeadByRoundTimeout)
 		require.NoError(t, err)
 		t.Logf("finalised hash in round %d: %s", i, fin)
 	}
@@ -95,9 +109,13 @@ func TestStress_Grandpa_NineAuthorities(t *testing.T) {
 		require.Len(t, errList, 0)
 	}()
 
+	ctx := context.Background()
+
 	numRounds := 3
 	for i := 1; i < numRounds+1; i++ {
-		fin, err := compareFinalizedHeadsWithRetry(t, nodes, uint64(i))
+		const getFinalizedHeadByRoundTimeout = time.Second
+		fin, err := compareFinalizedHeadsWithRetry(ctx, t, nodes,
+			uint64(i), getFinalizedHeadByRoundTimeout)
 		require.NoError(t, err)
 		t.Logf("finalised hash in round %d: %s", i, fin)
 	}
@@ -129,9 +147,12 @@ func TestStress_Grandpa_CatchUp(t *testing.T) {
 	require.NoError(t, err)
 	nodes = append(nodes, node)
 
+	ctx := context.Background()
+
 	numRounds := 10
 	for i := 1; i < numRounds+1; i++ {
-		fin, err := compareFinalizedHeadsWithRetry(t, nodes, uint64(i))
+		const getFinalizedHeadByRoundTimeout = time.Second
+		fin, err := compareFinalizedHeadsWithRetry(ctx, t, nodes, uint64(i), getFinalizedHeadByRoundTimeout)
 		require.NoError(t, err)
 		t.Logf("finalised hash in round %d: %s", i, fin)
 	}

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -26,15 +26,18 @@ var (
 
 // compareChainHeads calls getChainHead for each node in the array
 // it returns a map of chainHead hashes to node key names, and an error if the hashes don't all match
-func compareChainHeads(t *testing.T, nodes []*utils.Node) (map[common.Hash][]string, error) {
-	hashes := make(map[common.Hash][]string)
+func compareChainHeads(ctx context.Context, t *testing.T, nodes []*utils.Node,
+	getChainHeadTimeout time.Duration) (hashes map[common.Hash][]string, err error) {
+	hashes = make(map[common.Hash][]string)
 	for _, node := range nodes {
-		header := utils.GetChainHead(t, node)
+		getChainHeadCtx, cancel := context.WithTimeout(ctx, getChainHeadTimeout)
+		header := utils.GetChainHead(getChainHeadCtx, t, node)
+		cancel()
+
 		logger.Infof("got header with hash %s from node with key %s", header.Hash(), node.Key)
 		hashes[header.Hash()] = append(hashes[header.Hash()], node.Key)
 	}
 
-	var err error
 	if len(hashes) != 1 {
 		err = errChainHeadMismatch
 	}
@@ -43,17 +46,26 @@ func compareChainHeads(t *testing.T, nodes []*utils.Node) (map[common.Hash][]str
 }
 
 // compareChainHeadsWithRetry calls compareChainHeads, retrying up to maxRetries times if it errors.
-func compareChainHeadsWithRetry(t *testing.T, nodes []*utils.Node) error {
+func compareChainHeadsWithRetry(ctx context.Context, t *testing.T, nodes []*utils.Node,
+	getChainHeadTimeout time.Duration) error {
 	var hashes map[common.Hash][]string
 	var err error
 
 	for i := 0; i < maxRetries; i++ {
-		hashes, err = compareChainHeads(t, nodes)
+		hashes, err = compareChainHeads(ctx, t, nodes, getChainHeadTimeout)
 		if err == nil {
 			break
 		}
 
-		time.Sleep(time.Second)
+		timer := time.NewTimer(time.Second)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return err // last error
+		}
 	}
 
 	if err != nil {
@@ -81,7 +93,7 @@ func compareBlocksByNumber(ctx context.Context, t *testing.T, nodes []*utils.Nod
 			}
 
 			for { // retry until context gets canceled
-				result.hash, result.err = utils.GetBlockHash(t, node, num)
+				result.hash, result.err = utils.GetBlockHash(ctx, t, node, num)
 
 				if err := ctx.Err(); err != nil {
 					result.err = err
@@ -123,15 +135,18 @@ func compareBlocksByNumber(ctx context.Context, t *testing.T, nodes []*utils.Nod
 
 // compareFinalizedHeads calls getFinalizedHeadByRound for each node in the array
 // it returns a map of finalisedHead hashes to node key names, and an error if the hashes don't all match
-func compareFinalizedHeads(t *testing.T, nodes []*utils.Node) (map[common.Hash][]string, error) {
-	hashes := make(map[common.Hash][]string)
+func compareFinalizedHeads(ctx context.Context, t *testing.T, nodes []*utils.Node,
+	getFinalizedHeadTimeout time.Duration) (hashes map[common.Hash][]string, err error) {
+	hashes = make(map[common.Hash][]string)
 	for _, node := range nodes {
-		hash := utils.GetFinalizedHead(t, node)
+		getFinalizedHeadCtx, cancel := context.WithTimeout(ctx, getFinalizedHeadTimeout)
+		hash := utils.GetFinalizedHead(getFinalizedHeadCtx, t, node)
+		cancel()
+
 		logger.Infof("got finalised head with hash %s from node with key %s", hash, node.Key)
 		hashes[hash] = append(hashes[hash], node.Key)
 	}
 
-	var err error
 	if len(hashes) == 0 {
 		err = errNoFinalizedBlock
 	}
@@ -145,10 +160,15 @@ func compareFinalizedHeads(t *testing.T, nodes []*utils.Node) (map[common.Hash][
 
 // compareFinalizedHeadsByRound calls getFinalizedHeadByRound for each node in the array
 // it returns a map of finalisedHead hashes to node key names, and an error if the hashes don't all match
-func compareFinalizedHeadsByRound(t *testing.T, nodes []*utils.Node, round uint64) (map[common.Hash][]string, error) {
-	hashes := make(map[common.Hash][]string)
+func compareFinalizedHeadsByRound(ctx context.Context, t *testing.T, nodes []*utils.Node,
+	round uint64, getFinalizedHeadByRoundTimeout time.Duration) (
+	hashes map[common.Hash][]string, err error) {
+	hashes = make(map[common.Hash][]string)
 	for _, node := range nodes {
-		hash, err := utils.GetFinalizedHeadByRound(t, node, round)
+		getFinalizedHeadByRoundCtx, cancel := context.WithTimeout(ctx, getFinalizedHeadByRoundTimeout)
+		hash, err := utils.GetFinalizedHeadByRound(getFinalizedHeadByRoundCtx, t, node, round)
+		cancel()
+
 		if err != nil {
 			return nil, err
 		}
@@ -157,7 +177,6 @@ func compareFinalizedHeadsByRound(t *testing.T, nodes []*utils.Node, round uint6
 		hashes[hash] = append(hashes[hash], node.Key)
 	}
 
-	var err error
 	if len(hashes) == 0 {
 		err = errNoFinalizedBlock
 	}
@@ -171,12 +190,14 @@ func compareFinalizedHeadsByRound(t *testing.T, nodes []*utils.Node, round uint6
 
 // compareFinalizedHeadsWithRetry calls compareFinalizedHeadsByRound, retrying up to maxRetries times if it errors.
 // it returns the finalised hash if it succeeds
-func compareFinalizedHeadsWithRetry(t *testing.T, nodes []*utils.Node, round uint64) (common.Hash, error) {
+func compareFinalizedHeadsWithRetry(ctx context.Context, t *testing.T,
+	nodes []*utils.Node, round uint64,
+	getFinalizedHeadByRoundTimeout time.Duration) ( //nolint:unparam
+	hash common.Hash, err error) {
 	var hashes map[common.Hash][]string
-	var err error
 
 	for i := 0; i < maxRetries; i++ {
-		hashes, err = compareFinalizedHeadsByRound(t, nodes, round)
+		hashes, err = compareFinalizedHeadsByRound(ctx, t, nodes, round, getFinalizedHeadByRoundTimeout)
 		if err == nil {
 			break
 		}
@@ -199,8 +220,11 @@ func compareFinalizedHeadsWithRetry(t *testing.T, nodes []*utils.Node, round uin
 	return common.Hash{}, nil
 }
 
-func getPendingExtrinsics(t *testing.T, node *utils.Node) []string {
-	respBody, err := utils.PostRPC(utils.AuthorPendingExtrinsics, utils.NewEndpoint(node.RPCPort), "[]")
+func getPendingExtrinsics(ctx context.Context, t *testing.T, node *utils.Node) []string {
+	endpoint := utils.NewEndpoint(node.RPCPort)
+	method := utils.AuthorPendingExtrinsics
+	const params = "[]"
+	respBody, err := utils.PostRPC(ctx, endpoint, method, params)
 	require.NoError(t, err)
 
 	exts := new(modules.PendingExtrinsicsResponse)

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -192,7 +192,7 @@ func compareFinalizedHeadsByRound(ctx context.Context, t *testing.T, nodes []*ut
 // it returns the finalised hash if it succeeds
 func compareFinalizedHeadsWithRetry(ctx context.Context, t *testing.T,
 	nodes []*utils.Node, round uint64,
-	getFinalizedHeadByRoundTimeout time.Duration) ( //nolint:unparam
+	getFinalizedHeadByRoundTimeout time.Duration) (
 	hash common.Hash, err error) {
 	var hashes map[common.Hash][]string
 

--- a/tests/stress/network_test.go
+++ b/tests/stress/network_test.go
@@ -4,6 +4,7 @@
 package stress
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,8 +28,14 @@ func TestNetwork_MaxPeers(t *testing.T) {
 	// wait for nodes to connect
 	time.Sleep(time.Second * 10)
 
+	ctx := context.Background()
+
 	for i, node := range nodes {
-		peers := utils.GetPeers(t, node)
+		const getPeersTimeout = time.Second
+		getPeersCtx, cancel := context.WithTimeout(ctx, getPeersTimeout)
+		peers := utils.GetPeers(getPeersCtx, t, node)
+		cancel()
+
 		t.Logf("node %d: peer count=%d", i, len(peers))
 		require.LessOrEqual(t, len(peers), 5)
 	}

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -142,7 +142,10 @@ func TestSync_Basic(t *testing.T) {
 		require.Len(t, errList, 0)
 	}()
 
-	err = compareChainHeadsWithRetry(t, nodes)
+	ctx := context.Background()
+	const getChainHeadTimeout = time.Second
+
+	err = compareChainHeadsWithRetry(ctx, t, nodes, getChainHeadTimeout)
 	require.NoError(t, err)
 }
 
@@ -162,16 +165,24 @@ func TestSync_MultipleEpoch(t *testing.T) {
 
 	time.Sleep(time.Second * 10)
 
-	slotDuration := utils.SlotDuration(t, nodes[0])
-	epochLength := utils.EpochLength(t, nodes[0])
+	ctx := context.Background()
+
+	slotDurationCtx, cancel := context.WithTimeout(ctx, time.Second)
+	slotDuration := utils.SlotDuration(slotDurationCtx, t, nodes[0])
+	cancel()
+
+	epochLengthCtx, cancel := context.WithTimeout(ctx, time.Second)
+	epochLength := utils.EpochLength(epochLengthCtx, t, nodes[0])
+	cancel()
 
 	// Wait for epoch to pass
 	time.Sleep(time.Duration(uint64(slotDuration.Nanoseconds()) * epochLength))
 
-	ctx := context.Background()
-
 	// Just checking that everythings operating as expected
-	header := utils.GetChainHead(t, nodes[0])
+	getChainHeadCtx, cancel := context.WithTimeout(ctx, time.Second)
+	header := utils.GetChainHead(getChainHeadCtx, t, nodes[0])
+	cancel()
+
 	currentHeight := header.Number
 	for i := uint(0); i < currentHeight; i++ {
 		t.Log("comparing...", i)
@@ -235,8 +246,12 @@ func TestSync_Bench(t *testing.T) {
 		false, true)
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	for {
-		header, err := utils.GetChainHeadWithError(t, alice)
+		getChainHeadCtx, cancel := context.WithTimeout(ctx, time.Second)
+		header, err := utils.GetChainHeadWithError(getChainHeadCtx, t, alice)
+		cancel()
 		if err != nil {
 			continue
 		}
@@ -248,7 +263,10 @@ func TestSync_Bench(t *testing.T) {
 		time.Sleep(3 * time.Second)
 	}
 
-	err = utils.PauseBABE(t, alice)
+	pauseBabeCtx, cancel := context.WithTimeout(ctx, time.Second)
+	err = utils.PauseBABE(pauseBabeCtx, alice)
+	cancel()
+
 	require.NoError(t, err)
 	t.Log("BABE paused")
 
@@ -274,7 +292,10 @@ func TestSync_Bench(t *testing.T) {
 			t.Fatal("did not sync")
 		}
 
-		head, err := utils.GetChainHeadWithError(t, bob)
+		getChainHeadCtx, getChainHeadCancel := context.WithTimeout(ctx, time.Second)
+		head, err := utils.GetChainHeadWithError(getChainHeadCtx, t, bob)
+		getChainHeadCancel()
+
 		if err != nil {
 			continue
 		}
@@ -296,8 +317,6 @@ func TestSync_Bench(t *testing.T) {
 
 	// assert block is correct
 	t.Log("comparing block...", numBlocks)
-
-	ctx := context.Background()
 
 	const compareTimeout = 5 * time.Second
 	compareCtx, cancel := context.WithTimeout(ctx, compareTimeout)
@@ -449,7 +468,12 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 	extEnc, err := types.EncodeToHexString(ext)
 	require.NoError(t, err)
 
-	prevHeader := utils.GetChainHead(t, nodes[idx]) // get starting header so that we can lookup blocks by number later
+	ctx := context.Background()
+
+	// get starting header so that we can lookup blocks by number later
+	getChainHeadCtx, getChainHeadCancel := context.WithTimeout(ctx, time.Second)
+	prevHeader := utils.GetChainHead(getChainHeadCtx, t, nodes[idx])
+	getChainHeadCancel()
 
 	// Send the extrinsic
 	hash, err := api.RPC.Author.SubmitExtrinsic(ext)
@@ -460,7 +484,10 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 
 	// wait until there's no more pending extrinsics
 	for i := 0; i < maxRetries; i++ {
-		exts := getPendingExtrinsics(t, nodes[idx])
+		getPendingExtsCtx, getPendingExtsCancel := context.WithTimeout(ctx, time.Second)
+		exts := getPendingExtrinsics(getPendingExtsCtx, t, nodes[idx])
+		getPendingExtsCancel()
+
 		if len(exts) == 0 {
 			break
 		}
@@ -468,7 +495,9 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 		time.Sleep(time.Second)
 	}
 
-	header := utils.GetChainHead(t, nodes[idx])
+	getChainHeadCtx, cancel := context.WithTimeout(ctx, time.Second)
+	header := utils.GetChainHead(getChainHeadCtx, t, nodes[idx])
+	cancel()
 
 	// search from child -> parent blocks for extrinsic
 	var (
@@ -477,7 +506,10 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 	)
 
 	for i := 0; i < maxRetries; i++ {
-		block := utils.GetBlock(t, nodes[idx], header.ParentHash)
+		getBlockCtx, getBlockCancel := context.WithTimeout(ctx, time.Second)
+		block := utils.GetBlock(getBlockCtx, t, nodes[idx], header.ParentHash)
+		getBlockCancel()
+
 		if block == nil {
 			// couldn't get block, increment retry counter
 			continue
@@ -510,8 +542,6 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 	}
 
 	require.True(t, included)
-
-	ctx := context.Background()
 
 	const compareTimeout = 5 * time.Second
 	compareCtx, cancel := context.WithTimeout(ctx, compareTimeout)
@@ -708,12 +738,21 @@ func TestStress_SecondarySlotProduction(t *testing.T) {
 			secondaryPlainCount := 0
 			secondaryVRFCount := 0
 
+			ctx := context.Background()
+
 			for i := 1; i < 10; i++ {
 				fmt.Printf("%d iteration\n", i)
-				hash, err := utils.GetBlockHash(t, nodes[0], fmt.Sprintf("%d", i))
+
+				getBlockHashCtx, cancel := context.WithTimeout(ctx, time.Second)
+				hash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0], fmt.Sprintf("%d", i))
+				cancel()
+
 				require.NoError(t, err)
 
-				block := utils.GetBlock(t, nodes[0], hash)
+				getBlockCtx, cancel := context.WithTimeout(ctx, time.Second)
+				block := utils.GetBlock(getBlockCtx, t, nodes[0], hash)
+				cancel()
+
 				header := block.Header
 
 				preDigestItem := header.Digest.Types[0]

--- a/tests/sync/sync_test.go
+++ b/tests/sync/sync_test.go
@@ -4,6 +4,7 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -62,11 +63,20 @@ func TestMain(m *testing.M) {
 
 // this starts nodes and runs RPC calls (which loads db)
 func TestCalls(t *testing.T) {
+	ctx := context.Background()
+
 	err := framework.StartNodes(t)
 	require.Len(t, err, 0)
 	for _, call := range tests {
 		time.Sleep(call.delay)
-		_, err := framework.CallRPC(call.nodeIdx, call.method, call.params)
+
+		const callRPCTimeout = time.Second
+		callRPCCtx, cancel := context.WithTimeout(ctx, callRPCTimeout)
+
+		_, err := framework.CallRPC(callRPCCtx, call.nodeIdx, call.method, call.params)
+
+		cancel()
+
 		require.NoError(t, err)
 	}
 

--- a/tests/utils/common.go
+++ b/tests/utils/common.go
@@ -5,10 +5,7 @@ package utils
 
 import (
 	"encoding/json"
-	"net"
-	"net/http"
 	"os"
-	"time"
 )
 
 var (
@@ -25,21 +22,6 @@ var (
 
 	// NETWORK_SIZE is the value for the environnent variable NETWORK_SIZE.
 	NETWORK_SIZE = os.Getenv("NETWORK_SIZE") //nolint:revive
-
-	// ContentTypeJSON is the JSON header application/json.
-	ContentTypeJSON   = "application/json"
-	dialTimeout       = 60 * time.Second
-	httpClientTimeout = 120 * time.Second
-
-	transport = &http.Transport{
-		Dial: (&net.Dialer{
-			Timeout: dialTimeout,
-		}).Dial,
-	}
-	httpClient = &http.Client{
-		Transport: transport,
-		Timeout:   httpClientTimeout,
-	}
 )
 
 // ServerResponse wraps the RPC response

--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"context"
 	"encoding/binary"
 	"strconv"
 	"testing"
@@ -14,14 +15,19 @@ import (
 )
 
 // PauseBABE calls the endpoint dev_control with the params ["babe", "stop"]
-func PauseBABE(t *testing.T, node *Node) error {
-	_, err := PostRPC(DevControl, NewEndpoint(node.RPCPort), "[\"babe\", \"stop\"]")
+func PauseBABE(ctx context.Context, node *Node) error {
+	endpoint := NewEndpoint(node.RPCPort)
+	const params = `["babe", "stop"]`
+	_, err := PostRPC(ctx, endpoint, DevControl, params)
 	return err
 }
 
 // SlotDuration Calls dev endpoint for slot duration
-func SlotDuration(t *testing.T, node *Node) time.Duration {
-	slotDuration, err := PostRPC("dev_slotDuration", NewEndpoint(node.RPCPort), "[]")
+func SlotDuration(ctx context.Context, t *testing.T, node *Node) time.Duration {
+	endpoint := NewEndpoint(node.RPCPort)
+	const method = "dev_slotDuration"
+	const params = "[]"
+	slotDuration, err := PostRPC(ctx, endpoint, method, params)
 
 	if err != nil {
 		require.NoError(t, err)
@@ -38,9 +44,11 @@ func SlotDuration(t *testing.T, node *Node) time.Duration {
 }
 
 // EpochLength Calls dev endpoint for epoch length
-func EpochLength(t *testing.T, node *Node) uint64 {
-	epochLength, err := PostRPC("dev_epochLength", NewEndpoint(node.RPCPort), "[]")
-
+func EpochLength(ctx context.Context, t *testing.T, node *Node) uint64 {
+	endpoint := NewEndpoint(node.RPCPort)
+	const method = "dev_epochLength"
+	const params = "[]"
+	epochLength, err := PostRPC(ctx, endpoint, method, params)
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/tests/utils/framework.go
+++ b/tests/utils/framework.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -58,12 +59,13 @@ func (fw *Framework) KillNodes(t *testing.T) []error {
 }
 
 // CallRPC call RPC method with given params for node at idx
-func (fw *Framework) CallRPC(idx int, method, params string) (respJSON interface{}, err error) {
+func (fw *Framework) CallRPC(ctx context.Context, idx int, method, params string) (
+	respJSON interface{}, err error) {
 	if idx >= len(fw.nodes) {
 		return nil, fmt.Errorf("node index greater than quantity of nodes")
 	}
 	node := fw.nodes[idx]
-	respBody, err := PostRPC(method, NewEndpoint(node.RPCPort), params)
+	respBody, err := PostRPC(ctx, NewEndpoint(node.RPCPort), method, params)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -206,7 +206,8 @@ func startGossamer(t *testing.T, node *Node, websocket bool) error {
 		const checkNodeStartedTimeout = time.Second
 		checkNodeCtx, cancel := context.WithTimeout(ctx, checkNodeStartedTimeout)
 
-		err = checkNodeStarted(checkNodeCtx, t, "http://"+HOSTNAME+":"+node.RPCPort)
+		addr := fmt.Sprintf("http://%s:%s", HOSTNAME, node.RPCPort)
+		err = checkNodeStarted(checkNodeCtx, t, addr)
 
 		cancel()
 

--- a/tests/utils/system.go
+++ b/tests/utils/system.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/rpc/modules"
@@ -12,8 +13,11 @@ import (
 )
 
 // GetPeers calls the endpoint system_peers
-func GetPeers(t *testing.T, node *Node) []common.PeerInfo {
-	respBody, err := PostRPC("system_peers", NewEndpoint(node.RPCPort), "[]")
+func GetPeers(ctx context.Context, t *testing.T, node *Node) []common.PeerInfo {
+	endpoint := NewEndpoint(node.RPCPort)
+	const method = "system_peers"
+	const params = "[]"
+	respBody, err := PostRPC(ctx, endpoint, method, params)
 	require.NoError(t, err)
 
 	resp := new(modules.SystemPeersResponse)


### PR DESCRIPTION
## Changes

- Inject context to `PostRPC` and `PostRPCWithRetry`
- Swap method and url arguments for `PostRPC` and `PostRPCWithRetry`
- Remove some global variables
- Wrap all possible errors
- `PostRPCWithRetry` retries until context is canceled
- Keep 1s timeout for RPC calls

## Tests

Existing tests suites passing

## Issues

- #2386 

## Primary Reviewer

