### PR TITLE
chore(lib/runtime): `CheckRuntimeVersion` independent from existing runtime instance

### DIFF
--- a/dot/core/mocks_runtime_test.go
+++ b/dot/core/mocks_runtime_test.go
@@ -80,21 +80,6 @@ func (mr *MockInstanceMockRecorder) CheckInherents() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckInherents", reflect.TypeOf((*MockInstance)(nil).CheckInherents))
 }
 
-// CheckRuntimeVersion mocks base method.
-func (m *MockInstance) CheckRuntimeVersion(arg0 []byte) (runtime.Version, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRuntimeVersion", arg0)
-	ret0, _ := ret[0].(runtime.Version)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CheckRuntimeVersion indicates an expected call of CheckRuntimeVersion.
-func (mr *MockInstanceMockRecorder) CheckRuntimeVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRuntimeVersion", reflect.TypeOf((*MockInstance)(nil).CheckRuntimeVersion), arg0)
-}
-
 // DecodeSessionKeys mocks base method.
 func (m *MockInstance) DecodeSessionKeys(arg0 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -351,12 +351,11 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 	expectedInitialResponse.Method = "state_runtimeVersion"
 	expectedInitialResponse.Params.Result = expectedInitialVersion
 
-	instance := wasmer.NewTestInstance(t, runtime.NODE_RUNTIME)
 	polkadotRuntimeFilepath, err := runtime.GetRuntime(context.Background(), runtime.POLKADOT_RUNTIME)
 	require.NoError(t, err)
 	code, err := os.ReadFile(polkadotRuntimeFilepath)
 	require.NoError(t, err)
-	version, err := instance.CheckRuntimeVersion(code)
+	version, err := wasmer.CheckRuntimeVersion(code)
 	require.NoError(t, err)
 
 	expectedUpdatedVersion := modules.StateRuntimeVersionResponse{

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -355,7 +355,7 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 	require.NoError(t, err)
 	code, err := os.ReadFile(polkadotRuntimeFilepath)
 	require.NoError(t, err)
-	version, err := wasmer.CheckRuntimeVersion(code)
+	version, err := wasmer.GetRuntimeVersion(code)
 	require.NoError(t, err)
 
 	expectedUpdatedVersion := modules.StateRuntimeVersionResponse{

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -591,7 +591,7 @@ func (bs *BlockState) HandleRuntimeChanges(newState *rtstorage.TrieState,
 	codeSubBlockHash := bs.baseState.LoadCodeSubstitutedBlockHash()
 
 	if !codeSubBlockHash.Equal(common.Hash{}) {
-		newVersion, err := rt.CheckRuntimeVersion(code)
+		newVersion, err := wasmer.CheckRuntimeVersion(code)
 		if err != nil {
 			return err
 		}

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -591,7 +591,7 @@ func (bs *BlockState) HandleRuntimeChanges(newState *rtstorage.TrieState,
 	codeSubBlockHash := bs.baseState.LoadCodeSubstitutedBlockHash()
 
 	if !codeSubBlockHash.Equal(common.Hash{}) {
-		newVersion, err := wasmer.CheckRuntimeVersion(code)
+		newVersion, err := wasmer.GetRuntimeVersion(code)
 		if err != nil {
 			return err
 		}

--- a/dot/sync/mock_instance_test.go
+++ b/dot/sync/mock_instance_test.go
@@ -80,21 +80,6 @@ func (mr *MockInstanceMockRecorder) CheckInherents() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckInherents", reflect.TypeOf((*MockInstance)(nil).CheckInherents))
 }
 
-// CheckRuntimeVersion mocks base method.
-func (m *MockInstance) CheckRuntimeVersion(arg0 []byte) (runtime.Version, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRuntimeVersion", arg0)
-	ret0, _ := ret[0].(runtime.Version)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CheckRuntimeVersion indicates an expected call of CheckRuntimeVersion.
-func (mr *MockInstanceMockRecorder) CheckRuntimeVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRuntimeVersion", reflect.TypeOf((*MockInstance)(nil).CheckRuntimeVersion), arg0)
-}
-
 // DecodeSessionKeys mocks base method.
 func (m *MockInstance) DecodeSessionKeys(arg0 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/lib/blocktree/mock_instance_test.go
+++ b/lib/blocktree/mock_instance_test.go
@@ -80,21 +80,6 @@ func (mr *MockInstanceMockRecorder) CheckInherents() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckInherents", reflect.TypeOf((*MockInstance)(nil).CheckInherents))
 }
 
-// CheckRuntimeVersion mocks base method.
-func (m *MockInstance) CheckRuntimeVersion(arg0 []byte) (runtime.Version, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRuntimeVersion", arg0)
-	ret0, _ := ret[0].(runtime.Version)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CheckRuntimeVersion indicates an expected call of CheckRuntimeVersion.
-func (mr *MockInstanceMockRecorder) CheckRuntimeVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRuntimeVersion", reflect.TypeOf((*MockInstance)(nil).CheckRuntimeVersion), arg0)
-}
-
 // DecodeSessionKeys mocks base method.
 func (m *MockInstance) DecodeSessionKeys(arg0 []byte) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -16,7 +16,6 @@ import (
 // Instance is the interface a v0.8 runtime instance must implement
 type Instance interface {
 	UpdateRuntimeCode([]byte) error
-	CheckRuntimeVersion([]byte) (Version, error)
 	Stop()
 	NodeStorage() NodeStorage
 	NetworkService() BasicNetwork

--- a/lib/runtime/mocks/instance.go
+++ b/lib/runtime/mocks/instance.go
@@ -71,29 +71,6 @@ func (_m *Instance) CheckInherents() {
 	_m.Called()
 }
 
-// CheckRuntimeVersion provides a mock function with given fields: _a0
-func (_m *Instance) CheckRuntimeVersion(_a0 []byte) (runtime.Version, error) {
-	ret := _m.Called(_a0)
-
-	var r0 runtime.Version
-	if rf, ok := ret.Get(0).(func([]byte) runtime.Version); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(runtime.Version)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func([]byte) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // DecodeSessionKeys provides a mock function with given fields: enc
 func (_m *Instance) DecodeSessionKeys(enc []byte) ([]byte, error) {
 	ret := _m.Called(enc)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -944,7 +944,7 @@ func ext_misc_runtime_version_version_1(context unsafe.Pointer, dataSpan C.int64
 	instanceContext := wasm.IntoInstanceContext(context)
 	code := asMemorySlice(instanceContext, dataSpan)
 
-	version, err := CheckRuntimeVersion(code)
+	version, err := GetRuntimeVersion(code)
 	if err != nil {
 		logger.Errorf("failed to get runtime version: %s", err)
 		out, _ := toWasmMemoryOptional(instanceContext, nil)

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -110,7 +110,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	rtype "github.com/ChainSafe/gossamer/lib/common/types"
 	"github.com/ChainSafe/gossamer/lib/crypto"
@@ -118,7 +117,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/secp256k1"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/runtime"
-	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/transaction"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/lib/trie/proof"
@@ -944,20 +942,9 @@ func ext_misc_runtime_version_version_1(context unsafe.Pointer, dataSpan C.int64
 	logger.Trace("executing...")
 
 	instanceContext := wasm.IntoInstanceContext(context)
-	data := asMemorySlice(instanceContext, dataSpan)
+	code := asMemorySlice(instanceContext, dataSpan)
 
-	cfg := runtime.InstanceConfig{
-		LogLvl:  log.DoNotChange,
-		Storage: rtstorage.NewTrieState(nil),
-	}
-
-	instance, err := NewInstance(data, cfg)
-	if err != nil {
-		logger.Errorf("failed to create instance: %s", err)
-		return 0
-	}
-
-	version, err := instance.Version()
+	version, err := CheckRuntimeVersion(code)
 	if err != nil {
 		logger.Errorf("failed to get runtime version: %s", err)
 		out, _ := toWasmMemoryOptional(instanceContext, nil)

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -156,9 +156,9 @@ func (in *Instance) UpdateRuntimeCode(code []byte) (err error) {
 	return nil
 }
 
-// CheckRuntimeVersion finds the runtime version by initiating a temporary
+// GetRuntimeVersion finds the runtime version by initiating a temporary
 // runtime instance using the WASM code provided, and querying it.
-func CheckRuntimeVersion(code []byte) (version runtime.Version, err error) {
+func GetRuntimeVersion(code []byte) (version runtime.Version, err error) {
 	config := runtime.InstanceConfig{
 		LogLvl: log.DoNotChange,
 	}

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -159,21 +159,14 @@ func (in *Instance) UpdateRuntimeCode(code []byte) (err error) {
 // CheckRuntimeVersion finds the runtime version by initiating a temporary
 // runtime instance using the WASM code provided, and querying it.
 func CheckRuntimeVersion(code []byte) (version runtime.Version, err error) {
-	wasmInstance, allocator, err := setupVM(code)
+	config := runtime.InstanceConfig{
+		LogLvl: log.DoNotChange,
+	}
+	instance, err := NewInstance(code, config)
 	if err != nil {
-		return nil, fmt.Errorf("setting up VM: %w", err)
+		return version, fmt.Errorf("creating runtime instance: %w", err)
 	}
-
-	ctx := &runtime.Context{
-		Allocator: allocator,
-	}
-	wasmInstance.SetContextData(ctx)
-
-	instance := Instance{
-		vm:  wasmInstance,
-		ctx: ctx,
-	}
-	defer instance.close()
+	defer instance.Stop()
 
 	version, err = instance.Version()
 	if err != nil {

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -64,6 +64,18 @@ func Test_CheckRuntimeVersion(t *testing.T) {
 	require.Equal(t, expected.TransactionVersion(), version.TransactionVersion())
 }
 
+func Benchmark_CheckRuntimeVersion(b *testing.B) {
+	polkadotRuntimeFilepath, err := runtime.GetRuntime(
+		context.Background(), runtime.POLKADOT_RUNTIME)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		code, _ := os.ReadFile(polkadotRuntimeFilepath)
+		_, _ = CheckRuntimeVersion(code)
+	}
+}
+
 func TestDecompressWasm(t *testing.T) {
 	encoder, err := zstd.NewWriter(nil)
 	require.NoError(t, err)

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -36,14 +36,13 @@ func TestPointerSize(t *testing.T) {
 	require.Equal(t, in, res)
 }
 
-func TestInstance_CheckRuntimeVersion(t *testing.T) {
-	instance := NewTestInstance(t, runtime.NODE_RUNTIME)
+func Test_CheckRuntimeVersion(t *testing.T) {
 	polkadotRuntimeFilepath, err := runtime.GetRuntime(
 		context.Background(), runtime.POLKADOT_RUNTIME)
 	require.NoError(t, err)
 	code, err := os.ReadFile(polkadotRuntimeFilepath)
 	require.NoError(t, err)
-	version, err := instance.CheckRuntimeVersion(code)
+	version, err := CheckRuntimeVersion(code)
 	require.NoError(t, err)
 
 	expected := runtime.NewVersionData(

--- a/lib/runtime/wasmer/instance_test.go
+++ b/lib/runtime/wasmer/instance_test.go
@@ -36,13 +36,13 @@ func TestPointerSize(t *testing.T) {
 	require.Equal(t, in, res)
 }
 
-func Test_CheckRuntimeVersion(t *testing.T) {
+func Test_GetRuntimeVersion(t *testing.T) {
 	polkadotRuntimeFilepath, err := runtime.GetRuntime(
 		context.Background(), runtime.POLKADOT_RUNTIME)
 	require.NoError(t, err)
 	code, err := os.ReadFile(polkadotRuntimeFilepath)
 	require.NoError(t, err)
-	version, err := CheckRuntimeVersion(code)
+	version, err := GetRuntimeVersion(code)
 	require.NoError(t, err)
 
 	expected := runtime.NewVersionData(
@@ -64,7 +64,7 @@ func Test_CheckRuntimeVersion(t *testing.T) {
 	require.Equal(t, expected.TransactionVersion(), version.TransactionVersion())
 }
 
-func Benchmark_CheckRuntimeVersion(b *testing.B) {
+func Benchmark_GetRuntimeVersion(b *testing.B) {
 	polkadotRuntimeFilepath, err := runtime.GetRuntime(
 		context.Background(), runtime.POLKADOT_RUNTIME)
 	require.NoError(b, err)
@@ -72,7 +72,7 @@ func Benchmark_CheckRuntimeVersion(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		code, _ := os.ReadFile(polkadotRuntimeFilepath)
-		_, _ = CheckRuntimeVersion(code)
+		_, _ = GetRuntimeVersion(code)
 	}
 }
 


### PR DESCRIPTION
## Changes

Blocked by #2686 and #2685

- `CheckRuntimeVersion` as function instead of instance method
  - No dependency on existing instance
  - Fix: do not modify parent instance allocator
  - Fix: close temporary instance on exit
  - Remove `CheckRuntimeVersion` from Instance interface
- `ext_misc_runtime_version_version_1` uses `CheckRuntimeVersion`

## Tests

## Issues

#2418 

## Primary Reviewer

@timwu20
