### PR TITLE
feat(trie): decode all inlined node variants

### DIFF
--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -110,14 +110,11 @@ func decodeBranch(reader io.Reader, variant byte, partialKeyLength uint16) (
 		if len(hash) < hashLength {
 			// Handle inlined nodes
 			reader = bytes.NewReader(hash)
-			variant, partialKeyLength, err := decodeHeader(reader)
-			if err == nil && variant == leafVariant.bits {
-				childNode, err = decodeLeaf(reader, partialKeyLength)
-				if err != nil {
-					return nil, fmt.Errorf("%w: at index %d: %s",
-						ErrDecodeValue, i, err)
-				}
+			childNode, err = Decode(reader)
+			if err != nil {
+				return nil, fmt.Errorf("decoding inlined child at index %d: %w", i, err)
 			}
+			node.Descendants += childNode.Descendants
 		}
 
 		node.Descendants++

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -240,7 +240,7 @@ func Test_decodeBranch(t *testing.T) {
 			partialKeyLength: 1,
 			errWrapped:       io.EOF,
 			errMessage: "decoding inlined child at index 0: " +
-				"cannot decode header: cannot read header byte: EOF",
+				"decoding header: reading header byte: EOF",
 		},
 		"branch with inlined branch and leaf": {
 			reader: bytes.NewBuffer(concatByteSlices([][]byte{

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -182,7 +182,7 @@ func (t *Trie) load(db chaindb.Database, n *Node) error {
 
 		hash := child.HashDigest
 
-		if len(hash) == 0 && child.Type() == node.Leaf {
+		if len(hash) == 0 {
 			// node has already been loaded inline
 			// just set encoding + hash digest
 			_, _, err := child.EncodeAndHash(false)


### PR DESCRIPTION
## Changes

Extend from previously limited-to-leaf inlined decoding to all node variants.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -count 1 ./internal/trie/... ./lib/trie/...
```

## Issues

One step towards #2418 

## Primary Reviewer

@EclesioMeloJunior 