### PR TITLE
feat(e2e): build Gossamer on any test run

### DIFF
--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -25,9 +25,12 @@ func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 		return
 	}
 
+	err := utils.BuildGossamer()
+	require.NoError(t, err)
+
 	const nodePackageManager = "npm"
 	t.Logf("Checking %s is available...", nodePackageManager)
-	_, err := exec.LookPath(nodePackageManager)
+	_, err = exec.LookPath(nodePackageManager)
 	if err != nil {
 		t.Fatalf("%s is not available: %s", nodePackageManager, err)
 	}

--- a/tests/rpc/rpc_00_test.go
+++ b/tests/rpc/rpc_00_test.go
@@ -6,16 +6,28 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/rpc"
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	rpcSuite = "rpc"
-)
+func TestMain(m *testing.M) {
+	if utils.MODE != "rpc" {
+		fmt.Println("Going to skip RPC suite tests")
+		os.Exit(0)
+	}
+
+	err := utils.BuildGossamer()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
 
 type testCase struct {
 	description string

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/rpc/modules"
 	"github.com/ChainSafe/gossamer/lib/common"
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 	"github.com/ChainSafe/gossamer/tests/utils/retry"
@@ -22,11 +21,6 @@ import (
 const peerIDRegex = `^[a-zA-Z0-9]{52}$`
 
 func TestSystemRPC(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	const testTimeout = 8 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/centrifuge/go-substrate-rpc-client/v3/scale"
 
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 	"github.com/ChainSafe/gossamer/tests/utils/retry"
@@ -24,11 +23,6 @@ import (
 )
 
 func TestAuthorSubmitExtrinsic(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetDevGenesisSpecPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
@@ -100,11 +94,6 @@ func TestAuthorSubmitExtrinsic(t *testing.T) {
 }
 
 func TestAuthorRPC(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/rpc/subscription"
 	"github.com/ChainSafe/gossamer/lib/common"
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 	"github.com/ChainSafe/gossamer/tests/utils/retry"
@@ -32,11 +31,6 @@ const (
 )
 
 func TestChainRPC(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetDevGenesisSpecPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
@@ -129,11 +123,6 @@ func TestChainRPC(t *testing.T) {
 }
 
 func TestChainSubscriptionRPC(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetDevGenesisSpecPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -8,18 +8,12 @@ import (
 	"testing"
 
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 )
 
 func TestOffchainRPC(t *testing.T) {
 	t.SkipNow() // TODO
-
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
 
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/rpc/modules"
 	"github.com/ChainSafe/gossamer/lib/common"
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 	"github.com/ChainSafe/gossamer/tests/utils/rpc"
@@ -20,11 +19,6 @@ import (
 )
 
 func TestStateRPCResponseValidation(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
@@ -168,11 +162,6 @@ func TestStateRPCResponseValidation(t *testing.T) {
 }
 
 func TestStateRPCAPI(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
@@ -374,11 +363,6 @@ func TestStateRPCAPI(t *testing.T) {
 }
 
 func TestRPCStructParamUnmarshal(t *testing.T) {
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
-
 	genesisPath := libutils.GetDevGenesisSpecPathTest(t)
 	tomlConfig := config.Default()
 	tomlConfig.Core.BABELead = true

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -8,18 +8,12 @@ import (
 	"testing"
 
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 )
 
 func TestEngineRPC(t *testing.T) {
 	t.SkipNow()
-
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
 
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -8,18 +8,12 @@ import (
 	"testing"
 
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 )
 
 func TestPaymentRPC(t *testing.T) {
 	t.SkipNow() // TODO
-
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
 
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -8,18 +8,12 @@ import (
 	"testing"
 
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 )
 
 func TestContractsRPC(t *testing.T) {
 	t.SkipNow() // TODO
-
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
 
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -8,18 +8,12 @@ import (
 	"testing"
 
 	libutils "github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/ChainSafe/gossamer/tests/utils"
 	"github.com/ChainSafe/gossamer/tests/utils/config"
 	"github.com/ChainSafe/gossamer/tests/utils/node"
 )
 
 func TestBabeRPC(t *testing.T) {
 	t.SkipNow() // TODO
-
-	if utils.MODE != rpcSuite {
-		t.Log("Going to skip RPC suite tests")
-		return
-	}
 
 	genesisPath := libutils.GetGssmrGenesisRawPathTest(t)
 	tomlConfig := config.Default()

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -37,6 +37,12 @@ func TestMain(m *testing.M) {
 		return
 	}
 
+	err := utils.BuildGossamer()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
 	logLvl := log.Info
 	if utils.LOGLEVEL != "" {
 		var err error

--- a/tests/sync/sync_test.go
+++ b/tests/sync/sync_test.go
@@ -48,6 +48,9 @@ func TestCalls(t *testing.T) {
 		t.Skip("MODE != 'sync', skipping stress test")
 	}
 
+	err := utils.BuildGossamer()
+	require.NoError(t, err)
+
 	ctx := context.Background()
 
 	const qtyNodes = 3

--- a/tests/utils/build.go
+++ b/tests/utils/build.go
@@ -1,0 +1,32 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	libutils "github.com/ChainSafe/gossamer/lib/utils"
+)
+
+// BuildGossamer finds the project root path and builds the Gossamer
+// binary to ./bin/gossamer at the project root path.
+func BuildGossamer() (err error) {
+	rootPath, err := libutils.GetProjectRootPath()
+	if err != nil {
+		return fmt.Errorf("get project root path: %w", err)
+	}
+
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, "go", "build",
+		"-trimpath", "-o", "./bin/gossamer", "./cmd/gossamer")
+	cmd.Dir = rootPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("building Gossamer: %w\n%s", err, output)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Changes

This happened one too many times, us developers forgetting to re-build Gossamer before running an e2e test locally.

This changes e2e to build the binary every time a test is run. The first build takes 10s, but it only takes about 1.5s on rebuilds, which is well worth the avoided trouble of dev time wasted.

## Tests

End-to-end suites passing

## Issues

Fixes #2458 

## Primary Reviewer

@edwardmack 