### PR TITLE
chore(end-to-end): handle `Node` structure without pointer

### DIFF
--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -37,7 +37,7 @@ func TestStateRPCResponseValidation(t *testing.T) {
 	ctx := context.Background()
 
 	getBlockHashCtx, cancel := context.WithTimeout(ctx, time.Second)
-	blockHash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0], "")
+	blockHash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0].RPCPort, "")
 	cancel()
 	require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestStateRPCAPI(t *testing.T) {
 	ctx := context.Background()
 
 	getBlockHashCtx, cancel := context.WithTimeout(ctx, time.Second)
-	blockHash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0], "")
+	blockHash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0].RPCPort, "")
 	cancel()
 	require.NoError(t, err)
 

--- a/tests/stress/network_test.go
+++ b/tests/stress/network_test.go
@@ -33,7 +33,7 @@ func TestNetwork_MaxPeers(t *testing.T) {
 	for i, node := range nodes {
 		const getPeersTimeout = time.Second
 		getPeersCtx, cancel := context.WithTimeout(ctx, getPeersTimeout)
-		peers := utils.GetPeers(getPeersCtx, t, node)
+		peers := utils.GetPeers(getPeersCtx, t, node.RPCPort)
 		cancel()
 
 		t.Logf("node %d: peer count=%d", i, len(peers))

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -168,11 +168,11 @@ func TestSync_MultipleEpoch(t *testing.T) {
 	ctx := context.Background()
 
 	slotDurationCtx, cancel := context.WithTimeout(ctx, time.Second)
-	slotDuration := utils.SlotDuration(slotDurationCtx, t, nodes[0])
+	slotDuration := utils.SlotDuration(slotDurationCtx, t, nodes[0].RPCPort)
 	cancel()
 
 	epochLengthCtx, cancel := context.WithTimeout(ctx, time.Second)
-	epochLength := utils.EpochLength(epochLengthCtx, t, nodes[0])
+	epochLength := utils.EpochLength(epochLengthCtx, t, nodes[0].RPCPort)
 	cancel()
 
 	// Wait for epoch to pass
@@ -180,7 +180,7 @@ func TestSync_MultipleEpoch(t *testing.T) {
 
 	// Just checking that everythings operating as expected
 	getChainHeadCtx, cancel := context.WithTimeout(ctx, time.Second)
-	header := utils.GetChainHead(getChainHeadCtx, t, nodes[0])
+	header := utils.GetChainHead(getChainHeadCtx, t, nodes[0].RPCPort)
 	cancel()
 
 	currentHeight := header.Number
@@ -214,7 +214,7 @@ func TestSync_SingleSyncingNode(t *testing.T) {
 		utils.ConfigNoBABE, false, false)
 	require.NoError(t, err)
 
-	nodes := []*utils.Node{alice, bob}
+	nodes := []utils.Node{alice, bob}
 	defer func() {
 		errList := utils.StopNodes(t, nodes)
 		require.Len(t, errList, 0)
@@ -250,7 +250,7 @@ func TestSync_Bench(t *testing.T) {
 
 	for {
 		getChainHeadCtx, cancel := context.WithTimeout(ctx, time.Second)
-		header, err := utils.GetChainHeadWithError(getChainHeadCtx, t, alice)
+		header, err := utils.GetChainHeadWithError(getChainHeadCtx, t, alice.RPCPort)
 		cancel()
 		if err != nil {
 			continue
@@ -264,7 +264,7 @@ func TestSync_Bench(t *testing.T) {
 	}
 
 	pauseBabeCtx, cancel := context.WithTimeout(ctx, time.Second)
-	err = utils.PauseBABE(pauseBabeCtx, alice)
+	err = utils.PauseBABE(pauseBabeCtx, alice.RPCPort)
 	cancel()
 
 	require.NoError(t, err)
@@ -276,7 +276,7 @@ func TestSync_Bench(t *testing.T) {
 		utils.ConfigNotAuthority, false, true)
 	require.NoError(t, err)
 
-	nodes := []*utils.Node{alice, bob}
+	nodes := []utils.Node{alice, bob}
 	defer func() {
 		errList := utils.StopNodes(t, nodes)
 		require.Len(t, errList, 0)
@@ -293,7 +293,7 @@ func TestSync_Bench(t *testing.T) {
 		}
 
 		getChainHeadCtx, getChainHeadCancel := context.WithTimeout(ctx, time.Second)
-		head, err := utils.GetChainHeadWithError(getChainHeadCtx, t, bob)
+		head, err := utils.GetChainHeadWithError(getChainHeadCtx, t, bob.RPCPort)
 		getChainHeadCancel()
 
 		if err != nil {
@@ -404,7 +404,7 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 		utils.TestDir(t, utils.KeyList[0]), utils.GenesisDev,
 		utils.ConfigNoGrandpa, false, true)
 	require.NoError(t, err)
-	nodes := []*utils.Node{node}
+	nodes := []utils.Node{node}
 
 	// Start rest of nodes
 	node, err = utils.RunGossamer(t, 1,
@@ -472,7 +472,7 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 
 	// get starting header so that we can lookup blocks by number later
 	getChainHeadCtx, getChainHeadCancel := context.WithTimeout(ctx, time.Second)
-	prevHeader := utils.GetChainHead(getChainHeadCtx, t, nodes[idx])
+	prevHeader := utils.GetChainHead(getChainHeadCtx, t, nodes[idx].RPCPort)
 	getChainHeadCancel()
 
 	// Send the extrinsic
@@ -496,7 +496,7 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 	}
 
 	getChainHeadCtx, cancel := context.WithTimeout(ctx, time.Second)
-	header := utils.GetChainHead(getChainHeadCtx, t, nodes[idx])
+	header := utils.GetChainHead(getChainHeadCtx, t, nodes[idx].RPCPort)
 	cancel()
 
 	// search from child -> parent blocks for extrinsic
@@ -507,7 +507,7 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 
 	for i := 0; i < maxRetries; i++ {
 		getBlockCtx, getBlockCancel := context.WithTimeout(ctx, time.Second)
-		block := utils.GetBlock(getBlockCtx, t, nodes[idx], header.ParentHash)
+		block := utils.GetBlock(getBlockCtx, t, nodes[idx].RPCPort, header.ParentHash)
 		getBlockCancel()
 
 		if block == nil {
@@ -562,7 +562,7 @@ func Test_SubmitAndWatchExtrinsic(t *testing.T) {
 		utils.TestDir(t, utils.KeyList[0]),
 		utils.GenesisDev, utils.ConfigNoGrandpa, true, true)
 	require.NoError(t, err)
-	nodes := []*utils.Node{node}
+	nodes := []utils.Node{node}
 
 	defer func() {
 		t.Log("going to tear down gossamer...")
@@ -744,13 +744,13 @@ func TestStress_SecondarySlotProduction(t *testing.T) {
 				fmt.Printf("%d iteration\n", i)
 
 				getBlockHashCtx, cancel := context.WithTimeout(ctx, time.Second)
-				hash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0], fmt.Sprintf("%d", i))
+				hash, err := utils.GetBlockHash(getBlockHashCtx, t, nodes[0].RPCPort, fmt.Sprintf("%d", i))
 				cancel()
 
 				require.NoError(t, err)
 
 				getBlockCtx, cancel := context.WithTimeout(ctx, time.Second)
-				block := utils.GetBlock(getBlockCtx, t, nodes[0], hash)
+				block := utils.GetBlock(getBlockCtx, t, nodes[0].RPCPort, hash)
 				cancel()
 
 				header := block.Header

--- a/tests/utils/chain.go
+++ b/tests/utils/chain.go
@@ -17,8 +17,8 @@ import (
 )
 
 // GetChainHead calls the endpoint chain_getHeader to get the latest chain head
-func GetChainHead(ctx context.Context, t *testing.T, node *Node) *types.Header {
-	endpoint := NewEndpoint(node.RPCPort)
+func GetChainHead(ctx context.Context, t *testing.T, rpcPort string) *types.Header {
+	endpoint := NewEndpoint(rpcPort)
 	const params = "[]"
 	respBody, err := PostRPC(ctx, endpoint, ChainGetHeader, params)
 	require.NoError(t, err)
@@ -31,8 +31,8 @@ func GetChainHead(ctx context.Context, t *testing.T, node *Node) *types.Header {
 }
 
 // GetChainHeadWithError calls the endpoint chain_getHeader to get the latest chain head
-func GetChainHeadWithError(ctx context.Context, t *testing.T, node *Node) (*types.Header, error) {
-	endpoint := NewEndpoint(node.RPCPort)
+func GetChainHeadWithError(ctx context.Context, t *testing.T, rpcPort string) (*types.Header, error) {
+	endpoint := NewEndpoint(rpcPort)
 	const params = "[]"
 	respBody, err := PostRPC(ctx, endpoint, ChainGetHeader, params)
 	require.NoError(t, err)
@@ -48,8 +48,8 @@ func GetChainHeadWithError(ctx context.Context, t *testing.T, node *Node) (*type
 
 // GetBlockHash calls the endpoint chain_getBlockHash to get the latest chain head.
 // It will block until a response is received or the context gets canceled.
-func GetBlockHash(ctx context.Context, t *testing.T, node *Node, num string) (common.Hash, error) {
-	endpoint := NewEndpoint(node.RPCPort)
+func GetBlockHash(ctx context.Context, t *testing.T, rpcPort, num string) (common.Hash, error) {
+	endpoint := NewEndpoint(rpcPort)
 	params := "[" + num + "]"
 	const requestWait = time.Second
 	respBody, err := PostRPCWithRetry(ctx, endpoint, ChainGetBlockHash, params, requestWait)
@@ -64,8 +64,8 @@ func GetBlockHash(ctx context.Context, t *testing.T, node *Node, num string) (co
 }
 
 // GetFinalizedHead calls the endpoint chain_getFinalizedHead to get the latest finalised head
-func GetFinalizedHead(ctx context.Context, t *testing.T, node *Node) common.Hash {
-	endpoint := NewEndpoint(node.RPCPort)
+func GetFinalizedHead(ctx context.Context, t *testing.T, rpcPort string) common.Hash {
+	endpoint := NewEndpoint(rpcPort)
 	method := ChainGetFinalizedHead
 	const params = "[]"
 	respBody, err := PostRPC(ctx, endpoint, method, params)
@@ -79,9 +79,9 @@ func GetFinalizedHead(ctx context.Context, t *testing.T, node *Node) common.Hash
 
 // GetFinalizedHeadByRound calls the endpoint chain_getFinalizedHeadByRound to get the finalised head at a given round
 // TODO: add setID, hard-coded at 1 for now
-func GetFinalizedHeadByRound(ctx context.Context, t *testing.T, node *Node, round uint64) (common.Hash, error) {
+func GetFinalizedHeadByRound(ctx context.Context, t *testing.T, rpcPort string, round uint64) (common.Hash, error) {
 	p := strconv.Itoa(int(round))
-	endpoint := NewEndpoint(node.RPCPort)
+	endpoint := NewEndpoint(rpcPort)
 	method := ChainGetFinalizedHeadByRound
 	params := "[" + p + ",1]"
 	respBody, err := PostRPC(ctx, endpoint, method, params)
@@ -97,8 +97,8 @@ func GetFinalizedHeadByRound(ctx context.Context, t *testing.T, node *Node, roun
 }
 
 // GetBlock calls the endpoint chain_getBlock
-func GetBlock(ctx context.Context, t *testing.T, node *Node, hash common.Hash) *types.Block {
-	endpoint := NewEndpoint(node.RPCPort)
+func GetBlock(ctx context.Context, t *testing.T, rpcPort string, hash common.Hash) *types.Block {
+	endpoint := NewEndpoint(rpcPort)
 	method := ChainGetBlock
 	params := fmt.Sprintf(`["%s"]`, hash)
 	respBody, err := PostRPC(ctx, endpoint, method, params)

--- a/tests/utils/dev.go
+++ b/tests/utils/dev.go
@@ -15,16 +15,16 @@ import (
 )
 
 // PauseBABE calls the endpoint dev_control with the params ["babe", "stop"]
-func PauseBABE(ctx context.Context, node *Node) error {
-	endpoint := NewEndpoint(node.RPCPort)
+func PauseBABE(ctx context.Context, rpcPort string) error {
+	endpoint := NewEndpoint(rpcPort)
 	const params = `["babe", "stop"]`
 	_, err := PostRPC(ctx, endpoint, DevControl, params)
 	return err
 }
 
 // SlotDuration Calls dev endpoint for slot duration
-func SlotDuration(ctx context.Context, t *testing.T, node *Node) time.Duration {
-	endpoint := NewEndpoint(node.RPCPort)
+func SlotDuration(ctx context.Context, t *testing.T, rpcPort string) time.Duration {
+	endpoint := NewEndpoint(rpcPort)
 	const method = "dev_slotDuration"
 	const params = "[]"
 	slotDuration, err := PostRPC(ctx, endpoint, method, params)
@@ -44,8 +44,8 @@ func SlotDuration(ctx context.Context, t *testing.T, node *Node) time.Duration {
 }
 
 // EpochLength Calls dev endpoint for epoch length
-func EpochLength(ctx context.Context, t *testing.T, node *Node) uint64 {
-	endpoint := NewEndpoint(node.RPCPort)
+func EpochLength(ctx context.Context, t *testing.T, rpcPort string) uint64 {
+	endpoint := NewEndpoint(rpcPort)
 	const method = "dev_epochLength"
 	const params = "[]"
 	epochLength, err := PostRPC(ctx, endpoint, method, params)

--- a/tests/utils/framework.go
+++ b/tests/utils/framework.go
@@ -15,7 +15,7 @@ import (
 
 // Framework struct to hold references to framework data
 type Framework struct {
-	nodes   []*Node
+	nodes   []Node
 	db      *scribble.Driver
 	callQty int
 }
@@ -44,8 +44,9 @@ func InitFramework(qtyNodes int) (*Framework, error) {
 
 // StartNodes calls RestartGossamor for all nodes
 func (fw *Framework) StartNodes(t *testing.T) (errorList []error) {
-	for _, node := range fw.nodes {
-		err := startGossamer(t, node, false)
+	for i, node := range fw.nodes {
+		var err error
+		fw.nodes[i], err = startGossamer(t, node, false)
 		if err != nil {
 			errorList = append(errorList, err)
 		}

--- a/tests/utils/gossamer_utils.go
+++ b/tests/utils/gossamer_utils.go
@@ -82,7 +82,8 @@ type Node struct {
 }
 
 // InitGossamer initialises given node number and returns node reference
-func InitGossamer(idx int, basePath, genesis, config string) (*Node, error) {
+func InitGossamer(idx int, basePath, genesis, config string) (
+	node Node, err error) {
 	cmdInit := exec.Command(gossamerCMD, "init",
 		"--config", config,
 		"--basepath", basePath,
@@ -94,11 +95,11 @@ func InitGossamer(idx int, basePath, genesis, config string) (*Node, error) {
 	stdOutInit, err := cmdInit.CombinedOutput()
 	if err != nil {
 		fmt.Printf("%s", stdOutInit)
-		return nil, err
+		return node, err
 	}
 
 	Logger.Infof("initialised gossamer node %d!", idx)
-	return &Node{
+	return Node{
 		Idx:      idx,
 		RPCPort:  strconv.Itoa(BaseRPCPort + idx),
 		WSPort:   strconv.Itoa(BaseWSPort + idx),
@@ -108,7 +109,8 @@ func InitGossamer(idx int, basePath, genesis, config string) (*Node, error) {
 }
 
 // startGossamer starts given node
-func startGossamer(t *testing.T, node *Node, websocket bool) error {
+func startGossamer(t *testing.T, node Node, websocket bool) (
+	updatedNode Node, err error) {
 	var key string
 	var params = []string{"--port", strconv.Itoa(basePort + node.Idx),
 		"--config", node.config,
@@ -145,14 +147,14 @@ func startGossamer(t *testing.T, node *Node, websocket bool) error {
 	outfile, err := os.Create(filepath.Join(node.basePath, "log.out"))
 	if err != nil {
 		Logger.Errorf("Error when trying to set a log file for gossamer output: %s", err)
-		return err
+		return node, err
 	}
 
 	// create error log file
 	errfile, err := os.Create(filepath.Join(node.basePath, "error.out"))
 	if err != nil {
 		Logger.Errorf("Error when trying to set a log file for gossamer output: %s", err)
-		return err
+		return node, err
 	}
 
 	t.Cleanup(func() {
@@ -166,20 +168,20 @@ func startGossamer(t *testing.T, node *Node, websocket bool) error {
 	stdoutPipe, err := node.Process.StdoutPipe()
 	if err != nil {
 		Logger.Errorf("failed to get stdoutPipe from node %d: %s", node.Idx, err)
-		return err
+		return node, err
 	}
 
 	stderrPipe, err := node.Process.StderrPipe()
 	if err != nil {
 		Logger.Errorf("failed to get stderrPipe from node %d: %s", node.Idx, err)
-		return err
+		return node, err
 	}
 
 	Logger.Infof("starting gossamer at %s...", node.Process)
 	err = node.Process.Start()
 	if err != nil {
 		Logger.Errorf("Could not execute gossamer cmd: %s", err)
-		return err
+		return node, err
 	}
 
 	writer := bufio.NewWriter(outfile)
@@ -223,26 +225,27 @@ func startGossamer(t *testing.T, node *Node, websocket bool) error {
 		Logger.Criticalf("node didn't start: %s", err)
 		errFileContents, _ := os.ReadFile(errfile.Name())
 		t.Logf("%s\n", errFileContents)
-		return err
+		return node, err
 	}
 
-	return nil
+	return node, nil
 }
 
 // RunGossamer will initialise and start a gossamer instance
-func RunGossamer(t *testing.T, idx int, basepath, genesis, config string, websocket, babeLead bool) (*Node, error) {
-	node, err := InitGossamer(idx, basepath, genesis, config)
+func RunGossamer(t *testing.T, idx int, basepath, genesis, config string, websocket, babeLead bool) (
+	node Node, err error) {
+	node, err = InitGossamer(idx, basepath, genesis, config)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialise gossamer: %w", err)
+		return node, fmt.Errorf("could not initialise gossamer: %w", err)
 	}
 
 	if idx == 0 || babeLead {
 		node.BABELead = true
 	}
 
-	err = startGossamer(t, node, websocket)
+	node, err = startGossamer(t, node, websocket)
 	if err != nil {
-		return nil, fmt.Errorf("could not start gossamer: %w", err)
+		return node, fmt.Errorf("could not start gossamer: %w", err)
 	}
 
 	return node, nil
@@ -280,8 +283,7 @@ func killProcess(t *testing.T, cmd *exec.Cmd) error {
 }
 
 // InitNodes initialises given number of nodes
-func InitNodes(num int, config string) ([]*Node, error) {
-	var nodes []*Node
+func InitNodes(num int, config string) (nodes []Node, err error) {
 	tempDir, err := os.MkdirTemp("", "gossamer-stress-")
 	if err != nil {
 		return nil, err
@@ -300,9 +302,9 @@ func InitNodes(num int, config string) ([]*Node, error) {
 }
 
 // StartNodes starts given array of nodes
-func StartNodes(t *testing.T, nodes []*Node) error {
+func StartNodes(t *testing.T, nodes []Node) (err error) {
 	for i, n := range nodes {
-		err := startGossamer(t, n, false)
+		nodes[i], err = startGossamer(t, n, false)
 		if err != nil {
 			return fmt.Errorf("node %d of %d: %w",
 				i+1, len(nodes), err)
@@ -313,7 +315,7 @@ func StartNodes(t *testing.T, nodes []*Node) error {
 
 // InitializeAndStartNodes will spin up `num` gossamer nodes
 func InitializeAndStartNodes(t *testing.T, num int, genesis, config string) (
-	nodes []*Node, err error) {
+	nodes []Node, err error) {
 	var wg sync.WaitGroup
 	var nodesMutex, errMutex sync.Mutex
 	wg.Add(num)
@@ -353,7 +355,7 @@ func InitializeAndStartNodes(t *testing.T, num int, genesis, config string) (
 
 // InitializeAndStartNodesWebsocket will spin up `num` gossamer nodes running with Websocket rpc enabled
 func InitializeAndStartNodesWebsocket(t *testing.T, num int, genesis, config string) (
-	nodes []*Node, err error) {
+	nodes []Node, err error) {
 	var nodesMutex, errMutex sync.Mutex
 	var wg sync.WaitGroup
 
@@ -393,7 +395,7 @@ func InitializeAndStartNodesWebsocket(t *testing.T, num int, genesis, config str
 }
 
 // StopNodes stops the given nodes
-func StopNodes(t *testing.T, nodes []*Node) (errs []error) {
+func StopNodes(t *testing.T, nodes []Node) (errs []error) {
 	for i := range nodes {
 		cmd := nodes[i].Process
 		err := killProcess(t, cmd)
@@ -407,7 +409,7 @@ func StopNodes(t *testing.T, nodes []*Node) (errs []error) {
 }
 
 // TearDown stops the given nodes and remove their datadir
-func TearDown(t *testing.T, nodes []*Node) (errorList []error) {
+func TearDown(t *testing.T, nodes []Node) (errorList []error) {
 	for i, node := range nodes {
 		cmd := nodes[i].Process
 		err := killProcess(t, cmd)

--- a/tests/utils/system.go
+++ b/tests/utils/system.go
@@ -13,8 +13,8 @@ import (
 )
 
 // GetPeers calls the endpoint system_peers
-func GetPeers(ctx context.Context, t *testing.T, node *Node) []common.PeerInfo {
-	endpoint := NewEndpoint(node.RPCPort)
+func GetPeers(ctx context.Context, t *testing.T, rpcPort string) []common.PeerInfo {
+	endpoint := NewEndpoint(rpcPort)
 	const method = "system_peers"
 	const params = "[]"
 	respBody, err := PostRPC(ctx, endpoint, method, params)


### PR DESCRIPTION
## Changes

- Change all functions to use `Node` instead of `*Node` since there is no reason to use a pointer really
- Change RPC functions to take in RPC port string only
- This unblocks a refactor in a next PR

## Tests

All end to end tests to pass

## Issues

- #2388 

## Primary Reviewer

- @edwardmack 