### PR TITLE
fix(trie): Panic when deleting nonexistent keys from trie (GSR-10)

### DIFF
--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -969,7 +969,8 @@ func (t *Trie) deleteBranch(branch *Node, key []byte) (
 	}
 
 	commonPrefixLength := lenCommonPrefix(branch.Key, key)
-	if (commonPrefixLength + 1) > len(key) {
+	keyDoesNotExist := commonPrefixLength == len(key)
+	if keyDoesNotExist {
 		return branch, false, 0
 	}
 	childIndex := key[commonPrefixLength]

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -969,6 +969,9 @@ func (t *Trie) deleteBranch(branch *Node, key []byte) (
 	}
 
 	commonPrefixLength := lenCommonPrefix(branch.Key, key)
+	if (commonPrefixLength + 1) > len(key) {
+		return branch, false, 0
+	}
 	childIndex := key[commonPrefixLength]
 	childKey := key[commonPrefixLength+1:]
 	child := branch.Children[childIndex]

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -3606,8 +3606,6 @@ func Test_Trie_delete(t *testing.T) {
 					},
 				}),
 			},
-			updated:      false,
-			nodesRemoved: 0,
 		},
 	}
 

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -3573,6 +3573,42 @@ func Test_Trie_delete(t *testing.T) {
 			},
 			updated: true,
 		},
+		"handle nonexistent key (no op)": {
+			trie: Trie{
+				generation: 1,
+			},
+			parent: &Node{
+				Key:         []byte{1, 0, 2, 3},
+				Descendants: 1,
+				Children: padRightChildren([]*Node{
+					{ // full key 1, 0, 2
+						Key:   []byte{2},
+						Value: []byte{1},
+					},
+					{ // full key 1, 1, 2
+						Key:   []byte{2},
+						Value: []byte{2},
+					},
+				}),
+			},
+			key: []byte{1, 0, 2},
+			newParent: &Node{
+				Key:         []byte{1, 0, 2, 3},
+				Descendants: 1,
+				Children: padRightChildren([]*Node{
+					{ // full key 1, 0, 2
+						Key:   []byte{2},
+						Value: []byte{1},
+					},
+					{ // full key 1, 1, 2
+						Key:   []byte{2},
+						Value: []byte{2},
+					},
+				}),
+			},
+			updated:      false,
+			nodesRemoved: 0,
+		},
 	}
 
 	for name, testCase := range testCases {


### PR DESCRIPTION
## Changes

- Implement check to handle condition when deleting a nonexistent key K_x when the trie contains valid key K_y for which K_x is a prefix.  i.e. where `bytes.HasPrefix(k_y, k_x)` holds will no longer cause panic

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
 go test -run ^Test_Trie_delete$ github.com/ChainSafe/gossamer/lib/trie -v
```

## Issues
closes: #2404 
<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
