### PR TITLE
fix(lib/grandpa): clean up Grandpa tracked commit and vote messages

### DIFF
--- a/internal/grandpa/clean/commits.go
+++ b/internal/grandpa/clean/commits.go
@@ -1,0 +1,29 @@
+package clean
+
+import (
+	"container/ring"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+)
+
+type CommitsCleaner struct {
+	hashesRing *ring.Ring
+	cleanup    func(hash common.Hash)
+}
+
+func NewCommitsCleaner(maxSize int,
+	cleanup func(hash common.Hash)) *CommitsCleaner {
+	return &CommitsCleaner{
+		hashesRing: ring.New(maxSize),
+		cleanup:    cleanup,
+	}
+}
+
+func (cc *CommitsCleaner) TrackAndClean(hash common.Hash) {
+	if cc.hashesRing.Value != nil {
+		oldHash := cc.hashesRing.Value.(common.Hash)
+		cc.cleanup(oldHash)
+	}
+	cc.hashesRing.Value = hash
+	cc.hashesRing = cc.hashesRing.Next()
+}

--- a/internal/grandpa/clean/votes.go
+++ b/internal/grandpa/clean/votes.go
@@ -1,0 +1,40 @@
+package clean
+
+import (
+	"container/ring"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+)
+
+type VotesCleaner struct {
+	hashesRing *ring.Ring
+	cleanup    func(hash common.Hash, authorityID ed25519.PublicKeyBytes)
+}
+
+func NewVotesCleaner(maxSize int,
+	cleanup func(hash common.Hash, authorityID ed25519.PublicKeyBytes)) *VotesCleaner {
+	return &VotesCleaner{
+		hashesRing: ring.New(maxSize),
+		cleanup:    cleanup,
+	}
+}
+
+type hashAuthorityID struct {
+	hash        common.Hash
+	authorityID ed25519.PublicKeyBytes
+}
+
+func (vc *VotesCleaner) TrackAndClean(hash common.Hash, authorityID ed25519.PublicKeyBytes) {
+	if vc.hashesRing.Value != nil {
+		oldHashAuthorityID := vc.hashesRing.Value.(hashAuthorityID)
+		oldHash := oldHashAuthorityID.hash
+		oldAuthorityID := oldHashAuthorityID.authorityID
+		vc.cleanup(oldHash, oldAuthorityID)
+	}
+	vc.hashesRing.Value = hashAuthorityID{
+		hash:        hash,
+		authorityID: authorityID,
+	}
+	vc.hashesRing = vc.hashesRing.Next()
+}

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -76,10 +76,11 @@ func (t *tracker) addCommit(cm *CommitMessage) {
 	t.commitMessages[cm.Vote.Hash] = cm
 }
 
-func (t *tracker) addCatchUpResponse(cr *CatchUpResponse) {
+func (t *tracker) addCatchUpResponse(cr *CatchUpResponse) { //nolint:unparam
 	t.catchUpResponseMessageMutex.Lock()
 	defer t.catchUpResponseMessageMutex.Unlock()
-	t.catchUpResponseMessages[cr.Round] = cr
+	// uncomment when usage is setup properly, see #1531
+	// t.catchUpResponseMessages[cr.Round] = cr
 }
 
 func (t *tracker) handleBlocks() {


### PR DESCRIPTION
## Changes

- [x] Disable catch up response recording for now since it's unimplemented, to prevent a memory leak
- [x] Size driven cleanup, with a fixed maximum
  - [x] Clean up vote messages by first in first out, by block hash + authority ID
  - [x] Clean up commit messages by first in first out, by block hash
- [ ] Investigate correct maximum size
- [ ] Investigate how Subtrate does it

## Tests

```sh
go test github.com/ChainSafe/gossamer/internal/grandpa/clean/...
```

## Issues

#2398 

## Primary Reviewer
