### PR TITLE
chore(tests): cache runtimes to work offline

### DIFF
--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -941,9 +942,7 @@ func TestGlobalNodeName_WhenNodeAlreadyHasStoredName(t *testing.T) {
 	cfg := newTestConfig(t)
 	cfg.Global.Name = globalName
 
-	runtimeFilePath := filepath.Join(t.TempDir(), "runtime")
-	_, testRuntimeURL := runtime.GetRuntimeVars(runtime.NODE_RUNTIME)
-	err := runtime.GetRuntimeBlob(runtimeFilePath, testRuntimeURL)
+	runtimeFilePath, err := runtime.GetRuntime(context.Background(), runtime.NODE_RUNTIME)
 	require.NoError(t, err)
 	runtimeData, err := os.ReadFile(runtimeFilePath)
 	require.NoError(t, err)

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -135,19 +135,6 @@ func generateTestValidRemarkTxns(t *testing.T, pubKey []byte, accInfo types.Acco
 	return extBytes, rt
 }
 
-func TestMain(m *testing.M) {
-	err := runtime.GenerateRuntimeWasmFiles(context.Background())
-	if err != nil {
-		log.Errorf("failed to generate runtime wasm file: %s", err)
-		os.Exit(1)
-	}
-
-	// Start all tests
-	code := m.Run()
-
-	os.Exit(code)
-}
-
 func TestStartService(t *testing.T) {
 	s := NewTestService(t, nil)
 

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -6,6 +6,7 @@
 package dot
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"os"
@@ -271,9 +272,7 @@ func TestNode_PersistGlobalName_WhenInitialize(t *testing.T) {
 // newTestGenesisAndRuntime create a new test runtime and a new test genesis
 // file with the test runtime stored in raw data and returns the genesis file
 func newTestGenesisAndRuntime(t *testing.T) (filename string) {
-	runtimeFilePath := filepath.Join(t.TempDir(), "runtime")
-	_, testRuntimeURL := runtime.GetRuntimeVars(runtime.NODE_RUNTIME)
-	err := runtime.GetRuntimeBlob(runtimeFilePath, testRuntimeURL)
+	runtimeFilePath, err := runtime.GetRuntime(context.Background(), runtime.NODE_RUNTIME)
 	require.NoError(t, err)
 	runtimeData, err := os.ReadFile(runtimeFilePath)
 	require.NoError(t, err)

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -78,19 +78,6 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 	return runtimeInstance
 }
 
-func TestMain(m *testing.M) {
-	err := runtime.GenerateRuntimeWasmFiles(context.Background())
-	if err != nil {
-		log.Errorf("failed to generate runtime wasm file: %s", err)
-		os.Exit(1)
-	}
-
-	// Start all tests
-	code := m.Run()
-
-	os.Exit(code)
-}
-
 func TestAuthorModule_Pending_Integration(t *testing.T) {
 	t.Parallel()
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), nil)

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -6,6 +6,7 @@
 package modules
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -53,14 +54,9 @@ func useInstanceFromGenesis(t *testing.T, rtStorage *storage.TrieState) (instanc
 }
 
 func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (instance runtime.Instance) {
-	testRuntimeFilePath, testRuntimeURL := runtime.GetRuntimeVars(runtime.POLKADOT_RUNTIME_v0910)
-	err := runtime.GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL)
+	testRuntimeFilePath, err := runtime.GetRuntime(context.Background(), runtime.POLKADOT_RUNTIME_v0910)
 	require.NoError(t, err)
-
 	bytes, err := os.ReadFile(testRuntimeFilePath)
-	require.NoError(t, err)
-
-	err = runtime.RemoveFiles([]string{testRuntimeFilePath})
 	require.NoError(t, err)
 
 	rtStorage.Set(common.CodeKey, bytes)
@@ -83,7 +79,7 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 }
 
 func TestMain(m *testing.M) {
-	wasmFilePaths, err := runtime.GenerateRuntimeWasmFile()
+	err := runtime.GenerateRuntimeWasmFiles(context.Background())
 	if err != nil {
 		log.Errorf("failed to generate runtime wasm file: %s", err)
 		os.Exit(1)
@@ -92,7 +88,6 @@ func TestMain(m *testing.M) {
 	// Start all tests
 	code := m.Run()
 
-	runtime.RemoveFiles(wasmFilePaths)
 	os.Exit(code)
 }
 

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -4,13 +4,13 @@
 package subscription
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -352,11 +352,9 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 	expectedInitialResponse.Params.Result = expectedInitialVersion
 
 	instance := wasmer.NewTestInstance(t, runtime.NODE_RUNTIME)
-	err := runtime.GetRuntimeBlob(runtime.POLKADOT_RUNTIME_FP, runtime.POLKADOT_RUNTIME_URL)
+	polkadotRuntimeFilepath, err := runtime.GetRuntime(context.Background(), runtime.POLKADOT_RUNTIME)
 	require.NoError(t, err)
-	fp, err := filepath.Abs(runtime.POLKADOT_RUNTIME_FP)
-	require.NoError(t, err)
-	code, err := os.ReadFile(fp)
+	code, err := os.ReadFile(polkadotRuntimeFilepath)
 	require.NoError(t, err)
 	version, err := instance.CheckRuntimeVersion(code)
 	require.NoError(t, err)

--- a/dot/sync/syncer_integeration_test.go
+++ b/dot/sync/syncer_integeration_test.go
@@ -7,6 +7,7 @@
 package sync
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	wasmFilePaths, err := runtime.GenerateRuntimeWasmFile()
+	err := runtime.GenerateRuntimeWasmFiles(context.Background())
 	if err != nil {
 		log.Errorf("failed to generate runtime wasm file: %s", err)
 		os.Exit(1)
@@ -38,7 +39,6 @@ func TestMain(m *testing.M) {
 	// Start all tests
 	code := m.Run()
 
-	runtime.RemoveFiles(wasmFilePaths)
 	os.Exit(code)
 }
 

--- a/dot/sync/syncer_integeration_test.go
+++ b/dot/sync/syncer_integeration_test.go
@@ -7,9 +7,7 @@
 package sync
 
 import (
-	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,19 +26,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMain(m *testing.M) {
-	err := runtime.GenerateRuntimeWasmFiles(context.Background())
-	if err != nil {
-		log.Errorf("failed to generate runtime wasm file: %s", err)
-		os.Exit(1)
-	}
-
-	// Start all tests
-	code := m.Run()
-
-	os.Exit(code)
-}
 
 func newMockFinalityGadget() *mocks.FinalityGadget {
 	m := new(mocks.FinalityGadget)

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -6,8 +6,6 @@
 package babe
 
 import (
-	"context"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -152,21 +150,6 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 	babeService, err := NewService(cfg)
 	require.NoError(t, err)
 	return babeService
-}
-
-func TestMain(m *testing.M) {
-	err := runtime.GenerateRuntimeWasmFiles(context.Background())
-	if err != nil {
-		log.Errorf("failed to generate runtime wasm file: %s", err)
-		os.Exit(1)
-	}
-
-	logger = log.NewFromGlobal(log.SetLevel(defaultTestLogLvl))
-
-	// Start all tests
-	code := m.Run()
-
-	os.Exit(code)
 }
 
 func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *types.BabeConfiguration) {

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -6,6 +6,7 @@
 package babe
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -154,7 +155,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 }
 
 func TestMain(m *testing.M) {
-	wasmFilePaths, err := runtime.GenerateRuntimeWasmFile()
+	err := runtime.GenerateRuntimeWasmFiles(context.Background())
 	if err != nil {
 		log.Errorf("failed to generate runtime wasm file: %s", err)
 		os.Exit(1)
@@ -165,7 +166,6 @@ func TestMain(m *testing.M) {
 	// Start all tests
 	code := m.Run()
 
-	runtime.RemoveFiles(wasmFilePaths)
 	os.Exit(code)
 }
 

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -7,8 +7,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
-var runtimes = []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, POLKADOT_RUNTIME_v0917, NODE_RUNTIME, DEV_RUNTIME}
-
 //nolint:revive
 const (
 	// v0.9 substrate runtime

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -195,18 +195,6 @@ func generateEd25519Signatures(t *testing.T, n int) []*crypto.SignatureInfo {
 	return signs
 }
 
-// GenerateRuntimeWasmFiles generates all runtime wasm files.
-func GenerateRuntimeWasmFiles(ctx context.Context) error {
-	runtimes := []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, POLKADOT_RUNTIME_v0917, NODE_RUNTIME, DEV_RUNTIME}
-	for _, runtime := range runtimes {
-		_, err := GetRuntime(ctx, runtime)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // NewTestExtrinsic builds a new extrinsic using centrifuge pkg
 func NewTestExtrinsic(t *testing.T, rt Instance, genHash, blockHash common.Hash,
 	nonce uint64, call string, args ...interface{}) string {

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -5,10 +5,13 @@ package runtime
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -42,26 +45,106 @@ func NewInMemoryDB(t *testing.T) chaindb.Database {
 	return db
 }
 
-// GetRuntimeVars returns the testRuntimeFilePath and testRuntimeURL
-func GetRuntimeVars(targetRuntime string) (string, string) {
-	switch targetRuntime {
-	case NODE_RUNTIME:
-		return GetAbsolutePath(NODE_RUNTIME_FP), NODE_RUNTIME_URL
-	case NODE_RUNTIME_v098:
-		return GetAbsolutePath(NODE_RUNTIME_FP_v098), NODE_RUNTIME_URL_v098
-	case POLKADOT_RUNTIME_v0917:
-		return GetAbsolutePath(POLKADOT_RUNTIME_FP_v0917), POLKADOT_RUNTIME_URL_v0917
-	case POLKADOT_RUNTIME_v0910:
-		return GetAbsolutePath(POLKADOT_RUNTIME_FP_v0910), POLKADOT_RUNTIME_URL_v0910
-	case POLKADOT_RUNTIME:
-		return GetAbsolutePath(POLKADOT_RUNTIME_FP), POLKADOT_RUNTIME_URL
-	case HOST_API_TEST_RUNTIME:
-		return GetAbsolutePath(HOST_API_TEST_RUNTIME_FP), HOST_API_TEST_RUNTIME_URL
-	case DEV_RUNTIME:
-		return GetAbsolutePath(DEV_RUNTIME_FP), DEV_RUNTIME_URL
-	default:
-		return "", ""
+var (
+	ErrRuntimeUnknown  = errors.New("runtime is not known")
+	ErrHTTPStatusNotOK = errors.New("HTTP status code received is not OK")
+	ErrOpenRuntimeFile = errors.New("cannot open the runtime target file")
+)
+
+// GetRuntime returns the runtime file path located in the
+// /tmp/gossamer/runtimes directory (depending on OS and environment).
+// If the file did not exist, the runtime WASM blob is downloaded to that file.
+func GetRuntime(ctx context.Context, runtime string) (
+	runtimePath string, err error) {
+	basePath := filepath.Join(os.TempDir(), "/gossamer/runtimes/")
+	const perm = os.FileMode(0777)
+	err = os.MkdirAll(basePath, perm)
+	if err != nil {
+		return "", fmt.Errorf("cannot create directory for runtimes: %w", err)
 	}
+
+	var runtimeFilename, url string
+	switch runtime {
+	case NODE_RUNTIME:
+		runtimeFilename = NODE_RUNTIME_FP
+		url = NODE_RUNTIME_URL
+	case NODE_RUNTIME_v098:
+		runtimeFilename = NODE_RUNTIME_FP_v098
+		url = NODE_RUNTIME_URL_v098
+	case POLKADOT_RUNTIME_v0917:
+		runtimeFilename = POLKADOT_RUNTIME_FP_v0917
+		url = POLKADOT_RUNTIME_URL_v0917
+	case POLKADOT_RUNTIME_v0910:
+		runtimeFilename = POLKADOT_RUNTIME_FP_v0910
+		url = POLKADOT_RUNTIME_URL_v0910
+	case POLKADOT_RUNTIME:
+		runtimeFilename = POLKADOT_RUNTIME_FP
+		url = POLKADOT_RUNTIME_URL
+	case HOST_API_TEST_RUNTIME:
+		runtimeFilename = HOST_API_TEST_RUNTIME_FP
+		url = HOST_API_TEST_RUNTIME_URL
+	case DEV_RUNTIME:
+		runtimeFilename = DEV_RUNTIME_FP
+		url = DEV_RUNTIME_URL
+	default:
+		return "", fmt.Errorf("%w: %s", ErrRuntimeUnknown, runtime)
+	}
+
+	runtimePath = filepath.Join(basePath, runtimeFilename)
+	runtimePath, err = filepath.Abs(runtimePath)
+	if err != nil {
+		return "", fmt.Errorf("malformed relative path: %w", err)
+	}
+
+	if utils.PathExists(runtimePath) {
+		return runtimePath, nil
+	}
+
+	const requestTimeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot make HTTP request: %w", err)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("cannot get: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		_ = response.Body.Close()
+		return "", fmt.Errorf("%w: %d %s", ErrHTTPStatusNotOK,
+			response.StatusCode, response.Status)
+	}
+
+	const flag = os.O_TRUNC | os.O_CREATE | os.O_WRONLY
+	file, err := os.OpenFile(runtimePath, flag, perm) //nolint:gosec
+	if err != nil {
+		_ = response.Body.Close()
+		return "", fmt.Errorf("cannot open target destination file: %w", err)
+	}
+
+	_, err = io.Copy(file, response.Body)
+	if err != nil {
+		_ = response.Body.Close()
+		return "", fmt.Errorf("cannot copy response body to %s: %w",
+			runtimePath, err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		return "", fmt.Errorf("cannot close file: %w", err)
+	}
+
+	err = response.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("cannot close HTTP response body: %w", err)
+	}
+
+	return runtimePath, nil
 }
 
 // GetAbsolutePath returns the completePath for a given targetDir
@@ -71,37 +154,6 @@ func GetAbsolutePath(targetDir string) string {
 		panic("failed to get current working directory")
 	}
 	return path.Join(dir, targetDir)
-}
-
-// GetRuntimeBlob checks if the test wasm @testRuntimeFilePath exists and if not, it fetches it from @testRuntimeURL
-func GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL string) error {
-	if utils.PathExists(testRuntimeFilePath) {
-		return nil
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, testRuntimeURL, nil)
-	if err != nil {
-		return err
-	}
-
-	const runtimeReqTimout = time.Second * 30
-
-	httpcli := http.Client{Timeout: runtimeReqTimout}
-	resp, err := httpcli.Do(req)
-	if err != nil {
-		return err
-	}
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	return os.WriteFile(testRuntimeFilePath, respBody, os.ModePerm)
 }
 
 // TestRuntimeNetwork ...
@@ -143,25 +195,11 @@ func generateEd25519Signatures(t *testing.T, n int) []*crypto.SignatureInfo {
 	return signs
 }
 
-// GenerateRuntimeWasmFile generates all runtime wasm files.
-func GenerateRuntimeWasmFile() ([]string, error) {
-	var wasmFilePaths []string
-	for _, rt := range runtimes {
-		testRuntimeFilePath, testRuntimeURL := GetRuntimeVars(rt)
-		err := GetRuntimeBlob(testRuntimeFilePath, testRuntimeURL)
-		if err != nil {
-			return nil, err
-		}
-
-		wasmFilePaths = append(wasmFilePaths, testRuntimeFilePath)
-	}
-	return wasmFilePaths, nil
-}
-
-// RemoveFiles removes multiple files.
-func RemoveFiles(files []string) error {
-	for _, file := range files {
-		err := os.Remove(file)
+// GenerateRuntimeWasmFiles generates all runtime wasm files.
+func GenerateRuntimeWasmFiles(ctx context.Context) error {
+	runtimes := []string{HOST_API_TEST_RUNTIME, POLKADOT_RUNTIME, POLKADOT_RUNTIME_v0917, NODE_RUNTIME, DEV_RUNTIME}
+	for _, runtime := range runtimes {
+		_, err := GetRuntime(ctx, runtime)
 		if err != nil {
 			return err
 		}

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -5,16 +5,13 @@ package wasmer
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"net/http"
-	"os"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/ChainSafe/chaindb"
-	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/types"
 	"github.com/ChainSafe/gossamer/lib/crypto"
@@ -34,19 +31,6 @@ import (
 var testChildKey = []byte("childKey")
 var testKey = []byte("key")
 var testValue = []byte("value")
-
-func TestMain(m *testing.M) {
-	err := runtime.GenerateRuntimeWasmFiles(context.Background())
-	if err != nil {
-		log.Errorf("failed to generate runtime wasm file: %s", err)
-		os.Exit(1)
-	}
-
-	// Start all tests
-	code := m.Run()
-
-	os.Exit(code)
-}
 
 func Test_ext_offchain_timestamp_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -5,6 +5,7 @@ package wasmer
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"net/http"
 	"os"
@@ -35,7 +36,7 @@ var testKey = []byte("key")
 var testValue = []byte("value")
 
 func TestMain(m *testing.M) {
-	wasmFilePaths, err := runtime.GenerateRuntimeWasmFile()
+	err := runtime.GenerateRuntimeWasmFiles(context.Background())
 	if err != nil {
 		log.Errorf("failed to generate runtime wasm file: %s", err)
 		os.Exit(1)
@@ -44,7 +45,6 @@ func TestMain(m *testing.M) {
 	// Start all tests
 	code := m.Run()
 
-	runtime.RemoveFiles(wasmFilePaths)
 	os.Exit(code)
 }
 

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -4,8 +4,8 @@
 package wasmer
 
 import (
+	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/runtime"
@@ -38,11 +38,10 @@ func TestPointerSize(t *testing.T) {
 
 func TestInstance_CheckRuntimeVersion(t *testing.T) {
 	instance := NewTestInstance(t, runtime.NODE_RUNTIME)
-	err := runtime.GetRuntimeBlob(runtime.POLKADOT_RUNTIME_FP, runtime.POLKADOT_RUNTIME_URL)
+	polkadotRuntimeFilepath, err := runtime.GetRuntime(
+		context.Background(), runtime.POLKADOT_RUNTIME)
 	require.NoError(t, err)
-	fp, err := filepath.Abs(runtime.POLKADOT_RUNTIME_FP)
-	require.NoError(t, err)
-	code, err := os.ReadFile(fp)
+	code, err := os.ReadFile(polkadotRuntimeFilepath)
 	require.NoError(t, err)
 	version, err := instance.CheckRuntimeVersion(code)
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

**Why**: because without network I couldn't run integration tests yesterday and that drove me mad

- Download runtimes to ${TMP}/gossamer/runtimes/ depending on environment
- Do not remove runtime files and re-use them if found
- Merge `GetRuntimeVars` and `GetRuntimeBlob` into `GetRuntime`
- Improve HTTP fetching code for runtime wasms
- Remove `TestMain`-used `GetRuntimes` since we already have calls to `GetRuntime` wherever a runtime blob is needed.

## Tests

All tests passing

## Issues

Done since I couldn't work without it offline

## Primary Reviewer

@EclesioMeloJunior  