### PR TITLE
trie: add new variant headers

### DIFF
--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -39,13 +39,13 @@ func Decode(reader io.Reader) (n *Node, err error) {
 	}
 
 	switch variant {
-	case leafVariant.bits:
+	case leafVariant:
 		n, err = decodeLeaf(reader, partialKeyLength)
 		if err != nil {
 			return nil, fmt.Errorf("cannot decode leaf: %w", err)
 		}
 		return n, nil
-	case branchVariant.bits, branchWithValueVariant.bits:
+	case branchVariant, branchWithValueVariant:
 		n, err = decodeBranch(reader, variant, partialKeyLength)
 		if err != nil {
 			return nil, fmt.Errorf("cannot decode branch: %w", err)
@@ -63,7 +63,7 @@ func Decode(reader io.Reader) (n *Node, err error) {
 // reconstructing the child nodes from the encoding. This function instead stubs where the
 // children are known to be with an empty leaf. The children nodes hashes are then used to
 // find other storage values using the persistent database.
-func decodeBranch(reader io.Reader, variant byte, partialKeyLength uint16) (
+func decodeBranch(reader io.Reader, variant variant, partialKeyLength uint16) (
 	node *Node, err error) {
 	node = &Node{
 		Children: make([]*Node, ChildrenCapacity),
@@ -82,7 +82,7 @@ func decodeBranch(reader io.Reader, variant byte, partialKeyLength uint16) (
 
 	sd := scale.NewDecoder(reader)
 
-	if variant == branchWithValueVariant.bits {
+	if variant == branchWithValueVariant {
 		err := sd.Decode(&node.StorageValue)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", ErrDecodeStorageValue, err)

--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -39,6 +39,8 @@ func Decode(reader io.Reader) (n *Node, err error) {
 	}
 
 	switch variant {
+	case emptyVariant:
+		return nil, nil //nolint:nilnil
 	case leafVariant:
 		n, err = decodeLeaf(reader, partialKeyLength)
 		if err != nil {

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -50,9 +50,13 @@ func Test_Decode(t *testing.T) {
 			errMessage: "decoding header: reading header byte: EOF",
 		},
 		"unknown node variant": {
-			reader:     bytes.NewReader([]byte{0}),
+			reader:     bytes.NewReader([]byte{0b0000_1000}),
 			errWrapped: ErrVariantUnknown,
-			errMessage: "decoding header: decoding header byte: node variant is unknown: for header byte 00000000",
+			errMessage: "decoding header: decoding header byte: node variant is unknown: for header byte 00001000",
+		},
+		"empty node": {
+			reader: bytes.NewReader([]byte{emptyVariant.bits}),
+			n:      nil,
 		},
 		"leaf decoding error": {
 			reader: bytes.NewReader([]byte{

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -130,7 +130,7 @@ func Test_decodeBranch(t *testing.T) {
 
 	testCases := map[string]struct {
 		reader           io.Reader
-		variant          byte
+		nodeVariant      variant
 		partialKeyLength uint16
 		branch           *Node
 		errWrapped       error
@@ -140,7 +140,7 @@ func Test_decodeBranch(t *testing.T) {
 			reader: bytes.NewBuffer([]byte{
 				// missing key data byte
 			}),
-			variant:          branchVariant.bits,
+			nodeVariant:      branchVariant,
 			partialKeyLength: 1,
 			errWrapped:       io.EOF,
 			errMessage:       "cannot decode key: reading from reader: EOF",
@@ -150,7 +150,7 @@ func Test_decodeBranch(t *testing.T) {
 				9, // key data
 				// missing children bitmap 2 bytes
 			}),
-			variant:          branchVariant.bits,
+			nodeVariant:      branchVariant,
 			partialKeyLength: 1,
 			errWrapped:       ErrReadChildrenBitmap,
 			errMessage:       "cannot read children bitmap: EOF",
@@ -161,7 +161,7 @@ func Test_decodeBranch(t *testing.T) {
 				0, 4, // children bitmap
 				// missing children scale encoded data
 			}),
-			variant:          branchVariant.bits,
+			nodeVariant:      branchVariant,
 			partialKeyLength: 1,
 			errWrapped:       ErrDecodeChildHash,
 			errMessage:       "cannot decode child hash: at index 10: reading byte: EOF",
@@ -174,7 +174,7 @@ func Test_decodeBranch(t *testing.T) {
 					scaleEncodedChildHash,
 				}),
 			),
-			variant:          branchVariant.bits,
+			nodeVariant:      branchVariant,
 			partialKeyLength: 1,
 			branch: &Node{
 				PartialKey: []byte{9},
@@ -196,7 +196,7 @@ func Test_decodeBranch(t *testing.T) {
 					// missing encoded branch storage value
 				}),
 			),
-			variant:          branchWithValueVariant.bits,
+			nodeVariant:      branchWithValueVariant,
 			partialKeyLength: 1,
 			errWrapped:       ErrDecodeStorageValue,
 			errMessage:       "cannot decode storage value: reading byte: EOF",
@@ -208,7 +208,7 @@ func Test_decodeBranch(t *testing.T) {
 				scaleEncodeBytes(t, 7, 8, 9), // branch storage value
 				scaleEncodedChildHash,
 			})),
-			variant:          branchWithValueVariant.bits,
+			nodeVariant:      branchWithValueVariant,
 			partialKeyLength: 1,
 			branch: &Node{
 				PartialKey:   []byte{9},
@@ -230,7 +230,7 @@ func Test_decodeBranch(t *testing.T) {
 				scaleEncodeBytes(t, 1),     // branch storage value
 				{0},                        // garbage inlined node
 			})),
-			variant:          branchWithValueVariant.bits,
+			nodeVariant:      branchWithValueVariant,
 			partialKeyLength: 1,
 			errWrapped:       io.EOF,
 			errMessage: "decoding inlined child at index 0: " +
@@ -260,7 +260,7 @@ func Test_decodeBranch(t *testing.T) {
 					})),
 				})),
 			})),
-			variant:          branchVariant.bits,
+			nodeVariant:      branchVariant,
 			partialKeyLength: 1,
 			branch: &Node{
 				PartialKey:  []byte{1},
@@ -286,7 +286,7 @@ func Test_decodeBranch(t *testing.T) {
 			t.Parallel()
 
 			branch, err := decodeBranch(testCase.reader,
-				testCase.variant, testCase.partialKeyLength)
+				testCase.nodeVariant, testCase.partialKeyLength)
 
 			assert.ErrorIs(t, err, testCase.errWrapped)
 			if err != nil {

--- a/internal/trie/node/encode.go
+++ b/internal/trie/node/encode.go
@@ -21,6 +21,11 @@ func (n *Node) Encode(buffer Buffer) (err error) {
 		return fmt.Errorf("cannot encode header: %w", err)
 	}
 
+	if n == nil {
+		// only encode the empty variant byte header
+		return nil
+	}
+
 	keyLE := codec.NibblesToKeyLE(n.PartialKey)
 	_, err = buffer.Write(keyLE)
 	if err != nil {

--- a/internal/trie/node/encode_test.go
+++ b/internal/trie/node/encode_test.go
@@ -30,6 +30,15 @@ func Test_Node_Encode(t *testing.T) {
 		wrappedErr       error
 		errMessage       string
 	}{
+		"nil node": {
+			node: nil,
+			writes: []writeCall{
+				{
+					written: []byte{emptyVariant.bits},
+				},
+			},
+			expectedEncoding: []byte{emptyVariant.bits},
+		},
 		"leaf header encoding error": {
 			node: &Node{
 				PartialKey: make([]byte, 1),

--- a/internal/trie/node/header.go
+++ b/internal/trie/node/header.go
@@ -145,10 +145,13 @@ var ErrVariantUnknown = errors.New("node variant is unknown")
 // the decodeHeaderByte function below.
 // For 7 variants, the performance is improved by ~20%.
 var variantsOrderedByBitMask = [...]variant{
-	leafVariant,            // mask 1100_0000
-	branchVariant,          // mask 1100_0000
-	branchWithValueVariant, // mask 1100_0000
-	emptyVariant,           // mask 1111_1111
+	leafVariant,                   // mask 1100_0000
+	branchVariant,                 // mask 1100_0000
+	branchWithValueVariant,        // mask 1100_0000
+	leafContainingHashesVariant,   // mask 1110_0000
+	branchContainingHashesVariant, // mask 1111_0000
+	emptyVariant,                  // mask 1111_1111
+	compactEncodingVariant,        // mask 1111_1111
 }
 
 func decodeHeaderByte(header byte) (nodeVariant variant,

--- a/internal/trie/node/header.go
+++ b/internal/trie/node/header.go
@@ -11,6 +11,11 @@ import (
 
 // encodeHeader writes the encoded header for the node.
 func encodeHeader(node *Node, writer io.Writer) (err error) {
+	if node == nil {
+		_, err = writer.Write([]byte{emptyVariant.bits})
+		return err
+	}
+
 	partialKeyLength := len(node.PartialKey)
 	if partialKeyLength > int(maxPartialKeyLength) {
 		panic(fmt.Sprintf("partial key length is too big: %d", partialKeyLength))
@@ -84,6 +89,13 @@ func decodeHeader(reader io.Reader) (nodeVariant variant,
 	}
 
 	partialKeyLengthHeaderMask := nodeVariant.partialKeyLengthHeaderMask()
+	if partialKeyLengthHeaderMask == 0b0000_0000 {
+		// empty node or compact encoding which have no
+		// partial key. The partial key length mask is
+		// 0b0000_0000 since the variant mask is
+		// 0b1111_1111.
+		return nodeVariant, 0, nil
+	}
 
 	partialKeyLength = uint16(partialKeyLengthHeader)
 	if partialKeyLengthHeader < partialKeyLengthHeaderMask {
@@ -136,6 +148,7 @@ var variantsOrderedByBitMask = [...]variant{
 	leafVariant,            // mask 1100_0000
 	branchVariant,          // mask 1100_0000
 	branchWithValueVariant, // mask 1100_0000
+	emptyVariant,           // mask 1111_1111
 }
 
 func decodeHeaderByte(header byte) (nodeVariant variant,

--- a/internal/trie/node/header_test.go
+++ b/internal/trie/node/header_test.go
@@ -281,7 +281,7 @@ func Test_decodeHeader(t *testing.T) {
 
 	testCases := map[string]struct {
 		reads            []readCall
-		variant          byte
+		nodeVariant      variant
 		partialKeyLength uint16
 		errWrapped       error
 		errMessage       string
@@ -304,7 +304,7 @@ func Test_decodeHeader(t *testing.T) {
 			reads: []readCall{
 				{buffArgCap: 1, read: []byte{leafVariant.bits | 0b0011_1110}},
 			},
-			variant:          leafVariant.bits,
+			nodeVariant:      leafVariant,
 			partialKeyLength: uint16(0b0011_1110),
 		},
 		"long partial key length and second byte read error": {
@@ -321,7 +321,7 @@ func Test_decodeHeader(t *testing.T) {
 				{buffArgCap: 1, read: []byte{0b1111_1111}},
 				{buffArgCap: 1, read: []byte{0b1111_0000}},
 			},
-			variant:          leafVariant.bits,
+			nodeVariant:      leafVariant,
 			partialKeyLength: uint16(0b0011_1111 + 0b1111_1111 + 0b1111_0000),
 		},
 		"partial key length too long": {
@@ -357,9 +357,9 @@ func Test_decodeHeader(t *testing.T) {
 				previousCall = call
 			}
 
-			variant, partialKeyLength, err := decodeHeader(reader)
+			nodeVariant, partialKeyLength, err := decodeHeader(reader)
 
-			assert.Equal(t, testCase.variant, variant)
+			assert.Equal(t, testCase.nodeVariant, nodeVariant)
 			assert.Equal(t, int(testCase.partialKeyLength), int(partialKeyLength))
 			assert.ErrorIs(t, err, testCase.errWrapped)
 			if testCase.errWrapped != nil {
@@ -373,30 +373,26 @@ func Test_decodeHeaderByte(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		header                     byte
-		variantBits                byte
-		partialKeyLengthHeader     byte
-		partialKeyLengthHeaderMask byte
-		errWrapped                 error
-		errMessage                 string
+		header                 byte
+		nodeVariant            variant
+		partialKeyLengthHeader byte
+		errWrapped             error
+		errMessage             string
 	}{
 		"branch with value header": {
-			header:                     0b1110_1001,
-			variantBits:                0b1100_0000,
-			partialKeyLengthHeader:     0b0010_1001,
-			partialKeyLengthHeaderMask: 0b0011_1111,
+			header:                 0b1110_1001,
+			nodeVariant:            branchWithValueVariant,
+			partialKeyLengthHeader: 0b0010_1001,
 		},
 		"branch header": {
-			header:                     0b1010_1001,
-			variantBits:                0b1000_0000,
-			partialKeyLengthHeader:     0b0010_1001,
-			partialKeyLengthHeaderMask: 0b0011_1111,
+			header:                 0b1010_1001,
+			nodeVariant:            branchVariant,
+			partialKeyLengthHeader: 0b0010_1001,
 		},
 		"leaf header": {
-			header:                     0b0110_1001,
-			variantBits:                0b0100_0000,
-			partialKeyLengthHeader:     0b0010_1001,
-			partialKeyLengthHeaderMask: 0b0011_1111,
+			header:                 0b0110_1001,
+			nodeVariant:            leafVariant,
+			partialKeyLengthHeader: 0b0010_1001,
 		},
 		"unknown variant header": {
 			header:     0b0000_0000,
@@ -410,12 +406,11 @@ func Test_decodeHeaderByte(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			variantBits, partialKeyLengthHeader,
-				partialKeyLengthHeaderMask, err := decodeHeaderByte(testCase.header)
+			nodeVariant, partialKeyLengthHeader,
+				err := decodeHeaderByte(testCase.header)
 
-			assert.Equal(t, testCase.variantBits, variantBits)
+			assert.Equal(t, testCase.nodeVariant, nodeVariant)
 			assert.Equal(t, testCase.partialKeyLengthHeader, partialKeyLengthHeader)
-			assert.Equal(t, testCase.partialKeyLengthHeaderMask, partialKeyLengthHeaderMask)
 			assert.ErrorIs(t, err, testCase.errWrapped)
 			if testCase.errWrapped != nil {
 				assert.EqualError(t, err, testCase.errMessage)
@@ -448,6 +443,6 @@ func Benchmark_decodeHeaderByte(b *testing.B) {
 	header := leafVariant.bits | 0b0000_0001
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _, _ = decodeHeaderByte(header)
+		_, _, _ = decodeHeaderByte(header)
 	}
 }

--- a/internal/trie/node/header_test.go
+++ b/internal/trie/node/header_test.go
@@ -295,10 +295,10 @@ func Test_decodeHeader(t *testing.T) {
 		},
 		"header byte decoding error": {
 			reads: []readCall{
-				{buffArgCap: 1, read: []byte{0b0011_1110}},
+				{buffArgCap: 1, read: []byte{0b0000_1000}},
 			},
 			errWrapped: ErrVariantUnknown,
-			errMessage: "decoding header byte: node variant is unknown: for header byte 00111110",
+			errMessage: "decoding header byte: node variant is unknown: for header byte 00001000",
 		},
 		"partial key length contained in first byte": {
 			reads: []readCall{
@@ -398,6 +398,21 @@ func Test_decodeHeaderByte(t *testing.T) {
 			header:                 0b0110_1001,
 			nodeVariant:            leafVariant,
 			partialKeyLengthHeader: 0b0010_1001,
+		},
+		"leaf containing hashes header": {
+			header:                 0b0011_1001,
+			nodeVariant:            leafContainingHashesVariant,
+			partialKeyLengthHeader: 0b0001_1001,
+		},
+		"branch containing hashes header": {
+			header:                 0b0001_1001,
+			nodeVariant:            branchContainingHashesVariant,
+			partialKeyLengthHeader: 0b0000_1001,
+		},
+		"compact encoding header": {
+			header:                 0b0001_0000,
+			nodeVariant:            compactEncodingVariant,
+			partialKeyLengthHeader: 0b0000_0000,
 		},
 		"unknown variant header": {
 			header:     0b0000_1000,

--- a/internal/trie/node/header_test.go
+++ b/internal/trie/node/header_test.go
@@ -379,6 +379,11 @@ func Test_decodeHeaderByte(t *testing.T) {
 		errWrapped             error
 		errMessage             string
 	}{
+		"empty variant header": {
+			header:                 0b0000_0000,
+			nodeVariant:            emptyVariant,
+			partialKeyLengthHeader: 0b0000_0000,
+		},
 		"branch with value header": {
 			header:                 0b1110_1001,
 			nodeVariant:            branchWithValueVariant,
@@ -395,9 +400,9 @@ func Test_decodeHeaderByte(t *testing.T) {
 			partialKeyLengthHeader: 0b0010_1001,
 		},
 		"unknown variant header": {
-			header:     0b0000_0000,
+			header:     0b0000_1000,
 			errWrapped: ErrVariantUnknown,
-			errMessage: "node variant is unknown: for header byte 00000000",
+			errMessage: "node variant is unknown: for header byte 00001000",
 		},
 	}
 
@@ -428,7 +433,7 @@ func Test_variantsOrderedByBitMask(t *testing.T) {
 	copy(sortedSlice, variantsOrderedByBitMask[:])
 
 	sort.Slice(slice, func(i, j int) bool {
-		return slice[i].mask > slice[j].mask
+		return slice[i].mask < slice[j].mask
 	})
 
 	assert.Equal(t, sortedSlice, slice)

--- a/internal/trie/node/variants.go
+++ b/internal/trie/node/variants.go
@@ -23,8 +23,20 @@ var (
 		bits: 0b1100_0000,
 		mask: 0b1100_0000,
 	}
+	leafContainingHashesVariant = variant{ // leaf containing hashes 001
+		bits: 0b0010_0000,
+		mask: 0b1110_0000,
+	}
+	branchContainingHashesVariant = variant{ // branch containing hashes 0001
+		bits: 0b0001_0000,
+		mask: 0b1111_0000,
+	}
 	emptyVariant = variant{ // empty 0000 0000
 		bits: 0b0000_0000,
+		mask: 0b1111_1111,
+	}
+	compactEncodingVariant = variant{ // compact encoding 0001 0000
+		bits: 0b0001_0000,
 		mask: 0b1111_1111,
 	}
 )

--- a/internal/trie/node/variants.go
+++ b/internal/trie/node/variants.go
@@ -36,7 +36,7 @@ var (
 		mask: 0b1111_1111,
 	}
 	compactEncodingVariant = variant{ // compact encoding 0001 0000
-		bits: 0b0001_0000,
+		bits: 0b0000_0001,
 		mask: 0b1111_1111,
 	}
 )

--- a/internal/trie/node/variants.go
+++ b/internal/trie/node/variants.go
@@ -24,3 +24,11 @@ var (
 		mask: 0b1100_0000,
 	}
 )
+
+// partialKeyLengthHeaderMask returns the partial key length
+// header bit mask corresponding to the variant header bit mask.
+// For example for the leaf variant with variant mask 1100_000,
+// the partial key length header mask returned is 0011_1111.
+func (v variant) partialKeyLengthHeaderMask() byte {
+	return ^v.mask
+}

--- a/internal/trie/node/variants.go
+++ b/internal/trie/node/variants.go
@@ -23,6 +23,10 @@ var (
 		bits: 0b1100_0000,
 		mask: 0b1100_0000,
 	}
+	emptyVariant = variant{ // empty 0000 0000
+		bits: 0b0000_0000,
+		mask: 0b1111_1111,
+	}
 )
 
 // partialKeyLengthHeaderMask returns the partial key length


### PR DESCRIPTION
## Changes

*Note*: This is based on #2665 

- [x] Add node headers
- [ ] Reject decoding new headers when using `v0` state trie
- [ ] Proof verification to use compact encoding escape header
- [ ] Implement leaf with hashed subvalue
- [ ] Implement branch with hashed subvalue
- [ ] Support child tries upgrade
- [ ] Support proof generation/verification

Questions:

- [ ] Should `Encode` return the too-large values or take in a Database interface to store them directly? How about for proof generation?
- [ ] Should `Decode` take in a database interface to load values directly, or be passed a map of hash<->value? How about for proof verification?
- [x] How does Substrate retrieves subvalues from hashes? Using database lookup
- [ ] How to know which version to use to encode/decode nodes in the state trie?
- [x] How does Substrate delete subvalues? For 'dumb' KV, they prepend the subvalue hash with the node key to go around the storing another key value in another table from hash subvalue to reference counter.
- [x] Regarding the `ESCAPE_HEADER` (aka 'reserved for compact encoding' aka `00010000`), is the 'value node' just the scale encoding of the node subvalue bytes? Also why is this header needed if leaf and branch with hashed subvalue already have their own header `001` and `0001` (or the opposite, why did we need those 2 new headers if we have this compact encoding escape header)?
    ```rust
	/// Escape header byte sequence to indicate next node is a
	/// branch or leaf with hash of value, followed by the value node.
	const ESCAPE_HEADER: Option<u8> = None;
    ```

    See https://github.com/paritytech/substrate/discussions/11607#discussioncomment-3102924

Post checks:

- [ ] Review tests using `version.V0` and make them test cases with V1 as well

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./lib/trie/... ./internal/trie/...
```

## Issues

- #2418 

## Primary Reviewer
