### PR TITLE
fix(dot/sync): Fix flaky tests `Test_chainSync_logSyncSpeed` and `Test_chainSync_start`

### DIFF
--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -164,6 +164,7 @@ type chainSync struct {
 
 	logSyncTicker  *time.Ticker
 	logSyncTickerC <-chan time.Time // channel as field for unit testing
+	logSyncStarted bool
 	logSyncDone    chan struct{}
 }
 
@@ -225,6 +226,7 @@ func (cs *chainSync) start() {
 	cs.pendingBlockDoneCh = pendingBlockDoneCh
 	go cs.pendingBlocks.run(pendingBlockDoneCh)
 	go cs.sync()
+	cs.logSyncStarted = true
 	go cs.logSyncSpeed()
 }
 
@@ -233,7 +235,9 @@ func (cs *chainSync) stop() {
 		close(cs.pendingBlockDoneCh)
 	}
 	cs.cancel()
-	<-cs.logSyncDone
+	if cs.logSyncStarted {
+		<-cs.logSyncDone
+	}
 }
 
 func (cs *chainSync) syncState() chainSyncState {

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -1118,7 +1118,7 @@ func Test_chainSync_logSyncSpeed(t *testing.T) {
 
 	type fields struct {
 		blockStateBuilder func(ctrl *gomock.Controller) BlockState
-		networkBuilder    func(ctrl *gomock.Controller, cancel context.CancelFunc) Network
+		networkBuilder    func(ctrl *gomock.Controller) Network
 		state             chainSyncState
 		benchmarker       *syncBenchmarker
 	}
@@ -1135,7 +1135,7 @@ func Test_chainSync_logSyncSpeed(t *testing.T) {
 					mockBlockState.EXPECT().GetHighestFinalisedHeader().Return(&types.Header{}, nil)
 					return mockBlockState
 				},
-				networkBuilder: func(ctrl *gomock.Controller, cancel context.CancelFunc) Network {
+				networkBuilder: func(ctrl *gomock.Controller) Network {
 					mockNetwork := NewMockNetwork(ctrl)
 					mockNetwork.EXPECT().Peers().Return(nil)
 					return mockNetwork
@@ -1153,7 +1153,7 @@ func Test_chainSync_logSyncSpeed(t *testing.T) {
 					mockBlockState.EXPECT().GetHighestFinalisedHeader().Return(&types.Header{}, nil)
 					return mockBlockState
 				},
-				networkBuilder: func(ctrl *gomock.Controller, cancel context.CancelFunc) Network {
+				networkBuilder: func(ctrl *gomock.Controller) Network {
 					mockNetwork := NewMockNetwork(ctrl)
 					mockNetwork.EXPECT().Peers().Return(nil)
 					return mockNetwork
@@ -1174,7 +1174,7 @@ func Test_chainSync_logSyncSpeed(t *testing.T) {
 				ctx:            ctx,
 				cancel:         cancel,
 				blockState:     tt.fields.blockStateBuilder(ctrl),
-				network:        tt.fields.networkBuilder(ctrl, cancel),
+				network:        tt.fields.networkBuilder(ctrl),
 				state:          tt.fields.state,
 				benchmarker:    tt.fields.benchmarker,
 				logSyncTickerC: tickerChannel,


### PR DESCRIPTION
## Changes

- Production code had to be refactored to be event driven
- Fix `Test_chainSync_logSyncSpeed` to be fully event driven
- Fix `Test_chainSync_start` to be fully event driven

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/dot/sync/...
```

## Issues

## Primary Reviewer

@timwu20