### PR TITLE
If the direction in block request is descending, prune blocks from start.

### DIFF
--- a/dot/sync/message.go
+++ b/dot/sync/message.go
@@ -338,8 +338,14 @@ func (s *Service) handleChainByHash(ancestor, descendant common.Hash,
 		return nil, err
 	}
 
+	// If the direction is descending, prune from the start.
+	// if the direction is ascending it should prune from the end.
 	if uint(len(subchain)) > max {
-		subchain = subchain[:max]
+		if direction == network.Ascending {
+			subchain = subchain[:max]
+		} else {
+			subchain = subchain[uint(len(subchain))-max:]
+		}
 	}
 
 	data := make([]*types.BlockData, len(subchain))


### PR DESCRIPTION


## Changes
A block request contain start block, end block, direction and max size.
It could be the case that block between start and end are less than max
size. In such cases, so far we were pruning block from the end while
preparing a block response.

The correct way however would be to prune from the start, if the direction
is descending and prune from the end if the direction is ascending.

Since, we were pruning blocks the wrong way, we were preparing a
response which substrate was not expecting. And that used to result in
substrate dropping us.

This commit fixes that issue.

<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
Fixes #2595


## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
