### PR TITLE
fix(tests): fix block body regex in `TestChainRPC`

### DIFF
--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -102,7 +102,7 @@ func TestChainRPC(t *testing.T) {
 	}
 	block.Block.Header.Digest.Logs = nil
 	assert.Len(t, block.Block.Body, 1)
-	const bodyRegex = `^0x280403000b[0-9a-z]{8}8101$`
+	const bodyRegex = `^0x280403000b[0-9a-z]{8}8201$`
 	assert.Regexp(t, bodyRegex, block.Block.Body[0])
 	block.Block.Body = nil
 


### PR DESCRIPTION
## Changes

`TestChainRPC` broke on our development branch.

```
Expect "0x280403000bbbb895028201" to match "^0x280403000b[0-9a-z]{8}8101$"
```

I wrote that regex, and it was consistently ending with 8101, now it's 8201 out of the blue.
This PR updates the regex to use `8201` instead.
But ideally, someone can point why this changed? 🤔 

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
MODE=rpc go test -run ^TestChainRPC$ github.com/ChainSafe/gossamer/tests/rpc
```

## Issues

## Primary Reviewer

@timwu20
