### PR TITLE
fix(wasmer): fix flaky sort in `Test_ext_crypto_sr25519_public_keys_version_1`

### DIFF
--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1073,7 +1073,7 @@ func Test_ext_crypto_sr25519_public_keys_version_1(t *testing.T) {
 	ks, _ := inst.ctx.Keystore.GetKeystore(idData)
 	require.Equal(t, 0, ks.Size())
 
-	size := 5
+	const size = 5
 	pubKeys := make([][32]byte, size)
 	for i := range pubKeys {
 		kp, err := sr25519.GenerateKeypair()
@@ -1083,7 +1083,9 @@ func Test_ext_crypto_sr25519_public_keys_version_1(t *testing.T) {
 		copy(pubKeys[i][:], kp.Public().Encode())
 	}
 
-	sort.Slice(pubKeys, func(i int, j int) bool { return pubKeys[i][0] < pubKeys[j][0] })
+	sort.Slice(pubKeys, func(i int, j int) bool {
+		return bytes.Compare(pubKeys[i][:], pubKeys[j][:]) < 0
+	})
 
 	res, err := inst.Exec("rtm_ext_crypto_sr25519_public_keys_version_1", idData)
 	require.NoError(t, err)
@@ -1096,7 +1098,10 @@ func Test_ext_crypto_sr25519_public_keys_version_1(t *testing.T) {
 	err = scale.Unmarshal(out, &ret)
 	require.NoError(t, err)
 
-	sort.Slice(ret, func(i int, j int) bool { return ret[i][0] < ret[j][0] })
+	sort.Slice(ret, func(i int, j int) bool {
+		return bytes.Compare(ret[i][:], ret[j][:]) < 0
+	})
+
 	require.Equal(t, pubKeys, ret)
 }
 


### PR DESCRIPTION
## Changes

Fix flaky sort in `Test_ext_crypto_sr25519_public_keys_version_1` so it doesn't fail occasionally anymore.

## Tests

```sh
go test -run ^Test_ext_crypto_sr25519_public_keys_version_1$ github.com/ChainSafe/gossamer/lib/runtime/wasmer
```

## Issues

Found in https://github.com/ChainSafe/gossamer/runs/6905658052?check_suite_focus=true

Fixes #2164
Fixes #2355

## Primary Reviewer

@timwu20