### PR TITLE
fix(state/epoch): assign epoch 1 when block number is 0

### DIFF
--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -543,20 +543,19 @@ func (s *EpochState) StoreBABENextConfigData(epoch uint64, hash common.Hash, nex
 // check if the header is in the database then it's been finalized and
 // thus we can also set the corresponding EpochData in the database
 func (s *EpochState) FinalizeBABENextEpochData(finalizedHeader *types.Header) error {
-	if finalizedHeader.Number == 0 {
-		return nil
-	}
-
 	s.nextEpochDataLock.Lock()
 	defer s.nextEpochDataLock.Unlock()
 
-	finalizedBlockEpoch, err := s.GetEpochForBlock(finalizedHeader)
-	if err != nil {
-		return fmt.Errorf("cannot get epoch for block %d (%s): %w",
-			finalizedHeader.Number, finalizedHeader.Hash(), err)
-	}
+	var nextEpoch uint64 = 1
+	if finalizedHeader.Number != 0 {
+		finalizedBlockEpoch, err := s.GetEpochForBlock(finalizedHeader)
+		if err != nil {
+			return fmt.Errorf("cannot get epoch for block %d (%s): %w",
+				finalizedHeader.Number, finalizedHeader.Hash(), err)
+		}
 
-	nextEpoch := finalizedBlockEpoch + 1
+		nextEpoch = finalizedBlockEpoch + 1
+	}
 
 	epochInDatabase, err := s.getEpochDataFromDatabase(nextEpoch)
 
@@ -601,20 +600,19 @@ func (s *EpochState) FinalizeBABENextEpochData(finalizedHeader *types.Header) er
 // check if the header is in the database then it's been finalized and
 // thus we can also set the corresponding NextConfigData in the database
 func (s *EpochState) FinalizeBABENextConfigData(finalizedHeader *types.Header) error {
-	if finalizedHeader.Number == 0 {
-		return nil
-	}
-
 	s.nextConfigDataLock.Lock()
 	defer s.nextConfigDataLock.Unlock()
 
-	finalizedBlockEpoch, err := s.GetEpochForBlock(finalizedHeader)
-	if err != nil {
-		return fmt.Errorf("cannot get epoch for block %d (%s): %w",
-			finalizedHeader.Number, finalizedHeader.Hash(), err)
-	}
+	var nextEpoch uint64 = 1
+	if finalizedHeader.Number != 0 {
+		finalizedBlockEpoch, err := s.GetEpochForBlock(finalizedHeader)
+		if err != nil {
+			return fmt.Errorf("cannot get epoch for block %d (%s): %w",
+				finalizedHeader.Number, finalizedHeader.Hash(), err)
+		}
 
-	nextEpoch := finalizedBlockEpoch + 1
+		nextEpoch = finalizedBlockEpoch + 1
+	}
 
 	configInDatabase, err := s.getConfigDataFromDatabase(nextEpoch)
 

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -543,6 +543,10 @@ func (s *EpochState) StoreBABENextConfigData(epoch uint64, hash common.Hash, nex
 // check if the header is in the database then it's been finalized and
 // thus we can also set the corresponding EpochData in the database
 func (s *EpochState) FinalizeBABENextEpochData(finalizedHeader *types.Header) error {
+	if finalizedHeader.Number == 0 {
+		return nil
+	}
+
 	s.nextEpochDataLock.Lock()
 	defer s.nextEpochDataLock.Unlock()
 
@@ -597,6 +601,10 @@ func (s *EpochState) FinalizeBABENextEpochData(finalizedHeader *types.Header) er
 // check if the header is in the database then it's been finalized and
 // thus we can also set the corresponding NextConfigData in the database
 func (s *EpochState) FinalizeBABENextConfigData(finalizedHeader *types.Header) error {
+	if finalizedHeader.Number == 0 {
+		return nil
+	}
+
 	s.nextConfigDataLock.Lock()
 	defer s.nextConfigDataLock.Unlock()
 


### PR DESCRIPTION
## Changes

- The genesis block does not contain any BABE digest since this information is already persisted using the information in the `spec.json`

## Tests

<!-- Detail how to run relevant tests to the changes -->
When you start the gossamer node you should not see 
```
2022-06-08T17:52:16+05:30 EROR failed to persist babe next epoch data: cannot get epoch for block 0 (0xee87cc7ac5e87460094ec4ba29bbf8f28fb7741b69e7edb142233c3dd990b365): header does not contain pre-runtime digest	digest.go:L244	pkg=digest
2022-06-08T17:52:16+05:30 EROR failed to persist babe next epoch config: cannot get epoch for block 0 (0xee87cc7ac5e87460094ec4ba29bbf8f28fb7741b69e7edb142233c3dd990b365): header does not contain pre-runtime digest	digest.go:L249	pkg=digest
```
## Issues

- Related #2591

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kishansagathiya 