### PR TITLE
chore(lib/grandpa): SignedMessage `Hash` to `BlockHash`

### DIFF
--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -37,7 +37,7 @@ type FullVote struct {
 // SignedMessage represents a block hash and number signed by an authority
 type SignedMessage struct {
 	Stage       Subround // 0 for pre-vote, 1 for pre-commit, 2 for primary proposal
-	Hash        common.Hash
+	BlockHash   common.Hash
 	Number      uint32
 	Signature   [64]byte // ed25519.SignatureLength
 	AuthorityID ed25519.PublicKeyBytes
@@ -45,7 +45,7 @@ type SignedMessage struct {
 
 // String returns the SignedMessage as a string
 func (m SignedMessage) String() string {
-	return fmt.Sprintf("stage=%s hash=%s number=%d authorityID=%s", m.Stage, m.Hash, m.Number, m.AuthorityID)
+	return fmt.Sprintf("stage=%s hash=%s number=%d authorityID=%s", m.Stage, m.BlockHash, m.Number, m.AuthorityID)
 }
 
 // VoteMessage represents a network-level vote message

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -84,7 +84,7 @@ func TestDecodeMessage_VoteMessage(t *testing.T) {
 		SetID: 99,
 		Message: SignedMessage{
 			Stage:     precommit,
-			Hash:      common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
+			BlockHash: common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a"),
 			Number:    0x7777,
 			Signature: sig,
 			AuthorityID: ed25519.PublicKeyBytes(

--- a/lib/grandpa/message_test.go
+++ b/lib/grandpa/message_test.go
@@ -82,7 +82,7 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 		SetID: gs.state.setID,
 		Message: SignedMessage{
 			Stage:       precommit,
-			Hash:        v.Hash,
+			BlockHash:   v.Hash,
 			Number:      v.Number,
 			AuthorityID: gs.keypair.Public().(*ed25519.PublicKey).AsBytes(),
 		},
@@ -100,7 +100,7 @@ func TestVoteMessageToConsensusMessage(t *testing.T) {
 		SetID: gs.state.setID,
 		Message: SignedMessage{
 			Stage:       prevote,
-			Hash:        v.Hash,
+			BlockHash:   v.Hash,
 			Number:      v.Number,
 			AuthorityID: gs.keypair.Public().(*ed25519.PublicKey).AsBytes(),
 		},

--- a/lib/grandpa/message_tracker.go
+++ b/lib/grandpa/message_tracker.go
@@ -61,10 +61,10 @@ func (t *tracker) addVote(v *networkVoteMessage) {
 	t.mapLock.Lock()
 	defer t.mapLock.Unlock()
 
-	msgs, has := t.voteMessages[v.msg.Message.Hash]
+	msgs, has := t.voteMessages[v.msg.Message.BlockHash]
 	if !has {
 		msgs = make(map[ed25519.PublicKeyBytes]*networkVoteMessage)
-		t.voteMessages[v.msg.Message.Hash] = msgs
+		t.voteMessages[v.msg.Message.BlockHash] = msgs
 	}
 
 	msgs[v.msg.Message.AuthorityID] = v
@@ -143,7 +143,7 @@ func (t *tracker) handleTick() {
 			}
 
 			if v.msg.Round < t.handler.grandpa.state.round && v.msg.SetID == t.handler.grandpa.state.setID {
-				delete(t.voteMessages, v.msg.Message.Hash)
+				delete(t.voteMessages, v.msg.Message.BlockHash)
 			}
 		}
 	}

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -142,7 +142,7 @@ func TestMessageTracker_ProcessMessage(t *testing.T) {
 
 	time.Sleep(time.Second)
 	expectedVote := &Vote{
-		Hash:   msg.Message.Hash,
+		Hash:   msg.Message.BlockHash,
 		Number: msg.Message.Number,
 	}
 	pv, has := gs.prevotes.Load(kr.Alice().Public().(*ed25519.PublicKey).AsBytes())
@@ -194,7 +194,7 @@ func TestMessageTracker_handleTick(t *testing.T) {
 	msg := &VoteMessage{
 		Round: 100,
 		Message: SignedMessage{
-			Hash: testHash,
+			BlockHash: testHash,
 		},
 	}
 	gs.tracker.addVote(&networkVoteMessage{
@@ -218,7 +218,7 @@ func TestMessageTracker_handleTick(t *testing.T) {
 	msg = &VoteMessage{
 		Round: 0,
 		Message: SignedMessage{
-			Hash: testHash,
+			BlockHash: testHash,
 		},
 	}
 	gs.tracker.addVote(&networkVoteMessage{

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -42,7 +42,7 @@ func (s *Service) receiveVoteMessages(ctx context.Context) {
 			case prevote, primaryProposal:
 				s.telemetry.SendMessage(
 					telemetry.NewAfgReceivedPrevote(
-						vm.Message.Hash,
+						vm.Message.BlockHash,
 						fmt.Sprint(vm.Message.Number),
 						vm.Message.AuthorityID.String(),
 					),
@@ -50,7 +50,7 @@ func (s *Service) receiveVoteMessages(ctx context.Context) {
 			case precommit:
 				s.telemetry.SendMessage(
 					telemetry.NewAfgReceivedPrecommit(
-						vm.Message.Hash,
+						vm.Message.BlockHash,
 						fmt.Sprint(vm.Message.Number),
 						vm.Message.AuthorityID.String(),
 					),
@@ -101,7 +101,7 @@ func (s *Service) createSignedVoteAndVoteMessage(vote *Vote, stage Subround) (*S
 
 	sm := &SignedMessage{
 		Stage:       stage,
-		Hash:        pc.Vote.Hash,
+		BlockHash:   pc.Vote.Hash,
 		Number:      pc.Vote.Number,
 		Signature:   ed25519.NewSignatureBytes(sig),
 		AuthorityID: s.keypair.Public().(*ed25519.PublicKey).AsBytes(),
@@ -179,7 +179,7 @@ func (s *Service) validateVoteMessage(from peer.ID, m *VoteMessage) (*Vote, erro
 		return nil, err
 	}
 
-	vote := NewVote(m.Message.Hash, m.Message.Number)
+	vote := NewVote(m.Message.BlockHash, m.Message.Number)
 
 	// if the vote is from ourselves, return an error
 	kb := [32]byte(s.publicKeyBytes())
@@ -292,7 +292,7 @@ func (s *Service) validateVote(v *Vote) error {
 func validateMessageSignature(pk *ed25519.PublicKey, m *VoteMessage) error {
 	msg, err := scale.Marshal(FullVote{
 		Stage: m.Message.Stage,
-		Vote:  *NewVote(m.Message.Hash, m.Message.Number),
+		Vote:  *NewVote(m.Message.BlockHash, m.Message.Number),
 		Round: m.Round,
 		SetID: m.SetID,
 	})


### PR DESCRIPTION
## Changes

Just rename `SignedMessage` `Hash` field to `BlockHash` to avoid any confusion

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/grandpa
```

## Issues

Created following a discussion from #2485 

## Primary Reviewer

@jimjbrettj 