### PR TITLE
Dependabot should only use `dependencies` label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "dependabot"
+      - "dependencies"
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: "weekly"
     labels:
-      - "dependabot"
+      - "dependencies"
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: "weekly"
     labels:
-      - "dependabot"
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"


### PR DESCRIPTION
It looks like some of our "weird" labels were coming from Dependabot as some people had suggested. At the moment, this PR configures Dependabot to only use the `dependabot` label, but I'm happy to hear suggestions for other approaches.

Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels

Primary reviewers: @qdm12 & @timwu20 🙏🏻 