### PR TITLE
chore(lib/trie): split fuzz testing of the trie

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,4 +36,4 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod
 
       - name: Fuzz trie
-        run: go test -run Fuzz_Trie_PutAndGet -fuzz=Fuzz_Trie_PutAndGet -fuzztime=5m github.com/ChainSafe/gossamer/lib/trie
+        run: go test -run Fuzz_Trie_PutAndGet_Single -fuzz=Fuzz_Trie_PutAndGet_Single -fuzztime=5m github.com/ChainSafe/gossamer/lib/trie

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -63,7 +63,7 @@ func populateKeyValueMap(tb testing.TB, kv map[string][]byte,
 			continue
 		}
 
-		const minValueSize = 2
+		const minValueSize = 0
 		value := generateRandBytesMinMax(tb, minValueSize, maxValueSize, generator)
 
 		kv[keyString] = value

--- a/lib/trie/helpers_test.go
+++ b/lib/trie/helpers_test.go
@@ -64,7 +64,7 @@ func populateKeyValueMap(tb testing.TB, kv map[string][]byte,
 			continue
 		}
 
-		const minValueSize = 2
+		const minValueSize = 0
 		value := generateRandBytesMinMax(tb, minValueSize, maxValueSize, generator)
 
 		kv[keyString] = value

--- a/lib/trie/helpers_test.go
+++ b/lib/trie/helpers_test.go
@@ -64,7 +64,7 @@ func populateKeyValueMap(tb testing.TB, kv map[string][]byte,
 			continue
 		}
 
-		const minValueSize = 0
+		const minValueSize = 1 // not 0 otherwise it mixes empty and nil byte slices
 		value := generateRandBytesMinMax(tb, minValueSize, maxValueSize, generator)
 
 		kv[keyString] = value

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -101,17 +101,37 @@ func TestPutAndGetOddKeyLengths(t *testing.T) {
 	runTests(t, trie, tests)
 }
 
-func Fuzz_Trie_PutAndGet(f *testing.F) {
-	trie := NewEmptyTrie()
-	var trieMutex sync.Mutex
-
+func Fuzz_Trie_PutAndGet_Single(f *testing.F) {
 	f.Fuzz(func(t *testing.T, key, value []byte) {
-		trieMutex.Lock()
+		trie := NewEmptyTrie()
 		trie.Put(key, value)
 		retrievedValue := trie.Get(key)
-		trieMutex.Unlock()
 		assert.Equal(t, retrievedValue, value)
 	})
+}
+
+func Test_Trie_PutAndGet_Multiple(t *testing.T) {
+	trie := NewEmptyTrie()
+
+	const numberOfKeyValuePairs = 10000
+
+	generator := newGenerator()
+	keyValues := generateKeyValues(t, generator, numberOfKeyValuePairs)
+	for keyString, value := range keyValues {
+		key := []byte(keyString)
+		trie.Put(key, value)
+
+		// Check value is inserted correctly.
+		retrievedValue := trie.Get(key)
+		assert.Equal(t, retrievedValue, value)
+	}
+
+	// Check values were not mismoved in the trie.
+	for keyString, value := range keyValues {
+		key := []byte(keyString)
+		retrievedValue := trie.Get(key)
+		assert.Equal(t, retrievedValue, value)
+	}
 }
 
 func TestGetPartialKey(t *testing.T) {

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -113,7 +113,7 @@ func Fuzz_Trie_PutAndGet_Single(f *testing.F) {
 func Test_Trie_PutAndGet_Multiple(t *testing.T) {
 	trie := NewEmptyTrie()
 
-	const numberOfKeyValuePairs = 10000
+	const numberOfKeyValuePairs = 60000
 
 	generator := newGenerator()
 	keyValues := generateKeyValues(t, generator, numberOfKeyValuePairs)

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -123,14 +123,16 @@ func Test_Trie_PutAndGet_Multiple(t *testing.T) {
 
 		// Check value is inserted correctly.
 		retrievedValue := trie.Get(key)
-		assert.Equal(t, retrievedValue, value)
+		require.Equalf(t, retrievedValue, value,
+			"for key (nibbles) 0x%x", codec.KeyLEToNibbles(key))
 	}
 
 	// Check values were not mismoved in the trie.
 	for keyString, value := range keyValues {
 		key := []byte(keyString)
 		retrievedValue := trie.Get(key)
-		assert.Equal(t, retrievedValue, value)
+		require.Equalf(t, retrievedValue, value,
+			"for key (nibbles) 0x%x", codec.KeyLEToNibbles(key))
 	}
 }
 


### PR DESCRIPTION
## Changes

- Change trie put/get fuzz test to create a new trie per fuzz run, instead of using the same trie (to avoid OOM)
- Add unit test to test put/get with the same trie and 60000 key value pairs

## Tests

```sh
go test -fuzz=Fuzz_Trie_PutAndGet_Single -fuzztime=1m github.com/ChainSafe/gossamer/lib/trie
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

@EclesioMeloJunior 