### PR TITLE
chore(ci): limit `TestSync_Basic` to 1 minute

### DIFF
--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -138,6 +138,8 @@ func TestSync_Basic(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	nodes.InitAndStartTest(ctx, t, cancel)
+	ctx, cancel = context.WithTimeout(ctx, time.Minute)
+	defer cancel()
 
 	const getChainHeadTimeout = time.Second
 


### PR DESCRIPTION
## Changes

Otherwise it sometimes hangs forever retrying (i.e. when a node simply won't sync).
In that case, the test should just fail and move to the next one.

Quick-fix added after seeing https://github.com/ChainSafe/gossamer/runs/7281642432?check_suite_focus=true#step:3:32

## Tests

```sh
go test -run ^TestSync_Basic$ github.com/ChainSafe/gossamer/tests/stress
```

## Issues

## Primary Reviewer

@timwu20