### PR TITLE
fix(cmd): avoid nil pointer dereference

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -43,19 +43,20 @@ var (
 // loadConfigFile loads a default config file if --chain is specified, a specific
 // config if --config is specified, or the default gossamer config otherwise.
 func loadConfigFile(ctx *cli.Context, cfg *ctoml.Config) (err error) {
-	if cfgPath := ctx.GlobalString(ConfigFlag.Name); cfgPath != "" {
-		logger.Info("loading toml configuration from " + cfgPath + "...")
-		if cfg == nil {
-			cfg = &ctoml.Config{} // if configuration not set, create empty configuration
-		} else {
-			logger.Warn(
-				"overwriting default configuration with id " + cfg.Global.ID +
-					" with toml configuration values from " + cfgPath)
-		}
-		return loadConfig(cfg, cfgPath) // load toml values into configuration
+	cfgPath := ctx.GlobalString(ConfigFlag.Name)
+	if cfgPath == "" {
+		return loadConfig(cfg, defaultGssmrConfigPath)
 	}
 
-	return loadConfig(cfg, defaultGssmrConfigPath)
+	logger.Info("loading toml configuration from " + cfgPath + "...")
+	if cfg == nil {
+		cfg = new(ctoml.Config)
+	} else {
+		logger.Warn(
+			"overwriting default configuration with id " + cfg.Global.ID +
+				" with toml configuration values from " + cfgPath)
+	}
+	return loadConfig(cfg, cfgPath)
 }
 
 func setupConfigFromChain(ctx *cli.Context) (*ctoml.Config, *dot.Config, error) {
@@ -212,7 +213,7 @@ func createImportStateConfig(ctx *cli.Context) (*dot.Config, error) {
 }
 
 func createBuildSpecConfig(ctx *cli.Context) (*dot.Config, error) {
-	var tomlCfg *ctoml.Config = new(ctoml.Config)
+	tomlCfg := new(ctoml.Config)
 	err := loadConfigFile(ctx, tomlCfg)
 	if err != nil {
 		logger.Errorf("failed to load toml configuration: %s", err)

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -528,7 +528,7 @@ func setDotGlobalConfigName(ctx *cli.Context, tomlCfg *ctoml.Config, cfg *dot.Gl
 	}
 
 	// consider the name on config as a second priority
-	if tomlCfg.Global.Name != "" {
+	if tomlCfg != nil && tomlCfg.Global.Name != "" {
 		cfg.Name = tomlCfg.Global.Name
 		return nil
 	}

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -43,7 +43,6 @@ var (
 // loadConfigFile loads a default config file if --chain is specified, a specific
 // config if --config is specified, or the default gossamer config otherwise.
 func loadConfigFile(ctx *cli.Context, cfg *ctoml.Config) (err error) {
-	// check --config flag and load toml configuration from config.toml
 	if cfgPath := ctx.GlobalString(ConfigFlag.Name); cfgPath != "" {
 		logger.Info("loading toml configuration from " + cfgPath + "...")
 		if cfg == nil {
@@ -53,12 +52,10 @@ func loadConfigFile(ctx *cli.Context, cfg *ctoml.Config) (err error) {
 				"overwriting default configuration with id " + cfg.Global.ID +
 					" with toml configuration values from " + cfgPath)
 		}
-		err = loadConfig(cfg, cfgPath) // load toml values into configuration
-	} else {
-		err = loadConfig(cfg, defaultGssmrConfigPath)
+		return loadConfig(cfg, cfgPath) // load toml values into configuration
 	}
 
-	return err
+	return loadConfig(cfg, defaultGssmrConfigPath)
 }
 
 func setupConfigFromChain(ctx *cli.Context) (*ctoml.Config, *dot.Config, error) {
@@ -215,15 +212,14 @@ func createImportStateConfig(ctx *cli.Context) (*dot.Config, error) {
 }
 
 func createBuildSpecConfig(ctx *cli.Context) (*dot.Config, error) {
-	var tomlCfg *ctoml.Config
-	cfg := &dot.Config{}
+	var tomlCfg *ctoml.Config = new(ctoml.Config)
 	err := loadConfigFile(ctx, tomlCfg)
 	if err != nil {
 		logger.Errorf("failed to load toml configuration: %s", err)
 		return nil, err
 	}
 
-	// set global configuration values
+	cfg := new(dot.Config)
 	if err := setDotGlobalConfig(ctx, tomlCfg, &cfg.Global); err != nil {
 		logger.Errorf("failed to set global node configuration: %s", err)
 		return nil, err
@@ -528,7 +524,7 @@ func setDotGlobalConfigName(ctx *cli.Context, tomlCfg *ctoml.Config, cfg *dot.Gl
 	}
 
 	// consider the name on config as a second priority
-	if tomlCfg != nil && tomlCfg.Global.Name != "" {
+	if tomlCfg.Global.Name != "" {
 		cfg.Name = tomlCfg.Global.Name
 		return nil
 	}

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -80,9 +80,9 @@ var (
 		Description: "The build-spec command outputs current genesis JSON data.\n" +
 			"\tUsage: gossamer build-spec\n" +
 			"\tTo generate raw genesis file from default: " +
-			"gossamer build-spec --raw > genesis.json" +
+			"gossamer build-spec --raw --output genesis.json" +
 			"\tTo generate raw genesis file from specific genesis file: " +
-			"gossamer build-spec --raw --genesis genesis-spec.json > genesis.json",
+			"gossamer build-spec --raw --genesis genesis-spec.json --output genesis.json",
 	}
 
 	// importRuntime generates a genesis file given a .wasm runtime binary.

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -401,9 +401,10 @@ func buildSpecAction(ctx *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("cannot write genesis spec file: %w", err)
 		}
+	} else {
+		fmt.Printf("%s\n", res)
 	}
 
-	fmt.Println(res)
 	return nil
 }
 

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -397,11 +397,13 @@ func buildSpecAction(ctx *cli.Context) error {
 	}
 
 	if outputPath := ctx.String(OutputSpecFlag.Name); outputPath != "" {
-		return dot.WriteGenesisSpecFile(res, outputPath)
+		err = dot.WriteGenesisSpecFile(res, outputPath)
+		if err != nil {
+			return fmt.Errorf("cannot write genesis spec file: %w", err)
+		}
 	}
 
-	fmt.Printf("%s", res)
-
+	fmt.Println(res)
 	return nil
 }
 

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -397,12 +397,10 @@ func buildSpecAction(ctx *cli.Context) error {
 	}
 
 	if outputPath := ctx.String(OutputSpecFlag.Name); outputPath != "" {
-		if err = dot.WriteGenesisSpecFile(res, outputPath); err != nil {
-			return err
-		}
-	} else {
-		fmt.Printf("%s", res)
+		return dot.WriteGenesisSpecFile(res, outputPath)
 	}
+
+	fmt.Printf("%s", res)
 
 	return nil
 }

--- a/cmd/gossamer/toml_config.go
+++ b/cmd/gossamer/toml_config.go
@@ -46,7 +46,7 @@ func loadConfig(cfg *ctoml.Config, fp string) error {
 		},
 	}
 
-	if err = tomlSettings.NewDecoder(file).Decode(&cfg); err != nil {
+	if err = tomlSettings.NewDecoder(file).Decode(cfg); err != nil {
 		logger.Errorf("failed to decode configuration: %s", err)
 		return err
 	}


### PR DESCRIPTION
## Changes

- Check if a pointer is `nil` before accessing its value
- Change the description of `build-spec` command to use `build-spec --output file.json` rather than `build-spec > file.json` to avoid inserting logs outputs in the file

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
gossamer build-spec --raw --output ./genesis.json
```

## Issues

- Closes #2246

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kishansagathiya 
