### PR TITLE
chore(ci): only run Fuzz test in fuzz workflow

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,4 +36,4 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod
 
       - name: Fuzz trie
-        run: go test -fuzz=Fuzz_Trie_PutAndGet -fuzztime=5m github.com/ChainSafe/gossamer/lib/trie
+        run: go test -run Fuzz_Trie_PutAndGet -fuzz=Fuzz_Trie_PutAndGet -fuzztime=5m github.com/ChainSafe/gossamer/lib/trie


### PR DESCRIPTION
## Changes

> By default, all other tests in that package will run before fuzzing begins. This is to ensure that fuzzing won’t report any issues that would already be caught by an existing test.

Source: https://go.dev/doc/fuzz/

But in our case, we run unit tests in another required workflow, so this limits it to run the fuzz test only.

## Tests

## Issues

## Primary Reviewer

@timwu20
