### PR TITLE
chore(golang-ci): upgrade `golangci-lint` to `v1.45`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters-settings:
 
 linters:
   enable:
-    - bodyclose
+    # - bodyclose
     - depguard
     - errcheck
     - exportloopref
@@ -96,13 +96,13 @@ linters:
     - megacheck
     - megacheck
     - misspell
-    - nilerr
+    # - nilerr
     - nilnil
     - nolintlint
     - revive
-    - staticcheck
+    # - staticcheck
     - unconvert
-    - unparam
+    # - unparam
     - varcheck
 
   fast: false
@@ -165,6 +165,10 @@ issues:
     - linters:
         - nolintlint
       source: "^//nolint:revive"
+    
+    - linters:
+        - nolintlint
+      source: "^?//nolint(:staticcheck)?"
 
     # Exclude lll issues for long lines with go:generate
     - linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -165,10 +165,6 @@ issues:
     - linters:
         - nolintlint
       source: "^//nolint:revive"
-    
-    - linters:
-        - nolintlint
-      source: "//nolint:(staticcheck|nilerr|unparam|bodyclose)"
 
     # Exclude lll issues for long lines with go:generate
     - linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,7 +79,7 @@ linters-settings:
 
 linters:
   enable:
-    # - bodyclose
+    - bodyclose
     - depguard
     - errcheck
     - exportloopref
@@ -96,13 +96,13 @@ linters:
     - megacheck
     - megacheck
     - misspell
-    # - nilerr
+    - nilerr
     - nilnil
     - nolintlint
     - revive
-    # - staticcheck
+    - staticcheck
     - unconvert
-    # - unparam
+    - unparam
     - varcheck
 
   fast: false
@@ -168,7 +168,7 @@ issues:
     
     - linters:
         - nolintlint
-      source: "^?//nolint(:staticcheck)?"
+      source: "//nolint:(staticcheck|nilerr|unparam|bodyclose)"
 
     # Exclude lll issues for long lines with go:generate
     - linters:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ help: Makefile
 
 .PHONY: lint
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45
 	golangci-lint run --build-tags integration --timeout 10m
 
 clean:

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -65,7 +65,7 @@ func (gm *GrandpaModule) ProveFinality(r *http.Request, req *ProveFinalityReques
 	}
 
 	// Leaving check in for linter
-	if req.authorityID != uint64(0) { // nolint:staticcheck
+	if req.authorityID != uint64(0) { //// nolint:staticcheck
 		// TODO: Check if functionality relevant (#1404)
 	}
 

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -65,7 +65,7 @@ func (gm *GrandpaModule) ProveFinality(r *http.Request, req *ProveFinalityReques
 	}
 
 	// Leaving check in for linter
-	if req.authorityID != uint64(0) { //nolint:staticcheck
+	if req.authorityID != uint64(0) {
 		// TODO: Check if functionality relevant (#1404)
 	}
 

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -65,7 +65,7 @@ func (gm *GrandpaModule) ProveFinality(r *http.Request, req *ProveFinalityReques
 	}
 
 	// Leaving check in for linter
-	if req.authorityID != uint64(0) { //// nolint:staticcheck
+	if req.authorityID != uint64(0) { //nolint:staticcheck
 		// TODO: Check if functionality relevant (#1404)
 	}
 

--- a/internal/pprof/server_test.go
+++ b/internal/pprof/server_test.go
@@ -76,7 +76,7 @@ func Test_Server(t *testing.T) {
 		require.NoError(t, err)
 
 		go func(client *http.Client, request *http.Request, results chan<- httpResult) {
-			response, err := client.Do(request) //nolint:bodyclose
+			response, err := client.Do(request)
 			results <- httpResult{
 				url:      request.URL.String(),
 				response: response,

--- a/internal/pprof/server_test.go
+++ b/internal/pprof/server_test.go
@@ -76,7 +76,7 @@ func Test_Server(t *testing.T) {
 		require.NoError(t, err)
 
 		go func(client *http.Client, request *http.Request, results chan<- httpResult) {
-			response, err := client.Do(request) ////nolint:bodyclose
+			response, err := client.Do(request) //nolint:bodyclose
 			results <- httpResult{
 				url:      request.URL.String(),
 				response: response,

--- a/internal/pprof/server_test.go
+++ b/internal/pprof/server_test.go
@@ -76,7 +76,7 @@ func Test_Server(t *testing.T) {
 		require.NoError(t, err)
 
 		go func(client *http.Client, request *http.Request, results chan<- httpResult) {
-			response, err := client.Do(request) //nolint:bodyclose
+			response, err := client.Do(request) ////nolint:bodyclose
 			results <- httpResult{
 				url:      request.URL.String(),
 				response: response,

--- a/lib/runtime/life/resolver.go
+++ b/lib/runtime/life/resolver.go
@@ -429,7 +429,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 		if err != nil {
 			logger.Tracef("item in storage is not SCALE encoded, overwriting at key 0x%x", key)
 			storage.Set(key, append([]byte{4}, valueToAppend...))
-			return nil ////nolint:nilerr
+			return nil //nolint:nilerr
 		}
 
 		lengthBytes, err := scale.Marshal(currLength)

--- a/lib/runtime/life/resolver.go
+++ b/lib/runtime/life/resolver.go
@@ -429,7 +429,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 		if err != nil {
 			logger.Tracef("item in storage is not SCALE encoded, overwriting at key 0x%x", key)
 			storage.Set(key, append([]byte{4}, valueToAppend...))
-			return nil //nolint:nilerr
+			return nil ////nolint:nilerr
 		}
 
 		lengthBytes, err := scale.Marshal(currLength)

--- a/lib/runtime/life/resolver.go
+++ b/lib/runtime/life/resolver.go
@@ -429,7 +429,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 		if err != nil {
 			logger.Tracef("item in storage is not SCALE encoded, overwriting at key 0x%x", key)
 			storage.Set(key, append([]byte{4}, valueToAppend...))
-			return nil //nolint:nilerr
+			return nil
 		}
 
 		lengthBytes, err := scale.Marshal(currLength)

--- a/lib/runtime/life/test_helpers.go
+++ b/lib/runtime/life/test_helpers.go
@@ -19,7 +19,7 @@ import (
 var DefaultTestLogLvl = log.Info
 
 // newTestInstance will create a new runtime instance using the given target runtime
-func newTestInstance(t *testing.T, targetRuntime string) *Instance { ////nolint:unparam
+func newTestInstance(t *testing.T, targetRuntime string) *Instance { //nolint:unparam
 	return newTestInstanceWithTrie(t, runtime.HOST_API_TEST_RUNTIME, nil, DefaultTestLogLvl)
 }
 

--- a/lib/runtime/life/test_helpers.go
+++ b/lib/runtime/life/test_helpers.go
@@ -19,7 +19,7 @@ import (
 var DefaultTestLogLvl = log.Info
 
 // newTestInstance will create a new runtime instance using the given target runtime
-func newTestInstance(t *testing.T, targetRuntime string) *Instance { //nolint:unparam
+func newTestInstance(t *testing.T, targetRuntime string) *Instance {
 	return newTestInstanceWithTrie(t, runtime.HOST_API_TEST_RUNTIME, nil, DefaultTestLogLvl)
 }
 

--- a/lib/runtime/life/test_helpers.go
+++ b/lib/runtime/life/test_helpers.go
@@ -19,7 +19,7 @@ import (
 var DefaultTestLogLvl = log.Info
 
 // newTestInstance will create a new runtime instance using the given target runtime
-func newTestInstance(t *testing.T, targetRuntime string) *Instance { //nolint:unparam
+func newTestInstance(t *testing.T, targetRuntime string) *Instance { ////nolint:unparam
 	return newTestInstanceWithTrie(t, runtime.HOST_API_TEST_RUNTIME, nil, DefaultTestLogLvl)
 }
 

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1798,7 +1798,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 			logger.Tracef(
 				"item in storage is not SCALE encoded, overwriting at key 0x%x", key)
 			storage.Set(key, append([]byte{4}, valueToAppend...))
-			return nil ////nolint:nilerr
+			return nil //nolint:nilerr
 		}
 
 		lengthBytes, err := scale.Marshal(currLength)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1798,7 +1798,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 			logger.Tracef(
 				"item in storage is not SCALE encoded, overwriting at key 0x%x", key)
 			storage.Set(key, append([]byte{4}, valueToAppend...))
-			return nil //nolint:nilerr
+			return nil ////nolint:nilerr
 		}
 
 		lengthBytes, err := scale.Marshal(currLength)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1798,7 +1798,7 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 			logger.Tracef(
 				"item in storage is not SCALE encoded, overwriting at key 0x%x", key)
 			storage.Set(key, append([]byte{4}, valueToAppend...))
-			return nil //nolint:nilerr
+			return nil
 		}
 
 		lengthBytes, err := scale.Marshal(currLength)

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -199,7 +199,7 @@ func compareFinalizedHeadsWithRetry(t *testing.T, nodes []*utils.Node, round uin
 	return common.Hash{}, nil
 }
 
-//nolint
+////nolint
 func getPendingExtrinsics(t *testing.T, node *utils.Node) []string {
 	respBody, err := utils.PostRPC(utils.AuthorPendingExtrinsics, utils.NewEndpoint(node.RPCPort), "[]")
 	require.NoError(t, err)

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -199,7 +199,7 @@ func compareFinalizedHeadsWithRetry(t *testing.T, nodes []*utils.Node, round uin
 	return common.Hash{}, nil
 }
 
-////nolint
+//nolint
 func getPendingExtrinsics(t *testing.T, node *utils.Node) []string {
 	respBody, err := utils.PostRPC(utils.AuthorPendingExtrinsics, utils.NewEndpoint(node.RPCPort), "[]")
 	require.NoError(t, err)

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -199,7 +199,6 @@ func compareFinalizedHeadsWithRetry(t *testing.T, nodes []*utils.Node, round uin
 	return common.Hash{}, nil
 }
 
-//nolint
 func getPendingExtrinsics(t *testing.T, node *utils.Node) []string {
 	respBody, err := utils.PostRPC(utils.AuthorPendingExtrinsics, utils.NewEndpoint(node.RPCPort), "[]")
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

- In order to check golang 1.18 generic code we should upgrade golangci-lint to version `v1.45`
- Fixes PR https://github.com/ChainSafe/gossamer/pull/2339 CI

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
N/A
```

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->

- N/A

## Primary Reviewer

<!--
Please indicate one of the code owners that are required to review prior to merging changes (e.g. @noot)
-->

- @qdm12 
