### PR TITLE
chore(lib/grandpa): `lib/grandpa/models` package

### DIFF
--- a/dot/digest/interface.go
+++ b/dot/digest/interface.go
@@ -6,7 +6,7 @@ package digest
 import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
+	grandpa "github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
 

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/genesis"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
+	grandpa "github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"

--- a/dot/rpc/modules/grandpa_integration_test.go
+++ b/dot/rpc/modules/grandpa_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
+	grandpa "github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/dot/rpc/modules/grandpa_test.go
+++ b/dot/rpc/modules/grandpa_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
+	grandpa "github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
+	grandpa "github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/transaction"

--- a/dot/rpc/subscription/websocket_test.go
+++ b/dot/rpc/subscription/websocket_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ChainSafe/gossamer/dot/rpc/modules/mocks"
-	"github.com/ChainSafe/gossamer/pkg/scale"
-
 	"github.com/ChainSafe/gossamer/dot/rpc/modules"
+	"github.com/ChainSafe/gossamer/dot/rpc/modules/mocks"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/grandpa"
+	grandpa "github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/lib/grandpa/commits_tracker.go
+++ b/lib/grandpa/commits_tracker.go
@@ -7,6 +7,7 @@ import (
 	"container/list"
 
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 )
 
 // commitsTracker tracks vote messages that could
@@ -35,7 +36,7 @@ func newCommitsTracker(capacity int) commitsTracker {
 // add adds a commit message to the commit message tracker.
 // If the commit message tracker capacity is reached,
 // the oldest commit message is removed.
-func (ct *commitsTracker) add(commitMessage *CommitMessage) {
+func (ct *commitsTracker) add(commitMessage *models.CommitMessage) {
 	blockHash := commitMessage.Vote.Hash
 
 	listElement, has := ct.mapping[blockHash]
@@ -67,7 +68,7 @@ func (ct *commitsTracker) cleanup() {
 	oldestElement := ct.linkedList.Back()
 	ct.linkedList.Remove(oldestElement)
 
-	oldestCommitMessage := oldestElement.Value.(*CommitMessage)
+	oldestCommitMessage := oldestElement.Value.(*models.CommitMessage)
 	oldestBlockHash := oldestCommitMessage.Vote.Hash
 	delete(ct.mapping, oldestBlockHash)
 }
@@ -89,20 +90,20 @@ func (ct *commitsTracker) delete(blockHash common.Hash) {
 // the tracker. It returns nil if the block hash
 // does not exist in the tracker
 func (ct *commitsTracker) message(blockHash common.Hash) (
-	message *CommitMessage) {
+	message *models.CommitMessage) {
 	listElement, ok := ct.mapping[blockHash]
 	if !ok {
 		return nil
 	}
 
-	return listElement.Value.(*CommitMessage)
+	return listElement.Value.(*models.CommitMessage)
 }
 
 // forEach runs the function `f` on each
 // commit message stored in the tracker.
-func (ct *commitsTracker) forEach(f func(message *CommitMessage)) {
+func (ct *commitsTracker) forEach(f func(message *models.CommitMessage)) {
 	for _, data := range ct.mapping {
-		message := data.Value.(*CommitMessage)
+		message := data.Value.(*models.CommitMessage)
 		f(message)
 	}
 }

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -22,9 +22,6 @@ var (
 	ErrNilKeypair       = errors.New("cannot have nil keypair")
 	ErrNilNetwork       = errors.New("cannot have nil Network")
 
-	// ErrBlockDoesNotExist is returned when trying to validate a vote for a block that doesn't exist
-	ErrBlockDoesNotExist = errors.New("block does not exist")
-
 	// ErrInvalidSignature is returned when trying to validate a vote message with an invalid signature
 	ErrInvalidSignature = errors.New("signature is not valid")
 
@@ -35,9 +32,6 @@ var (
 
 	// ErrEquivocation is returned when trying to validate a vote for that is equivocatory
 	ErrEquivocation = errors.New("vote is equivocatory")
-
-	// ErrVoterNotFound is returned when trying to validate a vote for a voter that isn't in the voter set
-	ErrVoterNotFound = errors.New("voter is not in voter set")
 
 	// ErrDescendantNotFound is returned when trying to validate a vote
 	// for a block that isn't a descendant of the last finalised block

--- a/lib/grandpa/errors/errors.go
+++ b/lib/grandpa/errors/errors.go
@@ -1,7 +1,7 @@
 // Copyright 2022 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package models
+package errors
 
 import "errors"
 

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/golang/mock/gomock"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,10 +74,10 @@ func newTestState(t *testing.T) *state.Service {
 	}
 }
 
-func newTestVoters() []Voter {
-	vs := []Voter{}
+func newTestVoters() []models.Voter {
+	vs := []models.Voter{}
 	for i, k := range kr.Keys {
-		vs = append(vs, Voter{
+		vs = append(vs, models.Voter{
 			Key: *k.Public().(*ed25519.PublicKey),
 			ID:  uint64(i),
 		})
@@ -114,9 +114,9 @@ func TestUpdateAuthorities(t *testing.T) {
 	gs, _ := newTestService(t)
 	err := gs.updateAuthorities()
 	require.NoError(t, err)
-	require.Equal(t, uint64(0), gs.state.setID)
+	require.Equal(t, uint64(0), gs.state.SetID)
 
-	next := []Voter{
+	next := []models.Voter{
 		{Key: *kr.Alice().Public().(*ed25519.PublicKey), ID: 0},
 	}
 
@@ -129,19 +129,19 @@ func TestUpdateAuthorities(t *testing.T) {
 	err = gs.updateAuthorities()
 	require.NoError(t, err)
 
-	require.Equal(t, uint64(1), gs.state.setID)
-	require.Equal(t, next, gs.state.voters)
+	require.Equal(t, uint64(1), gs.state.SetID)
+	require.Equal(t, next, gs.state.Voters)
 }
 
 func TestGetDirectVotes(t *testing.T) {
 	gs, _ := newTestService(t)
 
-	voteA := Vote{
+	voteA := models.Vote{
 		Hash:   common.Hash{0xa},
 		Number: 1,
 	}
 
-	voteB := Vote{
+	voteB := models.Vote{
 		Hash:   common.Hash{0xb},
 		Number: 1,
 	}
@@ -150,17 +150,17 @@ func TestGetDirectVotes(t *testing.T) {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 5 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: voteA,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: voteB,
 			})
 		}
 	}
 
-	directVotes := gs.getDirectVotes(prevote)
+	directVotes := gs.getDirectVotes(models.Prevote)
 	require.Equal(t, 2, len(directVotes))
 	require.Equal(t, uint64(5), directVotes[voteA])
 	require.Equal(t, uint64(4), directVotes[voteB])
@@ -174,30 +174,30 @@ func TestGetVotesForBlock_NoDescendantVotes(t *testing.T) {
 	leaves := gs.blockState.Leaves()
 
 	// 1/3 of voters equivocate; ie. vote for both blocks
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 5 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
 	}
 
-	votesForA, err := gs.getVotesForBlock(voteA.Hash, prevote)
+	votesForA, err := gs.getVotesForBlock(voteA.Hash, models.Prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(5), votesForA)
 
-	votesForB, err := gs.getVotesForBlock(voteB.Hash, prevote)
+	votesForB, err := gs.getVotesForBlock(voteB.Hash, models.Prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(4), votesForB)
 }
@@ -213,41 +213,41 @@ func TestGetVotesForBlock_DescendantVotes(t *testing.T) {
 	require.NoError(t, err)
 
 	// A is a descendant of B
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(a.ParentHash, st.Block)
+	voteB, err := models.NewVoteFromHash(a.ParentHash, st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[1], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 5 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
 	}
 
-	votesForA, err := gs.getVotesForBlock(voteA.Hash, prevote)
+	votesForA, err := gs.getVotesForBlock(voteA.Hash, models.Prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), votesForA)
 
 	// votesForB should be # of votes for A + # of votes for B
-	votesForB, err := gs.getVotesForBlock(voteB.Hash, prevote)
+	votesForB, err := gs.getVotesForBlock(voteB.Hash, models.Prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(5), votesForB)
 
-	votesForC, err := gs.getVotesForBlock(voteC.Hash, prevote)
+	votesForC, err := gs.getVotesForBlock(voteC.Hash, models.Prevote)
 	require.NoError(t, err)
 	require.Equal(t, uint64(4), votesForC)
 }
@@ -263,37 +263,37 @@ func TestGetPossibleSelectedAncestors_SameAncestor(t *testing.T) {
 	require.Equal(t, 3, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
 	}
 
-	votes := gs.getVotes(prevote)
+	votes := gs.getVotes(models.Prevote)
 	prevoted := make(map[common.Hash]uint32)
 	var blocks map[common.Hash]uint32
 
 	for _, curr := range leaves {
-		blocks, err = gs.getPossibleSelectedAncestors(votes, curr, prevoted, prevote, gs.state.threshold())
+		blocks, err = gs.getPossibleSelectedAncestors(votes, curr, prevoted, models.Prevote, gs.state.Threshold())
 		require.NoError(t, err)
 	}
 
@@ -317,37 +317,37 @@ func TestGetPossibleSelectedAncestors_VaryingAncestor(t *testing.T) {
 	require.Equal(t, 3, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
 	}
 
-	votes := gs.getVotes(prevote)
+	votes := gs.getVotes(models.Prevote)
 	prevoted := make(map[common.Hash]uint32)
 	var blocks map[common.Hash]uint32
 
 	for _, curr := range leaves {
-		blocks, err = gs.getPossibleSelectedAncestors(votes, curr, prevoted, prevote, gs.state.threshold())
+		blocks, err = gs.getPossibleSelectedAncestors(votes, curr, prevoted, models.Prevote, gs.state.Threshold())
 		require.NoError(t, err)
 	}
 
@@ -371,43 +371,43 @@ func TestGetPossibleSelectedAncestors_VaryingAncestor_MoreBranches(t *testing.T)
 	require.Equal(t, 4, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
-	voteD, err := NewVoteFromHash(leaves[3], st.Block)
+	voteD, err := models.NewVoteFromHash(leaves[3], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else if i < 8 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteD,
 			})
 		}
 	}
 
-	votes := gs.getVotes(prevote)
+	votes := gs.getVotes(models.Prevote)
 	prevoted := make(map[common.Hash]uint32)
 	var blocks map[common.Hash]uint32
 
 	for _, curr := range leaves {
-		blocks, err = gs.getPossibleSelectedAncestors(votes, curr, prevoted, prevote, gs.state.threshold())
+		blocks, err = gs.getPossibleSelectedAncestors(votes, curr, prevoted, models.Prevote, gs.state.Threshold())
 		require.NoError(t, err)
 	}
 
@@ -427,26 +427,26 @@ func TestGetPossibleSelectedBlocks_OneBlock(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 7 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
 	}
 
-	blocks, err := gs.getPossibleSelectedBlocks(prevote, gs.state.threshold())
+	blocks, err := gs.getPossibleSelectedBlocks(models.Prevote, gs.state.Threshold())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	require.Equal(t, voteA.Number, blocks[voteA.Hash])
@@ -463,32 +463,32 @@ func TestGetPossibleSelectedBlocks_EqualVotes_SameAncestor(t *testing.T) {
 	require.Equal(t, 3, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
 	}
 
-	blocks, err := gs.getPossibleSelectedBlocks(prevote, gs.state.threshold())
+	blocks, err := gs.getPossibleSelectedBlocks(models.Prevote, gs.state.Threshold())
 	require.NoError(t, err)
 
 	expected, err := st.Block.GetHashByNumber(6)
@@ -510,32 +510,32 @@ func TestGetPossibleSelectedBlocks_EqualVotes_VaryingAncestor(t *testing.T) {
 	require.Equal(t, 3, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
 	}
 
-	blocks, err := gs.getPossibleSelectedBlocks(prevote, gs.state.threshold())
+	blocks, err := gs.getPossibleSelectedBlocks(models.Prevote, gs.state.Threshold())
 	require.NoError(t, err)
 
 	expectedAt6, err := st.Block.GetHashByNumber(6)
@@ -555,15 +555,15 @@ func TestGetPossibleSelectedBlocks_OneThirdEquivocating(t *testing.T) {
 	leaves := gs.blockState.Leaves()
 
 	// 1/3 of voters equivocate; ie. vote for both blocks
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
-	svA := &SignedVote{
+	svA := &models.SignedVote{
 		Vote: *voteA,
 	}
-	svB := &SignedVote{
+	svB := &models.SignedVote{
 		Vote: *voteB,
 	}
 
@@ -575,14 +575,14 @@ func TestGetPossibleSelectedBlocks_OneThirdEquivocating(t *testing.T) {
 		} else if i < 6 {
 			gs.prevotes.Store(voter, svB)
 		} else {
-			gs.pvEquivocations[voter] = []*SignedVote{svA, svB}
+			gs.pvEquivocations[voter] = []*models.SignedVote{svA, svB}
 		}
 	}
 
 	expectedAt6, err := st.Block.GetHashByNumber(6)
 	require.NoError(t, err)
 
-	blocks, err := gs.getPossibleSelectedBlocks(prevote, gs.state.threshold())
+	blocks, err := gs.getPossibleSelectedBlocks(models.Prevote, gs.state.Threshold())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(blocks))
 	require.Equal(t, uint32(6), blocks[expectedAt6])
@@ -596,17 +596,17 @@ func TestGetPossibleSelectedBlocks_MoreThanOneThirdEquivocating(t *testing.T) {
 	leaves := gs.blockState.Leaves()
 
 	// this tests a byzantine case where >1/3 of voters equivocate; ie. vote for multiple blocks
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
-	svA := &SignedVote{
+	svA := &models.SignedVote{
 		Vote: *voteA,
 	}
-	svB := &SignedVote{
+	svB := &models.SignedVote{
 		Vote: *voteB,
 	}
 
@@ -621,16 +621,16 @@ func TestGetPossibleSelectedBlocks_MoreThanOneThirdEquivocating(t *testing.T) {
 			gs.prevotes.Store(voter, svB)
 		} else if i < 5 {
 			// 1 vote for C
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		} else {
 			// 4 equivocators
-			gs.pvEquivocations[voter] = []*SignedVote{svA, svB}
+			gs.pvEquivocations[voter] = []*models.SignedVote{svA, svB}
 		}
 	}
 
-	blocks, err := gs.getPossibleSelectedBlocks(prevote, gs.state.threshold())
+	blocks, err := gs.getPossibleSelectedBlocks(models.Prevote, gs.state.Threshold())
 	require.NoError(t, err)
 	require.Equal(t, 2, len(blocks))
 }
@@ -642,20 +642,20 @@ func TestGetPreVotedBlock_OneBlock(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 7 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
@@ -677,26 +677,26 @@ func TestGetPreVotedBlock_MultipleCandidates(t *testing.T) {
 	require.Equal(t, 3, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
@@ -727,44 +727,44 @@ func TestGetPreVotedBlock_EvenMoreCandidates(t *testing.T) {
 	})
 
 	// voters vote for a blocks on a different chains
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
-	voteD, err := NewVoteFromHash(leaves[3], st.Block)
+	voteD, err := models.NewVoteFromHash(leaves[3], st.Block)
 	require.NoError(t, err)
-	voteE, err := NewVoteFromHash(leaves[4], st.Block)
+	voteE, err := models.NewVoteFromHash(leaves[4], st.Block)
 	require.NoError(t, err)
-	voteF, err := NewVoteFromHash(leaves[5], st.Block)
+	voteF, err := models.NewVoteFromHash(leaves[5], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 2 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 4 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		} else if i < 7 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteD,
 			})
 		} else if i < 8 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteE,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteF,
 			})
 		}
@@ -787,7 +787,7 @@ func TestFindParentWithNumber(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, nil)
 	leaves := gs.blockState.Leaves()
 
-	v, err := NewVoteFromHash(leaves[0], st.Block)
+	v, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
 
 	p, err := gs.findParentWithNumber(v, 1)
@@ -807,26 +807,26 @@ func TestGetBestFinalCandidate_OneBlock(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 7 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
@@ -845,9 +845,9 @@ func TestGetBestFinalCandidate_PrecommitAncestor(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	// in precommit round, 2/3 voters will vote for ancestor of A
@@ -858,17 +858,17 @@ func TestGetBestFinalCandidate_PrecommitAncestor(t *testing.T) {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 7 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
@@ -888,23 +888,23 @@ func TestGetBestFinalCandidate_NoPrecommit(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 7 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
@@ -924,26 +924,26 @@ func TestGetBestFinalCandidate_PrecommitOnAnotherChain(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 6 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
-			gs.precommits.Store(voter, &SignedVote{
+			gs.precommits.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		}
@@ -979,15 +979,15 @@ func TestDeterminePreVote_WithPrimaryPreVote(t *testing.T) {
 
 	derivePrimary := gs.derivePrimary()
 	primary := derivePrimary.PublicKeyBytes()
-	gs.prevotes.Store(primary, &SignedVote{
-		Vote: *NewVoteFromHeader(header),
+	gs.prevotes.Store(primary, &models.SignedVote{
+		Vote: *models.NewVoteFromHeader(header),
 	})
 
 	pv, err := gs.determinePreVote()
 	require.NoError(t, err)
 	p, has := gs.prevotes.Load(primary)
 	require.True(t, has)
-	require.Equal(t, pv, &p.(*SignedVote).Vote)
+	require.Equal(t, pv, &p.(*models.SignedVote).Vote)
 }
 
 func TestDeterminePreVote_WithInvalidPrimaryPreVote(t *testing.T) {
@@ -999,8 +999,8 @@ func TestDeterminePreVote_WithInvalidPrimaryPreVote(t *testing.T) {
 
 	derivePrimary := gs.derivePrimary()
 	primary := derivePrimary.PublicKeyBytes()
-	gs.prevotes.Store(primary, &SignedVote{
-		Vote: *NewVoteFromHeader(header),
+	gs.prevotes.Store(primary, &models.SignedVote{
+		Vote: *models.NewVoteFromHeader(header),
 	})
 
 	state.AddBlocksToState(t, st.Block, 5, false)
@@ -1019,20 +1019,20 @@ func TestGetGrandpaGHOST_CommonAncestor(t *testing.T) {
 	state.AddBlocksToStateWithFixedBranches(t, st.Block, 8, branches)
 	leaves := gs.blockState.Leaves()
 
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 4 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 5 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		}
@@ -1056,26 +1056,26 @@ func TestGetGrandpaGHOST_MultipleCandidates(t *testing.T) {
 	require.Equal(t, 3, len(leaves))
 
 	// 1/3 voters each vote for a block on a different chain
-	voteA, err := NewVoteFromHash(leaves[0], st.Block)
+	voteA, err := models.NewVoteFromHash(leaves[0], st.Block)
 	require.NoError(t, err)
-	voteB, err := NewVoteFromHash(leaves[1], st.Block)
+	voteB, err := models.NewVoteFromHash(leaves[1], st.Block)
 	require.NoError(t, err)
-	voteC, err := NewVoteFromHash(leaves[2], st.Block)
+	voteC, err := models.NewVoteFromHash(leaves[2], st.Block)
 	require.NoError(t, err)
 
 	for i, k := range kr.Keys {
 		voter := k.Public().(*ed25519.PublicKey).AsBytes()
 
 		if i < 1 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteA,
 			})
 		} else if i < 2 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteB,
 			})
 		} else if i < 3 {
-			gs.prevotes.Store(voter, &SignedVote{
+			gs.prevotes.Store(voter, &models.SignedVote{
 				Vote: *voteC,
 			})
 		}
@@ -1125,7 +1125,7 @@ func TestGrandpaServiceCreateJustification_ShouldCountEquivocatoryVotes(t *testi
 	var totalLegitVotes int
 	// voting on
 	for _, v := range fakeAuthorities {
-		vote := &SignedVote{
+		vote := &models.SignedVote{
 			AuthorityID: v.Public().(*ed25519.PublicKey).AsBytes(),
 			Vote: types.GrandpaVote{
 				Hash:   bfcHash,
@@ -1153,7 +1153,7 @@ func TestGrandpaServiceCreateJustification_ShouldCountEquivocatoryVotes(t *testi
 	gs.pvEquivocations = equivocatories
 	gs.prevotes = prevotes
 
-	justifications, err := gs.createJustification(bfcHash, prevote)
+	justifications, err := gs.createJustification(bfcHash, models.Prevote)
 	require.NoError(t, err)
 
 	var totalEqvVotes int

--- a/lib/grandpa/justification.go
+++ b/lib/grandpa/justification.go
@@ -1,0 +1,40 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package grandpa
+
+import "github.com/ChainSafe/gossamer/lib/grandpa/models"
+
+func compactToJustification(preCommitVotes []models.Vote, auths []models.AuthData) (
+	signedVotes []models.SignedVote, err error) {
+	if len(preCommitVotes) != len(auths) {
+		return nil, errVoteToSignatureMismatch
+	}
+
+	signedVotes = make([]models.SignedVote, len(preCommitVotes))
+	for i, v := range preCommitVotes {
+		signedVotes[i] = models.SignedVote{
+			Vote:        v,
+			Signature:   auths[i].Signature,
+			AuthorityID: auths[i].AuthorityID,
+		}
+	}
+
+	return signedVotes, nil
+}
+
+func justificationToCompact(signedVotes []models.SignedVote) (
+	preCommitVotes []models.Vote, auths []models.AuthData) {
+	preCommitVotes = make([]models.Vote, len(signedVotes))
+	auths = make([]models.AuthData, len(signedVotes))
+
+	for i, j := range signedVotes {
+		preCommitVotes[i] = j.Vote
+		auths[i] = models.AuthData{
+			Signature:   j.Signature,
+			AuthorityID: j.AuthorityID,
+		}
+	}
+
+	return preCommitVotes, auths
+}

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	grandpaerrors "github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
@@ -542,7 +543,7 @@ func (h *MessageHandler) verifyJustification(just *models.SignedVote, round, set
 		}
 	}
 	if !authFound {
-		return ErrVoterNotFound
+		return grandpaerrors.ErrVoterNotFound
 	}
 	return nil
 }

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	grandpaerrors "github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
@@ -543,7 +542,7 @@ func (h *MessageHandler) verifyJustification(just *models.SignedVote, round, set
 		}
 	}
 	if !authFound {
-		return grandpaerrors.ErrVoterNotFound
+		return models.ErrVoterNotFound
 	}
 	return nil
 }

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	grandpaerrors "github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/pkg/scale"
@@ -501,7 +500,7 @@ func TestVerifyJustification_InvalidAuthority(t *testing.T) {
 	}
 
 	err = h.verifyJustification(just, 77, gs.state.SetID, models.Precommit)
-	require.ErrorIs(t, err, grandpaerrors.ErrVoterNotFound)
+	require.ErrorIs(t, err, models.ErrVoterNotFound)
 }
 
 func TestMessageHandler_VerifyPreVoteJustification(t *testing.T) {

--- a/lib/grandpa/message_handler_test.go
+++ b/lib/grandpa/message_handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	grandpaerrors "github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/pkg/scale"
@@ -500,7 +501,7 @@ func TestVerifyJustification_InvalidAuthority(t *testing.T) {
 	}
 
 	err = h.verifyJustification(just, 77, gs.state.SetID, models.Precommit)
-	require.EqualError(t, err, ErrVoterNotFound.Error())
+	require.ErrorIs(t, err, grandpaerrors.ErrVoterNotFound)
 }
 
 func TestMessageHandler_VerifyPreVoteJustification(t *testing.T) {

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 
@@ -54,7 +53,7 @@ func TestMessageTracker_ValidateMessage(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, models.ErrBlockDoesNotExist)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
 	voteMessage := getMessageFromVotesTracker(gs.tracker.votes, fake.Hash(), authorityID)
 	require.Equal(t, msg, voteMessage)
@@ -91,7 +90,7 @@ func TestMessageTracker_SendMessage(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, models.ErrBlockDoesNotExist)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
 	voteMessage := getMessageFromVotesTracker(gs.tracker.votes, next.Hash(), authorityID)
 	require.Equal(t, msg, voteMessage)
@@ -143,7 +142,7 @@ func TestMessageTracker_ProcessMessage(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, models.ErrBlockDoesNotExist)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
 	voteMessage := getMessageFromVotesTracker(gs.tracker.votes, next.Hash(), authorityID)
 	require.Equal(t, msg, voteMessage)

--- a/lib/grandpa/message_tracker_test.go
+++ b/lib/grandpa/message_tracker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 
@@ -53,7 +54,7 @@ func TestMessageTracker_ValidateMessage(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.Equal(t, err, ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
 	voteMessage := getMessageFromVotesTracker(gs.tracker.votes, fake.Hash(), authorityID)
 	require.Equal(t, msg, voteMessage)
@@ -90,7 +91,7 @@ func TestMessageTracker_SendMessage(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.Equal(t, err, ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
 	voteMessage := getMessageFromVotesTracker(gs.tracker.votes, next.Hash(), authorityID)
 	require.Equal(t, msg, voteMessage)
@@ -142,7 +143,7 @@ func TestMessageTracker_ProcessMessage(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.Equal(t, ErrBlockDoesNotExist, err)
+	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
 	authorityID := kr.Alice().Public().(*ed25519.PublicKey).AsBytes()
 	voteMessage := getMessageFromVotesTracker(gs.tracker.votes, next.Hash(), authorityID)
 	require.Equal(t, msg, voteMessage)

--- a/lib/grandpa/messages.go
+++ b/lib/grandpa/messages.go
@@ -1,0 +1,50 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package grandpa
+
+import (
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/grandpa/models"
+)
+
+func (s *Service) newCatchUpResponse(round, setID uint64) (*models.CatchUpResponse, error) {
+	header, err := s.blockState.GetFinalisedHeader(round, setID)
+	if err != nil {
+		return nil, err
+	}
+
+	pvs, err := s.grandpaState.GetPrevotes(round, setID)
+	if err != nil {
+		return nil, err
+	}
+
+	pcs, err := s.grandpaState.GetPrecommits(round, setID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.CatchUpResponse{
+		SetID:                  setID,
+		Round:                  round,
+		PreVoteJustification:   pvs,
+		PreCommitJustification: pcs,
+		Hash:                   header.Hash(),
+		Number:                 uint32(header.Number),
+	}, nil
+}
+
+func (s *Service) newCommitMessage(header *types.Header, round uint64) (*models.CommitMessage, error) {
+	grandpaSignedVotes, err := s.grandpaState.GetPrecommits(round, s.state.SetID)
+	if err != nil {
+		return nil, err
+	}
+
+	precommits, authData := justificationToCompact(grandpaSignedVotes)
+	return &models.CommitMessage{
+		Round:      round,
+		Vote:       *models.NewVoteFromHeader(header),
+		Precommits: precommits,
+		AuthData:   authData,
+	}, nil
+}

--- a/lib/grandpa/models/errors.go
+++ b/lib/grandpa/models/errors.go
@@ -1,0 +1,11 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package models
+
+import "errors"
+
+var (
+	ErrBlockDoesNotExist = errors.New("block does not exist")
+	ErrVoterNotFound     = errors.New("voter is not in voter set")
+)

--- a/lib/grandpa/models/errors.go
+++ b/lib/grandpa/models/errors.go
@@ -1,7 +1,7 @@
 // Copyright 2022 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package errors
+package models
 
 import "errors"
 

--- a/lib/grandpa/models/network_votes.go
+++ b/lib/grandpa/models/network_votes.go
@@ -1,0 +1,13 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package models
+
+import "github.com/libp2p/go-libp2p-core/peer"
+
+// NetworkVoteMessage contains a vote message and the peer id
+// this vote is originating from.
+type NetworkVoteMessage struct {
+	From peer.ID
+	Msg  *VoteMessage
+}

--- a/lib/grandpa/models/types.go
+++ b/lib/grandpa/models/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/grandpa/errors"
 )
 
 //nolint:revive
@@ -71,7 +72,7 @@ func (s *State) PubkeyToVoter(pk *ed25519.PublicKey) (*Voter, error) {
 	}
 
 	if id == max {
-		return nil, ErrVoterNotFound
+		return nil, errors.ErrVoterNotFound
 	}
 
 	return &Voter{
@@ -117,7 +118,7 @@ func NewVoteFromHash(hash common.Hash, blockState HeaderGetter) (*Vote, error) {
 	}
 
 	if !has {
-		return nil, ErrBlockDoesNotExist
+		return nil, errors.ErrBlockDoesNotExist
 	}
 
 	h, err := blockState.GetHeader(hash)

--- a/lib/grandpa/models/types.go
+++ b/lib/grandpa/models/types.go
@@ -5,11 +5,11 @@ package models
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/grandpa/errors"
 )
 
 //nolint:revive
@@ -72,7 +72,7 @@ func (s *State) PubkeyToVoter(pk *ed25519.PublicKey) (*Voter, error) {
 	}
 
 	if id == max {
-		return nil, errors.ErrVoterNotFound
+		return nil, ErrVoterNotFound
 	}
 
 	return &Voter{
@@ -118,7 +118,7 @@ func NewVoteFromHash(hash common.Hash, blockState HeaderGetter) (*Vote, error) {
 	}
 
 	if !has {
-		return nil, errors.ErrBlockDoesNotExist
+		return nil, fmt.Errorf("%w: for block hash %s", ErrBlockDoesNotExist, hash)
 	}
 
 	h, err := blockState.GetHeader(hash)

--- a/lib/grandpa/models/types_test.go
+++ b/lib/grandpa/models/types_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package grandpa
+package models
 
 import (
 	"testing"
@@ -18,13 +18,27 @@ func TestPubkeyToVoter(t *testing.T) {
 	kr, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)
 
+	voters := []Voter{}
+	for i, k := range kr.Keys {
+		voters = append(voters, Voter{
+			Key: *k.Public().(*ed25519.PublicKey),
+			ID:  uint64(i),
+		})
+	}
+
 	state := NewState(voters, 0, 0)
-	voter, err := state.pubkeyToVoter(kr.Alice().Public().(*ed25519.PublicKey))
+	voter, err := state.PubkeyToVoter(kr.Alice().Public().(*ed25519.PublicKey))
 	require.NoError(t, err)
 	require.Equal(t, voters[0], *voter)
 }
 
 func TestSignedVoteEncoding(t *testing.T) {
+	testVote := &Vote{
+		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+		Number: 999,
+	}
+	testSignature := [64]byte{1, 2, 3, 4}
+	testAuthorityID := [32]byte{5, 6, 7, 8}
 	exp := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
 	just := SignedVote{
 		Vote:        *testVote,
@@ -44,6 +58,12 @@ func TestSignedVoteEncoding(t *testing.T) {
 }
 
 func TestSignedVoteArrayEncoding(t *testing.T) {
+	testVote := &Vote{
+		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+		Number: 999,
+	}
+	testSignature := [64]byte{1, 2, 3, 4}
+	testAuthorityID := [32]byte{5, 6, 7, 8}
 	exp := common.MustHexToBytes("0x040a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
 	just := []SignedVote{
 		{
@@ -65,6 +85,12 @@ func TestSignedVoteArrayEncoding(t *testing.T) {
 }
 
 func TestJustification(t *testing.T) {
+	testVote := &Vote{
+		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+		Number: 999,
+	}
+	testSignature := [64]byte{1, 2, 3, 4}
+	testAuthorityID := [32]byte{5, 6, 7, 8}
 	exp := common.MustHexToBytes("0x6300000000000000000000000000000000000000000000000000000000000000000000000000000000000000040a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
 	just := SignedVote{
 		Vote:        *testVote,

--- a/lib/grandpa/state.go
+++ b/lib/grandpa/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 )
 
 // BlockState is the interface required by GRANDPA into the block state
@@ -47,10 +48,10 @@ type GrandpaState interface { //nolint:revive
 	GetSetIDByBlockNumber(num uint) (uint64, error)
 	SetLatestRound(round uint64) error
 	GetLatestRound() (uint64, error)
-	SetPrevotes(round, setID uint64, data []SignedVote) error
-	SetPrecommits(round, setID uint64, data []SignedVote) error
-	GetPrevotes(round, setID uint64) ([]SignedVote, error)
-	GetPrecommits(round, setID uint64) ([]SignedVote, error)
+	SetPrevotes(round, setID uint64, data []models.SignedVote) error
+	SetPrecommits(round, setID uint64, data []models.SignedVote) error
+	GetPrevotes(round, setID uint64) ([]models.SignedVote, error)
+	GetPrecommits(round, setID uint64) ([]models.SignedVote, error)
 	NextGrandpaAuthorityChange(bestBlockHash common.Hash, bestBlockNumber uint) (blockHeight uint, err error)
 }
 

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/telemetry"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	grandpaerrors "github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
@@ -204,7 +205,7 @@ func (s *Service) validateVoteMessage(from peer.ID, m *models.VoteMessage) (*mod
 	}
 
 	err = s.validateVote(vote)
-	if errors.Is(err, ErrBlockDoesNotExist) ||
+	if errors.Is(err, grandpaerrors.ErrBlockDoesNotExist) ||
 		errors.Is(err, blocktree.ErrDescendantNotFound) ||
 		errors.Is(err, blocktree.ErrEndNodeNotFound) ||
 		errors.Is(err, blocktree.ErrStartNodeNotFound) {
@@ -286,7 +287,7 @@ func (s *Service) validateVote(v *models.Vote) error {
 	}
 
 	if !has {
-		return ErrBlockDoesNotExist
+		return grandpaerrors.ErrBlockDoesNotExist
 	}
 
 	// check if the block is an eventual descendant of a previously finalised block

--- a/lib/grandpa/vote_message.go
+++ b/lib/grandpa/vote_message.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/telemetry"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	grandpaerrors "github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
@@ -205,7 +204,7 @@ func (s *Service) validateVoteMessage(from peer.ID, m *models.VoteMessage) (*mod
 	}
 
 	err = s.validateVote(vote)
-	if errors.Is(err, grandpaerrors.ErrBlockDoesNotExist) ||
+	if errors.Is(err, models.ErrBlockDoesNotExist) ||
 		errors.Is(err, blocktree.ErrDescendantNotFound) ||
 		errors.Is(err, blocktree.ErrEndNodeNotFound) ||
 		errors.Is(err, blocktree.ErrStartNodeNotFound) {
@@ -287,7 +286,7 @@ func (s *Service) validateVote(v *models.Vote) error {
 	}
 
 	if !has {
-		return grandpaerrors.ErrBlockDoesNotExist
+		return models.ErrBlockDoesNotExist
 	}
 
 	// check if the block is an eventual descendant of a previously finalised block

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
+	"github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/stretchr/testify/require"
@@ -323,7 +324,7 @@ func TestValidateMessage_BlockDoesNotExist(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.Equal(t, err, ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
 }
 
 func TestValidateMessage_IsNotDescendant(t *testing.T) {

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
-	"github.com/ChainSafe/gossamer/lib/grandpa/errors"
 	"github.com/ChainSafe/gossamer/lib/grandpa/models"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/stretchr/testify/require"
@@ -324,7 +323,7 @@ func TestValidateMessage_BlockDoesNotExist(t *testing.T) {
 	gs.keypair = kr.Bob().(*ed25519.Keypair)
 
 	_, err = gs.validateVoteMessage("", msg)
-	require.ErrorIs(t, err, errors.ErrBlockDoesNotExist)
+	require.ErrorIs(t, err, models.ErrBlockDoesNotExist)
 }
 
 func TestValidateMessage_IsNotDescendant(t *testing.T) {


### PR DESCRIPTION
## Changes

- Dumb dumb moving of files from `lib/grandpa` to `lib/grandpa/models`
- Minimal diffs, only affects `lib/grandpa`

Why: because adding tests in `lib/grandpa` drove me mad having to fiddle with all the implementation details which can be abstracted with interfaces and (internal) sub-packages, since I don't want to pollute the grandpa library Go API even further with 'internally-used-only' interfaces. This is the nth time this triggers me as we can't break lib/grandpa in subpackages, and it makes development harder.


Also let me know if you prefer another name than `models` for the bunch of messages and other structs. Maybe we can name it `messages` :thinking: 

Other PRs should be made subsequently (to alleviate review load, this one is just moving):

1. Move `State` from `lib/grandpa/models` to `lib/grandpa` as `state` (5 minutes job)
1. Re-arrange grandpa models files a bit (5 minutes job) - see Eclesio's comment below!
1. Move models only used internally by lib/grandpa to `internal/grandpa/models` (20min job)


## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/grandpa/...
```

## Issues

Unblocks #2506 

## Primary Reviewer
