### PR TITLE
fix(internal/log): fix log level `DoNotChange`

### DIFF
--- a/internal/log/options.go
+++ b/internal/log/options.go
@@ -15,6 +15,9 @@ type Option func(s *settings)
 // The level defaults to the lowest level, trce.
 func SetLevel(level Level) Option {
 	return func(s *settings) {
+		if level == DoNotChange {
+			return
+		}
 		s.level = &level
 	}
 }


### PR DESCRIPTION
## Changes

- No longer logs at trace level when replacing runtime

## Tests

## Issues

## Primary Reviewer

@timwu20 