### PR TITLE
fix(ci): copyright workflow to exit if different files

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -23,3 +23,5 @@ jobs:
           check-latest: true
 
       - run: make license
+
+      - run: git diff --exit-code


### PR DESCRIPTION
## Changes

- Copyright workflow got broken a week ago with https://github.com/ChainSafe/gossamer/pull/2467 so this fixes it by using `git diff --exit-code`

## Tests

## Issues

## Primary Reviewer

@danforbes 
