### PR TITLE
chore(lib/trie): add tests for ParityTech/trie proofs are incompatible with gossamer/lib/trie #2329 

### DIFF
--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -3548,3 +3548,40 @@ func Benchmark_concatSlices(b *testing.B) {
 		}
 	})
 }
+
+// ParityTech/trie proofs are incompatible with gossamer/lib/trie #2329
+func TestTrieProofParityTechCompatible(t *testing.T) {
+	//TODO: enable it once #2329 is fixed
+	t.Skip("NOT YET FIXED")
+
+	key, err := hex.DecodeString("f0c365c3cf59d671eb72da0e7a4113c4bbd108c4899964f707fdaffb82636065")
+	require.NoError(t, err)
+
+	root, err := hex.DecodeString("5e1eb8e577ea88deaa94b456da24ab0c9f4c0c6d9372af1568edd7aeef3b4c4e")
+	require.NoError(t, err)
+
+	//nolint:lll
+	bytes1, err := hex.DecodeString("80fffd8028b54b9a0a90d41b7941c43e6a0597d5914e3b62bdcb244851b9fc806c28ea2480e2f0847174b6f8ea15133a8d70de58d1a6174b7542e8e12028154c611bc3ee5280ddd81bdda149a8bc6990d3548a719d4a90ddbe5ea4a598211aacf6afd0b23bf58038fe7e08c8e684bd600f25631f32e6510ed7d37f43fce0d5aa974009857aeb5b80aafc60caa3519d4b861e6b8da226266a15060e2071bba4184e194da61dfb208e80b34a4ee6e2f949f58b7cb7f4a7fb1aaea8cdc2a5cb27557d32da7096fdf157c58024a760a8f6c27928ae9e2fed9968bc5f6e17c3ae647398d8a615e5b2bb4b425f8085a0da830399f25fca4b653de654ffd3c92be39f3ae4f54e7c504961b5bd00cf80c2d44d371e5fc1f50227d7491ad65ad049630361cefb4ab1844831237609f08380c8ae6a1e8df858b43e050a3959a25b90d711413ee1a863622c3914d45250738980b5955ff982ab818fcba39b2d507a6723504cef4969fc7c722ee175df95a33ae280509bb016f2887d12137e73d26d7ddcd7f9c8ff458147cb9d309494655fe68de180009f8697d760fbe020564b07f407e6aad58ba9451b3d2d88b3ee03e12db7c47480952dcc0804e1120508a1753f1de4aa5b7481026a3320df8b48e918f0cecbaed380fff4f175da5ff30200fabfdc2bbdd45f864d84f339ec2432f80b5749ac35bbfc")
+	require.NoError(t, err)
+
+	//nolint:lll
+	bytes2, err := hex.DecodeString("9ec365c3cf59d671eb72da0e7a4113c41002505f0e7b9012096b41c4eb3aaf947f6ea429080000685f0f1f0515f462cdcf84e0f1d6045dfcbb2056145f077f010000")
+	require.NoError(t, err)
+
+	//nolint:lll
+	bytes3, err := hex.DecodeString("80050880149156720805d0ad098ae52fcffae34ff637b1d1f1a0fa8e7f94201b8615695580c1638f702aaa71e4b78cc8538ecae03e827bb494cc54279606b201ec071a5e24806d2a1e6d5236e1e13c5a5c84831f5f5383f97eba32df6f9faf80e32cf2f129bc")
+	require.NoError(t, err)
+
+	proof := [][]byte{
+		bytes1, bytes2, bytes3,
+	}
+
+	trie := NewEmptyTrie()
+
+	err = trie.LoadFromProof(proof, root)
+	require.NoError(t, err)
+
+	value := trie.Get(key)
+	// TODO add a concrete expected value once this test is fixed.
+	require.NotEmpty(t, value)
+}


### PR DESCRIPTION
I am adding the failing test case that was initially reported on #2329  so that it can be used as base for the fix and further validation.

## Changes

This PR adds test case for the reported issue #2329 

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
 go test -test.timeout=0 -run TestTrieProofParityTechCompatible -v github.com/ChainSafe/gossamer/lib/trie/...
```

## Issues

#2329 

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
@EclesioMeloJunior

