### PR TITLE
chore(tests): use mockery constructors to ensure assertions

### DIFF
--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -114,9 +114,9 @@ func TestServiceHandleTransactionMessage(t *testing.T) {
 	testEmptyHeader := types.NewEmptyHeader()
 	testExtrinsic := []types.Extrinsic{{1, 2, 3}}
 
-	runtimeMock := new(mocksruntime.Instance)
-	runtimeMock2 := new(mocksruntime.Instance)
-	runtimeMock3 := new(mocksruntime.Instance)
+	runtimeMock := mocksruntime.NewInstance(t)
+	runtimeMock2 := mocksruntime.NewInstance(t)
+	runtimeMock3 := mocksruntime.NewInstance(t)
 
 	type args struct {
 		peerID peer.ID

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -433,7 +433,7 @@ func Test_Service_handleBlock(t *testing.T) {
 		block.Header.Number = 21
 
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
@@ -458,7 +458,7 @@ func Test_Service_handleBlock(t *testing.T) {
 		block.Header.Number = 21
 
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
@@ -516,7 +516,7 @@ func Test_Service_HandleBlockProduced(t *testing.T) {
 		}
 
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
@@ -558,7 +558,7 @@ func Test_Service_maintainTransactionPool(t *testing.T) {
 		vt := transaction.NewValidTransaction(extrinsic, validity)
 
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("ValidateTransaction", types.Extrinsic{21}).Return(nil, errTestDummyError)
 		mockTxnState := NewMockTransactionState(ctrl)
 		mockTxnState.EXPECT().RemoveExtrinsic(types.Extrinsic{21}).Times(2)
@@ -593,7 +593,7 @@ func Test_Service_maintainTransactionPool(t *testing.T) {
 		tx := transaction.NewValidTransaction(types.Extrinsic{21}, &transaction.Validity{Propagate: true})
 
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("ValidateTransaction", types.Extrinsic{21}).
 			Return(&transaction.Validity{Propagate: true}, nil)
 		mockTxnState := NewMockTransactionState(ctrl)
@@ -682,7 +682,7 @@ func Test_Service_handleBlocksAsync(t *testing.T) {
 		block.Header.Number = 21
 
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("ValidateTransaction", types.Extrinsic{21}).Return(nil, errTestDummyError)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{}).Times(2)
@@ -812,7 +812,7 @@ func TestService_handleChainReorg(t *testing.T) {
 	t.Run("invalid transaction", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		runtimeMockErr := new(mocksruntime.Instance)
+		runtimeMockErr := mocksruntime.NewInstance(t)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().HighestCommonAncestor(testPrevHash, testCurrentHash).
 			Return(testAncestorHash, nil)
@@ -831,7 +831,7 @@ func TestService_handleChainReorg(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		runtimeMockOk := new(mocksruntime.Instance)
+		runtimeMockOk := mocksruntime.NewInstance(t)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().HighestCommonAncestor(testPrevHash, testCurrentHash).
 			Return(testAncestorHash, nil)
@@ -981,7 +981,7 @@ func TestService_DecodeSessionKeys(t *testing.T) {
 	t.Run("ok case", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("DecodeSessionKeys", testEncKeys).Return(testEncKeys, nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMock, nil)
@@ -1075,7 +1075,7 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil).MaxTimes(2)
 		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(ts, nil).MaxTimes(2)
 
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMock, nil)
 		runtimeMock.On("SetContextStorage", ts)
@@ -1154,7 +1154,7 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
-		runtimeMockErr := new(mocksruntime.Instance)
+		runtimeMockErr := mocksruntime.NewInstance(t)
 		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMockErr, nil).MaxTimes(2)
 
 		mockStorageState := NewMockStorageState(ctrl)
@@ -1179,7 +1179,7 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
 		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMock, nil).MaxTimes(2)
@@ -1258,7 +1258,7 @@ func TestServiceGetMetadata(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
-		runtimeMockOk := new(mocksruntime.Instance)
+		runtimeMockOk := mocksruntime.NewInstance(t)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMockOk, nil)
 		runtimeMockOk.On("SetContextStorage", &rtstorage.TrieState{})

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestRegisterModules(t *testing.T) {
-	rpcapiMocks := new(mocks.RPCAPI)
+	rpcapiMocks := mocks.NewRPCAPI(t)
 
 	mods := []string{
 		"system", "author", "chain",
@@ -177,7 +177,7 @@ func TestRPCUnsafeExpose(t *testing.T) {
 	_, err := buf.Write(data)
 	require.NoError(t, err)
 
-	netmock := new(mocks.NetworkAPI)
+	netmock := mocks.NewNetworkAPI(t)
 	netmock.On("AddReservedPeers", mock.AnythingOfType("string")).Return(nil)
 
 	cfg := &HTTPServerConfig{
@@ -214,7 +214,7 @@ func TestUnsafeRPCJustToLocalhost(t *testing.T) {
 	_, err := buf.Write(data)
 	require.NoError(t, err)
 
-	netmock := new(mocks.NetworkAPI)
+	netmock := mocks.NewNetworkAPI(t)
 	netmock.On("AddReservedPeers", mock.AnythingOfType("string")).Return(nil)
 
 	cfg := &HTTPServerConfig{
@@ -262,7 +262,7 @@ func TestRPCExternalEnable_UnsafeExternalNotEnabled(t *testing.T) {
 	safebuf := new(bytes.Buffer)
 	safebuf.Write(safeData)
 
-	netmock := new(mocks.NetworkAPI)
+	netmock := mocks.NewNetworkAPI(t)
 	netmock.On("NetworkState").Return(common.NetworkState{
 		PeerID: "peer id",
 	})

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -56,10 +56,6 @@ func TestRegisterModules(t *testing.T) {
 	}
 
 	NewHTTPServer(cfg)
-
-	for _, modName := range mods {
-		rpcapiMocks.AssertCalled(t, "BuildMethodNames", mock.Anything, modName)
-	}
 }
 
 func TestNewHTTPServer(t *testing.T) {

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -214,15 +214,11 @@ func TestUnsafeRPCJustToLocalhost(t *testing.T) {
 	_, err := buf.Write(data)
 	require.NoError(t, err)
 
-	netmock := mocks.NewNetworkAPI(t)
-	netmock.On("AddReservedPeers", mock.AnythingOfType("string")).Return(nil)
-
 	cfg := &HTTPServerConfig{
-		Modules:    []string{"system"},
-		RPCPort:    7880,
-		RPCAPI:     NewService(),
-		RPCUnsafe:  true,
-		NetworkAPI: netmock,
+		Modules:   []string{"system"},
+		RPCPort:   7880,
+		RPCAPI:    NewService(),
+		RPCUnsafe: true,
 	}
 
 	s := NewHTTPServer(cfg)

--- a/dot/rpc/modules/api_mocks.go
+++ b/dot/rpc/modules/api_mocks.go
@@ -4,6 +4,8 @@
 package modules
 
 import (
+	"testing"
+
 	modulesmocks "github.com/ChainSafe/gossamer/dot/rpc/modules/mocks"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -13,8 +15,8 @@ import (
 )
 
 // NewMockeryStorageAPI creates and return an rpc StorageAPI interface mock
-func NewMockeryStorageAPI() *modulesmocks.StorageAPI {
-	m := new(modulesmocks.StorageAPI)
+func NewMockeryStorageAPI(t *testing.T) *modulesmocks.StorageAPI {
+	m := modulesmocks.NewStorageAPI(t)
 	m.On("GetStorage", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8")).Return(nil, nil)
 	m.On("GetStorageFromChild", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8"),
 		mock.AnythingOfType("[]uint8")).Return(nil, nil)
@@ -28,8 +30,8 @@ func NewMockeryStorageAPI() *modulesmocks.StorageAPI {
 }
 
 // NewMockeryBlockAPI creates and return an rpc BlockAPI interface mock
-func NewMockeryBlockAPI() *modulesmocks.BlockAPI {
-	m := new(modulesmocks.BlockAPI)
+func NewMockeryBlockAPI(t *testing.T) *modulesmocks.BlockAPI {
+	m := modulesmocks.NewBlockAPI(t)
 	m.On("GetHeader", mock.AnythingOfType("common.Hash")).Return(nil, nil)
 	m.On("BestBlockHash").Return(common.Hash{})
 	m.On("GetBlockByHash", mock.AnythingOfType("common.Hash")).Return(nil, nil)
@@ -50,8 +52,8 @@ func NewMockeryBlockAPI() *modulesmocks.BlockAPI {
 }
 
 // NewMockTransactionStateAPI creates and return an rpc TransactionStateAPI interface mock
-func NewMockTransactionStateAPI() *modulesmocks.TransactionStateAPI {
-	m := new(modulesmocks.TransactionStateAPI)
+func NewMockTransactionStateAPI(t *testing.T) *modulesmocks.TransactionStateAPI {
+	m := modulesmocks.NewTransactionStateAPI(t)
 	m.On("FreeStatusNotifierChannel", mock.AnythingOfType("chan transaction.Status"))
 	m.On("GetStatusNotifierChannel", mock.AnythingOfType("types.Extrinsic")).Return(make(chan transaction.Status))
 	m.On("AddToPool", mock.AnythingOfType("transaction.ValidTransaction")).Return(common.Hash{})
@@ -59,8 +61,8 @@ func NewMockTransactionStateAPI() *modulesmocks.TransactionStateAPI {
 }
 
 // NewMockCoreAPI creates and return an rpc CoreAPI interface mock
-func NewMockCoreAPI() *modulesmocks.CoreAPI {
-	m := new(modulesmocks.CoreAPI)
+func NewMockCoreAPI(t *testing.T) *modulesmocks.CoreAPI {
+	m := modulesmocks.NewCoreAPI(t)
 	m.On("InsertKey", mock.AnythingOfType("crypto.Keypair"), mock.AnythingOfType("string")).Return(nil)
 	m.On("HasKey", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(false, nil)
 	m.On("GetRuntimeVersion", mock.AnythingOfType("*common.Hash")).

--- a/dot/rpc/modules/api_mocks.go
+++ b/dot/rpc/modules/api_mocks.go
@@ -17,36 +17,39 @@ import (
 // NewMockeryStorageAPI creates and return an rpc StorageAPI interface mock
 func NewMockeryStorageAPI(t *testing.T) *modulesmocks.StorageAPI {
 	m := modulesmocks.NewStorageAPI(t)
-	m.On("GetStorage", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8")).Return(nil, nil)
+	m.On("GetStorage", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8")).Return(nil, nil).Maybe()
 	m.On("GetStorageFromChild", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8"),
-		mock.AnythingOfType("[]uint8")).Return(nil, nil)
-	m.On("Entries", mock.AnythingOfType("*common.Hash")).Return(nil, nil)
-	m.On("GetStorageByBlockHash", mock.AnythingOfType("common.Hash"), mock.AnythingOfType("[]uint8")).Return(nil, nil)
-	m.On("RegisterStorageObserver", mock.Anything)
-	m.On("UnregisterStorageObserver", mock.Anything)
-	m.On("GetStateRootFromBlock", mock.AnythingOfType("*common.Hash")).Return(nil, nil)
-	m.On("GetKeysWithPrefix", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8")).Return(nil, nil)
+		mock.AnythingOfType("[]uint8")).Return(nil, nil).Maybe()
+	m.On("Entries", mock.AnythingOfType("*common.Hash")).Return(nil, nil).Maybe()
+	m.On("GetStorageByBlockHash", mock.AnythingOfType("common.Hash"), mock.AnythingOfType("[]uint8")).
+		Return(nil, nil).Maybe()
+	m.On("RegisterStorageObserver", mock.Anything).Maybe()
+	m.On("UnregisterStorageObserver", mock.Anything).Maybe()
+	m.On("GetStateRootFromBlock", mock.AnythingOfType("*common.Hash")).Return(nil, nil).Maybe()
+	m.On("GetKeysWithPrefix", mock.AnythingOfType("*common.Hash"), mock.AnythingOfType("[]uint8")).Return(nil, nil).Maybe()
 	return m
 }
 
 // NewMockeryBlockAPI creates and return an rpc BlockAPI interface mock
 func NewMockeryBlockAPI(t *testing.T) *modulesmocks.BlockAPI {
 	m := modulesmocks.NewBlockAPI(t)
-	m.On("GetHeader", mock.AnythingOfType("common.Hash")).Return(nil, nil)
-	m.On("BestBlockHash").Return(common.Hash{})
-	m.On("GetBlockByHash", mock.AnythingOfType("common.Hash")).Return(nil, nil)
-	m.On("GetHashByNumber", mock.AnythingOfType("uint")).Return(nil, nil)
-	m.On("GetFinalisedHash", mock.AnythingOfType("uint64"), mock.AnythingOfType("uint64")).Return(common.Hash{}, nil)
-	m.On("GetHighestFinalisedHash").Return(common.Hash{}, nil)
-	m.On("GetImportedBlockNotifierChannel").Return(make(chan *types.Block, 5))
-	m.On("FreeImportedBlockNotifierChannel", mock.AnythingOfType("chan *types.Block"))
-	m.On("GetFinalisedNotifierChannel").Return(make(chan *types.FinalisationInfo, 5))
-	m.On("FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo"))
-	m.On("GetJustification", mock.AnythingOfType("common.Hash")).Return(make([]byte, 10), nil)
-	m.On("HasJustification", mock.AnythingOfType("common.Hash")).Return(true, nil)
+	m.On("GetHeader", mock.AnythingOfType("common.Hash")).Return(nil, nil).Maybe()
+	m.On("BestBlockHash").Return(common.Hash{}).Maybe()
+	m.On("GetBlockByHash", mock.AnythingOfType("common.Hash")).Return(nil, nil).Maybe()
+	m.On("GetHashByNumber", mock.AnythingOfType("uint")).Return(nil, nil).Maybe()
+	m.On("GetFinalisedHash", mock.AnythingOfType("uint64"), mock.AnythingOfType("uint64")).
+		Return(common.Hash{}, nil).Maybe()
+	m.On("GetHighestFinalisedHash").Return(common.Hash{}, nil).Maybe()
+	m.On("GetImportedBlockNotifierChannel").Return(make(chan *types.Block, 5)).Maybe()
+	m.On("FreeImportedBlockNotifierChannel", mock.AnythingOfType("chan *types.Block")).Maybe()
+	m.On("GetFinalisedNotifierChannel").Return(make(chan *types.FinalisationInfo, 5)).Maybe()
+	m.On("FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo")).Maybe()
+	m.On("GetJustification", mock.AnythingOfType("common.Hash")).Return(make([]byte, 10), nil).Maybe()
+	m.On("HasJustification", mock.AnythingOfType("common.Hash")).Return(true, nil).Maybe()
 	m.On("SubChain", mock.AnythingOfType("common.Hash"), mock.AnythingOfType("common.Hash")).
-		Return(make([]common.Hash, 0), nil)
-	m.On("RegisterRuntimeUpdatedChannel", mock.AnythingOfType("chan<- runtime.Version")).Return(uint32(0), nil)
+		Return(make([]common.Hash, 0), nil).Maybe()
+	m.On("RegisterRuntimeUpdatedChannel", mock.AnythingOfType("chan<- runtime.Version")).
+		Return(uint32(0), nil).Maybe()
 
 	return m
 }
@@ -54,21 +57,21 @@ func NewMockeryBlockAPI(t *testing.T) *modulesmocks.BlockAPI {
 // NewMockTransactionStateAPI creates and return an rpc TransactionStateAPI interface mock
 func NewMockTransactionStateAPI(t *testing.T) *modulesmocks.TransactionStateAPI {
 	m := modulesmocks.NewTransactionStateAPI(t)
-	m.On("FreeStatusNotifierChannel", mock.AnythingOfType("chan transaction.Status"))
-	m.On("GetStatusNotifierChannel", mock.AnythingOfType("types.Extrinsic")).Return(make(chan transaction.Status))
-	m.On("AddToPool", mock.AnythingOfType("transaction.ValidTransaction")).Return(common.Hash{})
+	m.On("FreeStatusNotifierChannel", mock.AnythingOfType("chan transaction.Status")).Maybe()
+	m.On("GetStatusNotifierChannel", mock.AnythingOfType("types.Extrinsic")).Return(make(chan transaction.Status)).Maybe()
+	m.On("AddToPool", mock.AnythingOfType("transaction.ValidTransaction")).Return(common.Hash{}).Maybe()
 	return m
 }
 
 // NewMockCoreAPI creates and return an rpc CoreAPI interface mock
 func NewMockCoreAPI(t *testing.T) *modulesmocks.CoreAPI {
 	m := modulesmocks.NewCoreAPI(t)
-	m.On("InsertKey", mock.AnythingOfType("crypto.Keypair"), mock.AnythingOfType("string")).Return(nil)
-	m.On("HasKey", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(false, nil)
+	m.On("InsertKey", mock.AnythingOfType("crypto.Keypair"), mock.AnythingOfType("string")).Return(nil).Maybe()
+	m.On("HasKey", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(false, nil).Maybe()
 	m.On("GetRuntimeVersion", mock.AnythingOfType("*common.Hash")).
-		Return(runtime.Version{SpecName: []byte(`mock-spec`)}, nil)
-	m.On("IsBlockProducer").Return(false)
-	m.On("HandleSubmittedExtrinsic", mock.AnythingOfType("types.Extrinsic")).Return(nil)
-	m.On("GetMetadata", mock.AnythingOfType("*common.Hash")).Return(nil, nil)
+		Return(runtime.Version{SpecName: []byte(`mock-spec`)}, nil).Maybe()
+	m.On("IsBlockProducer").Return(false).Maybe()
+	m.On("HandleSubmittedExtrinsic", mock.AnythingOfType("types.Extrinsic")).Return(nil).Maybe()
+	m.On("GetMetadata", mock.AnythingOfType("*common.Hash")).Return(nil, nil).Maybe()
 	return m
 }

--- a/dot/rpc/modules/author_test.go
+++ b/dot/rpc/modules/author_test.go
@@ -36,9 +36,6 @@ func TestAuthorModule_HasSessionKeys(t *testing.T) {
 		"9a9d2a24213896ff06895db16aade8b6502f3a71cf56374cc38520426026696d6f6e8034309a9d2a24213896ff06895" +
 		"db16aade8b6502f3a71cf56374cc3852042602661756469")
 
-	coreMockAPIDecodeErr := mocks.NewCoreAPI(t)
-	coreMockAPIDecodeErr.On("DecodeSessionKeys", []byte{0x4, 0x1}).Return(nil, errors.New("decodeSessionKeys err"))
-
 	coreMockAPIUnmarshalErr := mocks.NewCoreAPI(t)
 	coreMockAPIUnmarshalErr.On("DecodeSessionKeys", []byte{0x4, 0x1}).Return([]byte{0x4, 0x1}, nil)
 
@@ -72,7 +69,7 @@ func TestAuthorModule_HasSessionKeys(t *testing.T) {
 		{
 			name: "Empty Request",
 			fields: fields{
-				authorModule: NewAuthorModule(log.New(log.SetWriter(io.Discard)), coreMockAPIDecodeErr, nil),
+				authorModule: NewAuthorModule(log.New(log.SetWriter(io.Discard)), nil, nil),
 			},
 			args: args{
 				req: &HasSessionKeyRequest{},
@@ -317,12 +314,6 @@ func TestAuthorModule_InsertKey(t *testing.T) {
 	mockCoreAPIHappyGran := mocks.NewCoreAPI(t)
 	mockCoreAPIHappyGran.On("InsertKey", kp2, "gran").Return(nil)
 
-	mockCoreAPIBadKey := mocks.NewCoreAPI(t)
-	mockCoreAPIBadKey.On("InsertKey", kp3, "babe").Return(nil)
-
-	mockCoreAPIUnknownKey := mocks.NewCoreAPI(t)
-	mockCoreAPIUnknownKey.On("InsertKey", kp3, "mack").Return(nil)
-
 	type fields struct {
 		logger     log.LeveledLogger
 		coreAPI    CoreAPI
@@ -369,8 +360,7 @@ func TestAuthorModule_InsertKey(t *testing.T) {
 		{
 			name: "invalid key",
 			fields: fields{
-				logger:  log.New(log.SetWriter(io.Discard)),
-				coreAPI: mockCoreAPIBadKey,
+				logger: log.New(log.SetWriter(io.Discard)),
 			},
 			args: args{
 				req: &KeyInsertRequest{"babe",
@@ -383,8 +373,7 @@ func TestAuthorModule_InsertKey(t *testing.T) {
 		{
 			name: "unknown key",
 			fields: fields{
-				logger:  log.New(log.SetWriter(io.Discard)),
-				coreAPI: mockCoreAPIUnknownKey,
+				logger: log.New(log.SetWriter(io.Discard)),
 			},
 			args: args{
 				req: &KeyInsertRequest{

--- a/dot/rpc/modules/author_test.go
+++ b/dot/rpc/modules/author_test.go
@@ -36,23 +36,23 @@ func TestAuthorModule_HasSessionKeys(t *testing.T) {
 		"9a9d2a24213896ff06895db16aade8b6502f3a71cf56374cc38520426026696d6f6e8034309a9d2a24213896ff06895" +
 		"db16aade8b6502f3a71cf56374cc3852042602661756469")
 
-	coreMockAPIDecodeErr := new(mocks.CoreAPI)
+	coreMockAPIDecodeErr := mocks.NewCoreAPI(t)
 	coreMockAPIDecodeErr.On("DecodeSessionKeys", []byte{0x4, 0x1}).Return(nil, errors.New("decodeSessionKeys err"))
 
-	coreMockAPIUnmarshalErr := new(mocks.CoreAPI)
+	coreMockAPIUnmarshalErr := mocks.NewCoreAPI(t)
 	coreMockAPIUnmarshalErr.On("DecodeSessionKeys", []byte{0x4, 0x1}).Return([]byte{0x4, 0x1}, nil)
 
-	coreMockAPIOk := new(mocks.CoreAPI)
+	coreMockAPIOk := mocks.NewCoreAPI(t)
 	coreMockAPIOk.On("DecodeSessionKeys", pkeys).Return(data, nil)
 	coreMockAPIOk.On("HasKey", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(true, nil)
 
-	coreMockAPIErr := new(mocks.CoreAPI)
+	coreMockAPIErr := mocks.NewCoreAPI(t)
 	coreMockAPIErr.On("DecodeSessionKeys", pkeys).Return(data, nil)
 	coreMockAPIErr.On("HasKey", mock.AnythingOfType("string"),
 		mock.AnythingOfType("string")).
 		Return(false, errors.New("HasKey err"))
 
-	coreMockAPIInvalidDec := new(mocks.CoreAPI)
+	coreMockAPIInvalidDec := mocks.NewCoreAPI(t)
 	coreMockAPIInvalidDec.On("DecodeSessionKeys", pkeys).Return([]byte{0x0}, nil)
 
 	type fields struct {
@@ -151,11 +151,11 @@ func TestAuthorModule_SubmitExtrinsic(t *testing.T) {
 		201, 74, 231, 222, 101, 85, 108, 102, 39, 31, 190, 210, 14, 215, 124, 19, 160, 180, 203, 54, 110, 167, 163,
 		149, 45, 12, 108, 80, 221, 65, 238, 57, 237, 199, 16, 10, 33, 185, 8, 244, 184, 243, 139, 5, 87, 252, 245,
 		24, 225, 37, 154, 163, 143}
-	errMockCoreAPI := &mocks.CoreAPI{}
+	errMockCoreAPI := mocks.NewCoreAPI(t)
 	errMockCoreAPI.On("HandleSubmittedExtrinsic",
 		types.Extrinsic(common.MustHexToBytes(fmt.Sprintf("0x%x", testInvalidExt)))).Return(fmt.Errorf("some error"))
 
-	mockCoreAPI := &mocks.CoreAPI{}
+	mockCoreAPI := mocks.NewCoreAPI(t)
 	mockCoreAPI.On("HandleSubmittedExtrinsic",
 		types.Extrinsic(common.MustHexToBytes(fmt.Sprintf("0x%x", testExt)))).Return(nil)
 	type fields struct {
@@ -226,10 +226,10 @@ func TestAuthorModule_SubmitExtrinsic(t *testing.T) {
 }
 
 func TestAuthorModule_PendingExtrinsics(t *testing.T) {
-	emptyMockTransactionStateAPI := &mocks.TransactionStateAPI{}
+	emptyMockTransactionStateAPI := mocks.NewTransactionStateAPI(t)
 	emptyMockTransactionStateAPI.On("Pending").Return([]*transaction.ValidTransaction{})
 
-	mockTransactionStateAPI := &mocks.TransactionStateAPI{}
+	mockTransactionStateAPI := mocks.NewTransactionStateAPI(t)
 	mockTransactionStateAPI.On("Pending").Return([]*transaction.ValidTransaction{
 		{
 			Extrinsic: types.NewExtrinsic([]byte("someExtrinsic")),
@@ -311,16 +311,16 @@ func TestAuthorModule_InsertKey(t *testing.T) {
 	require.NoError(t, err)
 	_ = kp3.Public().Hex()
 
-	mockCoreAPIHappyBabe := &mocks.CoreAPI{}
+	mockCoreAPIHappyBabe := mocks.NewCoreAPI(t)
 	mockCoreAPIHappyBabe.On("InsertKey", kp1, "babe").Return(nil)
 
-	mockCoreAPIHappyGran := &mocks.CoreAPI{}
+	mockCoreAPIHappyGran := mocks.NewCoreAPI(t)
 	mockCoreAPIHappyGran.On("InsertKey", kp2, "gran").Return(nil)
 
-	mockCoreAPIBadKey := &mocks.CoreAPI{}
+	mockCoreAPIBadKey := mocks.NewCoreAPI(t)
 	mockCoreAPIBadKey.On("InsertKey", kp3, "babe").Return(nil)
 
-	mockCoreAPIUnknownKey := &mocks.CoreAPI{}
+	mockCoreAPIUnknownKey := mocks.NewCoreAPI(t)
 	mockCoreAPIUnknownKey.On("InsertKey", kp3, "mack").Return(nil)
 
 	type fields struct {
@@ -418,13 +418,13 @@ func TestAuthorModule_HasKey(t *testing.T) {
 	kr, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 
-	mockCoreAPITrue := &mocks.CoreAPI{}
+	mockCoreAPITrue := mocks.NewCoreAPI(t)
 	mockCoreAPITrue.On("HasKey", kr.Alice().Public().Hex(), "babe").Return(true, nil)
 
-	mockCoreAPIFalse := &mocks.CoreAPI{}
+	mockCoreAPIFalse := mocks.NewCoreAPI(t)
 	mockCoreAPIFalse.On("HasKey", kr.Alice().Public().Hex(), "babe").Return(false, nil)
 
-	mockCoreAPIErr := &mocks.CoreAPI{}
+	mockCoreAPIErr := mocks.NewCoreAPI(t)
 	mockCoreAPIErr.On("HasKey", kr.Alice().Public().Hex(), "babe").Return(false, fmt.Errorf("some error"))
 
 	type fields struct {

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -21,16 +21,16 @@ func TestChainModule_GetBlock(t *testing.T) {
 	inputHash := common.MustHexToHash("0x0102000000000000000000000000000000000000000000000000000000000000")
 	emptyBlock := types.NewEmptyBlock()
 
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 	mockBlockAPI.On("GetBlockByHash", inputHash).Return(&emptyBlock, nil)
 	mockBlockAPI.On("BestBlockHash").Return(testHash, nil)
 
-	mockBlockAPIGetHashErr := new(mocks.BlockAPI)
+	mockBlockAPIGetHashErr := mocks.NewBlockAPI(t)
 	mockBlockAPIGetHashErr.On("GetBlockByHash", inputHash).Return(nil, errors.New("GetJustification error"))
 
 	bodyBlock := types.NewEmptyBlock()
 	bodyBlock.Body = types.BytesArrayToExtrinsics([][]byte{{1}})
-	mockBlockAPIWithBody := new(mocks.BlockAPI)
+	mockBlockAPIWithBody := mocks.NewBlockAPI(t)
 	mockBlockAPIWithBody.On("GetBlockByHash", inputHash).Return(&bodyBlock, nil)
 
 	chainModule := NewChainModule(mockBlockAPI)
@@ -118,11 +118,11 @@ func TestChainModule_GetBlockHash(t *testing.T) {
 	testHash := common.NewHash([]byte{0x01, 0x02})
 	i := []interface{}{"a"}
 
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 	mockBlockAPI.On("BestBlockHash").Return(testHash, nil)
 	mockBlockAPI.On("GetHashByNumber", uint(21)).Return(testHash, nil)
 
-	mockBlockAPIErr := new(mocks.BlockAPI)
+	mockBlockAPIErr := mocks.NewBlockAPI(t)
 	mockBlockAPIErr.On("BestBlockHash").Return(testHash, nil)
 	mockBlockAPIErr.On("GetHashByNumber", uint(21)).Return(nil, errors.New("GetBlockHash Error"))
 
@@ -224,10 +224,10 @@ func TestChainModule_GetBlockHash(t *testing.T) {
 
 func TestChainModule_GetFinalizedHead(t *testing.T) {
 	testHash := common.NewHash([]byte{0x01, 0x02})
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 	mockBlockAPI.On("GetHighestFinalisedHash").Return(testHash, nil)
 
-	mockBlockAPIErr := new(mocks.BlockAPI)
+	mockBlockAPIErr := mocks.NewBlockAPI(t)
 	mockBlockAPIErr.On("GetHighestFinalisedHash").Return(nil, errors.New("GetHighestFinalisedHash Error"))
 
 	expRes := ChainHashResponse(common.BytesToHex(testHash[:]))
@@ -285,10 +285,10 @@ func TestChainModule_GetFinalizedHead(t *testing.T) {
 
 func TestChainModule_GetFinalizedHeadByRound(t *testing.T) {
 	testHash := common.NewHash([]byte{0x01, 0x02})
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 	mockBlockAPI.On("GetFinalisedHash", uint64(21), uint64(21)).Return(testHash, nil)
 
-	mockBlockAPIErr := new(mocks.BlockAPI)
+	mockBlockAPIErr := mocks.NewBlockAPI(t)
 	mockBlockAPIErr.On("GetFinalisedHash", uint64(21), uint64(21)).Return(nil, errors.New("GetFinalisedHash Error"))
 
 	expRes := ChainHashResponse(common.BytesToHex(testHash[:]))
@@ -356,10 +356,10 @@ func TestChainModule_GetHeader(t *testing.T) {
 	inputHash, err := common.HexToHash("0x0102000000000000000000000000000000000000000000000000000000000000")
 	require.NoError(t, err)
 
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 	mockBlockAPI.On("GetHeader", inputHash).Return(emptyHeader, nil)
 
-	mockBlockAPIErr := new(mocks.BlockAPI)
+	mockBlockAPIErr := mocks.NewBlockAPI(t)
 	mockBlockAPIErr.On("GetHeader", inputHash).Return(nil, errors.New("GetFinalisedHash Error"))
 
 	expRes, err := HeaderToJSON(*emptyHeader)
@@ -420,7 +420,7 @@ func TestChainModule_GetHeader(t *testing.T) {
 func TestChainModule_ErrSubscriptionTransport(t *testing.T) {
 	req := &EmptyRequest{}
 	res := &ChainBlockHeaderResponse{}
-	cm := NewChainModule(new(mocks.BlockAPI))
+	cm := NewChainModule(mocks.NewBlockAPI(t))
 
 	err := cm.SubscribeFinalizedHeads(nil, req, res)
 	require.ErrorIs(t, err, ErrSubscriptionTransport)

--- a/dot/rpc/modules/chain_test.go
+++ b/dot/rpc/modules/chain_test.go
@@ -123,7 +123,6 @@ func TestChainModule_GetBlockHash(t *testing.T) {
 	mockBlockAPI.On("GetHashByNumber", uint(21)).Return(testHash, nil)
 
 	mockBlockAPIErr := mocks.NewBlockAPI(t)
-	mockBlockAPIErr.On("BestBlockHash").Return(testHash, nil)
 	mockBlockAPIErr.On("GetHashByNumber", uint(21)).Return(nil, errors.New("GetBlockHash Error"))
 
 	expRes := ChainHashResponse(testHash.String())

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -56,7 +56,6 @@ func TestChildStateModule_GetKeys(t *testing.T) {
 	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
-	mockBlockAPI.On("GetBlockHash").Return(hash)
 	mockBlockAPI.On("BestBlockHash").Return(hash)
 
 	mockStorageAPI.On("GetStateRootFromBlock", &hash).Return(&sr, nil)
@@ -167,7 +166,6 @@ func TestChildStateModule_GetStorageSize(t *testing.T) {
 	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
-	mockBlockAPI.On("GetBlockHash").Return(hash)
 	mockBlockAPI.On("BestBlockHash").Return(hash)
 
 	mockStorageAPI.On("GetStateRootFromBlock", &hash).Return(&sr, nil)
@@ -279,7 +277,6 @@ func TestChildStateModule_GetStorageHash(t *testing.T) {
 	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
-	mockBlockAPI.On("GetBlockHash").Return(hash)
 	mockBlockAPI.On("BestBlockHash").Return(hash)
 
 	mockStorageAPI.On("GetStateRootFromBlock", &hash).Return(&sr, nil)
@@ -391,7 +388,6 @@ func TestChildStateModule_GetStorage(t *testing.T) {
 	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
-	mockBlockAPI.On("GetBlockHash").Return(hash)
 	mockBlockAPI.On("BestBlockHash").Return(hash)
 
 	mockStorageAPI.On("GetStateRootFromBlock", &hash).Return(&sr, nil)

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -50,10 +50,10 @@ func TestChildStateModule_GetKeys(t *testing.T) {
 		expHexKeys[idx] = common.BytesToHex(k)
 	}
 
-	mockStorageAPI := new(apimocks.StorageAPI)
-	mockErrorStorageAPI1 := new(apimocks.StorageAPI)
-	mockErrorStorageAPI2 := new(apimocks.StorageAPI)
-	mockBlockAPI := new(apimocks.BlockAPI)
+	mockStorageAPI := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI1 := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI2 := apimocks.NewStorageAPI(t)
+	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	mockBlockAPI.On("GetBlockHash").Return(hash)
@@ -161,10 +161,10 @@ func TestChildStateModule_GetKeys(t *testing.T) {
 func TestChildStateModule_GetStorageSize(t *testing.T) {
 	_, sr := createTestTrieState(t)
 
-	mockStorageAPI := new(apimocks.StorageAPI)
-	mockErrorStorageAPI1 := new(apimocks.StorageAPI)
-	mockErrorStorageAPI2 := new(apimocks.StorageAPI)
-	mockBlockAPI := new(apimocks.BlockAPI)
+	mockStorageAPI := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI1 := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI2 := apimocks.NewStorageAPI(t)
+	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	mockBlockAPI.On("GetBlockHash").Return(hash)
@@ -273,10 +273,10 @@ func TestChildStateModule_GetStorageSize(t *testing.T) {
 func TestChildStateModule_GetStorageHash(t *testing.T) {
 	_, sr := createTestTrieState(t)
 
-	mockStorageAPI := new(apimocks.StorageAPI)
-	mockErrorStorageAPI1 := new(apimocks.StorageAPI)
-	mockErrorStorageAPI2 := new(apimocks.StorageAPI)
-	mockBlockAPI := new(apimocks.BlockAPI)
+	mockStorageAPI := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI1 := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI2 := apimocks.NewStorageAPI(t)
+	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	mockBlockAPI.On("GetBlockHash").Return(hash)
@@ -385,10 +385,10 @@ func TestChildStateModule_GetStorageHash(t *testing.T) {
 func TestChildStateModule_GetStorage(t *testing.T) {
 	_, sr := createTestTrieState(t)
 
-	mockStorageAPI := new(apimocks.StorageAPI)
-	mockErrorStorageAPI1 := new(apimocks.StorageAPI)
-	mockErrorStorageAPI2 := new(apimocks.StorageAPI)
-	mockBlockAPI := new(apimocks.BlockAPI)
+	mockStorageAPI := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI1 := apimocks.NewStorageAPI(t)
+	mockErrorStorageAPI2 := apimocks.NewStorageAPI(t)
+	mockBlockAPI := apimocks.NewBlockAPI(t)
 
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	mockBlockAPI.On("GetBlockHash").Return(hash)

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -75,7 +75,7 @@ func newBABEService(t *testing.T) *babe.Service {
 		EpochState:         es,
 		Keypair:            kr.Alice().(*sr25519.Keypair),
 		IsDev:              true,
-		BlockImportHandler: new(babemocks.BlockImportHandler),
+		BlockImportHandler: babemocks.NewBlockImportHandler(t),
 	}
 
 	babe, err := babe.NewService(cfg)

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -53,7 +53,7 @@ func Test_uint64ToHex(t *testing.T) {
 }
 
 func TestDevModule_EpochLength(t *testing.T) {
-	mockBlockProducerAPI := new(mocks.BlockProducerAPI)
+	mockBlockProducerAPI := mocks.NewBlockProducerAPI(t)
 	mockBlockProducerAPI.On("EpochLength").Return(uint64(23))
 	devModule := NewDevModule(mockBlockProducerAPI, nil)
 
@@ -103,7 +103,7 @@ func TestDevModule_EpochLength(t *testing.T) {
 }
 
 func TestDevModule_SlotDuration(t *testing.T) {
-	mockBlockProducerAPI := new(mocks.BlockProducerAPI)
+	mockBlockProducerAPI := mocks.NewBlockProducerAPI(t)
 	mockBlockProducerAPI.On("SlotDuration").Return(uint64(23))
 
 	type fields struct {
@@ -152,10 +152,10 @@ func TestDevModule_SlotDuration(t *testing.T) {
 }
 
 func TestDevModule_Control(t *testing.T) {
-	mockBlockProducerAPI := new(mocks.BlockProducerAPI)
-	mockErrorBlockProducerAPI := new(mocks.BlockProducerAPI)
-	mockNetworkAPI := new(mocks.NetworkAPI)
-	mockErrorNetworkAPI := new(mocks.NetworkAPI)
+	mockBlockProducerAPI := mocks.NewBlockProducerAPI(t)
+	mockErrorBlockProducerAPI := mocks.NewBlockProducerAPI(t)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
+	mockErrorNetworkAPI := mocks.NewNetworkAPI(t)
 
 	mockErrorBlockProducerAPI.On("Pause").Return(errors.New("babe pause error"))
 	mockBlockProducerAPI.On("Pause").Return(nil)

--- a/dot/rpc/modules/grandpa_integration_test.go
+++ b/dot/rpc/modules/grandpa_integration_test.go
@@ -60,7 +60,7 @@ func TestRoundState(t *testing.T) {
 		})
 	}
 
-	grandpamock := new(rpcmocks.BlockFinalityAPI)
+	grandpamock := rpcmocks.NewBlockFinalityAPI(t)
 	grandpamock.On("GetVoters").Return(voters)
 	grandpamock.On("GetSetID").Return(uint64(0))
 	grandpamock.On("GetRound").Return(uint64(2))

--- a/dot/rpc/modules/grandpa_test.go
+++ b/dot/rpc/modules/grandpa_test.go
@@ -122,8 +122,8 @@ func TestGrandpaModule_RoundState(t *testing.T) {
 		})
 	}
 
-	mockBlockAPI := new(mocks.BlockAPI)
-	mockBlockFinalityAPI := new(mocks.BlockFinalityAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
+	mockBlockFinalityAPI := mocks.NewBlockFinalityAPI(t)
 	mockBlockFinalityAPI.On("GetVoters").Return(voters)
 	mockBlockFinalityAPI.On("GetSetID").Return(uint64(0))
 	mockBlockFinalityAPI.On("GetRound").Return(uint64(2))

--- a/dot/rpc/modules/offchain_integration_test.go
+++ b/dot/rpc/modules/offchain_integration_test.go
@@ -23,7 +23,7 @@ func TestOffchainStorageGet(t *testing.T) {
 
 	for kind, test := range testFuncs {
 		expectedValue := common.BytesToHex([]byte("some-value"))
-		st := new(mocks.RuntimeStorageAPI)
+		st := mocks.NewRuntimeStorageAPI(t)
 		st.On(test, mock.AnythingOfType("[]uint8")).Return([]byte("some-value"), nil).Once()
 
 		m := new(OffchainModule)
@@ -76,7 +76,7 @@ func TestOffchainStorageSet(t *testing.T) {
 	}
 
 	for kind, test := range testFuncs {
-		st := new(mocks.RuntimeStorageAPI)
+		st := mocks.NewRuntimeStorageAPI(t)
 		st.On(test, mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8")).Return(nil).Once()
 
 		m := new(OffchainModule)

--- a/dot/rpc/modules/offchain_integration_test.go
+++ b/dot/rpc/modules/offchain_integration_test.go
@@ -38,7 +38,6 @@ func TestOffchainStorageGet(t *testing.T) {
 		err := m.LocalStorageGet(nil, req, &res)
 		require.NoError(t, err)
 		require.Equal(t, res, StringResponse(expectedValue))
-		st.AssertCalled(t, test, mock.AnythingOfType("[]uint8"))
 
 		st.
 			On(test, mock.AnythingOfType("[]uint8")).
@@ -47,7 +46,6 @@ func TestOffchainStorageGet(t *testing.T) {
 
 		err = m.LocalStorageGet(nil, req, nil)
 		require.Error(t, err, "problem to retrieve")
-		st.AssertCalled(t, test, mock.AnythingOfType("[]uint8"))
 	}
 }
 
@@ -92,7 +90,6 @@ func TestOffchainStorageSet(t *testing.T) {
 		err := m.LocalStorageSet(nil, req, &res)
 		require.NoError(t, err)
 		require.Empty(t, res)
-		st.AssertCalled(t, test, mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8"))
 
 		st.
 			On(test, mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8")).
@@ -102,6 +99,5 @@ func TestOffchainStorageSet(t *testing.T) {
 		err = m.LocalStorageSet(nil, req, &res)
 		require.Error(t, err, "problem to store")
 		require.Empty(t, res)
-		st.AssertCalled(t, test, mock.AnythingOfType("[]uint8"), mock.AnythingOfType("[]uint8"))
 	}
 }

--- a/dot/rpc/modules/offchain_test.go
+++ b/dot/rpc/modules/offchain_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestOffchainModule_LocalStorageGet(t *testing.T) {
-	mockRuntimeStorageAPI := new(mocks.RuntimeStorageAPI)
+	mockRuntimeStorageAPI := mocks.NewRuntimeStorageAPI(t)
 	mockRuntimeStorageAPI.On("GetPersistent", common.MustHexToBytes("0x11111111111111")).
 		Return(nil, errors.New("GetPersistent error"))
 	mockRuntimeStorageAPI.On("GetLocal", common.MustHexToBytes("0x11111111111111")).Return([]byte("some-value"), nil)
@@ -107,7 +107,7 @@ func TestOffchainModule_LocalStorageGet(t *testing.T) {
 }
 
 func TestOffchainModule_LocalStorageSet(t *testing.T) {
-	mockRuntimeStorageAPI := new(mocks.RuntimeStorageAPI)
+	mockRuntimeStorageAPI := mocks.NewRuntimeStorageAPI(t)
 	mockRuntimeStorageAPI.On("SetLocal",
 		common.MustHexToBytes("0x11111111111111"), common.MustHexToBytes("0x22222222222222")).
 		Return(nil)

--- a/dot/rpc/modules/payment_integration_test.go
+++ b/dot/rpc/modules/payment_integration_test.go
@@ -36,10 +36,10 @@ func TestPaymentQueryInfo(t *testing.T) {
 			PartialFee: scale.MaxUint128.String(),
 		}
 
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("PaymentQueryInfo", mock.AnythingOfType("[]uint8")).Return(mockedQueryInfo, nil)
 
-		blockAPIMock := new(mocks.BlockAPI)
+		blockAPIMock := mocks.NewBlockAPI(t)
 		blockAPIMock.On("BestBlockHash").Return(bestBlockHash)
 
 		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).Return(runtimeMock, nil)
@@ -65,7 +65,7 @@ func TestPaymentQueryInfo(t *testing.T) {
 	})
 
 	t.Run("When could not get runtime", func(t *testing.T) {
-		blockAPIMock := new(mocks.BlockAPI)
+		blockAPIMock := mocks.NewBlockAPI(t)
 		blockAPIMock.On("BestBlockHash").Return(bestBlockHash)
 
 		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).
@@ -90,10 +90,10 @@ func TestPaymentQueryInfo(t *testing.T) {
 	})
 
 	t.Run("When PaymentQueryInfo returns error", func(t *testing.T) {
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("PaymentQueryInfo", mock.AnythingOfType("[]uint8")).Return(nil, errors.New("mocked error"))
 
-		blockAPIMock := new(mocks.BlockAPI)
+		blockAPIMock := mocks.NewBlockAPI(t)
 		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).Return(runtimeMock, nil)
 
 		mod := &PaymentModule{
@@ -118,10 +118,10 @@ func TestPaymentQueryInfo(t *testing.T) {
 	})
 
 	t.Run("When PaymentQueryInfo returns a nil info", func(t *testing.T) {
-		runtimeMock := new(mocksruntime.Instance)
+		runtimeMock := mocksruntime.NewInstance(t)
 		runtimeMock.On("PaymentQueryInfo", mock.AnythingOfType("[]uint8")).Return(nil, nil)
 
-		blockAPIMock := new(mocks.BlockAPI)
+		blockAPIMock := mocks.NewBlockAPI(t)
 		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).Return(runtimeMock, nil)
 
 		mod := &PaymentModule{

--- a/dot/rpc/modules/payment_integration_test.go
+++ b/dot/rpc/modules/payment_integration_test.go
@@ -57,11 +57,6 @@ func TestPaymentQueryInfo(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, expected, res)
-
-		// should be called because req.Hash is nil
-		blockAPIMock.AssertCalled(t, "BestBlockHash")
-		blockAPIMock.AssertCalled(t, "GetRuntime", mock.AnythingOfType("*common.Hash"))
-		runtimeMock.AssertCalled(t, "PaymentQueryInfo", mock.AnythingOfType("[]uint8"))
 	})
 
 	t.Run("When could not get runtime", func(t *testing.T) {
@@ -84,9 +79,6 @@ func TestPaymentQueryInfo(t *testing.T) {
 
 		require.Error(t, err)
 		require.Equal(t, res, PaymentQueryInfoResponse{})
-
-		blockAPIMock.AssertCalled(t, "BestBlockHash")
-		blockAPIMock.AssertCalled(t, "GetRuntime", mock.AnythingOfType("*common.Hash"))
 	})
 
 	t.Run("When PaymentQueryInfo returns error", func(t *testing.T) {
@@ -110,11 +102,6 @@ func TestPaymentQueryInfo(t *testing.T) {
 
 		require.Error(t, err)
 		require.Equal(t, res, PaymentQueryInfoResponse{})
-
-		// should be called because req.Hash is nil
-		blockAPIMock.AssertNotCalled(t, "BestBlockHash")
-		blockAPIMock.AssertCalled(t, "GetRuntime", mock.AnythingOfType("*common.Hash"))
-		runtimeMock.AssertCalled(t, "PaymentQueryInfo", mock.AnythingOfType("[]uint8"))
 	})
 
 	t.Run("When PaymentQueryInfo returns a nil info", func(t *testing.T) {
@@ -138,10 +125,5 @@ func TestPaymentQueryInfo(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, res, PaymentQueryInfoResponse{})
-
-		// should be called because req.Hash is nil
-		blockAPIMock.AssertNotCalled(t, "BestBlockHash")
-		blockAPIMock.AssertCalled(t, "GetRuntime", mock.AnythingOfType("*common.Hash"))
-		runtimeMock.AssertCalled(t, "PaymentQueryInfo", mock.AnythingOfType("[]uint8"))
 	})
 }

--- a/dot/rpc/modules/payment_test.go
+++ b/dot/rpc/modules/payment_test.go
@@ -24,14 +24,14 @@ func TestPaymentModule_QueryInfo(t *testing.T) {
 	u, err := scale.NewUint128(new(big.Int).SetBytes([]byte{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6}))
 	require.NoError(t, err)
 
-	runtimeMock := new(mocksruntime.Instance)
-	runtimeMock2 := new(mocksruntime.Instance)
-	runtimeErrorMock := new(mocksruntime.Instance)
+	runtimeMock := mocksruntime.NewInstance(t)
+	runtimeMock2 := mocksruntime.NewInstance(t)
+	runtimeErrorMock := mocksruntime.NewInstance(t)
 
-	blockAPIMock := new(mocks.BlockAPI)
-	blockAPIMock2 := new(mocks.BlockAPI)
-	blockErrorAPIMock1 := new(mocks.BlockAPI)
-	blockErrorAPIMock2 := new(mocks.BlockAPI)
+	blockAPIMock := mocks.NewBlockAPI(t)
+	blockAPIMock2 := mocks.NewBlockAPI(t)
+	blockErrorAPIMock1 := mocks.NewBlockAPI(t)
+	blockErrorAPIMock2 := mocks.NewBlockAPI(t)
 
 	blockAPIMock.On("BestBlockHash").Return(testHash, nil)
 	blockAPIMock.On("GetRuntime", &testHash).Return(runtimeMock, nil)

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -491,7 +491,7 @@ func TestStateModule_GetKeysPaged(t *testing.T) {
 }
 
 func TestGetReadProof_WhenCoreAPIReturnsError(t *testing.T) {
-	coreAPIMock := new(mocks.CoreAPI)
+	coreAPIMock := mocks.NewCoreAPI(t)
 	coreAPIMock.
 		On("GetReadProofAt", mock.AnythingOfType("common.Hash"), mock.AnythingOfType("[][]uint8")).
 		Return(common.Hash{}, nil, errors.New("mocked error"))
@@ -510,7 +510,7 @@ func TestGetReadProof_WhenReturnsProof(t *testing.T) {
 	expectedBlock := common.BytesToHash([]byte("random hash"))
 	mockedProof := [][]byte{[]byte("proof-1"), []byte("proof-2")}
 
-	coreAPIMock := new(mocks.CoreAPI)
+	coreAPIMock := mocks.NewCoreAPI(t)
 	coreAPIMock.
 		On("GetReadProofAt", mock.AnythingOfType("common.Hash"), mock.AnythingOfType("[][]uint8")).
 		Return(expectedBlock, mockedProof, nil)

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -40,7 +40,6 @@ func TestStateModuleGetPairs(t *testing.T) {
 
 	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
-	mockStorageAPI.On("Entries", &hash).Return(m, nil)
 	mockStorageAPI.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).Return([][]byte{{1}, {1}}, nil)
 	mockStorageAPI.On("GetStorage", &hash, []byte{1}).Return([]byte{21}, nil)
 
@@ -50,12 +49,10 @@ func TestStateModuleGetPairs(t *testing.T) {
 
 	mockStorageAPIGetKeysEmpty := mocks.NewStorageAPI(t)
 	mockStorageAPIGetKeysEmpty.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
-	mockStorageAPIGetKeysEmpty.On("Entries", &hash).Return(m, nil)
 	mockStorageAPIGetKeysEmpty.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).Return([][]byte{}, nil)
 
 	mockStorageAPIGetKeysErr := mocks.NewStorageAPI(t)
 	mockStorageAPIGetKeysErr.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
-	mockStorageAPIGetKeysErr.On("Entries", &hash).Return(m, nil)
 	mockStorageAPIGetKeysErr.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).
 		Return(nil, errors.New("GetKeysWithPrefix Err"))
 
@@ -68,7 +65,6 @@ func TestStateModuleGetPairs(t *testing.T) {
 
 	mockStorageAPIGetStorageErr := mocks.NewStorageAPI(t)
 	mockStorageAPIGetStorageErr.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
-	mockStorageAPIGetStorageErr.On("Entries", &hash).Return(m, nil)
 	mockStorageAPIGetStorageErr.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).Return([][]byte{{2}, {2}}, nil)
 	mockStorageAPIGetStorageErr.On("GetStorage", &hash, []byte{2}).Return(nil, errors.New("GetStorage Err"))
 

--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -38,35 +38,35 @@ func TestStateModuleGetPairs(t *testing.T) {
 	m["a"] = []byte{21, 22}
 	m["b"] = []byte{23, 24}
 
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
 	mockStorageAPI.On("Entries", &hash).Return(m, nil)
 	mockStorageAPI.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).Return([][]byte{{1}, {1}}, nil)
 	mockStorageAPI.On("GetStorage", &hash, []byte{1}).Return([]byte{21}, nil)
 
-	mockStorageAPINil := new(mocks.StorageAPI)
+	mockStorageAPINil := mocks.NewStorageAPI(t)
 	mockStorageAPINil.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
 	mockStorageAPINil.On("Entries", &hash).Return(m, nil)
 
-	mockStorageAPIGetKeysEmpty := new(mocks.StorageAPI)
+	mockStorageAPIGetKeysEmpty := mocks.NewStorageAPI(t)
 	mockStorageAPIGetKeysEmpty.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
 	mockStorageAPIGetKeysEmpty.On("Entries", &hash).Return(m, nil)
 	mockStorageAPIGetKeysEmpty.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).Return([][]byte{}, nil)
 
-	mockStorageAPIGetKeysErr := new(mocks.StorageAPI)
+	mockStorageAPIGetKeysErr := mocks.NewStorageAPI(t)
 	mockStorageAPIGetKeysErr.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
 	mockStorageAPIGetKeysErr.On("Entries", &hash).Return(m, nil)
 	mockStorageAPIGetKeysErr.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).
 		Return(nil, errors.New("GetKeysWithPrefix Err"))
 
-	mockStorageAPIEntriesErr := new(mocks.StorageAPI)
+	mockStorageAPIEntriesErr := mocks.NewStorageAPI(t)
 	mockStorageAPIEntriesErr.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
 	mockStorageAPIEntriesErr.On("Entries", &hash).Return(nil, errors.New("entries Err"))
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("GetStateRootFromBlock", &hash).Return(nil, errors.New("GetStateRootFromBlock Err"))
 
-	mockStorageAPIGetStorageErr := new(mocks.StorageAPI)
+	mockStorageAPIGetStorageErr := mocks.NewStorageAPI(t)
 	mockStorageAPIGetStorageErr.On("GetStateRootFromBlock", &hash).Return(&hash, nil)
 	mockStorageAPIGetStorageErr.On("Entries", &hash).Return(m, nil)
 	mockStorageAPIGetStorageErr.On("GetKeysWithPrefix", &hash, common.MustHexToBytes(str)).Return([][]byte{{2}, {2}}, nil)
@@ -189,15 +189,15 @@ func TestStateModuleGetPairs(t *testing.T) {
 }
 
 func TestStateModuleGetKeysPaged(t *testing.T) {
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetKeysWithPrefix", (*common.Hash)(nil), common.MustHexToBytes("0x")).
 		Return([][]byte{{1}, {2}}, nil)
 
-	mockStorageAPI2 := new(mocks.StorageAPI)
+	mockStorageAPI2 := mocks.NewStorageAPI(t)
 	mockStorageAPI2.On("GetKeysWithPrefix", (*common.Hash)(nil), common.MustHexToBytes("0x")).
 		Return([][]byte{{1, 1, 1}, {1, 1, 1}}, nil)
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("GetKeysWithPrefix", (*common.Hash)(nil), common.MustHexToBytes("0x")).
 		Return(nil, errors.New("GetKeysWithPrefix Err"))
 
@@ -281,8 +281,8 @@ func TestStateModuleGetKeysPaged(t *testing.T) {
 
 // Implement Tests once function is implemented
 func TestCall(t *testing.T) {
-	mockNetworkAPI := new(mocks.NetworkAPI)
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	sm := NewStateModule(mockNetworkAPI, mockStorageAPI, nil, nil)
 
 	err := sm.Call(nil, nil, nil)
@@ -292,10 +292,10 @@ func TestCall(t *testing.T) {
 func TestStateModuleGetMetadata(t *testing.T) {
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 
-	mockCoreAPI := new(mocks.CoreAPI)
+	mockCoreAPI := mocks.NewCoreAPI(t)
 	mockCoreAPI.On("GetMetadata", &hash).Return(common.MustHexToBytes(testdata.NewTestMetadata()), nil)
 
-	mockCoreAPIErr := new(mocks.CoreAPI)
+	mockCoreAPIErr := mocks.NewCoreAPI(t)
 	mockCoreAPIErr.On("GetMetadata", &hash).Return(nil, errors.New("GetMetadata Error"))
 
 	mockStateModule := NewStateModule(nil, nil, mockCoreAPIErr, nil)
@@ -366,10 +366,10 @@ func TestStateModuleGetReadProof(t *testing.T) {
 		expKeys[i] = bKey
 	}
 
-	mockCoreAPI := new(mocks.CoreAPI)
+	mockCoreAPI := mocks.NewCoreAPI(t)
 	mockCoreAPI.On("GetReadProofAt", hash, expKeys).Return(hash, [][]byte{{1, 1, 1}, {1, 1, 1}}, nil)
 
-	mockCoreAPIErr := new(mocks.CoreAPI)
+	mockCoreAPIErr := mocks.NewCoreAPI(t)
 	mockCoreAPIErr.On("GetReadProofAt", hash, expKeys).Return(nil, nil, errors.New("GetReadProofAt Error"))
 
 	type fields struct {
@@ -461,10 +461,10 @@ func TestStateModuleGetRuntimeVersion(t *testing.T) {
 		TransactionVersion: 5,
 	}
 
-	mockCoreAPI := new(mocks.CoreAPI)
+	mockCoreAPI := mocks.NewCoreAPI(t)
 	mockCoreAPI.On("GetRuntimeVersion", &hash).Return(version, nil)
 
-	mockCoreAPIErr := new(mocks.CoreAPI)
+	mockCoreAPIErr := mocks.NewCoreAPI(t)
 	mockCoreAPIErr.On("GetRuntimeVersion", &hash).
 		Return(runtime.Version{}, errors.New("GetRuntimeVersion Error"))
 
@@ -531,11 +531,11 @@ func TestStateModuleGetStorage(t *testing.T) {
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	reqBytes := common.MustHexToBytes("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetStorageByBlockHash", &hash, reqBytes).Return([]byte{21}, nil)
 	mockStorageAPI.On("GetStorage", (*common.Hash)(nil), reqBytes).Return([]byte{21}, nil)
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("GetStorageByBlockHash", &hash, reqBytes).Return(nil, errors.New("GetStorageByBlockHash Error"))
 	mockStorageAPIErr.On("GetStorage", (*common.Hash)(nil), reqBytes).Return(nil, errors.New("GetStorage Error"))
 
@@ -621,11 +621,11 @@ func TestStateModuleGetStorageHash(t *testing.T) {
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	reqBytes := common.MustHexToBytes("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetStorageByBlockHash", &hash, reqBytes).Return([]byte{21}, nil)
 	mockStorageAPI.On("GetStorage", (*common.Hash)(nil), reqBytes).Return([]byte{21}, nil)
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("GetStorageByBlockHash", &hash, reqBytes).Return(nil, errors.New("GetStorageByBlockHash Error"))
 	mockStorageAPIErr.On("GetStorage", (*common.Hash)(nil), reqBytes).Return(nil, errors.New("GetStorage Error"))
 
@@ -711,11 +711,11 @@ func TestStateModuleGetStorageSize(t *testing.T) {
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 	reqBytes := common.MustHexToBytes("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
 
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetStorageByBlockHash", &hash, reqBytes).Return([]byte{21}, nil)
 	mockStorageAPI.On("GetStorage", (*common.Hash)(nil), reqBytes).Return([]byte{21}, nil)
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("GetStorageByBlockHash", &hash, reqBytes).Return(nil, errors.New("GetStorageByBlockHash Error"))
 	mockStorageAPIErr.On("GetStorage", (*common.Hash)(nil), reqBytes).Return(nil, errors.New("GetStorage Error"))
 

--- a/dot/rpc/modules/sync_state_test.go
+++ b/dot/rpc/modules/sync_state_test.go
@@ -17,10 +17,10 @@ import (
 
 func TestSyncStateModule_GenSyncSpec(t *testing.T) {
 	g := new(genesis.Genesis)
-	mockSyncStateAPI := new(mocks.SyncStateAPI)
+	mockSyncStateAPI := mocks.NewSyncStateAPI(t)
 	mockSyncStateAPI.On("GenSyncSpec", true).Return(g, nil)
 
-	mockSyncStateAPIErr := new(mocks.SyncStateAPI)
+	mockSyncStateAPIErr := mocks.NewSyncStateAPI(t)
 	mockSyncStateAPIErr.On("GenSyncSpec", true).Return(nil, errors.New("GenSyncSpec error"))
 
 	syncStateModule := NewSyncStateModule(mockSyncStateAPI)
@@ -84,10 +84,10 @@ func TestNewStateSync(t *testing.T) {
 	g1 := &genesis.Genesis{}
 	g2 := &genesis.Genesis{}
 	raw := make(map[string][]byte)
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("Entries", (*common.Hash)(nil)).Return(raw, nil)
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("Entries", (*common.Hash)(nil)).Return(nil, errors.New("entries error"))
 
 	type args struct {

--- a/dot/rpc/modules/system_integration_test.go
+++ b/dot/rpc/modules/system_integration_test.go
@@ -96,7 +96,7 @@ func newNetworkService(t *testing.T) *network.Service {
 
 // Test RPC's System.Health() response
 func TestSystemModule_Health(t *testing.T) {
-	networkMock := new(mocks.NetworkAPI)
+	networkMock := mocks.NewNetworkAPI(t)
 	networkMock.On("Health").Return(testHealth)
 
 	sys := NewSystemModule(networkMock, nil, nil, nil, nil, nil, nil)
@@ -160,8 +160,8 @@ var testGenesisData = &genesis.Data{
 	ChainType: "Local",
 }
 
-func newMockSystemAPI() *mocks.SystemAPI {
-	sysapimock := new(mocks.SystemAPI)
+func newMockSystemAPI(t *testing.T) *mocks.SystemAPI {
+	sysapimock := mocks.NewSystemAPI(t)
 	sysapimock.On("SystemName").Return(testSystemInfo.SystemName)
 	sysapimock.On("SystemVersion").Return(testSystemInfo.SystemVersion)
 	sysapimock.On("ChainName").Return(testGenesisData.Name)
@@ -172,7 +172,7 @@ func newMockSystemAPI() *mocks.SystemAPI {
 }
 
 func TestSystemModule_Chain(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(), nil, nil, nil, nil, nil)
+	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
 
 	res := new(string)
 	err := sys.Chain(nil, nil, res)
@@ -181,7 +181,7 @@ func TestSystemModule_Chain(t *testing.T) {
 }
 
 func TestSystemModule_ChainType(t *testing.T) {
-	api := newMockSystemAPI()
+	api := newMockSystemAPI(t)
 
 	sys := NewSystemModule(nil, api, nil, nil, nil, nil, nil)
 
@@ -190,7 +190,7 @@ func TestSystemModule_ChainType(t *testing.T) {
 	require.Equal(t, testGenesisData.ChainType, *res)
 }
 func TestSystemModule_Name(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(), nil, nil, nil, nil, nil)
+	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
 
 	res := new(string)
 	err := sys.Name(nil, nil, res)
@@ -199,7 +199,7 @@ func TestSystemModule_Name(t *testing.T) {
 }
 
 func TestSystemModule_Version(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(), nil, nil, nil, nil, nil)
+	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
 
 	res := new(string)
 	err := sys.Version(nil, nil, res)
@@ -208,7 +208,7 @@ func TestSystemModule_Version(t *testing.T) {
 }
 
 func TestSystemModule_Properties(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(), nil, nil, nil, nil, nil)
+	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
 
 	expected := map[string]interface{}(nil)
 
@@ -398,11 +398,11 @@ func TestSyncState(t *testing.T) {
 		Number: 49,
 	}
 
-	blockapiMock := new(mocks.BlockAPI)
+	blockapiMock := mocks.NewBlockAPI(t)
 	blockapiMock.On("BestBlockHash").Return(fakeCommonHash)
 	blockapiMock.On("GetHeader", fakeCommonHash).Return(fakeHeader, nil).Once()
 
-	netapiMock := new(mocks.NetworkAPI)
+	netapiMock := mocks.NewNetworkAPI(t)
 	netapiMock.On("StartingBlock").Return(int64(10))
 
 	syncapiCtrl := gomock.NewController(t)
@@ -440,7 +440,7 @@ func TestLocalListenAddresses(t *testing.T) {
 		Multiaddrs: []multiaddr.Multiaddr{ma},
 	}
 
-	mockNetAPI := new(mocks.NetworkAPI)
+	mockNetAPI := mocks.NewNetworkAPI(t)
 	mockNetAPI.On("NetworkState").Return(mockedNetState).Once()
 
 	res := make([]string, 0)
@@ -467,7 +467,7 @@ func TestLocalPeerId(t *testing.T) {
 		PeerID: peerID,
 	}
 
-	mocknetAPI := new(mocks.NetworkAPI)
+	mocknetAPI := mocks.NewNetworkAPI(t)
 	mocknetAPI.On("NetworkState").Return(state).Once()
 
 	sysmodules := new(SystemModule)
@@ -487,7 +487,7 @@ func TestLocalPeerId(t *testing.T) {
 
 func TestAddReservedPeer(t *testing.T) {
 	t.Run("Test Add and Remove reserved peers with success", func(t *testing.T) {
-		networkMock := new(mocks.NetworkAPI)
+		networkMock := mocks.NewNetworkAPI(t)
 		networkMock.On("AddReservedPeers", mock.AnythingOfType("string")).Return(nil).Once()
 		networkMock.On("RemoveReservedPeers", mock.AnythingOfType("string")).Return(nil).Once()
 
@@ -508,7 +508,7 @@ func TestAddReservedPeer(t *testing.T) {
 	})
 
 	t.Run("Test Add and Remove reserved peers without success", func(t *testing.T) {
-		networkMock := new(mocks.NetworkAPI)
+		networkMock := mocks.NewNetworkAPI(t)
 		networkMock.On("AddReservedPeers", mock.AnythingOfType("string")).Return(errors.New("some problems")).Once()
 		networkMock.On("RemoveReservedPeers", mock.AnythingOfType("string")).Return(errors.New("other problems")).Once()
 

--- a/dot/rpc/modules/system_integration_test.go
+++ b/dot/rpc/modules/system_integration_test.go
@@ -160,19 +160,10 @@ var testGenesisData = &genesis.Data{
 	ChainType: "Local",
 }
 
-func newMockSystemAPI(t *testing.T) *mocks.SystemAPI {
-	sysapimock := mocks.NewSystemAPI(t)
-	sysapimock.On("SystemName").Return(testSystemInfo.SystemName)
-	sysapimock.On("SystemVersion").Return(testSystemInfo.SystemVersion)
-	sysapimock.On("ChainName").Return(testGenesisData.Name)
-	sysapimock.On("Properties").Return(nil)
-	sysapimock.On("ChainType").Return(testGenesisData.ChainType)
-
-	return sysapimock
-}
-
 func TestSystemModule_Chain(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
+	api := mocks.NewSystemAPI(t)
+	api.On("ChainName").Return(testGenesisData.Name)
+	sys := NewSystemModule(nil, api, nil, nil, nil, nil, nil)
 
 	res := new(string)
 	err := sys.Chain(nil, nil, res)
@@ -181,7 +172,8 @@ func TestSystemModule_Chain(t *testing.T) {
 }
 
 func TestSystemModule_ChainType(t *testing.T) {
-	api := newMockSystemAPI(t)
+	api := mocks.NewSystemAPI(t)
+	api.On("ChainType").Return(testGenesisData.ChainType)
 
 	sys := NewSystemModule(nil, api, nil, nil, nil, nil, nil)
 
@@ -190,7 +182,9 @@ func TestSystemModule_ChainType(t *testing.T) {
 	require.Equal(t, testGenesisData.ChainType, *res)
 }
 func TestSystemModule_Name(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
+	api := mocks.NewSystemAPI(t)
+	api.On("SystemName").Return(testSystemInfo.SystemName)
+	sys := NewSystemModule(nil, api, nil, nil, nil, nil, nil)
 
 	res := new(string)
 	err := sys.Name(nil, nil, res)
@@ -199,7 +193,10 @@ func TestSystemModule_Name(t *testing.T) {
 }
 
 func TestSystemModule_Version(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
+	api := mocks.NewSystemAPI(t)
+	api.On("SystemVersion").Return(testSystemInfo.SystemVersion)
+
+	sys := NewSystemModule(nil, api, nil, nil, nil, nil, nil)
 
 	res := new(string)
 	err := sys.Version(nil, nil, res)
@@ -208,7 +205,10 @@ func TestSystemModule_Version(t *testing.T) {
 }
 
 func TestSystemModule_Properties(t *testing.T) {
-	sys := NewSystemModule(nil, newMockSystemAPI(t), nil, nil, nil, nil, nil)
+	api := mocks.NewSystemAPI(t)
+	api.On("Properties").Return(nil)
+
+	sys := NewSystemModule(nil, api, nil, nil, nil, nil, nil)
 
 	expected := map[string]interface{}(nil)
 

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -23,8 +23,9 @@ import (
 func TestSystemModule_ChainTest(t *testing.T) {
 	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("ChainName").Return("polkadot", nil)
-	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		systemAPI: mockSystemAPI,
+	}
 
 	req := &EmptyRequest{}
 	var res string
@@ -37,8 +38,9 @@ func TestSystemModule_ChainTest(t *testing.T) {
 func TestSystemModule_NameTest(t *testing.T) {
 	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("SystemName").Return("kusama", nil)
-	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		systemAPI: mockSystemAPI,
+	}
 
 	req := &EmptyRequest{}
 	var res string
@@ -51,8 +53,9 @@ func TestSystemModule_NameTest(t *testing.T) {
 func TestSystemModule_ChainTypeTest(t *testing.T) {
 	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("ChainType").Return("testChainType", nil)
-	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		systemAPI: mockSystemAPI,
+	}
 
 	req := &EmptyRequest{}
 	var res string
@@ -66,8 +69,9 @@ func TestSystemModule_PropertiesTest(t *testing.T) {
 	var emptyMap map[string]interface{}
 	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("Properties").Return(emptyMap)
-	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		systemAPI: mockSystemAPI,
+	}
 
 	req := &EmptyRequest{}
 	var resMap interface{}
@@ -79,8 +83,9 @@ func TestSystemModule_PropertiesTest(t *testing.T) {
 func TestSystemModule_SystemVersionTest(t *testing.T) {
 	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("SystemVersion").Return("1.2.1", nil)
-	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		systemAPI: mockSystemAPI,
+	}
 
 	req := &EmptyRequest{}
 	var res string
@@ -93,8 +98,9 @@ func TestSystemModule_SystemVersionTest(t *testing.T) {
 func TestSystemModule_HealthTest(t *testing.T) {
 	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("Health").Return(common.Health{}, nil)
-	sm := NewSystemModule(mockNetworkAPI, mocks.NewSystemAPI(t), mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		networkAPI: mockNetworkAPI,
+	}
 
 	req := &EmptyRequest{}
 	var sysHealthRes SystemHealthResponse
@@ -106,8 +112,9 @@ func TestSystemModule_HealthTest(t *testing.T) {
 func TestSystemModule_NetworkStateTest(t *testing.T) {
 	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("NetworkState").Return(common.NetworkState{}, nil)
-	sm := NewSystemModule(mockNetworkAPI, mocks.NewSystemAPI(t), mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		networkAPI: mockNetworkAPI,
+	}
 
 	req := &EmptyRequest{}
 	var networkStateRes SystemNetworkStateResponse
@@ -119,8 +126,9 @@ func TestSystemModule_NetworkStateTest(t *testing.T) {
 func TestSystemModule_PeersTest(t *testing.T) {
 	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("Peers").Return([]common.PeerInfo{}, nil)
-	sm := NewSystemModule(mockNetworkAPI, mocks.NewSystemAPI(t), mocks.NewCoreAPI(t),
-		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
+	sm := &SystemModule{
+		networkAPI: mockNetworkAPI,
+	}
 
 	req := &EmptyRequest{}
 	var sysPeerRes SystemPeersResponse

--- a/dot/rpc/modules/system_test.go
+++ b/dot/rpc/modules/system_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 func TestSystemModule_ChainTest(t *testing.T) {
-	mockSystemAPI := new(mocks.SystemAPI)
+	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("ChainName").Return("polkadot", nil)
-	sm := NewSystemModule(new(mocks.NetworkAPI), mockSystemAPI, new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var res string
@@ -35,10 +35,10 @@ func TestSystemModule_ChainTest(t *testing.T) {
 }
 
 func TestSystemModule_NameTest(t *testing.T) {
-	mockSystemAPI := new(mocks.SystemAPI)
+	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("SystemName").Return("kusama", nil)
-	sm := NewSystemModule(new(mocks.NetworkAPI), mockSystemAPI, new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var res string
@@ -49,10 +49,10 @@ func TestSystemModule_NameTest(t *testing.T) {
 }
 
 func TestSystemModule_ChainTypeTest(t *testing.T) {
-	mockSystemAPI := new(mocks.SystemAPI)
+	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("ChainType").Return("testChainType", nil)
-	sm := NewSystemModule(new(mocks.NetworkAPI), mockSystemAPI, new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var res string
@@ -64,10 +64,10 @@ func TestSystemModule_ChainTypeTest(t *testing.T) {
 
 func TestSystemModule_PropertiesTest(t *testing.T) {
 	var emptyMap map[string]interface{}
-	mockSystemAPI := new(mocks.SystemAPI)
+	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("Properties").Return(emptyMap)
-	sm := NewSystemModule(new(mocks.NetworkAPI), mockSystemAPI, new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var resMap interface{}
@@ -77,10 +77,10 @@ func TestSystemModule_PropertiesTest(t *testing.T) {
 }
 
 func TestSystemModule_SystemVersionTest(t *testing.T) {
-	mockSystemAPI := new(mocks.SystemAPI)
+	mockSystemAPI := mocks.NewSystemAPI(t)
 	mockSystemAPI.On("SystemVersion").Return("1.2.1", nil)
-	sm := NewSystemModule(new(mocks.NetworkAPI), mockSystemAPI, new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mocks.NewNetworkAPI(t), mockSystemAPI, mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var res string
@@ -91,10 +91,10 @@ func TestSystemModule_SystemVersionTest(t *testing.T) {
 }
 
 func TestSystemModule_HealthTest(t *testing.T) {
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("Health").Return(common.Health{}, nil)
-	sm := NewSystemModule(mockNetworkAPI, new(mocks.SystemAPI), new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mockNetworkAPI, mocks.NewSystemAPI(t), mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var sysHealthRes SystemHealthResponse
@@ -104,10 +104,10 @@ func TestSystemModule_HealthTest(t *testing.T) {
 }
 
 func TestSystemModule_NetworkStateTest(t *testing.T) {
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("NetworkState").Return(common.NetworkState{}, nil)
-	sm := NewSystemModule(mockNetworkAPI, new(mocks.SystemAPI), new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mockNetworkAPI, mocks.NewSystemAPI(t), mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var networkStateRes SystemNetworkStateResponse
@@ -117,10 +117,10 @@ func TestSystemModule_NetworkStateTest(t *testing.T) {
 }
 
 func TestSystemModule_PeersTest(t *testing.T) {
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("Peers").Return([]common.PeerInfo{}, nil)
-	sm := NewSystemModule(mockNetworkAPI, new(mocks.SystemAPI), new(mocks.CoreAPI),
-		new(mocks.StorageAPI), new(mocks.TransactionStateAPI), new(mocks.BlockAPI), nil)
+	sm := NewSystemModule(mockNetworkAPI, mocks.NewSystemAPI(t), mocks.NewCoreAPI(t),
+		mocks.NewStorageAPI(t), new(mocks.TransactionStateAPI), mocks.NewBlockAPI(t), nil)
 
 	req := &EmptyRequest{}
 	var sysPeerRes SystemPeersResponse
@@ -130,16 +130,16 @@ func TestSystemModule_PeersTest(t *testing.T) {
 }
 
 func TestSystemModule_NodeRolesTest(t *testing.T) {
-	mockNetworkAPI1 := new(mocks.NetworkAPI)
+	mockNetworkAPI1 := mocks.NewNetworkAPI(t)
 	mockNetworkAPI1.On("NodeRoles").Return(common.FullNodeRole, nil)
 
-	mockNetworkAPI2 := new(mocks.NetworkAPI)
+	mockNetworkAPI2 := mocks.NewNetworkAPI(t)
 	mockNetworkAPI2.On("NodeRoles").Return(common.LightClientRole, nil)
 
-	mockNetworkAPI3 := new(mocks.NetworkAPI)
+	mockNetworkAPI3 := mocks.NewNetworkAPI(t)
 	mockNetworkAPI3.On("NodeRoles").Return(common.AuthorityRole, nil)
 
-	mockNetworkAPI4 := new(mocks.NetworkAPI)
+	mockNetworkAPI4 := mocks.NewNetworkAPI(t)
 	mockNetworkAPI4.On("NodeRoles").Return(common.Roles(21), nil)
 
 	type args struct {
@@ -213,25 +213,25 @@ func TestSystemModule_AccountNextIndex(t *testing.T) {
 		Validity:  new(transaction.Validity),
 	}
 
-	mockTxStateAPI := new(mocks.TransactionStateAPI)
+	mockTxStateAPI := mocks.NewTransactionStateAPI(t)
 	mockTxStateAPI.On("Pending").Return(v, nil)
 
-	mockCoreAPI := new(mocks.CoreAPI)
+	mockCoreAPI := mocks.NewCoreAPI(t)
 	mockCoreAPI.On("GetMetadata", (*common.Hash)(nil)).Return(common.MustHexToBytes(testdata.NewTestMetadata()), nil)
 
-	mockCoreAPIErr := new(mocks.CoreAPI)
+	mockCoreAPIErr := mocks.NewCoreAPI(t)
 	mockCoreAPIErr.On("GetMetadata", (*common.Hash)(nil)).Return(nil, errors.New("getMetadata error"))
 
 	// Magic number mismatch
-	mockCoreAPIMagicNumMismatch := new(mocks.CoreAPI)
+	mockCoreAPIMagicNumMismatch := mocks.NewCoreAPI(t)
 	mockCoreAPIMagicNumMismatch.On("GetMetadata", (*common.Hash)(nil)).Return(storageKeyHex, nil)
 
-	mockStorageAPI := new(mocks.StorageAPI)
+	mockStorageAPI := mocks.NewStorageAPI(t)
 	mockStorageAPI.On("GetStorage", (*common.Hash)(nil), storageKeyHex).
 		Return(common.MustHexToBytes("0x0300000000000000000000000000000000000000000000000000000000000000000000"+
 			"0000000000000000000000000000000000000000000000000000000000000000000000000000000000"), nil)
 
-	mockStorageAPIErr := new(mocks.StorageAPI)
+	mockStorageAPIErr := mocks.NewStorageAPI(t)
 	mockStorageAPIErr.On("GetStorage", (*common.Hash)(nil), storageKeyHex).Return(nil, errors.New("getStorage error"))
 
 	type args struct {
@@ -309,15 +309,15 @@ func TestSystemModule_AccountNextIndex(t *testing.T) {
 
 func TestSystemModule_SyncState(t *testing.T) {
 	hash := common.MustHexToHash("0x3aa96b0149b6ca3688878bdbd19464448624136398e3ce45b9e755d3ab61355a")
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 	mockBlockAPI.On("BestBlockHash").Return(hash)
 	mockBlockAPI.On("GetHeader", hash).Return(types.NewEmptyHeader(), nil)
 
-	mockBlockAPIErr := new(mocks.BlockAPI)
+	mockBlockAPIErr := mocks.NewBlockAPI(t)
 	mockBlockAPIErr.On("BestBlockHash").Return(hash)
 	mockBlockAPIErr.On("GetHeader", hash).Return(nil, errors.New("GetHeader Err"))
 
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("StartingBlock").Return(int64(23))
 
 	ctrlSyncAPI := gomock.NewController(t)
@@ -372,7 +372,7 @@ func TestSystemModule_SyncState(t *testing.T) {
 }
 
 func TestSystemModule_LocalListenAddresses(t *testing.T) {
-	mockNetworkAPIEmpty := new(mocks.NetworkAPI)
+	mockNetworkAPIEmpty := mocks.NewNetworkAPI(t)
 	mockNetworkAPIEmpty.On("NetworkState").Return(common.NetworkState{})
 
 	addr, err := multiaddr.NewMultiaddr("/ip4/1.2.3.4/tcp/80")
@@ -384,7 +384,7 @@ func TestSystemModule_LocalListenAddresses(t *testing.T) {
 		Multiaddrs: multiAddy,
 	}
 
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("NetworkState").Return(ns, nil)
 
 	type args struct {
@@ -432,7 +432,7 @@ func TestSystemModule_LocalListenAddresses(t *testing.T) {
 }
 
 func TestSystemModule_LocalPeerId(t *testing.T) {
-	mockNetworkAPIEmpty := new(mocks.NetworkAPI)
+	mockNetworkAPIEmpty := mocks.NewNetworkAPI(t)
 	mockNetworkAPIEmpty.On("NetworkState").Return(common.NetworkState{})
 
 	addr, err := multiaddr.NewMultiaddr("/ip4/1.2.3.4/tcp/80")
@@ -444,7 +444,7 @@ func TestSystemModule_LocalPeerId(t *testing.T) {
 		Multiaddrs: multiAddy,
 	}
 
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("NetworkState").Return(ns, nil)
 
 	type args struct {
@@ -491,10 +491,10 @@ func TestSystemModule_LocalPeerId(t *testing.T) {
 }
 
 func TestSystemModule_AddReservedPeer(t *testing.T) {
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("AddReservedPeers", "jimbo").Return(nil)
 
-	mockNetworkAPIErr := new(mocks.NetworkAPI)
+	mockNetworkAPIErr := mocks.NewNetworkAPI(t)
 	mockNetworkAPIErr.On("AddReservedPeers", "jimbo").Return(errors.New("addReservedPeer error"))
 
 	type args struct {
@@ -549,10 +549,10 @@ func TestSystemModule_AddReservedPeer(t *testing.T) {
 }
 
 func TestSystemModule_RemoveReservedPeer(t *testing.T) {
-	mockNetworkAPI := new(mocks.NetworkAPI)
+	mockNetworkAPI := mocks.NewNetworkAPI(t)
 	mockNetworkAPI.On("RemoveReservedPeers", "jimbo").Return(nil)
 
-	mockNetworkAPIErr := new(mocks.NetworkAPI)
+	mockNetworkAPIErr := mocks.NewNetworkAPI(t)
 	mockNetworkAPIErr.On("RemoveReservedPeers", "jimbo").Return(errors.New("removeReservedPeer error"))
 
 	type args struct {

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -83,7 +83,7 @@ func TestBlockListener_Listen(t *testing.T) {
 	wsconn, ws, cancel := setupWSConn(t)
 	defer cancel()
 
-	BlockAPI := new(mocks.BlockAPI)
+	BlockAPI := mocks.NewBlockAPI(t)
 	BlockAPI.On("FreeImportedBlockNotifierChannel", mock.AnythingOfType("chan *types.Block"))
 
 	wsconn.BlockAPI = BlockAPI
@@ -131,7 +131,7 @@ func TestBlockFinalizedListener_Listen(t *testing.T) {
 	wsconn, ws, cancel := setupWSConn(t)
 	defer cancel()
 
-	BlockAPI := new(mocks.BlockAPI)
+	BlockAPI := mocks.NewBlockAPI(t)
 	BlockAPI.On("FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo"))
 
 	wsconn.BlockAPI = BlockAPI
@@ -183,13 +183,13 @@ func TestExtrinsicSubmitListener_Listen(t *testing.T) {
 	notifyFinalizedChan := make(chan *types.FinalisationInfo, 100)
 	txStatusChan := make(chan transaction.Status)
 
-	BlockAPI := new(mocks.BlockAPI)
+	BlockAPI := mocks.NewBlockAPI(t)
 	BlockAPI.On("FreeImportedBlockNotifierChannel", mock.AnythingOfType("chan *types.Block"))
 	BlockAPI.On("FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo"))
 
 	wsconn.BlockAPI = BlockAPI
 
-	TxStateAPI := modules.NewMockTransactionStateAPI()
+	TxStateAPI := modules.NewMockTransactionStateAPI(t)
 	wsconn.TxStateAPI = TxStateAPI
 
 	esl := ExtrinsicSubmitListener{
@@ -262,7 +262,7 @@ func TestGrandpaJustification_Listen(t *testing.T) {
 		mockedJustBytes, err := scale.Marshal(mockedJust)
 		require.NoError(t, err)
 
-		blockStateMock := new(mocks.BlockAPI)
+		blockStateMock := mocks.NewBlockAPI(t)
 		blockStateMock.On("GetJustification", mock.AnythingOfType("common.Hash")).Return(mockedJustBytes, nil)
 		blockStateMock.On("FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo"))
 		wsconn.BlockAPI = blockStateMock
@@ -339,7 +339,7 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 		wsconn:        mockConnection,
 		subID:         0,
 		runtimeUpdate: notifyChan,
-		coreAPI:       modules.NewMockCoreAPI(),
+		coreAPI:       modules.NewMockCoreAPI(t),
 	}
 
 	expectedInitialVersion := modules.StateRuntimeVersionResponse{

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -148,8 +148,6 @@ func TestBlockFinalizedListener_Listen(t *testing.T) {
 	bfl.Listen()
 	defer func() {
 		require.NoError(t, bfl.Stop())
-		time.Sleep(time.Millisecond * 10)
-		BlockAPI.AssertCalled(t, "FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo"))
 	}()
 
 	notifyChan <- &types.FinalisationInfo{
@@ -213,10 +211,6 @@ func TestExtrinsicSubmitListener_Listen(t *testing.T) {
 	esl.Listen()
 	defer func() {
 		require.NoError(t, esl.Stop())
-		time.Sleep(time.Millisecond * 10)
-
-		BlockAPI.AssertCalled(t, "FreeImportedBlockNotifierChannel", mock.AnythingOfType("chan *types.Block"))
-		BlockAPI.AssertCalled(t, "FreeFinalisedNotifierChannel", mock.AnythingOfType("chan *types.FinalisationInfo"))
 	}()
 
 	notifyImportedChan <- block

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -104,8 +104,6 @@ func TestBlockListener_Listen(t *testing.T) {
 	go bl.Listen()
 	defer func() {
 		require.NoError(t, bl.Stop())
-		time.Sleep(time.Millisecond * 10)
-		BlockAPI.AssertCalled(t, "FreeImportedBlockNotifierChannel", mock.AnythingOfType("chan *types.Block"))
 	}()
 
 	notifyChan <- &block

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -40,7 +40,7 @@ func TestWSConn_HandleConn(t *testing.T) {
 		`"error":{"code":null,"message":"error StorageAPI not set"},`+
 		`"id":1}`+"\n"), msg)
 
-	wsconn.StorageAPI = modules.NewMockeryStorageAPI()
+	wsconn.StorageAPI = modules.NewMockeryStorageAPI(t)
 
 	res, err = wsconn.initStorageChangeListener(1, nil)
 	require.Nil(t, res)
@@ -166,7 +166,7 @@ func TestWSConn_HandleConn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","error":{"code":null,"message":"error BlockAPI not set"},"id":1}`+"\n"), msg)
 
-	wsconn.BlockAPI = modules.NewMockeryBlockAPI()
+	wsconn.BlockAPI = modules.NewMockeryBlockAPI(t)
 
 	res, err = wsconn.initBlockListener(1, nil)
 	require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestWSConn_HandleConn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","error":{"code":null,"message":"error BlockAPI not set"},"id":1}`+"\n"), msg)
 
-	wsconn.BlockAPI = modules.NewMockeryBlockAPI()
+	wsconn.BlockAPI = modules.NewMockeryBlockAPI(t)
 
 	res, err = wsconn.initBlockFinalizedListener(1, nil)
 	require.NoError(t, err)
@@ -207,9 +207,9 @@ func TestWSConn_HandleConn(t *testing.T) {
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":7,"id":1}`+"\n"), msg)
 
 	// test initExtrinsicWatch
-	wsconn.CoreAPI = modules.NewMockCoreAPI()
+	wsconn.CoreAPI = modules.NewMockCoreAPI(t)
 	wsconn.BlockAPI = nil
-	wsconn.TxStateAPI = modules.NewMockTransactionStateAPI()
+	wsconn.TxStateAPI = modules.NewMockTransactionStateAPI(t)
 	listner, err := wsconn.initExtrinsicWatch(0, []string{"NotHex"})
 	require.EqualError(t, err, "could not byteify non 0x prefixed string: NotHex")
 	require.Nil(t, listner)
@@ -218,7 +218,7 @@ func TestWSConn_HandleConn(t *testing.T) {
 	require.EqualError(t, err, "error BlockAPI not set")
 	require.Nil(t, listner)
 
-	wsconn.BlockAPI = modules.NewMockeryBlockAPI()
+	wsconn.BlockAPI = modules.NewMockeryBlockAPI(t)
 	listner, err = wsconn.initExtrinsicWatch(0, []interface{}{"0x26aa"})
 	require.NoError(t, err)
 	require.NotNil(t, listner)
@@ -229,7 +229,7 @@ func TestWSConn_HandleConn(t *testing.T) {
 	require.Equal(t, `{"jsonrpc":"2.0","result":8,"id":0}`+"\n", string(msg))
 
 	// test initExtrinsicWatch with invalid transaction
-	coreAPI := new(mocks.CoreAPI)
+	coreAPI := mocks.NewCoreAPI(t)
 	coreAPI.On("HandleSubmittedExtrinsic", mock.AnythingOfType("types.Extrinsic")).Return(runtime.ErrInvalidTransaction)
 	wsconn.CoreAPI = coreAPI
 	listner, err = wsconn.initExtrinsicWatch(0,
@@ -253,8 +253,8 @@ func TestWSConn_HandleConn(t *testing.T) {
 	mockedJustBytes, err := scale.Marshal(mockedJust)
 	require.NoError(t, err)
 
-	wsconn.CoreAPI = modules.NewMockCoreAPI()
-	BlockAPI := new(mocks.BlockAPI)
+	wsconn.CoreAPI = modules.NewMockCoreAPI(t)
+	BlockAPI := mocks.NewBlockAPI(t)
 
 	fCh := make(chan *types.FinalisationInfo, 5)
 	BlockAPI.On("GetFinalisedNotifierChannel").Return(fCh)
@@ -306,7 +306,7 @@ func TestSubscribeAllHeads(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","error":{"code":null,"message":"error BlockAPI not set"},"id":1}`+"\n"), msg)
 
-	mockBlockAPI := new(mocks.BlockAPI)
+	mockBlockAPI := mocks.NewBlockAPI(t)
 
 	wsconn.BlockAPI = mockBlockAPI
 

--- a/dot/rpc/websocket_test.go
+++ b/dot/rpc/websocket_test.go
@@ -65,10 +65,10 @@ func TestHTTPServer_ServeHTTP(t *testing.T) {
 		SystemName: "gossamer",
 	}
 	sysAPI := system.NewService(si, nil)
-	bAPI := modules.NewMockeryBlockAPI()
-	sAPI := modules.NewMockeryStorageAPI()
+	bAPI := modules.NewMockeryBlockAPI(t)
+	sAPI := modules.NewMockeryStorageAPI(t)
 
-	TxStateAPI := modules.NewMockTransactionStateAPI()
+	TxStateAPI := modules.NewMockTransactionStateAPI(t)
 
 	cfg := &HTTPServerConfig{
 		Modules:             []string{"system", "chain"},

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -37,9 +37,9 @@ type StorageState struct {
 	sync.RWMutex
 
 	// change notifiers
-	changedLock  sync.RWMutex
-	observerList []Observer
-	pruner       pruner.Pruner
+	observerListMutex sync.RWMutex
+	observerList      []Observer
+	pruner            pruner.Pruner
 }
 
 // NewStorageState creates a new StorageState backed by the given block state

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -24,7 +24,7 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 	require.NoError(t, err)
 
 	mockfilter := map[string][]byte{}
-	mockobs := &MockObserver{}
+	mockobs := NewMockObserver(t)
 
 	mockobs.On("Update", mock.AnythingOfType("*state.SubscriptionResult"))
 	mockobs.On("GetID").Return(uint(10))
@@ -63,7 +63,7 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 
 	for i := 0; i < num; i++ {
 		mockfilter := map[string][]byte{}
-		mockobs := &MockObserver{}
+		mockobs := NewMockObserver(t)
 
 		mockobs.On("Update", mock.AnythingOfType("*state.SubscriptionResult"))
 		mockobs.On("GetID").Return(uint(10))
@@ -119,7 +119,7 @@ func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 	}
 
 	for i := 0; i < num; i++ {
-		mockobs := &MockObserver{}
+		mockobs := NewMockObserver(t)
 		mockobs.On("Update", mock.AnythingOfType("*state.SubscriptionResult"))
 		mockobs.On("GetID").Return(uint(i))
 		mockobs.On("GetFilter").Return(filter)

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -54,26 +54,13 @@ var (
 
 //go:generate mockgen -destination=mock_telemetry_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/dot/telemetry Client
 
-func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
+func createTestService(t *testing.T, cfg ServiceConfig) *Service {
 	wasmer.DefaultTestLogLvl = 1
 
 	gen, genTrie, genHeader := genesis.NewDevGenesisWithTrieAndHeader(t)
 	genesisHeader = genHeader
 
 	var err error
-
-	if cfg == nil {
-		cfg = &ServiceConfig{
-			Authority: true,
-		}
-	}
-
-	blockImportHandler := mocks.NewBlockImportHandler(t)
-	cfg.BlockImportHandler = blockImportHandler
-	blockImportHandler.
-		On("HandleBlockProduced",
-			mock.AnythingOfType("*types.Block"), mock.AnythingOfType("*storage.TrieState")).
-		Return(nil)
 
 	if cfg.Keypair == nil {
 		cfg.Keypair = keyring.Alice().(*sr25519.Keypair)
@@ -147,7 +134,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 
 	cfg.IsDev = true
 	cfg.LogLvl = defaultTestLogLvl
-	babeService, err := NewService(cfg)
+	babeService, err := NewService(&cfg)
 	require.NoError(t, err)
 	return babeService
 }
@@ -210,9 +197,15 @@ func TestService_SlotDuration(t *testing.T) {
 }
 
 func TestService_ProducesBlocks(t *testing.T) {
-	cfg := &ServiceConfig{
-		Authority: true,
-		Lead:      true,
+	blockImportHandler := mocks.NewBlockImportHandler(t)
+	blockImportHandler.
+		On("HandleBlockProduced",
+			mock.AnythingOfType("*types.Block"), mock.AnythingOfType("*storage.TrieState")).
+		Return(nil)
+	cfg := ServiceConfig{
+		Authority:          true,
+		Lead:               true,
+		BlockImportHandler: blockImportHandler,
 	}
 	babeService := createTestService(t, cfg)
 
@@ -264,9 +257,8 @@ func TestService_GetAuthorityIndex(t *testing.T) {
 }
 
 func TestStartAndStop(t *testing.T) {
-	bs := createTestService(t, &ServiceConfig{
-		LogLvl: log.Critical,
-	})
+	serviceConfig := ServiceConfig{}
+	bs := createTestService(t, serviceConfig)
 	err := bs.Start()
 	require.NoError(t, err)
 	err = bs.Stop()
@@ -274,9 +266,8 @@ func TestStartAndStop(t *testing.T) {
 }
 
 func TestService_PauseAndResume(t *testing.T) {
-	bs := createTestService(t, &ServiceConfig{
-		LogLvl: log.Critical,
-	})
+	serviceConfig := ServiceConfig{}
+	bs := createTestService(t, serviceConfig)
 	err := bs.Start()
 	require.NoError(t, err)
 	time.Sleep(time.Second)

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -68,8 +68,9 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		}
 	}
 
-	cfg.BlockImportHandler = new(mocks.BlockImportHandler)
-	cfg.BlockImportHandler.(*mocks.BlockImportHandler).
+	blockImportHandler := mocks.NewBlockImportHandler(t)
+	cfg.BlockImportHandler = blockImportHandler
+	blockImportHandler.
 		On("HandleBlockProduced",
 			mock.AnythingOfType("*types.Block"), mock.AnythingOfType("*storage.TrieState")).
 		Return(nil)

--- a/lib/babe/build_integration_test.go
+++ b/lib/babe/build_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/golang/mock/gomock"
 
-	"github.com/ChainSafe/gossamer/internal/log"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v4/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v4/signature"
 	ctypes "github.com/centrifuge/go-substrate-rpc-client/v4/types"
@@ -92,9 +91,8 @@ func TestBuildBlock_ok(t *testing.T) {
 	telemetryMock := NewMockClient(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		TransactionState: state.NewTransactionState(telemetryMock),
-		LogLvl:           log.Info,
 	}
 
 	babeService := createTestService(t, cfg)
@@ -133,9 +131,8 @@ func TestApplyExtrinsic(t *testing.T) {
 	telemetryMock := NewMockClient(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		TransactionState: state.NewTransactionState(telemetryMock),
-		LogLvl:           log.Info,
 	}
 
 	babeService := createTestService(t, cfg)
@@ -229,9 +226,8 @@ func TestBuildAndApplyExtrinsic(t *testing.T) {
 	telemetryMock := NewMockClient(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		TransactionState: state.NewTransactionState(telemetryMock),
-		LogLvl:           log.Info,
 	}
 
 	babeService := createTestService(t, cfg)
@@ -310,7 +306,7 @@ func TestBuildBlock_failing(t *testing.T) {
 	telemetryMock := NewMockClient(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		TransactionState: state.NewTransactionState(telemetryMock),
 	}
 
@@ -402,7 +398,11 @@ func TestBuildBlockTimeMonitor(t *testing.T) {
 	metrics.Enabled = true
 	metrics.Unregister(buildBlockTimer)
 
-	babeService := createTestService(t, nil)
+	cfg := ServiceConfig{
+		Authority: true,
+	}
+
+	babeService := createTestService(t, cfg)
 
 	parent, err := babeService.blockState.BestBlockHeader()
 	require.NoError(t, err)

--- a/lib/babe/epoch_integration_test.go
+++ b/lib/babe/epoch_integration_test.go
@@ -16,7 +16,10 @@ import (
 )
 
 func TestInitiateEpoch_Epoch0(t *testing.T) {
-	bs := createTestService(t, nil)
+	cfg := ServiceConfig{
+		Authority: true,
+	}
+	bs := createTestService(t, cfg)
 	bs.constants.epochLength = 20
 	startSlot := uint64(1000)
 
@@ -31,7 +34,10 @@ func TestInitiateEpoch_Epoch0(t *testing.T) {
 }
 
 func TestInitiateEpoch_Epoch1(t *testing.T) {
-	bs := createTestService(t, nil)
+	cfg := ServiceConfig{
+		Authority: true,
+	}
+	bs := createTestService(t, cfg)
 	bs.constants.epochLength = 10
 
 	state.AddBlocksToState(t, bs.blockState.(*state.BlockState), 1, false)
@@ -131,7 +137,11 @@ func TestInitiateEpoch_Epoch1(t *testing.T) {
 }
 
 func TestIncrementEpoch(t *testing.T) {
-	bs := createTestService(t, nil)
+	cfg := ServiceConfig{
+		Authority: true,
+	}
+	bs := createTestService(t, cfg)
+
 	next, err := bs.incrementEpoch()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), next)

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -65,7 +65,12 @@ func newTestVerificationManager(t *testing.T, genCfg *types.BabeConfiguration) *
 // See https://github.com/ChainSafe/gossamer/issues/2704
 func TestVerificationManager_OnDisabled_InvalidIndex(t *testing.T) {
 	vm := newTestVerificationManager(t, nil)
-	babeService := createTestService(t, nil)
+
+	cfg := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, cfg)
+
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
 	require.NoError(t, err)
 
@@ -80,10 +85,9 @@ func TestVerificationManager_OnDisabled_NewDigest(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		Keypair: kp,
 	}
-
 	babeService := createTestService(t, cfg)
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
 	require.NoError(t, err)
@@ -119,10 +123,9 @@ func TestVerificationManager_OnDisabled_DuplicateDigest(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		Keypair: kp,
 	}
-
 	babeService := createTestService(t, cfg)
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
 	require.NoError(t, err)
@@ -153,7 +156,11 @@ func TestVerificationManager_OnDisabled_DuplicateDigest(t *testing.T) {
 // TODO: add test against latest dev runtime
 // See https://github.com/ChainSafe/gossamer/issues/2704
 func TestVerificationManager_VerifyBlock_Ok(t *testing.T) {
-	babeService := createTestService(t, nil)
+	serviceConfig := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, serviceConfig)
+
 	rt, err := babeService.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
@@ -177,7 +184,11 @@ func TestVerificationManager_VerifyBlock_Ok(t *testing.T) {
 // TODO: add test against latest dev runtime
 // See https://github.com/ChainSafe/gossamer/issues/2704
 func TestVerificationManager_VerifyBlock_Secondary(t *testing.T) {
-	babeService := createTestService(t, nil)
+	serviceConfig := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, serviceConfig)
+
 	rt, err := babeService.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
@@ -241,7 +252,11 @@ func TestVerificationManager_VerifyBlock_Secondary(t *testing.T) {
 
 func TestVerificationManager_VerifyBlock_MultipleEpochs(t *testing.T) {
 	t.Skip() // TODO: no idea why it's complaining it can't find the epoch data. fix later
-	babeService := createTestService(t, nil)
+	serviceConfig := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, serviceConfig)
+
 	rt, err := babeService.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
@@ -287,7 +302,11 @@ func TestVerificationManager_VerifyBlock_MultipleEpochs(t *testing.T) {
 // TODO: add test against latest dev runtime
 // See https://github.com/ChainSafe/gossamer/issues/2704
 func TestVerificationManager_VerifyBlock_InvalidBlockOverThreshold(t *testing.T) {
-	babeService := createTestService(t, nil)
+	serviceConfig := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, serviceConfig)
+
 	rt, err := babeService.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
@@ -312,7 +331,11 @@ func TestVerificationManager_VerifyBlock_InvalidBlockOverThreshold(t *testing.T)
 // TODO: add test against latest dev runtime
 // See https://github.com/ChainSafe/gossamer/issues/2704
 func TestVerificationManager_VerifyBlock_InvalidBlockAuthority(t *testing.T) {
-	babeService := createTestService(t, nil)
+	serviceConfig := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, serviceConfig)
+
 	rt, err := babeService.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
@@ -338,10 +361,9 @@ func TestVerifyPimarySlotWinner(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		Keypair: kp,
 	}
-
 	babeService := createTestService(t, cfg)
 	epochData, err := babeService.initiateEpoch(0)
 	require.NoError(t, err)
@@ -381,7 +403,11 @@ func TestVerifyPimarySlotWinner(t *testing.T) {
 // TODO: add test against latest dev runtime
 // See https://github.com/ChainSafe/gossamer/issues/2704
 func TestVerifyAuthorshipRight(t *testing.T) {
-	babeService := createTestService(t, nil)
+	serviceConfig := ServiceConfig{
+		Authority: true,
+	}
+	babeService := createTestService(t, serviceConfig)
+
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
 	require.NoError(t, err)
 	epochData.threshold = maxThreshold
@@ -404,7 +430,7 @@ func TestVerifyAuthorshipRight_Equivocation(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	cfg := &ServiceConfig{
+	cfg := ServiceConfig{
 		Keypair: kp,
 	}
 

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newMemoryMock(size uint32) *mockMemory {
-	m := new(mockMemory)
+func newMemoryMock(t *testing.T, size uint32) *mockMemory {
+	m := newMockMemory(t)
 	testobj := make([]byte, size)
 
 	m.On("Data").Return(testobj)
@@ -278,7 +278,7 @@ var allTests = []testHolder{
 //  test holder
 func TestAllocator(t *testing.T) {
 	for _, test := range allTests {
-		memmock := newMemoryMock(1 << 16)
+		memmock := newMemoryMock(t, 1<<16)
 		allocator := NewAllocator(memmock, test.offset)
 
 		for _, theTest := range test.tests {
@@ -324,7 +324,7 @@ func compareState(allocator FreeingBumpHeapAllocator, state allocatorState,
 
 // test that allocator should grow memory if the allocation request is larger than current size
 func TestShouldGrowMemory(t *testing.T) {
-	mem := newMemoryMock(1 << 16)
+	mem := newMemoryMock(t, 1<<16)
 	currentSize := mem.Length()
 
 	fbha := NewAllocator(mem, 0)
@@ -337,7 +337,7 @@ func TestShouldGrowMemory(t *testing.T) {
 
 // test that the allocator should grow memory if it's already full
 func TestShouldGrowMemoryIfFull(t *testing.T) {
-	mem := newMemoryMock(1 << 16)
+	mem := newMemoryMock(t, 1<<16)
 	currentSize := mem.Length()
 	fbha := NewAllocator(mem, 0)
 
@@ -357,10 +357,10 @@ func TestShouldGrowMemoryIfFull(t *testing.T) {
 // test to confirm that allocator can allocate the MaxPossibleAllocation
 func TestShouldAllocateMaxPossibleAllocationSize(t *testing.T) {
 	// given, grow heap memory so that we have at least MaxPossibleAllocation available
-	mem := newMemoryMock(1 << 16)
+	mem := newMemoryMock(t, 1<<16)
 
 	pagesNeeded := (MaxPossibleAllocation / PageSize) - (mem.Length() / PageSize) + 1
-	mem = newMemoryMock(mem.Length() + pagesNeeded*65*1024)
+	mem = newMemoryMock(t, mem.Length()+pagesNeeded*65*1024)
 
 	fbha := NewAllocator(mem, 0)
 
@@ -376,7 +376,7 @@ func TestShouldAllocateMaxPossibleAllocationSize(t *testing.T) {
 
 // test that allocator should not allocate memory if request is too large
 func TestShouldNotAllocateIfRequestSizeTooLarge(t *testing.T) {
-	fbha := NewAllocator(newMemoryMock(1<<16), 0)
+	fbha := NewAllocator(newMemoryMock(t, 1<<16), 0)
 
 	// when
 	_, err := fbha.Allocate(MaxPossibleAllocation + 1)

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -419,13 +419,8 @@ func TestShouldWriteU32CorrectlyIntoLe(t *testing.T) {
 	// NOTE: we used the go's binary.LittleEndianPutUint32 function
 	//  so this test isn't necessary, but is included for completeness
 
-	//given
 	heap := make([]byte, 5)
-
-	// when
 	binary.LittleEndian.PutUint32(heap, 1)
-
-	//then
 	if !reflect.DeepEqual(heap, []byte{1, 0, 0, 0, 0}) {
 		t.Error("Error Write U32 to LE")
 	}
@@ -436,13 +431,8 @@ func TestShouldWriteU32MaxCorrectlyIntoLe(t *testing.T) {
 	// NOTE: we used the go's binary.LittleEndianPutUint32 function
 	//  so this test isn't necessary, but is included for completeness
 
-	//given
 	heap := make([]byte, 5)
-
-	// when
 	binary.LittleEndian.PutUint32(heap, math.MaxUint32)
-
-	//then
 	if !reflect.DeepEqual(heap, []byte{255, 255, 255, 255, 0}) {
 		t.Error("Error Write U32 MAX to LE")
 	}
@@ -450,13 +440,8 @@ func TestShouldWriteU32MaxCorrectlyIntoLe(t *testing.T) {
 
 // test that getItemSizeFromIndex method gets expected item size from index
 func TestShouldGetItemFromIndex(t *testing.T) {
-	// given
 	index := uint(0)
-
-	// when
 	itemSize := getItemSizeFromIndex(index)
-
-	//then
 	if itemSize != 8 {
 		t.Error("item_size should be 8, got item_size:", itemSize)
 	}
@@ -465,13 +450,8 @@ func TestShouldGetItemFromIndex(t *testing.T) {
 // that that getItemSizeFromIndex method gets expected item size from index
 //  max index position
 func TestShouldGetMaxFromIndex(t *testing.T) {
-	// given
 	index := uint(21)
-
-	// when
 	itemSize := getItemSizeFromIndex(index)
-
-	//then
 	if itemSize != MaxPossibleAllocation {
 		t.Errorf("item_size should be %d, got item_size: %d", MaxPossibleAllocation, itemSize)
 	}

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -66,15 +66,15 @@ func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level,
 		LogLvl:      lvl,
 		NodeStorage: ns,
 		Network:     new(runtime.TestRuntimeNetwork),
-		Transaction: newTransactionStateMock(),
+		Transaction: newTransactionStateMock(t),
 		Role:        role,
 		testVersion: version,
 	}
 }
 
 // NewTransactionStateMock create and return an runtime Transaction State interface mock
-func newTransactionStateMock() *mocks.TransactionState {
-	m := new(mocks.TransactionState)
+func newTransactionStateMock(t *testing.T) *mocks.TransactionState {
+	m := mocks.NewTransactionState(t)
 	m.On("AddToPool", mock.AnythingOfType("*transaction.ValidTransaction")).Return(common.BytesToHash([]byte("test")))
 	return m
 }

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime/mocks"
 	"github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,15 +65,8 @@ func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level,
 		LogLvl:      lvl,
 		NodeStorage: ns,
 		Network:     new(runtime.TestRuntimeNetwork),
-		Transaction: newTransactionStateMock(t),
+		Transaction: mocks.NewTransactionState(t),
 		Role:        role,
 		testVersion: version,
 	}
-}
-
-// NewTransactionStateMock create and return an runtime Transaction State interface mock
-func newTransactionStateMock(t *testing.T) *mocks.TransactionState {
-	m := mocks.NewTransactionState(t)
-	m.On("AddToPool", mock.AnythingOfType("*transaction.ValidTransaction")).Return(common.BytesToHash([]byte("test")))
-	return m
 }

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -24,7 +24,7 @@ func TestServiceRegistry_RegisterService(t *testing.T) {
 func TestServiceRegistry_StartStopAll(t *testing.T) {
 	r := NewServiceRegistry(log.New(log.SetWriter(io.Discard)))
 
-	m := new(mocks.Service)
+	m := mocks.NewService(t)
 	m.On("Start").Return(nil)
 	m.On("Stop").Return(nil)
 
@@ -40,7 +40,7 @@ func TestServiceRegistry_StartStopAll(t *testing.T) {
 func TestServiceRegistry_Get_Err(t *testing.T) {
 	r := NewServiceRegistry(log.New(log.SetWriter(io.Discard)))
 
-	a := new(mocks.Service)
+	a := mocks.NewService(t)
 	a.On("Start").Return(nil)
 	a.On("Stop").Return(nil)
 

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -31,10 +31,7 @@ func TestServiceRegistry_StartStopAll(t *testing.T) {
 	r.RegisterService(m)
 
 	r.StartAll()
-	m.AssertCalled(t, "Start")
-
 	r.StopAll()
-	m.AssertCalled(t, "Stop")
 }
 
 func TestServiceRegistry_Get_Err(t *testing.T) {

--- a/lib/services/services_test.go
+++ b/lib/services/services_test.go
@@ -41,8 +41,6 @@ func TestServiceRegistry_Get_Err(t *testing.T) {
 	r := NewServiceRegistry(log.New(log.SetWriter(io.Discard)))
 
 	a := mocks.NewService(t)
-	a.On("Start").Return(nil)
-	a.On("Stop").Return(nil)
 
 	r.RegisterService(a)
 	require.NotNil(t, r.Get(a))


### PR DESCRIPTION
## Changes

- [x] Use generated mockery constructors for mockery mocks to ensure assertions are done in the test
- [x] Fix bugs caused by the now-fixed mock assertions
- [x] Remove existing `.Assert*` mocks calls

## Tests

All unit tests passing

## Issues

## Primary Reviewer

@EclesioMeloJunior 