### PR TITLE
Added checks to avoid decoding handshakes as messages

### DIFF
--- a/dot/network/block_announce.go
+++ b/dot/network/block_announce.go
@@ -18,6 +18,8 @@ import (
 var (
 	_ NotificationsMessage = &BlockAnnounceMessage{}
 	_ NotificationsMessage = &BlockAnnounceHandshake{}
+
+	errExpectedBlockAnnounceMsg = errors.New("found block announce handshake instead of message")
 )
 
 // BlockAnnounceMessage is a state block header
@@ -223,6 +225,10 @@ func (s *Service) validateBlockAnnounceHandshake(from peer.ID, hs Handshake) err
 // if some more blocks are required to sync the announced block, the node will open a sync stream
 // with its peer and send a BlockRequest message
 func (s *Service) handleBlockAnnounceMessage(from peer.ID, msg NotificationsMessage) (propagate bool, err error) {
+	if msg.IsHandshake() {
+		return false, errExpectedBlockAnnounceMsg
+	}
+
 	bam, ok := msg.(*BlockAnnounceMessage)
 	if !ok {
 		return false, errors.New("invalid message")

--- a/dot/network/transaction.go
+++ b/dot/network/transaction.go
@@ -18,6 +18,8 @@ import (
 var (
 	_ NotificationsMessage = &TransactionMessage{}
 	_ NotificationsMessage = &transactionHandshake{}
+
+	errExpectedTransactionMsg = errors.New("found transaction handshake instead of message")
 )
 
 // txnBatchChTimeout is the timeout for adding a transaction to the batch processing channel
@@ -191,6 +193,10 @@ func decodeTransactionMessage(in []byte) (NotificationsMessage, error) {
 }
 
 func (s *Service) handleTransactionMessage(peerID peer.ID, msg NotificationsMessage) (bool, error) {
+	if msg.IsHandshake() {
+		return false, errExpectedTransactionMsg
+	}
+
 	txMsg, ok := msg.(*TransactionMessage)
 	if !ok {
 		return false, errors.New("invalid transaction type")


### PR DESCRIPTION
## Changes

These changes  would show the appropriate error messages instead of genesis mismatch and also avoid banning the other peer.

<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
#2636
## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
