### PR TITLE
chore(lib/runtime/storage): `NewTrieState` not returning an error

### DIFF
--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -93,10 +93,9 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	if cfg.Runtime == nil {
 		var rtCfg runtime.InstanceConfig
 
-		var err error
-		rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-		require.NoError(t, err)
+		rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
+		var err error
 		rtCfg.CodeHash, err = cfg.StorageState.LoadCodeHash(nil)
 		require.NoError(t, err)
 

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -26,7 +26,6 @@ import (
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/transaction"
-	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/golang/mock/gomock"
@@ -60,8 +59,7 @@ func generateTestValidRemarkTxns(t *testing.T, pubKey []byte, accInfo types.Acco
 	genTrie, err := genesis.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
-	genState, err := rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := rtstorage.NewTrieState(genTrie)
 
 	nodeStorage := runtime.NodeStorage{
 		BaseDB: runtime.NewInMemoryDB(t),
@@ -665,8 +663,7 @@ func TestService_HandleCodeSubstitutes(t *testing.T) {
 
 	s.blockState.StoreRuntime(blockHash, rt)
 
-	ts, err := rtstorage.NewTrieState(trie.NewEmptyTrie())
-	require.NoError(t, err)
+	ts := rtstorage.NewTrieState(nil)
 
 	err = s.handleCodeSubstitution(blockHash, ts, wasmer.NewInstance)
 	require.NoError(t, err)
@@ -694,8 +691,7 @@ func TestService_HandleRuntimeChangesAfterCodeSubstitutes(t *testing.T) {
 		Body: *body,
 	}
 
-	ts, err := rtstorage.NewTrieState(trie.NewEmptyTrie())
-	require.NoError(t, err)
+	ts := rtstorage.NewTrieState(nil)
 
 	err = s.handleCodeSubstitution(blockHash, ts, wasmer.NewInstance)
 	require.NoError(t, err)

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -22,7 +22,6 @@ import (
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/transaction"
-	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	cscale "github.com/centrifuge/go-substrate-rpc-client/v3/scale"
 	"github.com/centrifuge/go-substrate-rpc-client/v3/signature"
@@ -118,9 +117,9 @@ func generateExtrinsic(t *testing.T) (extrinsic, externalExtrinsic types.Extrins
 
 func Test_Service_StorageRoot(t *testing.T) {
 	t.Parallel()
-	emptyTrie := trie.NewEmptyTrie()
-	ts, err := rtstorage.NewTrieState(emptyTrie)
-	require.NoError(t, err)
+
+	ts := rtstorage.NewTrieState(nil)
+
 	tests := []struct {
 		name          string
 		service       *Service
@@ -290,9 +289,7 @@ func Test_Service_handleBlock(t *testing.T) {
 
 	t.Run("storeTrie error", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		testHeader := types.NewEmptyHeader()
 		block := types.NewBlock(*testHeader, *types.NewBody([]types.Extrinsic{[]byte{21}}))
@@ -308,9 +305,7 @@ func Test_Service_handleBlock(t *testing.T) {
 
 	t.Run("addBlock quit error", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		testHeader := types.NewEmptyHeader()
 		block := types.NewBlock(*testHeader, *types.NewBody([]types.Extrinsic{[]byte{21}}))
@@ -331,9 +326,7 @@ func Test_Service_handleBlock(t *testing.T) {
 
 	t.Run("addBlock parent not found error", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		testHeader := types.NewEmptyHeader()
 		block := types.NewBlock(*testHeader, *types.NewBody([]types.Extrinsic{[]byte{21}}))
@@ -354,9 +347,7 @@ func Test_Service_handleBlock(t *testing.T) {
 
 	t.Run("addBlock error continue", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		testHeader := types.NewEmptyHeader()
 		block := types.NewBlock(*testHeader, *types.NewBody([]types.Extrinsic{[]byte{21}}))
@@ -378,9 +369,7 @@ func Test_Service_handleBlock(t *testing.T) {
 
 	t.Run("handle runtime changes error", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		testHeader := types.NewEmptyHeader()
 		block := types.NewBlock(*testHeader, *types.NewBody([]types.Extrinsic{[]byte{21}}))
@@ -405,9 +394,7 @@ func Test_Service_handleBlock(t *testing.T) {
 
 	t.Run("code substitution ok", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		testHeader := types.NewEmptyHeader()
 		block := types.NewBlock(*testHeader, *types.NewBody([]types.Extrinsic{[]byte{21}}))
@@ -448,12 +435,10 @@ func Test_Service_HandleBlockProduced(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
-		emptyTrie := trie.NewEmptyTrie()
-		trieState, err := rtstorage.NewTrieState(emptyTrie)
-		require.NoError(t, err)
+		trieState := rtstorage.NewTrieState(nil)
 
 		digest := types.NewDigest()
-		err = digest.Add(
+		err := digest.Add(
 			types.PreRuntimeDigest{
 				ConsensusEngineID: types.BabeEngineID,
 				Data:              common.MustHexToBytes("0x0201000000ef55a50f00000000"),
@@ -974,9 +959,8 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		[]runtime.APIItem{testAPIItem},
 		transactionVersion,
 	)
-	emptyTrie := trie.NewEmptyTrie()
-	ts, err := rtstorage.NewTrieState(emptyTrie)
-	require.NoError(t, err)
+
+	ts := rtstorage.NewTrieState(nil)
 
 	execTest := func(t *testing.T, s *Service, bhash *common.Hash, exp runtime.Version, expErr error) {
 		res, err := s.GetRuntimeVersion(bhash)

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -415,8 +415,7 @@ func newCoreServiceTest(t *testing.T) *core.Service {
 
 	var rtCfg runtime.InstanceConfig
 
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	rtCfg.CodeHash, err = cfg.StorageState.LoadCodeHash(nil)
 	require.NoError(t, err)

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -363,8 +363,7 @@ func newTestStateService(t *testing.T) *state.Service {
 
 	var rtCfg runtime.InstanceConfig
 
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	if stateSrvc != nil {
 		rtCfg.NodeStorage.BaseDB = stateSrvc.Base

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -22,8 +22,7 @@ func createTestTrieState(t *testing.T) (*trie.Trie, common.Hash) {
 	t.Helper()
 
 	_, genTrie, _ := genesis.NewTestGenesisWithTrieAndHeader(t)
-	tr, err := rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	tr := rtstorage.NewTrieState(genTrie)
 
 	tr.Set([]byte(":first_key"), []byte(":value1"))
 	tr.Set([]byte(":second_key"), []byte(":second_value"))
@@ -33,7 +32,7 @@ func createTestTrieState(t *testing.T) (*trie.Trie, common.Hash) {
 	childTr.Put([]byte(":child_second"), []byte(":child_second_value"))
 	childTr.Put([]byte(":another_child"), []byte("value"))
 
-	err = tr.SetChild([]byte(":child_storage_key"), childTr)
+	err := tr.SetChild([]byte(":child_storage_key"), childTr)
 	require.NoError(t, err)
 
 	stateRoot, err := tr.Root()

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -76,8 +76,7 @@ func newStateServiceWithoutMock(t *testing.T) *state.Service {
 
 	var rtCfg runtime.InstanceConfig
 
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	rtCfg.CodeHash, err = stateSrvc.Storage.LoadCodeHash(nil)
 	require.NoError(t, err)

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -267,8 +267,7 @@ func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 
 	var rtCfg runtime.InstanceConfig
 
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	rtCfg.CodeHash, err = stateSrvc.Storage.LoadCodeHash(nil)
 	require.NoError(t, err)

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -157,10 +157,7 @@ func (s *Service) storeInitialValues(data *genesis.Data, t *trie.Trie) error {
 // CreateGenesisRuntime creates runtime instance form genesis
 func (s *Service) CreateGenesisRuntime(t *trie.Trie, gen *genesis.Genesis) (runtime.Instance, error) {
 	// load genesis state into database
-	genTrie, err := rtstorage.NewTrieState(t)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate TrieState: %w", err)
-	}
+	genTrie := rtstorage.NewTrieState(t)
 
 	// create genesis runtime
 	rtCfg := runtime.InstanceConfig{

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -131,10 +131,7 @@ func (s *StorageState) TrieState(root *common.Hash) (*rtstorage.TrieState, error
 	}
 
 	nextTrie := t.Snapshot()
-	next, err := rtstorage.NewTrieState(nextTrie)
-	if err != nil {
-		return nil, err
-	}
+	next := rtstorage.NewTrieState(nextTrie)
 
 	logger.Tracef("returning trie with root %s to be modified", root)
 	return next, nil

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -45,8 +45,7 @@ func TestStorage_StoreAndLoadTrie(t *testing.T) {
 
 	trie, err := storage.LoadFromDB(root)
 	require.NoError(t, err)
-	ts2, err := runtime.NewTrieState(trie)
-	require.NoError(t, err)
+	ts2 := runtime.NewTrieState(trie)
 	new := ts2.Snapshot()
 	require.Equal(t, ts.Trie(), new)
 }
@@ -200,8 +199,7 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	storage, err := NewStorageState(db, blockState, tries, pruner.Config{})
 	require.NoError(t, err)
 
-	trieState, err := runtime.NewTrieState(genTrie)
-	require.NoError(t, err)
+	trieState := runtime.NewTrieState(genTrie)
 
 	header, err := types.NewHeader(blockState.GenesisHash(), trieState.MustRoot(),
 		common.Hash{}, 1, types.NewDigest())

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 //go:generate mockgen -destination=mock_instance_test.go -package=$GOPACKAGE github.com/ChainSafe/gossamer/lib/runtime Instance
@@ -68,7 +67,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				}, nil)
 				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(nil, mockError)
 				chainProcessor.blockState = mockBlockState
-				trieState := newTrieState(t)
+				trieState := storage.NewTrieState(nil)
 				mockStorageState := NewMockStorageState(ctrl)
 				mockStorageState.EXPECT().Lock()
 				mockStorageState.EXPECT().TrieState(&testHash).Return(trieState, nil)
@@ -83,7 +82,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 		},
 		"handle runtime ExecuteBlock error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				trieState := newTrieState(t)
+				trieState := storage.NewTrieState(nil)
 				mockBlockState := NewMockBlockState(ctrl)
 				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
 					StateRoot: testHash,
@@ -107,7 +106,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 		},
 		"handle block import error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				trieState := newTrieState(t)
+				trieState := storage.NewTrieState(nil)
 				mockBlockState := NewMockBlockState(ctrl)
 				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
 					StateRoot: testHash,
@@ -138,7 +137,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockBlock := &types.Block{
 					Body: types.Body{}, // empty slice of extrinsics
 				}
-				trieState := newTrieState(t)
+				trieState := storage.NewTrieState(nil)
 				mockBlockState := NewMockBlockState(ctrl)
 				mockHeader := &types.Header{
 					Number:    0,
@@ -194,7 +193,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 		blockState := NewMockBlockState(ctrl)
 		blockState.EXPECT().GetHeader(common.Hash{1}).
 			Return(&types.Header{StateRoot: common.Hash{2}}, nil)
-		trieState := newTrieState(t)
+		trieState := storage.NewTrieState(nil)
 		storageState := NewMockStorageState(ctrl)
 		lockCall := storageState.EXPECT().Lock()
 		trieStateCall := storageState.EXPECT().TrieState(&common.Hash{2}).
@@ -209,13 +208,6 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 			_ = chainProcessor.handleBlock(bock)
 		})
 	})
-}
-
-func newTrieState(t *testing.T) *storage.TrieState {
-	t.Helper()
-	trieState, err := storage.NewTrieState(nil)
-	require.NoError(t, err)
-	return trieState
 }
 
 func Test_chainProcessor_handleBody(t *testing.T) {
@@ -574,7 +566,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 		},
 		"handle block import": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockTrieState := newTrieState(t)
+				mockTrieState := storage.NewTrieState(nil)
 				mockBlockState := NewMockBlockState(ctrl)
 				mockBlockState.EXPECT().HasHeader(common.Hash{1, 2, 3}).Return(true, nil)
 				mockBlockState.EXPECT().HasBlockBody(common.Hash{1, 2, 3}).Return(true, nil)
@@ -614,7 +606,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 		"handle header": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				stateRootHash := common.MustHexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-				mockTrieState := newTrieState(t)
+				mockTrieState := storage.NewTrieState(nil)
 				runtimeHash := common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a")
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(mockTrieState)
@@ -659,7 +651,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				stateRootHash := common.MustHexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
 				runtimeHash := common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a")
-				mockTrieState, _ := storage.NewTrieState(nil)
+				mockTrieState := storage.NewTrieState(nil)
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(mockTrieState)
 				mockInstance.EXPECT().ExecuteBlock(&types.Block{Header: types.Header{}, Body: types.Body{}})

--- a/dot/sync/syncer_integration_test.go
+++ b/dot/sync/syncer_integration_test.go
@@ -70,8 +70,7 @@ func newTestSyncer(t *testing.T) *Service {
 	}
 
 	// initialise runtime
-	genState, err := rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := rtstorage.NewTrieState(genTrie)
 
 	rtCfg := runtime.InstanceConfig{
 		Storage: genState,

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -125,8 +125,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 	}
 
 	var rtCfg runtime.InstanceConfig
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	storageState := cfg.StorageState.(core.StorageState)
 	rtCfg.CodeHash, err = storageState.LoadCodeHash(nil)
@@ -178,9 +177,10 @@ func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *
 		_ = dbSrv.Stop()
 	})
 
-	var rtCfg runtime.InstanceConfig
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg := runtime.InstanceConfig{
+		Storage: rtstorage.NewTrieState(genTrie),
+	}
+
 	rt, err := wasmer.NewRuntimeFromGenesis(rtCfg)
 	require.NoError(t, err)
 

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -59,8 +59,7 @@ func newTestState(t *testing.T) *state.Service {
 
 	var rtCfg runtime.InstanceConfig
 
-	rtCfg.Storage, err = rtstorage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	rt, err := wasmer.NewRuntimeFromGenesis(rtCfg)
 	require.NoError(t, err)

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -21,16 +21,14 @@ type TrieState struct {
 }
 
 // NewTrieState returns a new TrieState with the given trie
-func NewTrieState(t *trie.Trie) (*TrieState, error) {
+func NewTrieState(t *trie.Trie) *TrieState {
 	if t == nil {
 		t = trie.NewEmptyTrie()
 	}
 
-	ts := &TrieState{
+	return &TrieState{
 		t: t,
 	}
-
-	return ts, nil
 }
 
 // Trie returns the TrieState's underlying trie

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -15,13 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestTrieState returns an initialised TrieState
-func newTestTrieState(t *testing.T) *TrieState {
-	ts, err := NewTrieState(nil)
-	require.NoError(t, err)
-	return ts
-}
-
 var testCases = []string{
 	"asdf",
 	"ghjk",
@@ -43,7 +36,7 @@ func TestTrieState_SetGet(t *testing.T) {
 		}
 	}
 
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 	testFunc(ts)
 }
 
@@ -58,7 +51,7 @@ func TestTrieState_Delete(t *testing.T) {
 		require.False(t, has)
 	}
 
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 	testFunc(ts)
 }
 
@@ -72,12 +65,12 @@ func TestTrieState_Root(t *testing.T) {
 		require.Equal(t, expected, ts.MustRoot())
 	}
 
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 	testFunc(ts)
 }
 
 func TestTrieState_ClearPrefix(t *testing.T) {
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	keys := []string{
 		"noot",
@@ -102,7 +95,7 @@ func TestTrieState_ClearPrefix(t *testing.T) {
 }
 
 func TestTrieState_ClearPrefixInChild(t *testing.T) {
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 	child := trie.NewEmptyTrie()
 
 	keys := []string{
@@ -135,7 +128,7 @@ func TestTrieState_ClearPrefixInChild(t *testing.T) {
 }
 
 func TestTrieState_NextKey(t *testing.T) {
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	for _, tc := range testCases {
 		ts.Set([]byte(tc), []byte(tc))
@@ -156,7 +149,7 @@ func TestTrieState_NextKey(t *testing.T) {
 }
 
 func TestTrieState_CommitStorageTransaction(t *testing.T) {
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	for _, tc := range testCases {
 		ts.Set([]byte(tc), []byte(tc))
@@ -172,7 +165,7 @@ func TestTrieState_CommitStorageTransaction(t *testing.T) {
 }
 
 func TestTrieState_RollbackStorageTransaction(t *testing.T) {
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	for _, tc := range testCases {
 		ts.Set([]byte(tc), []byte(tc))
@@ -188,7 +181,7 @@ func TestTrieState_RollbackStorageTransaction(t *testing.T) {
 }
 
 func TestTrieState_DeleteChildLimit(t *testing.T) {
-	ts := newTestTrieState(t)
+	ts := &TrieState{t: trie.NewEmptyTrie()}
 	child := trie.NewEmptyTrie()
 
 	keys := []string{

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -173,8 +173,7 @@ func TestInstance_Version_KusamaRuntime(t *testing.T) {
 	require.Equal(t, expectedGenesisRoot, genTrie.MustHash())
 
 	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := storage.NewTrieState(genTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: genState,
@@ -296,8 +295,7 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := storage.NewTrieState(genTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: genState,
@@ -509,12 +507,11 @@ func TestInstance_ExecuteBlock_NodeRuntime(t *testing.T) {
 	block := runtime.InitializeRuntimeToTest(t, instance, common.Hash{})
 
 	// reset state back to parent state before executing
-	parentState, err := storage.NewTrieState(nil)
-	require.NoError(t, err)
+	parentState := storage.NewTrieState(nil)
 	instance.SetContextStorage(parentState)
 
 	block.Header.Digest = types.NewDigest()
-	_, err = instance.ExecuteBlock(block)
+	_, err := instance.ExecuteBlock(block)
 	require.NoError(t, err)
 }
 
@@ -528,8 +525,7 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 	require.NoError(t, err)
 
 	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := storage.NewTrieState(genTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: genState,
@@ -542,8 +538,7 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 	block := runtime.InitializeRuntimeToTest(t, instance, common.Hash{})
 
 	// reset state back to parent state before executing
-	parentState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	parentState := storage.NewTrieState(genTrie)
 	instance.SetContextStorage(parentState)
 
 	_, err = instance.ExecuteBlock(block)
@@ -560,8 +555,7 @@ func TestInstance_ApplyExtrinsic_GossamerRuntime(t *testing.T) {
 	require.NoError(t, err)
 
 	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := storage.NewTrieState(genTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: genState,
@@ -572,8 +566,7 @@ func TestInstance_ApplyExtrinsic_GossamerRuntime(t *testing.T) {
 	require.NoError(t, err)
 
 	// reset state back to parent state before executing
-	parentState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	parentState := storage.NewTrieState(genTrie)
 	instance.SetContextStorage(parentState)
 
 	parentHash := common.Hash{}
@@ -602,12 +595,11 @@ func TestInstance_ExecuteBlock_PolkadotRuntime(t *testing.T) {
 	block := runtime.InitializeRuntimeToTest(t, instance, common.Hash{})
 
 	// reset state back to parent state before executing
-	parentState, err := storage.NewTrieState(nil)
-	require.NoError(t, err)
+	parentState := storage.NewTrieState(nil)
 	instance.SetContextStorage(parentState)
 
 	block.Header.Digest = types.NewDigest()
-	_, err = instance.ExecuteBlock(block)
+	_, err := instance.ExecuteBlock(block)
 	require.NoError(t, err)
 }
 
@@ -623,8 +615,7 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 	require.Equal(t, expectedGenesisRoot, genTrie.MustHash())
 
 	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := storage.NewTrieState(genTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: genState,
@@ -676,8 +667,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 	require.Equal(t, expectedGenesisRoot, genTrie.MustHash())
 
 	// set state to genesis state
-	genState, err := storage.NewTrieState(genTrie)
-	require.NoError(t, err)
+	genState := storage.NewTrieState(genTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: genState,
@@ -723,8 +713,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock3784(t *testing.T) {
 	require.Equal(t, expectedRoot, gossTrie3783.MustHash())
 
 	// set state to genesis state
-	state3783, err := storage.NewTrieState(gossTrie3783)
-	require.NoError(t, err)
+	state3783 := storage.NewTrieState(gossTrie3783)
 
 	cfg := runtime.InstanceConfig{
 		Storage: state3783,
@@ -770,8 +759,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442(t *testing.T) {
 	require.Equal(t, expectedRoot, ksmTrie901441.MustHash())
 
 	// set state to genesis state
-	state901441, err := storage.NewTrieState(ksmTrie901441)
-	require.NoError(t, err)
+	state901441 := storage.NewTrieState(ksmTrie901441)
 
 	cfg := runtime.InstanceConfig{
 		Storage: state901441,
@@ -817,8 +805,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1377831(t *testing.T) {
 	require.Equal(t, expectedRoot, ksmTrie.MustHash())
 
 	// set state to genesis state
-	state, err := storage.NewTrieState(ksmTrie)
-	require.NoError(t, err)
+	state := storage.NewTrieState(ksmTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: state,
@@ -864,8 +851,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1482003(t *testing.T) {
 	require.Equal(t, expectedRoot, ksmTrie.MustHash())
 
 	// set state to genesis state
-	state, err := storage.NewTrieState(ksmTrie)
-	require.NoError(t, err)
+	state := storage.NewTrieState(ksmTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: state,
@@ -913,8 +899,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock4939774(t *testing.T) {
 	require.Equal(t, expectedRoot, ksmTrie.MustHash())
 
 	// set state to genesis state
-	state, err := storage.NewTrieState(ksmTrie)
-	require.NoError(t, err)
+	state := storage.NewTrieState(ksmTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: state,
@@ -957,8 +942,7 @@ func TestInstance_ExecuteBlock_PolkadotBlock1089328(t *testing.T) {
 	require.Equal(t, expectedRoot, dotTrie.MustHash())
 
 	// set state to genesis state
-	state, err := storage.NewTrieState(dotTrie)
-	require.NoError(t, err)
+	state := storage.NewTrieState(dotTrie)
 
 	cfg := runtime.InstanceConfig{
 		Storage: state,

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -941,10 +941,9 @@ func ext_misc_runtime_version_version_1(context unsafe.Pointer, dataSpan C.int64
 	instanceContext := wasm.IntoInstanceContext(context)
 	data := asMemorySlice(instanceContext, dataSpan)
 
-	trieState, _ := rtstorage.NewTrieState(nil)
 	cfg := runtime.InstanceConfig{
 		LogLvl:  log.DoNotChange,
-		Storage: trieState,
+		Storage: rtstorage.NewTrieState(nil),
 	}
 
 	instance, err := NewInstance(data, cfg)

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -44,8 +44,7 @@ func NewTestInstanceWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie) 
 func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role byte) runtime.InstanceConfig {
 	t.Helper()
 
-	s, err := storage.NewTrieState(tt)
-	require.NoError(t, err)
+	s := storage.NewTrieState(tt)
 
 	ns := runtime.NodeStorage{
 		LocalStorage:      runtime.NewInMemoryDB(t),


### PR DESCRIPTION
## Changes

- Remove unneeded `newTestTrieState` helpers
- Remove several test no error assertions
- Remove some error checks for this function returns

## Tests

## Issues

Quick refactored whilst versioning the state trie all over the place

## Primary Reviewer

@edwardmack 