### PR TITLE
fix(dot): no error logged for init check

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -519,7 +519,7 @@ func setDotGlobalConfigFromFlags(ctx *cli.Context, cfg *dot.GlobalConfig) error 
 
 func setDotGlobalConfigName(ctx *cli.Context, tomlCfg *ctoml.Config, cfg *dot.GlobalConfig) error {
 	globalBasePath := utils.ExpandDir(cfg.BasePath)
-	initialised := dot.NodeInitialized(globalBasePath)
+	initialised := dot.IsNodeInitialised(globalBasePath)
 
 	// consider the --name flag as higher priority
 	if ctx.GlobalString(NameFlag.Name) != "" {

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -226,7 +226,7 @@ func gossamerAction(ctx *cli.Context) error {
 	// from createDotConfig because dot config should not include expanded path)
 	cfg.Global.BasePath = utils.ExpandDir(cfg.Global.BasePath)
 
-	if !dot.NodeInitialized(cfg.Global.BasePath) {
+	if !dot.IsNodeInitialised(cfg.Global.BasePath) {
 		// initialise node (initialise state database and load genesis data)
 		err = dot.InitNode(cfg)
 		if err != nil {
@@ -320,8 +320,7 @@ func initAction(ctx *cli.Context) error {
 	// from createDotConfig because dot config should not include expanded path)
 	cfg.Global.BasePath = utils.ExpandDir(cfg.Global.BasePath)
 	// check if node has been initialised (expected false - no warning log)
-	if dot.NodeInitialized(cfg.Global.BasePath) {
-
+	if dot.IsNodeInitialised(cfg.Global.BasePath) {
 		// use --force value to force initialise the node
 		force := ctx.Bool(ForceFlag.Name)
 

--- a/dot/mock_node_builder_test.go
+++ b/dot/mock_node_builder_test.go
@@ -211,6 +211,20 @@ func (mr *MocknodeBuilderIfaceMockRecorder) initNode(config interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "initNode", reflect.TypeOf((*MocknodeBuilderIface)(nil).initNode), config)
 }
 
+// isNodeInitialised mocks base method.
+func (m *MocknodeBuilderIface) isNodeInitialised(basepath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "isNodeInitialised", basepath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// isNodeInitialised indicates an expected call of isNodeInitialised.
+func (mr *MocknodeBuilderIfaceMockRecorder) isNodeInitialised(basepath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "isNodeInitialised", reflect.TypeOf((*MocknodeBuilderIface)(nil).isNodeInitialised), basepath)
+}
+
 // loadRuntime mocks base method.
 func (m *MocknodeBuilderIface) loadRuntime(cfg *Config, ns *runtime.NodeStorage, stateSrvc *state.Service, ks *keystore.GlobalKeystore, net *network.Service) error {
 	m.ctrl.T.Helper()
@@ -238,18 +252,4 @@ func (m *MocknodeBuilderIface) newSyncService(cfg *Config, st *state.Service, fg
 func (mr *MocknodeBuilderIfaceMockRecorder) newSyncService(cfg, st, fg, verifier, cs, net, telemetryMailer interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newSyncService", reflect.TypeOf((*MocknodeBuilderIface)(nil).newSyncService), cfg, st, fg, verifier, cs, net, telemetryMailer)
-}
-
-// nodeInitialised mocks base method.
-func (m *MocknodeBuilderIface) nodeInitialised(arg0 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "nodeInitialised", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// nodeInitialised indicates an expected call of nodeInitialised.
-func (mr *MocknodeBuilderIfaceMockRecorder) nodeInitialised(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "nodeInitialised", reflect.TypeOf((*MocknodeBuilderIface)(nil).nodeInitialised), arg0)
 }

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -68,13 +68,13 @@ func TestNodeInitializedIntegration(t *testing.T) {
 
 	cfg.Init.Genesis = genFile
 
-	result := NodeInitialized(cfg.Global.BasePath)
+	result := IsNodeInitialised(cfg.Global.BasePath)
 	require.False(t, result)
 
 	err := InitNode(cfg)
 	require.NoError(t, err)
 
-	result = NodeInitialized(cfg.Global.BasePath)
+	result = IsNodeInitialised(cfg.Global.BasePath)
 	require.True(t, result)
 }
 

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -154,7 +154,7 @@ func TestNewNode(t *testing.T) {
 	mockServiceRegistry.EXPECT().RegisterService(gomock.Any()).Times(8)
 
 	m := NewMocknodeBuilderIface(ctrl)
-	m.EXPECT().nodeInitialised(dotConfig.Global.BasePath).Return(nil)
+	m.EXPECT().isNodeInitialised(dotConfig.Global.BasePath).Return(nil)
 	m.EXPECT().createStateService(dotConfig).DoAndReturn(func(cfg *Config) (*state.Service, error) {
 		stateSrvc := state.NewService(config)
 		// create genesis from configuration file
@@ -285,7 +285,7 @@ func TestNodeInitialized(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NodeInitialized(tt.basepath)
+			got := IsNodeInitialised(tt.basepath)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Changes

- Rename `NodeInitialized` to `IsNodeInitialised`
- Rename `nodeInitialised` to `isNodeInitialised`
- Do not log `IsNodeInitialised` error

## Tests

## Issues

Found these strange logs while working on #2470 

## Primary Reviewer


@timwu20
