### PR TITLE
fix(lib/babe): ensure the slot time is correct before build a block

### DIFF
--- a/lib/babe/epoch_handler.go
+++ b/lib/babe/epoch_handler.go
@@ -91,17 +91,16 @@ func (h *epochHandler) run(ctx context.Context, errCh chan<- error) {
 		}
 
 		startTime := getSlotStartTime(authoringSlot, h.constants.slotDuration)
-
 		waitTime := startTime.Sub(time.Now())
 		timer := time.NewTimer(waitTime)
 
 		slotTimeTimers = append(slotTimeTimers, &slotWithTimer{
 			timer:     timer,
-			startTime: startTime,
 			slotNum:   authoringSlot,
+			startTime: startTime,
 		})
 
-		logger.Debugf("start time of slot %d: %v", authoringSlot, startTime.UnixMilli())
+		logger.Debugf("start time of slot %d: %v", authoringSlot, startTime)
 	}
 
 	defer func() {
@@ -125,9 +124,10 @@ func (h *epochHandler) run(ctx context.Context, errCh chan<- error) {
 			// we must do a time correction as the slot timer sometimes is triggered
 			// before the time defined in the constructor due to an inconsistency
 			// of the language -> https://github.com/golang/go/issues/17696
-			diff := time.Now().Sub(swt.startTime).Nanoseconds()
+
+			diff := time.Since(swt.startTime)
 			if diff < 0 {
-				time.Sleep(-time.Duration(diff))
+				time.Sleep(-diff)
 			}
 
 			if _, has := h.slotToPreRuntimeDigest[swt.slotNum]; !has {


### PR DESCRIPTION
## Changes

- Replace `time.Until` by `startTime.Sub(time.Now())`
- Use `time.Sleep` to correct the time if there is a negative difference between the current time (when the channel is triggered) and the time defined in the slot

## Tests

It is possible to see the time being adjusted after the modifications

![Screen Shot 2022-07-06 at 15 35 38](https://user-images.githubusercontent.com/17255488/177629966-75088932-f51a-4c92-ad49-5f2af0c0e34d.png)

## Issues

- Closes #2634

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@qdm12 
