### PR TITLE
fix(dot/subscription): unsafe type casting from untrusted input

### DIFF
--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -6,7 +6,7 @@ metrics-address = ":9876"
 [log]
 core = ""
 network = ""
-rpc = ""
+rpc = "warn"
 state = ""
 runtime = ""
 babe = ""

--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -6,7 +6,7 @@ metrics-address = ":9876"
 [log]
 core = ""
 network = ""
-rpc = "warn"
+rpc = ""
 state = ""
 runtime = ""
 babe = ""

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -163,6 +163,8 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 	}
 
 	switch filter := params.(type) {
+	case string:
+		stgobs.filter[filter] = []byte{}
 	case []string:
 		for _, key := range filter {
 			stgobs.filter[key] = []byte{}
@@ -176,8 +178,6 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 
 			stgobs.filter[key] = []byte{}
 		}
-	case string:
-		stgobs.filter[filter] = []byte{}
 	default:
 		return nil, fmt.Errorf("expected type equals string or []string. got %T", params)
 	}

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -35,7 +35,6 @@ type httpclient interface {
 var (
 	errUnexpectedType          = errors.New("unexpected type")
 	errUnexpectedParamLen      = errors.New("unexpected params length")
-	errCannotUnmarshalMessage  = errors.New("cannot unmarshal websocket message data")
 	errCannotReadFromWebsocket = errors.New("cannot read message from websocket")
 	errEmptyMethod             = errors.New("empty method")
 )

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -274,12 +274,12 @@ func (c *WSConn) initExtrinsicWatch(reqID float64, params interface{}) (Listener
 	switch encodedHex := params.(type) {
 	case []string:
 		if len(encodedHex) != 1 {
-			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedType, len(encodedHex))
+			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedParamLen, len(encodedHex))
 		}
 		encodedExtrinsic = encodedHex[0]
 	case []interface{}:
 		if len(encodedHex) != 1 {
-			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedType, len(encodedHex))
+			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedParamLen, len(encodedHex))
 		}
 
 		var ok bool

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -28,7 +28,7 @@ type httpclient interface {
 
 var (
 	errCannotReadFromWebsocket = errors.New("cannot read message from websocket")
-	errCannotUnmarshalMessage  = errors.New("cannot unmarshal webasocket message data")
+	errCannotUnmarshalMessage  = errors.New("cannot unmarshal websocket message data")
 )
 
 var logger = log.NewFromGlobal(log.AddContext("pkg", "rpc/subscription"))

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -166,7 +166,8 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 
 	// the following type checking/casting is needed in order to satisfy some
 	// websocket request field params eg.:
-	// "params": "[["0x...", "0x..."]]"
+	// "params": ["0x..."] or
+	// "params": [["0x...", "0x..."]]
 	switch filters := params.(type) {
 	case []interface{}:
 		for _, interfaceKey := range filters {
@@ -181,11 +182,13 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 				for _, k := range key {
 					k, ok := k.(string)
 					if !ok {
-						return nil, fmt.Errorf("%w: %T, expected type string", errUnexpectedType, interfaceKey)
+						return nil, fmt.Errorf("%w: %T, expected type string", errUnexpectedType, k)
 					}
 
 					stgobs.filter[k] = []byte{}
 				}
+			default:
+				return nil, fmt.Errorf("%w: %T, expected type string, []string, []interface{}", errUnexpectedType, interfaceKey)
 			}
 		}
 	default:

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -276,14 +276,14 @@ func (c *WSConn) initExtrinsicWatch(reqID float64, params interface{}) (Listener
 	switch encodedHex := params.(type) {
 	case []string:
 		if len(encodedHex) != 1 {
-			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedParamLen, len(encodedHex))
+			return nil, fmt.Errorf("%w: expected 1 param, got: %d", errUnexpectedParamLen, len(encodedHex))
 		}
 		encodedExtrinsic = encodedHex[0]
 	// the bellow case is needed to cover a interface{} slice containing one string
 	// as `[]interface{"a"}` is not the same as `[]string{"a"}`
 	case []interface{}:
 		if len(encodedHex) != 1 {
-			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedParamLen, len(encodedHex))
+			return nil, fmt.Errorf("%w: expected 1 param, got: %d", errUnexpectedParamLen, len(encodedHex))
 		}
 
 		var ok bool

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -171,6 +171,8 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 		for _, key := range filter {
 			stgobs.filter[key] = []byte{}
 		}
+	// the bellow case is needed to cover a interface{} slice full of strings
+	// as `[]interface{"a", "b"}` is not the same as `[]string{"a", "b"}`
 	case []interface{}:
 		for _, interfaceKey := range filter {
 			key, ok := interfaceKey.(string)
@@ -181,7 +183,7 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 			stgobs.filter[key] = []byte{}
 		}
 	default:
-		return nil, fmt.Errorf("%w: %T, expected type string or []string", errUnexpectedType, params)
+		return nil, fmt.Errorf("%w: %T, expected type string, []string or []interface{}", errUnexpectedType, params)
 	}
 
 	c.mu.Lock()
@@ -277,6 +279,8 @@ func (c *WSConn) initExtrinsicWatch(reqID float64, params interface{}) (Listener
 			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedParamLen, len(encodedHex))
 		}
 		encodedExtrinsic = encodedHex[0]
+	// the bellow case is needed to cover a interface{} slice containing one string
+	// as `[]interface{"a"}` is not the same as `[]string{"a"}`
 	case []interface{}:
 		if len(encodedHex) != 1 {
 			return nil, fmt.Errorf("%w: %d, expected 1 param", errUnexpectedParamLen, len(encodedHex))
@@ -288,7 +292,7 @@ func (c *WSConn) initExtrinsicWatch(reqID float64, params interface{}) (Listener
 			return nil, fmt.Errorf("%w: %T, expected type string", errUnexpectedType, encodedHex[0])
 		}
 	default:
-		return nil, fmt.Errorf("%w: %T, expected type []string", errUnexpectedType, params)
+		return nil, fmt.Errorf("%w: %T, expected type []string or []interface{}", errUnexpectedType, params)
 	}
 
 	// The passed parameter should be a HEX of a SCALE encoded extrinsic

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -45,7 +45,8 @@ func TestWSConn_HandleComm(t *testing.T) {
 	res, err = wsconn.initStorageChangeListener(1, nil)
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 0)
-	require.EqualError(t, err, "unexpected type: <nil>, expected type string or []string")
+	require.ErrorIs(t, err, errUnexpectedType)
+	require.EqualError(t, err, "unexpected type: <nil>, expected type string, []string or []interface{}")
 
 	res, err = wsconn.initStorageChangeListener(2, []interface{}{})
 	require.NotNil(t, res)
@@ -74,12 +75,14 @@ func TestWSConn_HandleComm(t *testing.T) {
 
 	var testFilterWrongType = []interface{}{"0x26aa", 1}
 	res, err = wsconn.initStorageChangeListener(5, testFilterWrongType)
+	require.ErrorIs(t, err, errUnexpectedType)
 	require.EqualError(t, err, "unexpected type: int, expected type string")
 	require.Nil(t, res)
 	// keep subscriptions len == 3, no additions was made
 	require.Len(t, wsconn.Subscriptions, 3)
 
 	res, err = wsconn.initStorageChangeListener(6, []interface{}{1})
+	require.ErrorIs(t, err, errUnexpectedType)
 	require.EqualError(t, err, "unexpected type: int, expected type string")
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 3)

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -56,7 +56,8 @@ func TestWSConn_HandleComm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":1,"id":2}`+"\n"), msg)
 
-	res, err = wsconn.initStorageChangeListener(3, "0x26aa")
+	var testFilter0 = []interface{}{"0x26aa"}
+	res, err = wsconn.initStorageChangeListener(3, testFilter0)
 	require.NotNil(t, res)
 	require.NoError(t, err)
 	require.Len(t, wsconn.Subscriptions, 2)
@@ -64,7 +65,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":2,"id":3}`+"\n"), msg)
 
-	var testFilter1 = []string{"0x26aa", "0x26a1"}
+	var testFilter1 = []interface{}{[]interface{}{"0x26aa", "0x26a1"}}
 	res, err = wsconn.initStorageChangeListener(4, testFilter1)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -73,17 +74,17 @@ func TestWSConn_HandleComm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":3,"id":4}`+"\n"), msg)
 
-	var testFilterWrongType = []interface{}{"0x26aa", 1}
+	var testFilterWrongType = []interface{}{[]int{123}}
 	res, err = wsconn.initStorageChangeListener(5, testFilterWrongType)
 	require.ErrorIs(t, err, errUnexpectedType)
-	require.EqualError(t, err, "unexpected type: int, expected type string")
+	require.EqualError(t, err, "unexpected type: []int, expected type string, []string, []interface{}")
 	require.Nil(t, res)
 	// keep subscriptions len == 3, no additions was made
 	require.Len(t, wsconn.Subscriptions, 3)
 
 	res, err = wsconn.initStorageChangeListener(6, []interface{}{1})
 	require.ErrorIs(t, err, errUnexpectedType)
-	require.EqualError(t, err, "unexpected type: int, expected type string")
+	require.EqualError(t, err, "unexpected type: int, expected type string, []string, []interface{}")
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 3)
 

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -45,7 +45,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 	res, err = wsconn.initStorageChangeListener(1, nil)
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 0)
-	require.EqualError(t, err, "expected type equals string or []string. got <nil>")
+	require.EqualError(t, err, "unexpected type: <nil>, expected type string or []string")
 
 	res, err = wsconn.initStorageChangeListener(2, []interface{}{})
 	require.NotNil(t, res)
@@ -74,13 +74,13 @@ func TestWSConn_HandleComm(t *testing.T) {
 
 	var testFilterWrongType = []interface{}{"0x26aa", 1}
 	res, err = wsconn.initStorageChangeListener(5, testFilterWrongType)
-	require.EqualError(t, err, "expected type equals string. got int")
+	require.EqualError(t, err, "unexpected type: int, expected type string")
 	require.Nil(t, res)
 	// keep subscriptions len == 3, no additions was made
 	require.Len(t, wsconn.Subscriptions, 3)
 
 	res, err = wsconn.initStorageChangeListener(6, []interface{}{1})
-	require.EqualError(t, err, "expected type equals string. got int")
+	require.EqualError(t, err, "unexpected type: int, expected type string")
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 3)
 

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -45,7 +45,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 	res, err = wsconn.initStorageChangeListener(1, nil)
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 0)
-	require.EqualError(t, err, "unknown parameter type")
+	require.EqualError(t, err, "expected type equals string or []string. got <nil>")
 
 	res, err = wsconn.initStorageChangeListener(2, []interface{}{})
 	require.NotNil(t, res)
@@ -63,25 +63,24 @@ func TestWSConn_HandleComm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":2,"id":3}`+"\n"), msg)
 
-	var testFilters = []interface{}{}
-	var testFilter1 = []interface{}{"0x26aa", "0x26a1"}
-	res, err = wsconn.initStorageChangeListener(4, append(testFilters, testFilter1))
-	require.NotNil(t, res)
+	var testFilter1 = []string{"0x26aa", "0x26a1"}
+	res, err = wsconn.initStorageChangeListener(4, testFilter1)
 	require.NoError(t, err)
+	require.NotNil(t, res)
 	require.Len(t, wsconn.Subscriptions, 3)
 	_, msg, err = c.ReadMessage()
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":3,"id":4}`+"\n"), msg)
 
 	var testFilterWrongType = []interface{}{"0x26aa", 1}
-	res, err = wsconn.initStorageChangeListener(5, append(testFilters, testFilterWrongType))
-	require.EqualError(t, err, "unknown parameter type")
+	res, err = wsconn.initStorageChangeListener(5, testFilterWrongType)
+	require.EqualError(t, err, "expected type equals string. got int")
 	require.Nil(t, res)
 	// keep subscriptions len == 3, no additions was made
 	require.Len(t, wsconn.Subscriptions, 3)
 
 	res, err = wsconn.initStorageChangeListener(6, []interface{}{1})
-	require.EqualError(t, err, "unknown parameter type")
+	require.EqualError(t, err, "expected type equals string. got int")
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 3)
 

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -46,7 +46,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 	require.Nil(t, res)
 	require.Len(t, wsconn.Subscriptions, 0)
 	require.ErrorIs(t, err, errUnexpectedType)
-	require.EqualError(t, err, "unexpected type: <nil>, expected type string, []string or []interface{}")
+	require.EqualError(t, err, "unexpected type: <nil>, expected type []interface{}")
 
 	res, err = wsconn.initStorageChangeListener(2, []interface{}{})
 	require.NotNil(t, res)

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -55,7 +55,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(`{"jsonrpc":"2.0","result":1,"id":2}`+"\n"), msg)
 
-	res, err = wsconn.initStorageChangeListener(3, []interface{}{"0x26aa"})
+	res, err = wsconn.initStorageChangeListener(3, "0x26aa")
 	require.NotNil(t, res)
 	require.NoError(t, err)
 	require.Len(t, wsconn.Subscriptions, 2)
@@ -206,7 +206,7 @@ func TestWSConn_HandleComm(t *testing.T) {
 	wsconn.CoreAPI = modules.NewMockCoreAPI()
 	wsconn.BlockAPI = nil
 	wsconn.TxStateAPI = modules.NewMockTransactionStateAPI()
-	listner, err := wsconn.initExtrinsicWatch(0, []interface{}{"NotHex"})
+	listner, err := wsconn.initExtrinsicWatch(0, []string{"NotHex"})
 	require.EqualError(t, err, "could not byteify non 0x prefixed string: NotHex")
 	require.Nil(t, listner)
 


### PR DESCRIPTION
## Changes

- Add checks in methods `initExtrinsicWatch` and `initStorageChangeListener` to safely casting types from untrusted inputs

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/rpc/subscription
```

## Issues

- Closes #2412

## Primary Reviewer

@edwardmack 
