### PR TITLE
chore(ci): simplify Docker setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,23 +112,14 @@ jobs:
 
   docker-build-n-push:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
-          file: ./Dockerfile
-          platforms: linux/amd64
           push: true
           tags: chainsafe/gossamer:latest
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-grandpa.yml
+++ b/.github/workflows/docker-grandpa.yml
@@ -19,22 +19,13 @@ name: docker-grandpa
 jobs:
   docker-grandpa-tests:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           load: true
-          file: ./Dockerfile
           target: builder
-          platforms: linux/amd64
-          push: false
           tags: chainsafe/gossamer:test
 
       - name: Run grandpa

--- a/.github/workflows/docker-js.yml
+++ b/.github/workflows/docker-js.yml
@@ -19,22 +19,13 @@ name: docker-js
 jobs:
   docker-polkadotjs-tests:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           load: true
-          file: ./Dockerfile
           target: builder
-          platforms: linux/amd64
-          push: false
           tags: chainsafe/gossamer:test
 
       - name: Run polkadotjs tests

--- a/.github/workflows/docker-rpc.yml
+++ b/.github/workflows/docker-rpc.yml
@@ -19,22 +19,13 @@ name: docker-rpc
 jobs:
   docker-rpc-tests:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           load: true
-          file: ./Dockerfile
-          platforms: linux/amd64
           target: builder
-          push: false
           tags: chainsafe/gossamer:test
 
       - name: Run rpc tests

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -19,22 +19,13 @@ name: docker-stable
 jobs:
   docker-stable-tests:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           load: true
-          file: ./Dockerfile
           target: builder
-          platforms: linux/amd64
-          push: false
           tags: chainsafe/gossamer:test
 
       - name: Run stable tests

--- a/.github/workflows/docker-stress.yml
+++ b/.github/workflows/docker-stress.yml
@@ -19,22 +19,13 @@ name: docker-stress
 jobs:
   docker-stress-tests:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           load: true
-          file: ./Dockerfile
           target: builder
-          platforms: linux/amd64
-          push: false
           tags: chainsafe/gossamer:test
 
       - name: Run stress


### PR DESCRIPTION
## Changes

- Use built-in `DOCKER_BUILDKIT=1`
- Remove QEMU setup (no emulation)
- Remove Buildx setup (no emulation)
- Remove default values: `file: ./Dockerfile`, `platforms: linux/amd64`, `push: false`
- Remove unneeded `name` and `id` of Docker steps

## Tests

CI suite passing

## Issues

## Primary Reviewer

@EclesioMeloJunior