### PR TITLE
fix: ensure we convert the `uint` type

### DIFF
--- a/lib/common/variadic/uint32OrHash.go
+++ b/lib/common/variadic/uint32OrHash.go
@@ -23,6 +23,10 @@ func NewUint32OrHash(value interface{}) (*Uint32OrHash, error) {
 		return &Uint32OrHash{
 			value: uint32(v),
 		}, nil
+	case uint:
+		return &Uint32OrHash{
+			value: uint32(v),
+		}, nil
 	case uint32:
 		return &Uint32OrHash{
 			value: v,
@@ -98,6 +102,7 @@ func (x *Uint32OrHash) IsUint32() bool {
 	if x == nil {
 		return false
 	}
+
 	_, is := x.value.(uint32)
 	return is
 }

--- a/lib/common/variadic/uint32OrHash_test.go
+++ b/lib/common/variadic/uint32OrHash_test.go
@@ -25,6 +25,10 @@ func TestNewUint32OrHash(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(num), res.Value())
 
+	res, err = NewUint32OrHash(uint(num))
+	require.NoError(t, err)
+	require.Equal(t, uint32(num), res.Value())
+
 	res, err = NewUint32OrHash(uint32(num))
 	require.NoError(t, err)
 	require.Equal(t, uint32(num), res.Value())


### PR DESCRIPTION
## Changes

- Add the `uint` type while creating the `Uint32OrHash` concrete type

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/lib/common/variadic
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

- Closes #2625

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@qdm12 
