### PR TITLE
chore(ci): disable Codecov patch status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   range: "60...80"
   status:
+    patch: off
     project:
       default:
         target: 60%


### PR DESCRIPTION
## Changes

This is changed such that changing a single line without covering it won't make the CI 🔴 (note the codecov patch is not a required workflow though).

## Tests

## Issues

## Primary Reviewer

@timwu20
