### PR TITLE
chore(ci): split unit test workflow by package

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,6 +53,38 @@ jobs:
 
   unit-tests:
     timeout-minutes: 60
+    strategy:
+      matrix:
+        packages:
+          [
+            github.com/ChainSafe/gossamer/cmd/gossamer,
+            github.com/ChainSafe/gossamer/dot,
+            github.com/ChainSafe/gossamer/dot/config/...,
+            github.com/ChainSafe/gossamer/dot/core/...,
+            github.com/ChainSafe/gossamer/dot/digest/...,
+            github.com/ChainSafe/gossamer/dot/network/...,
+            github.com/ChainSafe/gossamer/dot/peerset/...,
+            github.com/ChainSafe/gossamer/dot/rpc/...,
+            github.com/ChainSafe/gossamer/dot/state/...,
+            github.com/ChainSafe/gossamer/dot/sync/...,
+            github.com/ChainSafe/gossamer/dot/system/...,
+            github.com/ChainSafe/gossamer/dot/telemetry/...,
+            github.com/ChainSafe/gossamer/dot/types/...,
+            github.com/ChainSafe/gossamer/internal/...,
+            github.com/ChainSafe/gossamer/lib/babe/...,
+            github.com/ChainSafe/gossamer/lib/blocktree/...,
+            github.com/ChainSafe/gossamer/lib/common/...,
+            github.com/ChainSafe/gossamer/lib/crypto/...,
+            github.com/ChainSafe/gossamer/lib/genesis/...,
+            github.com/ChainSafe/gossamer/lib/grandpa/...,
+            github.com/ChainSafe/gossamer/lib/keystore/...,
+            github.com/ChainSafe/gossamer/lib/runtime/...,
+            github.com/ChainSafe/gossamer/lib/services/...,
+            github.com/ChainSafe/gossamer/lib/transaction/...,
+            github.com/ChainSafe/gossamer/lib/trie/...,
+            github.com/ChainSafe/gossamer/lib/utils/...,
+            github.com/ChainSafe/gossamer/pkg/...,
+          ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -100,7 +132,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Run unit tests
-        run: go test -short -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
+        run: go test -short -coverprofile=coverage.out -covermode=atomic -timeout=30m ${{ matrix.packages }}
 
       - uses: codecov/codecov-action@v3.1.0
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,39 @@ on:
 name: unit-tests
 
 jobs:
+  state-race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+          stable: true
+          check-latest: true
+
+      - name: Set cache variables
+        id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+      - uses: actions/checkout@v3
+
+      - name: Go build cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-build
+
+      - name: Go modules cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-mod
+
+      - run: make test-state-race
+
   unit-tests:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -68,9 +101,6 @@ jobs:
 
       - name: Run unit tests
         run: go test -short -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
-
-      - name: Test State - Race
-        run: make test-state-race
 
       - uses: codecov/codecov-action@v3.1.0
         with:


### PR DESCRIPTION
## Changes

Advantages:

- Faster feedback since jobs are parallelised
- All unit tests 'fail fast', if one matrix job fails, others are canceled

Disadvantages:

- we need to add new packages to the matrix
- code coverage is no longer CI-tracked (like integration tests already)

We should one day revert these changes once unit tests are fast (< 5 minutes imo)

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

