### PR TITLE
chore(lib/babe): epoch error wrapping fixed up

### DIFF
--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -323,7 +323,9 @@ func (s *EpochState) HasEpochData(epoch uint64) (bool, error) {
 		return has, nil
 	}
 
-	if !errors.Is(chaindb.ErrKeyNotFound, err) {
+	// we can have `has == false` and `err == nil`
+	// so ensure the error is not nil in the condition below.
+	if err != nil && !errors.Is(chaindb.ErrKeyNotFound, err) {
 		return false, fmt.Errorf("cannot check database for epoch key %d: %w", epoch, err)
 	}
 

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -399,7 +399,7 @@ func (b *Service) initiate() {
 func (b *Service) initiateAndGetEpochHandler(epoch uint64) (*epochHandler, error) {
 	epochData, err := b.initiateEpoch(epoch)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initiate epoch %d: %w", epoch, err)
+		return nil, fmt.Errorf("failed to initiate epoch: %w", err)
 	}
 
 	logger.Debugf("initiated epoch with threshold %s, randomness 0x%x and authorities %v",
@@ -430,7 +430,7 @@ func (b *Service) runEngine() error {
 		if errors.Is(err, errServicePaused) || errors.Is(err, context.Canceled) {
 			return nil
 		} else if err != nil {
-			return err
+			return fmt.Errorf("cannot handle epoch: %w", err)
 		}
 
 		epoch = next
@@ -442,7 +442,7 @@ func (b *Service) handleEpoch(epoch uint64) (next uint64, err error) {
 	defer cancel()
 	b.epochHandler, err = b.initiateAndGetEpochHandler(epoch)
 	if err != nil {
-		return 0, fmt.Errorf("cannot initiate and get epoch handler for epoch %d: %w", epoch, err)
+		return 0, fmt.Errorf("cannot initiate and get epoch handler: %w", err)
 	}
 
 	// get start slot for current epoch

--- a/lib/babe/epoch.go
+++ b/lib/babe/epoch.go
@@ -92,7 +92,7 @@ func (b *Service) getEpochDataAndStartSlot(epoch uint64) (*epochData, uint64, er
 
 	has, err := b.epochState.HasEpochData(epoch)
 	if err != nil {
-		return nil, 0, fmt.Errorf("cannot check for epoch data for epoch %d: %w", epoch, err)
+		return nil, 0, fmt.Errorf("cannot check epoch state: %w", err)
 	}
 
 	if !has {


### PR DESCRIPTION
## Changes

I just saw this ugliest error logged out on Dan's test runtime run, so I had to fix it:

- Error is returned only if it's not nil and not `chaindb.ErrKeyNotFound` in `HasEpochData` (it was logged as `%w (nil)` previously)
- Only `HasEpochData` wraps the epoch number context, not all above callers, to avoid repeating information

## Tests

## Issues

## Primary Reviewer

@EclesioMeloJunior  