### PR TITLE
chore(build): upgrade Go to 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
           stable: true
           check-latest: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG DEBIAN_VERSION=bullseye-slim
-ARG GO_VERSION=1.18-buster
+ARG GO_VERSION=1.19-buster
 
 FROM golang:${GO_VERSION} AS builder
 

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.19
 
 ARG chain="polkadot"
 ARG basepath="~/.gossamer"

--- a/README.md
+++ b/README.md
@@ -53,12 +53,8 @@ and start a development network.
 [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) is required
 to acquire the Gossamer source code, and
 [Make](https://tilburgsciencehub.com/building-blocks/configure-your-computer/automation-and-workflows/make/)
-is used to build it. Building Gossamer requires version 1.18 of
+is used to build it. Building Gossamer requires version 1.19 or higher of
 [Golang](https://go.dev/dl/).
-
-> **Warning**
->
-> Gossamer will NOT work with version 1.19 of Golang.
 
 ### Installation
 

--- a/devnet/alice.Dockerfile
+++ b/devnet/alice.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM golang:1.18
+FROM golang:1.19
 
 ARG POLKADOT_VERSION=v0.9.10
 

--- a/devnet/bob.Dockerfile
+++ b/devnet/bob.Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 ChainSafe Systems (ON)
 # SPDX-License-Identifier: LGPL-3.0-only
 
-FROM golang:1.18
+FROM golang:1.19
 
 ARG POLKADOT_VERSION=v0.9.10
 

--- a/devnet/go.mod
+++ b/devnet/go.mod
@@ -1,6 +1,6 @@
 module github.com/ChainSafe/gossamer/devnet
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.42.22

--- a/devnet/substrate_alice.Dockerfile
+++ b/devnet/substrate_alice.Dockerfile
@@ -3,7 +3,7 @@
 
 ARG POLKADOT_VERSION=v0.9.10
 
-FROM golang:1.18 as openmetrics
+FROM golang:1.19 as openmetrics
 ARG METRICS_NAMESPACE=substrate.local.devnet
 
 WORKDIR /devnet

--- a/devnet/substrate_bob.Dockerfile
+++ b/devnet/substrate_bob.Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 ARG POLKADOT_VERSION=v0.9.10
 
-FROM golang:1.18 as openmetrics
+FROM golang:1.19 as openmetrics
 
 ARG METRICS_NAMESPACE=substrate.local.devnet
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -8,7 +8,7 @@ permalink: /getting-started/installation
 
 ## Prerequisites
 
-Install [Go](https://go.dev/doc/install) version [`>=1.18`](https://go.dev/dl/#go1.18)
+Install [Go](https://go.dev/doc/install) version [`>=1.19`](https://go.dev/dl/#go1.19)
 
 ## Installation
 

--- a/dot/network/proto/api.v1.pb.go
+++ b/dot/network/proto/api.v1.pb.go
@@ -85,6 +85,7 @@ type BlockRequest struct {
 	// Start from this block.
 	//
 	// Types that are assignable to FromBlock:
+	//
 	//	*BlockRequest_Hash
 	//	*BlockRequest_Number
 	FromBlock isBlockRequest_FromBlock `protobuf_oneof:"from_block"`

--- a/dot/network/proto/proto_generate.go
+++ b/dot/network/proto/proto_generate.go
@@ -1,6 +1,7 @@
 // Copyright 2022 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
+// Package proto contains protobuf generated Go structures.
 package proto
 
 //go:generate protoc --go_out=. --go_opt=paths=source_relative api.v1.proto

--- a/dot/rpc/modules/chain.go
+++ b/dot/rpc/modules/chain.go
@@ -71,7 +71,7 @@ func NewChainModule(api BlockAPI) *ChainModule {
 }
 
 // GetBlock Get header and body of a relay chain block. If no block hash is provided,
-//  the latest block body will be returned.
+// the latest block body will be returned.
 func (cm *ChainModule) GetBlock(r *http.Request, req *ChainHashRequest, res *ChainBlockResponse) error {
 	hash := cm.hashLookup(req)
 	block, err := cm.blockAPI.GetBlockByHash(hash)
@@ -97,7 +97,7 @@ func (cm *ChainModule) GetBlock(r *http.Request, req *ChainHashRequest, res *Cha
 }
 
 // GetBlockHash Get hash of the 'n-th' block in the canon chain. If no parameters are provided,
-//  the latest block hash gets returned.
+// the latest block hash gets returned.
 func (cm *ChainModule) GetBlockHash(r *http.Request, req *ChainBlockNumberRequest, res *ChainHashResponse) error {
 	// if request is empty, return highest hash
 	if req.Block == nil {
@@ -139,7 +139,7 @@ func (cm *ChainModule) GetFinalizedHeadByRound(
 	return nil
 }
 
-//GetHeader Get header of a relay chain block. If no block hash is provided, the latest block header will be returned.
+// GetHeader Get header of a relay chain block. If no block hash is provided, the latest block header will be returned.
 func (cm *ChainModule) GetHeader(r *http.Request, req *ChainHashRequest, res *ChainBlockHeaderResponse) error {
 	hash := cm.hashLookup(req)
 	header, err := cm.blockAPI.GetHeader(hash)
@@ -152,19 +152,19 @@ func (cm *ChainModule) GetHeader(r *http.Request, req *ChainHashRequest, res *Ch
 }
 
 // SubscribeFinalizedHeads handled by websocket handler, but this func should remain
-//  here so it's added to rpc_methods list
+// here so it's added to rpc_methods list
 func (cm *ChainModule) SubscribeFinalizedHeads(_ *http.Request, _ *EmptyRequest, _ *ChainBlockHeaderResponse) error {
 	return ErrSubscriptionTransport
 }
 
 // SubscribeNewHead handled by websocket handler, but this func should remain
-//  here so it's added to rpc_methods list
+// here so it's added to rpc_methods list
 func (cm *ChainModule) SubscribeNewHead(r *http.Request, req *EmptyRequest, res *ChainBlockHeaderResponse) error {
 	return ErrSubscriptionTransport
 }
 
 // SubscribeNewHeads handled by websocket handler, but this func should remain
-//  here so it's added to rpc_methods list
+// here so it's added to rpc_methods list
 func (cm *ChainModule) SubscribeNewHeads(r *http.Request, req *EmptyRequest, res *ChainBlockHeaderResponse) error {
 	return ErrSubscriptionTransport
 }
@@ -200,7 +200,7 @@ func (cm *ChainModule) unwindRequest(req interface{}) ([]string, error) {
 }
 
 // lookupHashByInterface parses given interface to determine block number, then
-//  finds hash for that block number
+// finds hash for that block number
 func (cm *ChainModule) lookupHashByInterface(i interface{}) (string, error) {
 	var num uint
 	switch x := i.(type) {

--- a/dot/rpc/modules/grandpa.go
+++ b/dot/rpc/modules/grandpa.go
@@ -56,9 +56,9 @@ type ProveFinalityRequest struct {
 type ProveFinalityResponse []string
 
 // ProveFinality for the provided block number, the Justification for the last block in the set is written to the
-//  response. The response is a SCALE encoded proof array.  The proof array is empty if the block number is
-//  not finalized.
-//  Returns error which are included in the response if they occur.
+// response. The response is a SCALE encoded proof array.  The proof array is empty if the block number is
+// not finalized.
+// Returns error which are included in the response if they occur.
 func (gm *GrandpaModule) ProveFinality(r *http.Request, req *ProveFinalityRequest, res *ProveFinalityResponse) error {
 	blockHash, err := gm.blockAPI.GetHashByNumber(uint(req.BlockNumber))
 	if err != nil {

--- a/dot/rpc/modules/state.go
+++ b/dot/rpc/modules/state.go
@@ -363,7 +363,7 @@ func (sm *StateModule) GetStorage(
 }
 
 // GetStorageHash returns the blake2b hash of a storage entry at a block's state.
-//  If no block hash is provided, the latest value is returned.
+// If no block hash is provided, the latest value is returned.
 func (sm *StateModule) GetStorageHash(
 	_ *http.Request, req *StateStorageHashRequest, res *StateStorageHashResponse) error {
 	var (
@@ -499,9 +499,9 @@ func (sm *StateModule) SubscribeRuntimeVersion(
 }
 
 // SubscribeStorage Storage subscription. If storage keys are specified, it creates a message for each block which
-//  changes the specified storage keys. If none are specified, then it creates a message for every block.
-//  This endpoint communicates over the Websocket protocol, but this func should remain here so it's
-// 	added to rpc_methods list
+// changes the specified storage keys. If none are specified, then it creates a message for every block.
+// This endpoint communicates over the Websocket protocol, but this func should remain here so it's
+// added to rpc_methods list
 func (*StateModule) SubscribeStorage(
 	_ *http.Request, _ *StateStorageQueryRangeRequest, _ *StorageChangeSetResponse) error {
 	return nil

--- a/dot/rpc/modules/sync_state_integration_test.go
+++ b/dot/rpc/modules/sync_state_integration_test.go
@@ -7,7 +7,7 @@ package modules
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,7 +19,7 @@ import (
 func TestSyncStateModule(t *testing.T) {
 	fp := utils.GetWestendDevRawGenesisPath(t)
 
-	data, err := ioutil.ReadFile(filepath.Clean(fp))
+	data, err := os.ReadFile(filepath.Clean(fp))
 	require.NoError(t, err)
 
 	g := new(genesis.Genesis)

--- a/dot/rpc/modules/system.go
+++ b/dot/rpc/modules/system.go
@@ -262,8 +262,7 @@ func (sm *SystemModule) LocalListenAddresses(r *http.Request, req *EmptyRequest,
 }
 
 // LocalPeerId Returns the base58-encoded PeerId fo the node.
-//nolint
-func (sm *SystemModule) LocalPeerId(r *http.Request, req *EmptyRequest, res *string) error {
+func (sm *SystemModule) LocalPeerId(r *http.Request, req *EmptyRequest, res *string) error { //nolint:revive
 	netstate := sm.networkAPI.NetworkState()
 	if netstate.PeerID == "" {
 		return errors.New("peer id cannot be empty")

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -827,9 +827,9 @@ func (cs *chainSync) determineSyncPeers(req *network.BlockRequestMessage, peersT
 // validateResponse performs pre-validation of a block response before placing it into either the
 // pendingBlocks or readyBlocks set.
 // It checks the following:
-// 	- the response is not empty
-//  - the response contains all the expected fields
-//  - each block has the correct parent, ie. the response constitutes a valid chain
+//   - the response is not empty
+//   - the response contains all the expected fields
+//   - each block has the correct parent, ie. the response constitutes a valid chain
 func (cs *chainSync) validateResponse(req *network.BlockRequestMessage,
 	resp *network.BlockResponseMessage, p peer.ID) error {
 	if resp == nil || len(resp.BlockData) == 0 {

--- a/dot/types/babe.go
+++ b/dot/types/babe.go
@@ -32,8 +32,7 @@ var (
 )
 
 // BabeConfiguration contains the genesis data for BABE
-//nolint:lll
-// see: https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/consensus/babe/primitives/src/lib.rs#L132
+// See https://github.com/paritytech/substrate/blob/426c26b8bddfcdbaf8d29f45b128e0864b57de1c/core/consensus/babe/primitives/src/lib.rs#L132
 type BabeConfiguration struct {
 	SlotDuration       uint64 // milliseconds
 	EpochLength        uint64 // duration of epoch in slots

--- a/dot/types/tx.go
+++ b/dot/types/tx.go
@@ -34,7 +34,7 @@ const (
 )
 
 // RuntimeDispatchInfo represents information related to a dispatchable's class, weight, and fee that can be queried
-//  from the runtime
+// from the runtime
 type RuntimeDispatchInfo struct {
 	Weight uint64
 	// Class could be Normal (0), Operational (1), Mandatory (2)

--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,7 +68,7 @@ func TestCreateJSONRawFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			CreateJSONRawFile(tt.args.bs, tt.args.fp)
 
-			b, err := ioutil.ReadFile(tt.args.fp)
+			b, err := os.ReadFile(tt.args.fp)
 			require.NoError(t, err)
 			digest := sha256.Sum256(b)
 			hexDigest := fmt.Sprintf("%x", digest)

--- a/go.mod
+++ b/go.mod
@@ -180,4 +180,4 @@ require (
 	lukechampine.com/blake3 v1.1.7 // indirect
 )
 
-go 1.18
+go 1.19

--- a/lib/babe/parachain_inherents.go
+++ b/lib/babe/parachain_inherents.go
@@ -245,7 +245,7 @@ type collatorID []byte
 // collatorSignature is the signature on a candidate's block data signed by a collator.
 type collatorSignature signature
 
-//  validationCodeHash is the blake2-256 hash of the validation code bytes.
+// validationCodeHash is the blake2-256 hash of the validation code bytes.
 type validationCodeHash common.Hash
 
 // candidateDescriptor is a unique descriptor of the candidate receipt.

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -231,7 +231,6 @@ func newVerifier(blockState BlockState, epoch uint64, info *verifierInfo) *verif
 	}
 }
 
-//gocyclo:ignore
 // verifyAuthorshipRight verifies that the authority that produced a block was authorized to produce it.
 func (b *verifier) verifyAuthorshipRight(header *types.Header) error {
 	// header should have 2 digest items (possibly more in the future)

--- a/lib/grandpa/message_handler.go
+++ b/lib/grandpa/message_handler.go
@@ -403,7 +403,7 @@ func (h *MessageHandler) verifyPreCommitJustification(msg *CatchUpResponse) erro
 }
 
 // VerifyBlockJustification verifies the finality justification for a block, returns scale encoded justification with
-//  any extra bytes removed.
+// any extra bytes removed.
 func (s *Service) VerifyBlockJustification(hash common.Hash, justification []byte) ([]byte, error) {
 	fj := Justification{}
 	err := scale.Unmarshal(justification, &fj)

--- a/lib/grandpa/round_integration_test.go
+++ b/lib/grandpa/round_integration_test.go
@@ -297,7 +297,7 @@ func TestPlayGrandpaRound(t *testing.T) {
 				latestHash = serviceFinalizedHash
 			}
 
-			var latestCommit *CommitMessage = producedCommitMessages[0]
+			latestCommit := producedCommitMessages[0]
 			for _, commitMessage := range producedCommitMessages[1:] {
 				require.NotNil(t, commitMessage)
 				require.GreaterOrEqual(t, len(commitMessage.Precommits), len(tt.voters)/2)
@@ -455,7 +455,7 @@ func TestPlayGrandpaRoundMultipleRounds(t *testing.T) {
 		assertSamefinalisationAndChainGrowth(t, grandpaServices,
 			uint64(currentRound), setID)
 
-		var latestCommit *CommitMessage = producedCommitMessages[0]
+		latestCommit := producedCommitMessages[0]
 		for _, commitMessage := range producedCommitMessages[1:] {
 			require.NotNil(t, commitMessage)
 			require.GreaterOrEqual(t, len(commitMessage.Precommits), len(voters)/2)

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -296,7 +296,7 @@ func UnlockKeys(ks Inserter, dir, unlock, password string) error {
 }
 
 // DetermineKeyType takes string as defined in https://github.com/w3f/PSPs/blob/psp-rpc-api/psp-002.md#Key-types
-//  and returns the crypto.KeyType
+// and returns the crypto.KeyType
 func DetermineKeyType(t string) crypto.KeyType {
 	switch t {
 	case "babe":

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -40,14 +40,14 @@ type FreeingBumpHeapAllocator struct {
 //
 // # Arguments
 //
-// * `mem` - A runtime.Memory to the available memory which is
-//   used as the heap.
+//   - `mem` - A runtime.Memory to the available memory which is
+//     used as the heap.
 //
-// * `ptrOffset` - The pointers returned by `Allocate()` start from this
-//   offset on. The pointer offset needs to be aligned to a multiple of 8,
-//   hence a padding might be added to align `ptrOffset` properly.
+//   - `ptrOffset` - The pointers returned by `Allocate()` start from this
+//     offset on. The pointer offset needs to be aligned to a multiple of 8,
+//     hence a padding might be added to align `ptrOffset` properly.
 //
-// * returns a pointer to an initilized FreeingBumpHeapAllocator
+//   - returns a pointer to an initilized FreeingBumpHeapAllocator
 func NewAllocator(mem Memory, ptrOffset uint32) *FreeingBumpHeapAllocator {
 	fbha := new(FreeingBumpHeapAllocator)
 
@@ -83,8 +83,8 @@ func (fbha *FreeingBumpHeapAllocator) growHeap(numPages uint32) error {
 }
 
 // Allocate determines if there is space available in WASM heap to grow the heap by 'size'.  If there is space
-//   available it grows the heap to fit give 'size'.  The heap grows is chunks of Powers of 2, so the growth becomes
-//   the next highest power of 2 of the requested size.
+// available it grows the heap to fit give 'size'.  The heap grows is chunks of Powers of 2, so the growth becomes
+// the next highest power of 2 of the requested size.
 func (fbha *FreeingBumpHeapAllocator) Allocate(size uint32) (uint32, error) {
 	// test for space allocation
 	if size > MaxPossibleAllocation {

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -38,7 +38,7 @@ type allocatorState struct {
 }
 
 // struct to hold set of test (allocateTest or freeTest), expected output (return result of test (if any))
-//  state, expected state of the allocator after given test is run
+// state, expected state of the allocator after given test is run
 type testSet struct {
 	test   interface{}
 	output interface{}
@@ -255,7 +255,7 @@ var allTests = []testHolder{
 }
 
 // iterates allTests and runs tests on them based on data contained in
-//  test holder
+// test holder
 func TestAllocator(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
@@ -451,7 +451,7 @@ func TestShouldGetItemFromIndex(t *testing.T) {
 }
 
 // that that getItemSizeFromIndex method gets expected item size from index
-//  max index position
+// max index position
 func TestShouldGetMaxFromIndex(t *testing.T) {
 	index := uint(21)
 	itemSize := getItemSizeFromIndex(index)

--- a/lib/transaction/types.go
+++ b/lib/transaction/types.go
@@ -50,24 +50,30 @@ func NewValidTransaction(extrinsic types.Extrinsic, validity *Validity) *ValidTr
 // 	BlockHash          *common.Hash
 // }
 
-// Status represents possible transaction statuses.
-//
-// The status events can be grouped based on their kinds as:
-// 1. Entering/Moving within the pool:
-// 		- `Future`
-// 		- `Ready`
-// 2. Inside `Ready` queue:
-// 		- `Broadcast`
-// 3. Leaving the pool:
-// 		- `InBlock`
-// 		- `Invalid`
-// 		- `Usurped`
-// 		- `Dropped`
-// 	4. Re-entering the pool:
-// 		- `Retracted`
-// 	5. Block finalized:
-// 		- `Finalized`
-// 		- `FinalityTimeout`
+/*
+Status represents possible transaction statuses.
+
+The status events can be grouped based on their kinds as:
+1. Entering/Moving within the pool:
+  - `Future`
+  - `Ready`
+
+2. Inside `Ready` queue:
+  - `Broadcast`
+
+3. Leaving the pool:
+  - `InBlock`
+  - `Invalid`
+  - `Usurped`
+  - `Dropped`
+
+4. Re-entering the pool:
+  - `Retracted`
+
+5. Block finalized:
+  - `Finalized`
+  - `FinalityTimeout`
+*/
 type Status int64
 
 const (

--- a/tests/polkadotjs_test/empty.go
+++ b/tests/polkadotjs_test/empty.go
@@ -1,4 +1,5 @@
 // Copyright 2021 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
+// Package polkadotjs runs end to end tests using PolkadotJS.
 package polkadotjs

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -111,8 +111,8 @@ func TestSystemRPC(t *testing.T) { //nolint:tparallel
 
 		expectedResponse := modules.SystemPeersResponse{
 			// Assert they all have the same best block number and hash
-			{Roles: 4, PeerID: ""},
-			{Roles: 4, PeerID: ""},
+			common.PeerInfo{Roles: 4, PeerID: ""},
+			common.PeerInfo{Roles: 4, PeerID: ""},
 		}
 		for i := range response {
 			// Check randomly generated peer IDs and clear them

--- a/tests/rpc/rpc_01-system_test.go
+++ b/tests/rpc/rpc_01-system_test.go
@@ -111,8 +111,8 @@ func TestSystemRPC(t *testing.T) { //nolint:tparallel
 
 		expectedResponse := modules.SystemPeersResponse{
 			// Assert they all have the same best block number and hash
-			common.PeerInfo{Roles: 4, PeerID: ""},
-			common.PeerInfo{Roles: 4, PeerID: ""},
+			{Roles: 4, PeerID: ""},
+			{Roles: 4, PeerID: ""},
 		}
 		for i := range response {
 			// Check randomly generated peer IDs and clear them


### PR DESCRIPTION
## Changes

- CI uses Go 1.19
- Dockerfiles use Go 1.19
- go.mod uses Go 1.19
- Readme: remove Go 1.19 incompatibility warning
- Readme: update requirement to Go 1.19 or higher
- Re-generate proto files to match Go 1.19 new comments format
- Fix all comments to match Go 1.19 new comments format
- Replace `ioutil` import with `os`
- Fix new lint errors introduced
- Remove old `//gocyclo:ignore` comment

## Tests

## Issues

Fixes #2768 

## Primary Reviewer

@EclesioMeloJunior 