### PR TITLE
chore(ci): remove `GO111MODULE: on`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,8 +11,6 @@ on:
     #   - go.sum
 
 name: checks
-env:
-  GO111MODULE: on
 
 jobs:
   linting:

--- a/.github/workflows/docker-grandpa.yml
+++ b/.github/workflows/docker-grandpa.yml
@@ -15,8 +15,6 @@ on:
     #   - go.mod
     #   - go.sum
 name: docker-grandpa
-env:
-  GO111MODULE: on
 
 jobs:
   docker-grandpa-tests:

--- a/.github/workflows/docker-js.yml
+++ b/.github/workflows/docker-js.yml
@@ -15,8 +15,6 @@ on:
     #   - go.mod
     #   - go.sum
 name: docker-js
-env:
-  GO111MODULE: on
 
 jobs:
   docker-polkadotjs-tests:

--- a/.github/workflows/docker-rpc.yml
+++ b/.github/workflows/docker-rpc.yml
@@ -15,8 +15,6 @@ on:
     #   - go.mod
     #   - go.sum
 name: docker-rpc
-env:
-  GO111MODULE: on
 
 jobs:
   docker-rpc-tests:

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -15,8 +15,6 @@ on:
     #   - go.mod
     #   - go.sum
 name: docker-stable
-env:
-  GO111MODULE: on
 
 jobs:
   docker-stable-tests:

--- a/.github/workflows/docker-stress.yml
+++ b/.github/workflows/docker-stress.yml
@@ -15,8 +15,6 @@ on:
     #   - go.mod
     #   - go.sum
 name: docker-stress
-env:
-  GO111MODULE: on
 
 jobs:
   docker-stress-tests:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - staging
 
-env:
-  GO111MODULE: on
-
 jobs:
   update:
     strategy:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,8 +16,6 @@ on:
     #   - go.sum
     #   - Makefile
 name: unit-tests
-env:
-  GO111MODULE: on
 
 jobs:
   unit-tests:

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -4,8 +4,6 @@ ARG chain="polkadot"
 ARG basepath="~/.gossamer"
 ARG DD_API_KEY
 
-ENV GO111MODULE=on
-
 ENV chain=${chain}
 ENV basepath=${basepath}
 ENV DD_API_KEY=${DD_API_KEY}


### PR DESCRIPTION
## Changes

- GO111MODULE is enabled by default since Go 1.16, and we use Go 1.18, so it's removed

## Tests

All test suites passing

## Issues

## Primary Reviewer

- @timwu20 