### PR TITLE
fix(trie): descendants count for clear prefix

### DIFF
--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -877,10 +877,11 @@ func (t *Trie) clearPrefix(parent *Node, prefix []byte) (
 			return parent, nodesRemoved
 		}
 
-		nodesRemoved = 1
+		nodesRemoved = 1 + child.Descendants
 		copySettings := node.DefaultCopySettings
 		branch = t.prepBranchForMutation(branch, copySettings)
 		branch.Children[childIndex] = nil
+		branch.Descendants -= nodesRemoved
 		var branchChildMerged bool
 		newParent, branchChildMerged = handleDeletion(branch, prefix)
 		if branchChildMerged {


### PR DESCRIPTION
## Changes

Fix removing descendants for the ClearPrefix operation.
That was found with a sometimes flaky trie test in the CI.

## Tests

```sh
go test -count 1 ./internal/trie/... ./lib/trie/...  
```

## Issues


## Primary Reviewer

@kishansagathiya 