### PR TITLE
fix(dot/subscription): check websocket message from untrusted data

### DIFF
--- a/dot/rpc/http.go
+++ b/dot/rpc/http.go
@@ -233,7 +233,7 @@ func (h *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wsc := NewWSConn(ws, h.serverConfig)
 	h.wsConns = append(h.wsConns, wsc)
 
-	go wsc.HandleComm()
+	go wsc.HandleConn()
 }
 
 // NewWSConn to create new WebSocket Connection struct

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -69,15 +69,14 @@ func (c *WSConn) HandleConn() {
 		mbytes, err := c.readWebsocketMessage()
 		if errors.Is(err, errCannotReadFromWebsocket) {
 			return
-		} else if errors.Is(err, errCannotUnmarshalMessage) {
+		} else if err != nil {
 			c.safeSendError(0, big.NewInt(InvalidRequestCode), InvalidRequestMessage)
-			continue
 		}
 
 		msg := new(websocketMessage)
 		err = json.Unmarshal(mbytes, &msg)
 		if err != nil {
-			logger.Debugf("failed to unmarshal websocket request message: %s", err)
+			c.safeSendError(0, big.NewInt(InvalidRequestCode), InvalidRequestMessage)
 			continue
 		}
 

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -56,7 +56,7 @@ func (c *WSConn) readWebsocketMessage() (bytes []byte, err error) {
 	_, bytes, err = c.Wsconn.ReadMessage()
 	if err != nil {
 		logger.Debugf("websocket failed to read message: %s", err)
-		return bytes, errCannotReadFromWebsocket
+		return nil, errCannotReadFromWebsocket
 	}
 
 	logger.Tracef("websocket message received: %s", string(bytes))
@@ -77,7 +77,7 @@ func (c *WSConn) HandleConn() {
 		msg := new(websocketMessage)
 		err = json.Unmarshal(mbytes, &msg)
 		if err != nil {
-			logger.Debugf("websocket failed to unmarshal request message: %s", err)
+			logger.Debugf("failed to unmarshal websocket request message: %s", err)
 			continue
 		}
 

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -52,24 +52,23 @@ type WSConn struct {
 }
 
 // readWebsocketMessage will read and parse the message data to a string->interface{} data
-func (c *WSConn) readWebsocketMessage() ([]byte, *websocketMessage, error) {
-	_, mbytes, err := c.Wsconn.ReadMessage()
+func (c *WSConn) readWebsocketMessage() (bytes []byte, msg websocketMessage, err error) {
+	_, bytes, err = c.Wsconn.ReadMessage()
 	if err != nil {
 		logger.Debugf("websocket failed to read message: %s", err)
-		return nil, nil, errCannotReadFromWebsocket
+		return bytes, msg, errCannotReadFromWebsocket
 	}
 
-	logger.Tracef("websocket message received: %s", string(mbytes))
+	logger.Tracef("websocket message received: %s", string(bytes))
 
-	msg := new(websocketMessage)
-	err = json.Unmarshal(mbytes, &msg)
+	err = json.Unmarshal(bytes, &msg)
 
 	if err != nil {
 		logger.Debugf("websocket failed to unmarshal request message: %s", err)
-		return nil, nil, errCannotUnmarshalMessage
+		return bytes, msg, errCannotUnmarshalMessage
 	}
 
-	return mbytes, msg, nil
+	return bytes, msg, nil
 }
 
 //HandleConn handles messages received on websocket connections

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -25,7 +25,7 @@ import (
 type websocketMessage struct {
 	ID     float64 `json:"id"`
 	Method string  `json:"method"`
-	Params any
+	Params any     `json:"params"`
 }
 
 type httpclient interface {
@@ -57,13 +57,13 @@ func (c *WSConn) readWebsocketMessage() (rawBytes []byte, wsMessage *websocketMe
 		return nil, nil, fmt.Errorf("%w: %s", errCannotReadFromWebsocket, err.Error())
 	}
 
-	msg := new(websocketMessage)
-	err = json.Unmarshal(rawBytes, &msg)
+	wsMessage = new(websocketMessage)
+	err = json.Unmarshal(rawBytes, wsMessage)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return rawBytes, msg, nil
+	return rawBytes, wsMessage, nil
 }
 
 // HandleConn handles messages received on websocket connections

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -68,8 +68,6 @@ func (c *WSConn) readWebsocketMessage() (rawBytes []byte, wsMessage *websocketMe
 
 // HandleConn handles messages received on websocket connections
 func (c *WSConn) HandleConn() {
-	defer c.Wsconn.Close()
-
 	for {
 		rawBytes, wsMessage, err := c.readWebsocketMessage()
 		if err != nil {
@@ -83,12 +81,14 @@ func (c *WSConn) HandleConn() {
 		}
 
 		logger.Tracef("websocket message received: %s", string(rawBytes))
+
 		if wsMessage.Method == "" {
 			c.safeSendError(0, big.NewInt(InvalidRequestCode), InvalidRequestMessage)
 			continue
 		}
 
 		logger.Debugf("ws method %s called with params %v", wsMessage.Method, wsMessage.Params)
+
 		if !strings.Contains(wsMessage.Method, "_unsubscribe") && !strings.Contains(wsMessage.Method, "_unwatch") {
 			setupListener := c.getSetupListener(wsMessage.Method)
 

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -33,7 +33,6 @@ type httpclient interface {
 }
 
 var errCannotReadFromWebsocket = errors.New("cannot read message from websocket")
-var errCannotUnmarshalMessage = errors.New("cannot unmarshal webasocket message data")
 var logger = log.NewFromGlobal(log.AddContext("pkg", "rpc/subscription"))
 
 // WSConn struct to hold WebSocket Connection references

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -71,7 +71,7 @@ func (c *WSConn) readWebsocketMessage() (bytes []byte, msg websocketMessage, err
 	return bytes, msg, nil
 }
 
-//HandleConn handles messages received on websocket connections
+// HandleConn handles messages received on websocket connections
 func (c *WSConn) HandleConn() {
 	for {
 		mbytes, msg, err := c.readWebsocketMessage()

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -72,8 +72,8 @@ func (c *WSConn) readWebsocketMessage() ([]byte, *websocketMessage, error) {
 	return mbytes, msg, nil
 }
 
-//HandleComm handles messages received on websocket connections
-func (c *WSConn) HandleComm() {
+//HandleConn handles messages received on websocket connections
+func (c *WSConn) HandleConn() {
 	for {
 		mbytes, msg, err := c.readWebsocketMessage()
 		if errors.Is(err, errCannotReadFromWebsocket) {

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -66,10 +66,8 @@ func (c *WSConn) readWebsocketMessage() (bytes []byte, err error) {
 func (c *WSConn) HandleConn() {
 	for {
 		mbytes, err := c.readWebsocketMessage()
-		if errors.Is(err, errCannotReadFromWebsocket) {
+		if err != nil {
 			return
-		} else if err != nil {
-			c.safeSendError(0, big.NewInt(InvalidRequestCode), InvalidRequestMessage)
 		}
 
 		msg := new(websocketMessage)

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -26,7 +26,7 @@ func TestWSConn_CheckWebsocketInvalidData(t *testing.T) {
 	wsconn.Subscriptions = make(map[uint32]Listener)
 	defer cancel()
 
-	go wsconn.HandleComm()
+	go wsconn.HandleConn()
 
 	tests := []struct {
 		sentMessage []byte
@@ -68,12 +68,12 @@ func TestWSConn_CheckWebsocketInvalidData(t *testing.T) {
 	}
 }
 
-func TestWSConn_HandleComm(t *testing.T) {
+func TestWSConn_HandleConn(t *testing.T) {
 	wsconn, c, cancel := setupWSConn(t)
 	wsconn.Subscriptions = make(map[uint32]Listener)
 	defer cancel()
 
-	go wsconn.HandleComm()
+	go wsconn.HandleConn()
 	time.Sleep(time.Second * 2)
 
 	// test storageChangeListener
@@ -341,7 +341,7 @@ func TestSubscribeAllHeads(t *testing.T) {
 	wsconn.Subscriptions = make(map[uint32]Listener)
 	defer cancel()
 
-	go wsconn.HandleComm()
+	go wsconn.HandleConn()
 	time.Sleep(time.Second * 2)
 
 	_, err := wsconn.initAllBlocksListerner(1, nil)

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWSConn_EmptyMethod(t *testing.T) {
+func TestWSConn_CheckWebsocketInvalidData(t *testing.T) {
 	wsconn, c, cancel := setupWSConn(t)
 	wsconn.Subscriptions = make(map[uint32]Listener)
 	defer cancel()
@@ -44,6 +44,15 @@ func TestWSConn_EmptyMethod(t *testing.T) {
 		{
 			sentMessage: []byte(`{
 			"jsonrpc": "2.0",
+			"params": []
+			}`),
+			expected: []byte(`{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"},"id":0}` + "\n"),
+		},
+		{
+			sentMessage: []byte(`{
+			"jsonrpc": "2.0",
+			"id": "abcdef"
+			"method": "some_method_name"
 			"params": []
 			}`),
 			expected: []byte(`{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid request"},"id":0}` + "\n"),


### PR DESCRIPTION
## Changes

- Created a struct with the required fields: `ID float64`, `Method string` and `Params any` to ensure the types and avoid conversions over `interface{}`
- Created a condition to don't allow an empty `Method` field

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/rpc/subscription
```

## Issues

- Closes #2413

## Primary Reviewer

@jimjbrettj 