### PR TITLE
fix(dot/sync): fix `Test_lockQueue_threadSafety`

### DIFF
--- a/dot/sync/block_queue_test.go
+++ b/dot/sync/block_queue_test.go
@@ -219,6 +219,17 @@ func Test_lockQueue_threadSafety(t *testing.T) {
 	}
 	blockHash := common.Hash{1}
 
+	endWg.Add(1)
+	go func() {
+		defer endWg.Done()
+		<-ctx.Done()
+		// Empty queue channel to make sure `push` does not block
+		// when the context is cancelled.
+		for len(blockQueue.queue) > 0 {
+			<-blockQueue.queue
+		}
+	}()
+
 	for i := 0; i < parallelism; i++ {
 		go runInLoop(func() {
 			blockQueue.push(blockData)


### PR DESCRIPTION
## Changes

The test was running 3 operations in parallel for 50ms.
The `push` method writes to a buffered queue channel, and so would block at the end of the test (when the context would be canceled) since the channel would sometimes be full.
To fix this, an additional goroutine takes care of draining the channel when the context is canceled, so that push can write one last time to the queue channel and exit.

## Tests

```sh
go test -timeout 10s -race -run ^Test_lockQueue_threadSafety$ github.com/ChainSafe/gossamer/dot/sync
```

## Issues

## Primary Reviewer

@edwardmack 