### PR TITLE
chore(cmd/gossamer): `exportConfig` returns an error instead of calling `os.Exit(1)`

### DIFF
--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -80,9 +80,7 @@ func TestConfigFromChainFlag(t *testing.T) {
 
 // TestInitConfigFromFlags tests createDotInitConfig using relevant init flags
 func TestInitConfigFromFlags(t *testing.T) {
-	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
+	_, testCfgFile := newTestConfigWithFile(t)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -96,7 +94,7 @@ func TestInitConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --genesis",
 			[]string{"config", "genesis", "pruning", "retain-blocks"},
-			[]interface{}{testCfgFile.Name(), "test_genesis", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
+			[]interface{}{testCfgFile, "test_genesis", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
 			dot.InitConfig{
 				Genesis: "test_genesis",
 			},
@@ -118,8 +116,6 @@ func TestInitConfigFromFlags(t *testing.T) {
 // TestGlobalConfigFromFlags tests createDotGlobalConfig using relevant global flags
 func TestGlobalConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -133,7 +129,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --config",
 			[]string{"config", "name"},
-			[]interface{}{testCfgFile.Name(), testCfg.Global.Name},
+			[]interface{}{testCfgFile, testCfg.Global.Name},
 			dot.GlobalConfig{
 				Name:           testCfg.Global.Name,
 				ID:             testCfg.Global.ID,
@@ -146,7 +142,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test kusama --chain",
 			[]string{"config", "chain", "name"},
-			[]interface{}{testCfgFile.Name(), "kusama", dot.KusamaConfig().Global.Name},
+			[]interface{}{testCfgFile, "kusama", dot.KusamaConfig().Global.Name},
 			dot.GlobalConfig{
 				Name:           dot.KusamaConfig().Global.Name,
 				ID:             "ksmcc3",
@@ -159,7 +155,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --name",
 			[]string{"config", "name"},
-			[]interface{}{testCfgFile.Name(), "test_name"},
+			[]interface{}{testCfgFile, "test_name"},
 			dot.GlobalConfig{
 				Name:           "test_name",
 				ID:             testCfg.Global.ID,
@@ -172,7 +168,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --basepath",
 			[]string{"config", "basepath", "name"},
-			[]interface{}{testCfgFile.Name(), "test_basepath", testCfg.Global.Name},
+			[]interface{}{testCfgFile, "test_basepath", testCfg.Global.Name},
 			dot.GlobalConfig{
 				Name:           testCfg.Global.Name,
 				ID:             testCfg.Global.ID,
@@ -185,7 +181,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --roles",
 			[]string{"config", "roles", "name"},
-			[]interface{}{testCfgFile.Name(), "1", testCfg.Global.Name},
+			[]interface{}{testCfgFile, "1", testCfg.Global.Name},
 			dot.GlobalConfig{
 				Name:           testCfg.Global.Name,
 				ID:             testCfg.Global.ID,
@@ -198,7 +194,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --publish-metrics",
 			[]string{"config", "publish-metrics", "name"},
-			[]interface{}{testCfgFile.Name(), true, testCfg.Global.Name},
+			[]interface{}{testCfgFile, true, testCfg.Global.Name},
 			dot.GlobalConfig{
 				Name:           testCfg.Global.Name,
 				ID:             testCfg.Global.ID,
@@ -211,7 +207,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --metrics-address",
 			[]string{"config", "metrics-address", "name"},
-			[]interface{}{testCfgFile.Name(), ":9871", testCfg.Global.Name},
+			[]interface{}{testCfgFile, ":9871", testCfg.Global.Name},
 			dot.GlobalConfig{
 				Name:           testCfg.Global.Name,
 				ID:             testCfg.Global.ID,
@@ -224,7 +220,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --no-telemetry",
 			[]string{"config", "no-telemetry", "name"},
-			[]interface{}{testCfgFile.Name(), true, testCfg.Global.Name},
+			[]interface{}{testCfgFile, true, testCfg.Global.Name},
 			dot.GlobalConfig{
 				Name:           testCfg.Global.Name,
 				ID:             testCfg.Global.ID,
@@ -239,7 +235,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			"Test gossamer --telemetry-url",
 			[]string{"config", "telemetry-url", "name"},
 			[]interface{}{
-				testCfgFile.Name(),
+				testCfgFile,
 				[]string{"ws://localhost:8001/submit 0", "ws://foo/bar 0"},
 				testCfg.Global.Name,
 			},
@@ -274,8 +270,6 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 
 func TestGlobalConfigFromFlagsFails(t *testing.T) {
 	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -290,7 +284,7 @@ func TestGlobalConfigFromFlagsFails(t *testing.T) {
 			"Test gossamer --telemetry-url invalid format",
 			[]string{"config", "telemetry-url", "name"},
 			[]interface{}{
-				testCfgFile.Name(),
+				testCfgFile,
 				[]string{"ws://localhost:8001/submit"},
 				testCfg.Global.Name,
 			},
@@ -300,7 +294,7 @@ func TestGlobalConfigFromFlagsFails(t *testing.T) {
 			"Test gossamer invalid --telemetry-url invalid verbosity",
 			[]string{"config", "telemetry-url", "name"},
 			[]interface{}{
-				testCfgFile.Name(),
+				testCfgFile,
 				[]string{"ws://foo/bar k"},
 				testCfg.Global.Name,
 			},
@@ -326,8 +320,6 @@ func TestGlobalConfigFromFlagsFails(t *testing.T) {
 // TestAccountConfigFromFlags tests createDotAccountConfig using relevant account flags
 func TestAccountConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -341,7 +333,7 @@ func TestAccountConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --key",
 			[]string{"config", "key"},
-			[]interface{}{testCfgFile.Name(), "alice"},
+			[]interface{}{testCfgFile, "alice"},
 			dot.AccountConfig{
 				Key:    "alice",
 				Unlock: testCfg.Account.Unlock,
@@ -350,7 +342,7 @@ func TestAccountConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --unlock",
 			[]string{"config", "key", "unlock"},
-			[]interface{}{testCfgFile.Name(), "alice", "0"},
+			[]interface{}{testCfgFile, "alice", "0"},
 			dot.AccountConfig{
 				Key:    "alice",
 				Unlock: "0",
@@ -373,8 +365,6 @@ func TestAccountConfigFromFlags(t *testing.T) {
 // TestCoreConfigFromFlags tests createDotCoreConfig using relevant core flags
 func TestCoreConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -388,7 +378,7 @@ func TestCoreConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --roles",
 			[]string{"config", "roles"},
-			[]interface{}{testCfgFile.Name(), "4"},
+			[]interface{}{testCfgFile, "4"},
 			dot.CoreConfig{
 				Roles:            4,
 				BabeAuthority:    true,
@@ -400,7 +390,7 @@ func TestCoreConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --roles",
 			[]string{"config", "roles"},
-			[]interface{}{testCfgFile.Name(), "0"},
+			[]interface{}{testCfgFile, "0"},
 			dot.CoreConfig{
 				Roles:            0,
 				BabeAuthority:    false,
@@ -426,8 +416,6 @@ func TestCoreConfigFromFlags(t *testing.T) {
 // TestNetworkConfigFromFlags tests createDotNetworkConfig using relevant network flags
 func TestNetworkConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -441,7 +429,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --port",
 			[]string{"config", "port"},
-			[]interface{}{testCfgFile.Name(), "1234"},
+			[]interface{}{testCfgFile, "1234"},
 			dot.NetworkConfig{
 				Port:              1234,
 				Bootnodes:         testCfg.Network.Bootnodes,
@@ -456,7 +444,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --bootnodes",
 			[]string{"config", "bootnodes"},
-			[]interface{}{testCfgFile.Name(), "peer1,peer2"},
+			[]interface{}{testCfgFile, "peer1,peer2"},
 			dot.NetworkConfig{
 				Port:              testCfg.Network.Port,
 				Bootnodes:         []string{"peer1", "peer2"},
@@ -471,7 +459,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --protocol",
 			[]string{"config", "protocol"},
-			[]interface{}{testCfgFile.Name(), "/gossamer/test/0"},
+			[]interface{}{testCfgFile, "/gossamer/test/0"},
 			dot.NetworkConfig{
 				Port:              testCfg.Network.Port,
 				Bootnodes:         testCfg.Network.Bootnodes,
@@ -486,7 +474,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --nobootstrap",
 			[]string{"config", "nobootstrap"},
-			[]interface{}{testCfgFile.Name(), "true"},
+			[]interface{}{testCfgFile, "true"},
 			dot.NetworkConfig{
 				Port:              testCfg.Network.Port,
 				Bootnodes:         testCfg.Network.Bootnodes,
@@ -501,7 +489,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --nomdns",
 			[]string{"config", "nomdns"},
-			[]interface{}{testCfgFile.Name(), "true"},
+			[]interface{}{testCfgFile, "true"},
 			dot.NetworkConfig{
 				Port:              testCfg.Network.Port,
 				Bootnodes:         testCfg.Network.Bootnodes,
@@ -516,7 +504,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --pubip",
 			[]string{"config", "pubip"},
-			[]interface{}{testCfgFile.Name(), "10.0.5.2"},
+			[]interface{}{testCfgFile, "10.0.5.2"},
 			dot.NetworkConfig{
 				Port:              testCfg.Network.Port,
 				Bootnodes:         testCfg.Network.Bootnodes,
@@ -532,7 +520,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --pubdns",
 			[]string{"config", "pubdns"},
-			[]interface{}{testCfgFile.Name(), "alice"},
+			[]interface{}{testCfgFile, "alice"},
 			dot.NetworkConfig{
 				Port:              testCfg.Network.Port,
 				Bootnodes:         testCfg.Network.Bootnodes,
@@ -562,8 +550,6 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 // TestRPCConfigFromFlags tests createDotRPCConfig using relevant rpc flags
 func TestRPCConfigFromFlags(t *testing.T) {
 	testCfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, testCfg)
-	require.NotNil(t, testCfgFile)
 
 	testApp := cli.NewApp()
 	testApp.Writer = io.Discard
@@ -577,7 +563,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpc",
 			[]string{"config", "rpc"},
-			[]interface{}{testCfgFile.Name(), "true"},
+			[]interface{}{testCfgFile, "true"},
 			dot.RPCConfig{
 				Enabled:    true,
 				External:   testCfg.RPC.External,
@@ -592,7 +578,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpc false",
 			[]string{"config", "rpc"},
-			[]interface{}{testCfgFile.Name(), "false"},
+			[]interface{}{testCfgFile, "false"},
 			dot.RPCConfig{
 				Enabled:    false,
 				External:   testCfg.RPC.External,
@@ -607,7 +593,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpc-external",
 			[]string{"config", "rpc-external"},
-			[]interface{}{testCfgFile.Name(), "true"},
+			[]interface{}{testCfgFile, "true"},
 			dot.RPCConfig{
 				Enabled:    true,
 				External:   true,
@@ -622,7 +608,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpc-external false",
 			[]string{"config", "rpc-external"},
-			[]interface{}{testCfgFile.Name(), "false"},
+			[]interface{}{testCfgFile, "false"},
 			dot.RPCConfig{
 				Enabled:    true,
 				External:   false,
@@ -637,7 +623,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpchost",
 			[]string{"config", "rpchost"},
-			[]interface{}{testCfgFile.Name(), "testhost"}, // rpc must be enabled
+			[]interface{}{testCfgFile, "testhost"}, // rpc must be enabled
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -652,7 +638,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpcport",
 			[]string{"config", "rpcport"},
-			[]interface{}{testCfgFile.Name(), "5678"}, // rpc must be enabled
+			[]interface{}{testCfgFile, "5678"}, // rpc must be enabled
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -667,7 +653,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --rpcsmods",
 			[]string{"config", "rpcmods"},
-			[]interface{}{testCfgFile.Name(), "mod1,mod2"}, // rpc must be enabled
+			[]interface{}{testCfgFile, "mod1,mod2"}, // rpc must be enabled
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -682,7 +668,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --wsport",
 			[]string{"config", "wsport"},
-			[]interface{}{testCfgFile.Name(), "7070"},
+			[]interface{}{testCfgFile, "7070"},
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -697,7 +683,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --ws",
 			[]string{"config", "ws"},
-			[]interface{}{testCfgFile.Name(), true},
+			[]interface{}{testCfgFile, true},
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -712,7 +698,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --ws false",
 			[]string{"config", "w"},
-			[]interface{}{testCfgFile.Name(), false},
+			[]interface{}{testCfgFile, false},
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -727,7 +713,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --ws-external",
 			[]string{"config", "ws-external"},
-			[]interface{}{testCfgFile.Name(), true},
+			[]interface{}{testCfgFile, true},
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -742,7 +728,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		{
 			"Test gossamer --ws-external false",
 			[]string{"config", "ws-external"},
-			[]interface{}{testCfgFile.Name(), false},
+			[]interface{}{testCfgFile, false},
 			dot.RPCConfig{
 				Enabled:    testCfg.RPC.Enabled,
 				External:   testCfg.RPC.External,
@@ -776,7 +762,7 @@ func TestUpdateConfigFromGenesisJSON(t *testing.T) {
 	ctx, err := newTestContext(
 		t.Name(),
 		[]string{"config", "genesis", "name"},
-		[]interface{}{testCfgFile.Name(), genFile, testCfg.Global.Name},
+		[]interface{}{testCfgFile, genFile, testCfg.Global.Name},
 	)
 	require.NoError(t, err)
 
@@ -830,7 +816,7 @@ func TestUpdateConfigFromGenesisJSON_Default(t *testing.T) {
 	ctx, err := newTestContext(
 		t.Name(),
 		[]string{"config", "genesis", "name"},
-		[]interface{}{testCfgFile.Name(), "", testCfg.Global.Name},
+		[]interface{}{testCfgFile, "", testCfg.Global.Name},
 	)
 	require.NoError(t, err)
 
@@ -880,7 +866,7 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 	ctx, err := newTestContext(
 		t.Name(),
 		[]string{"config", "genesis", "name"},
-		[]interface{}{testCfgFile.Name(), genFile, testCfg.Global.Name},
+		[]interface{}{testCfgFile, genFile, testCfg.Global.Name},
 	)
 	require.NoError(t, err)
 
@@ -954,7 +940,6 @@ func TestGlobalNodeName_WhenNodeAlreadyHasStoredName(t *testing.T) {
 
 	cfg := newTestConfig(t)
 	cfg.Global.Name = globalName
-	require.NotNil(t, cfg)
 
 	runtimeFilePath := filepath.Join(t.TempDir(), "runtime")
 	_, testRuntimeURL := runtime.GetRuntimeVars(runtime.NODE_RUNTIME)
@@ -1036,8 +1021,6 @@ func TestGlobalNodeName_WhenNodeAlreadyHasStoredName(t *testing.T) {
 
 func TestGlobalNodeNamePriorityOrder(t *testing.T) {
 	cfg, testCfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, cfg)
-	require.NotNil(t, testCfgFile)
 
 	// call another command and test the name
 	testApp := cli.NewApp()
@@ -1052,7 +1035,7 @@ func TestGlobalNodeNamePriorityOrder(t *testing.T) {
 	}{
 		"Test gossamer --basepath --name --config",
 		[]string{"basepath", "name", "config"},
-		[]interface{}{cfg.Global.BasePath, "mydefinedname", testCfgFile.Name()},
+		[]interface{}{cfg.Global.BasePath, "mydefinedname", testCfgFile},
 		"mydefinedname",
 	}
 
@@ -1075,7 +1058,7 @@ func TestGlobalNodeNamePriorityOrder(t *testing.T) {
 	}{
 		"Test gossamer --basepath --config",
 		[]string{"basepath", "config"},
-		[]interface{}{cfg.Global.BasePath, testCfgFile.Name()},
+		[]interface{}{cfg.Global.BasePath, testCfgFile},
 		cfg.Global.Name,
 	}
 

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/ChainSafe/gossamer/dot"
@@ -48,10 +49,13 @@ func exportAction(ctx *cli.Context) error {
 	}
 
 	tomlCfg := dotConfigToToml(cfg)
-	file := exportConfig(tomlCfg, config)
-	// export config will exit and log error on error
 
-	logger.Info("exported toml configuration to " + file.Name())
+	config = filepath.Clean(config)
+	err = exportConfig(tomlCfg, config)
+	if err != nil {
+		return fmt.Errorf("failed exporting TOML configuration: %w", err)
+	}
+	logger.Info("exported toml configuration to " + config)
 
 	return nil
 }

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -55,7 +55,7 @@ func exportAction(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed exporting TOML configuration: %w", err)
 	}
-	logger.Info("exported toml configuration to " + config)
+	logger.Infof("exported toml configuration to %s", config)
 
 	return nil
 }

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestExportCommand test "gossamer export --config"
 func TestExportCommand(t *testing.T) {
-	testCfg, testConfigFile := newTestConfigWithFile(t)
+	testCfg, testConfig := newTestConfigWithFile(t)
 	testDir := testCfg.Global.BasePath
 	genFile := dot.NewTestGenesisRawFile(t, testCfg)
 
@@ -28,7 +28,6 @@ func TestExportCommand(t *testing.T) {
 	testName := "testnode"
 	testBootnode := "bootnode"
 	testProtocol := "/protocol/test/0"
-	testConfig := testConfigFile.Name()
 
 	testcases := []struct {
 		description string

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -29,22 +29,22 @@ func TestFixFlagOrder(t *testing.T) {
 		{
 			"Test gossamer --config --genesis --log --force --pruning --retain-blocks",
 			[]string{"config", "genesis", "log", "force", "pruning", "retain-blocks"},
-			[]interface{}{testConfig.Name(), genFile, "trace", true, dev.DefaultPruningMode, dev.DefaultRetainBlocks},
+			[]interface{}{testConfig, genFile, "trace", true, dev.DefaultPruningMode, dev.DefaultRetainBlocks},
 		},
 		{
 			"Test gossamer --config --genesis --force --log --pruning --retain-blocks",
 			[]string{"config", "genesis", "force", "log", "pruning", "retain-blocks"},
-			[]interface{}{testConfig.Name(), genFile, true, "trace", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
+			[]interface{}{testConfig, genFile, true, "trace", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
 		},
 		{
 			"Test gossamer --config --force --genesis --log ---pruning --retain-blocks",
 			[]string{"config", "force", "genesis", "log", "pruning", "retain-blocks"},
-			[]interface{}{testConfig.Name(), true, genFile, "trace", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
+			[]interface{}{testConfig, true, genFile, "trace", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
 		},
 		{
 			"Test gossamer --force --config --genesis --log --pruning --retain-blocks",
 			[]string{"force", "config", "genesis", "log", "pruning", "retain-blocks"},
-			[]interface{}{true, testConfig.Name(), genFile, "trace", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
+			[]interface{}{true, testConfig, genFile, "trace", dev.DefaultPruningMode, dev.DefaultRetainBlocks},
 		},
 	}
 

--- a/cmd/gossamer/toml_config.go
+++ b/cmd/gossamer/toml_config.go
@@ -61,6 +61,8 @@ func exportConfig(cfg *ctoml.Config, targetPath string) (err error) {
 		return fmt.Errorf("failed to marshal configuration: %w", err)
 	}
 
+	// read and write for the current user
+	// read only for the user group and others
 	const perms = fs.FileMode(0644)
 	err = os.WriteFile(targetPath, b, perms)
 	if err != nil {

--- a/cmd/gossamer/toml_config.go
+++ b/cmd/gossamer/toml_config.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -54,34 +55,17 @@ func loadConfig(cfg *ctoml.Config, fp string) error {
 }
 
 // exportConfig exports a dot configuration to a toml configuration file
-func exportConfig(cfg *ctoml.Config, fp string) *os.File {
-	var (
-		newFile *os.File
-		err     error
-		raw     []byte
-	)
-
-	if raw, err = toml.Marshal(*cfg); err != nil {
-		logger.Errorf("failed to marshal configuration: %s", err)
-		os.Exit(1)
-	}
-
-	newFile, err = os.Create(filepath.Clean(fp))
+func exportConfig(cfg *ctoml.Config, targetPath string) (err error) {
+	b, err := toml.Marshal(*cfg)
 	if err != nil {
-		logger.Errorf("failed to create configuration file: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to marshal configuration: %w", err)
 	}
 
-	_, err = newFile.Write(raw)
+	const perms = fs.FileMode(0644)
+	err = os.WriteFile(targetPath, b, perms)
 	if err != nil {
-		logger.Errorf("failed to write to configuration file: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to write configuration to file: %w", err)
 	}
 
-	if err := newFile.Close(); err != nil {
-		logger.Errorf("failed to close configuration file: %s", err)
-		os.Exit(1)
-	}
-
-	return newFile
+	return nil
 }

--- a/cmd/gossamer/toml_config_test.go
+++ b/cmd/gossamer/toml_config_test.go
@@ -16,7 +16,6 @@ import (
 // TestLoadConfig tests loading a toml configuration file
 func TestLoadConfig(t *testing.T) {
 	cfg, cfgFile := newTestConfigWithFile(t)
-	require.NotNil(t, cfg)
 
 	genFile := dot.NewTestGenesisRawFile(t, cfg)
 
@@ -25,7 +24,7 @@ func TestLoadConfig(t *testing.T) {
 	err := dot.InitNode(cfg)
 	require.NoError(t, err)
 
-	err = loadConfig(dotConfigToToml(cfg), cfgFile.Name())
+	err = loadConfig(dotConfigToToml(cfg), cfgFile)
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 }

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/internal/log"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
 	terminal "golang.org/x/term"
 )
@@ -105,12 +106,16 @@ func newTestConfig(t *testing.T) *dot.Config {
 }
 
 // newTestConfigWithFile returns a new test configuration and a temporary configuration file
-func newTestConfigWithFile(t *testing.T) (*dot.Config, *os.File) {
-	cfg := newTestConfig(t)
+func newTestConfigWithFile(t *testing.T) (cfg *dot.Config, configPath string) {
+	t.Helper()
 
-	filename := filepath.Join(cfg.Global.BasePath, "config.toml")
+	cfg = newTestConfig(t)
 
 	tomlCfg := dotConfigToToml(cfg)
-	cfgFile := exportConfig(tomlCfg, filename)
-	return cfg, cfgFile
+
+	configPath = filepath.Join(cfg.Global.BasePath, "config.toml")
+	err := exportConfig(tomlCfg, configPath)
+	require.NoError(t, err)
+
+	return cfg, configPath
 }


### PR DESCRIPTION
## Changes

Following a conversation on #2112 this simply refactors `exportConfig` to not call `os.Exit(1)` but return an error instead.

It's also a bit changed to only return an error, since the file handler that was returned wasn't used except to get the file name string.

## Tests

## Issues

## Primary Reviewer

- Anyone