### PR TITLE
fix(ci): fix staging workflow

### DIFF
--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -20,7 +20,7 @@ RUN ["sh", "-c", "mv .github/workflows/staging/openmetrics.d/${chain}-conf.yaml 
 RUN service datadog-agent start
 
 RUN go get ./...
-RUN go build github.com/ChainSafe/gossamer/cmd/gossamer
+RUN go install -trimpath github.com/ChainSafe/gossamer/cmd/gossamer
 
 RUN ["sh", "-c", "gossamer init --chain=${chain}"]
 ENTRYPOINT ["sh", "-c", "service datadog-agent restart && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]


### PR DESCRIPTION
## Changes

- Use `go install` instead of `go build`.  Something must have changed for default target path of `go build` in 1.18.

## Tests

<!-- Detail how to run relevant tests to the changes -->

Ensure staging workflow is able to build the container and deploy to staging

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@EclesioMeloJunior 
