### PR TITLE
fix(lib/grandpa): Duplicate votes is GRANDPA are counted as equivocatory votes (GSR-11)

### DIFF
--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -98,5 +98,4 @@ var (
 	errVoteToSignatureMismatch = errors.New("votes and authority count mismatch")
 	errVoteBlockMismatch       = errors.New("block in vote is not descendant of previously finalised block")
 	errVoteFromSelf            = errors.New("got vote from ourselves")
-	errInvalidMultiplicity     = errors.New("more than two equivocatory votes for a voter")
 )

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -290,10 +290,8 @@ func getEquivocatoryVoters(votes []AuthData) map[ed25519.PublicKeyBytes]struct{}
 
 	for _, v := range votes {
 		signature, present := voters[v.AuthorityID]
-		if present {
-			if !bytes.Equal(signature[:], v.Signature[:]) {
-				eqvVoters[v.AuthorityID] = struct{}{}
-			}
+		if present && !bytes.Equal(signature[:], v.Signature[:]) {
+			eqvVoters[v.AuthorityID] = struct{}{}
 		} else {
 			voters[v.AuthorityID] = v.Signature
 		}

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -298,6 +298,7 @@ func getEquivocatoryVoters(votes []AuthData) map[ed25519.PublicKeyBytes]struct{}
 			voters[v.AuthorityID] = v.Signature
 		}
 	}
+
 	return eqvVoters
 }
 

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -546,40 +546,41 @@ func (h *MessageHandler) verifyJustification(just *SignedVote, round, setID uint
 	return nil
 }
 
-// VerifyBlockJustification verifies the finality justification for a block
-func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byte) error {
+// VerifyBlockJustification verifies the finality justification for a block, returns scale encoded justification with
+//  any extra bytes removed.
+func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byte) ([]byte, error) {
 	fj := Justification{}
 	err := scale.Unmarshal(justification, &fj)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	setID, err := s.grandpaState.GetSetIDByBlockNumber(uint(fj.Commit.Number))
 	if err != nil {
-		return fmt.Errorf("cannot get set ID from block number: %w", err)
+		return nil, fmt.Errorf("cannot get set ID from block number: %w", err)
 	}
 
 	has, err := s.blockState.HasFinalisedBlock(fj.Round, setID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if has {
-		return fmt.Errorf("already have finalised block with setID=%d and round=%d", setID, fj.Round)
+		return nil, fmt.Errorf("already have finalised block with setID=%d and round=%d", setID, fj.Round)
 	}
 
 	isDescendant, err := isDescendantOfHighestFinalisedBlock(s.blockState, fj.Commit.Hash)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !isDescendant {
-		return errVoteBlockMismatch
+		return nil, errVoteBlockMismatch
 	}
 
 	auths, err := s.grandpaState.GetAuthorities(setID)
 	if err != nil {
-		return fmt.Errorf("cannot get authorities for set ID: %w", err)
+		return nil, fmt.Errorf("cannot get authorities for set ID: %w", err)
 	}
 
 	// threshold is two-thirds the number of authorities,
@@ -587,7 +588,7 @@ func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byt
 	threshold := (2 * len(auths) / 3)
 
 	if len(fj.Commit.Precommits) < threshold {
-		return ErrMinVotesNotMet
+		return nil, ErrMinVotesNotMet
 	}
 
 	authPubKeys := make([]AuthData, len(fj.Commit.Precommits))
@@ -607,20 +608,20 @@ func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byt
 		// check if vote was for descendant of committed block
 		isDescendant, err := s.blockState.IsDescendantOf(hash, just.Vote.Hash)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if !isDescendant {
-			return ErrPrecommitBlockMismatch
+			return nil, ErrPrecommitBlockMismatch
 		}
 
 		pk, err := ed25519.NewPublicKey(just.AuthorityID[:])
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if !isInAuthSet(pk, auths) {
-			return ErrAuthorityNotInSet
+			return nil, ErrAuthorityNotInSet
 		}
 
 		// verify signature for each precommit
@@ -631,16 +632,16 @@ func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byt
 			SetID: setID,
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		ok, err := pk.Verify(msg, just.Signature[:])
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if !ok {
-			return ErrInvalidSignature
+			return nil, ErrInvalidSignature
 		}
 
 		if _, ok := equivocatoryVoters[just.AuthorityID]; ok {
@@ -651,30 +652,30 @@ func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byt
 	}
 
 	if count+len(equivocatoryVoters) < threshold {
-		return ErrMinVotesNotMet
+		return nil, ErrMinVotesNotMet
 	}
 
 	err = verifyBlockHashAgainstBlockNumber(s.blockState, fj.Commit.Hash, uint(fj.Commit.Number))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, preCommit := range fj.Commit.Precommits {
 		err := verifyBlockHashAgainstBlockNumber(s.blockState, preCommit.Vote.Hash, uint(preCommit.Vote.Number))
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	err = s.blockState.SetFinalisedHash(hash, fj.Round, setID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	logger.Debugf(
 		"set finalised block with hash %s, round %d and set id %d",
 		hash, fj.Round, setID)
-	return nil
+	return scale.Marshal(fj)
 }
 
 func verifyBlockHashAgainstBlockNumber(bs BlockState, hash common.Hash, number uint) error {


### PR DESCRIPTION
## Changes
- Implement fix to `getEquivocatoryVoters` that does not include duplicate votes as equivocatory votes, addressing Sigma Prime - Gossamer Audit issue 11 (GSR-11)
- Add unit tests for testing duplicate votes condition.

<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -run ^Test_getEquivocatoryVoters$ github.com/ChainSafe/gossamer/lib/grandpa -v
```

## Issues
closes: #2410 
<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kishansagathiya 
