### PR TITLE
fix(trie): use direct Merkle value for database keys

### DIFF
--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -105,7 +105,7 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 	}
 
 	latestBlockNum := header.Number
-	keys := make(map[common.Hash]struct{})
+	merkleValues := make(map[string]struct{})
 
 	logger.Infof("Latest block number is %d", latestBlockNum)
 
@@ -121,7 +121,7 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 			return err
 		}
 
-		tr.PopulateNodeHashes(tr.RootNode(), keys)
+		tr.PopulateMerkleValues(tr.RootNode(), merkleValues)
 
 		// get parent header of current block
 		header, err = p.blockState.GetHeader(header.ParentHash)
@@ -131,14 +131,14 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 		blockNum = header.Number
 	}
 
-	for key := range keys {
-		err = p.bloom.put(key.ToBytes())
+	for key := range merkleValues {
+		err = p.bloom.put([]byte(key))
 		if err != nil {
 			return err
 		}
 	}
 
-	logger.Infof("Total keys added in bloom filter: %d", len(keys))
+	logger.Infof("Total keys added in bloom filter: %d", len(merkleValues))
 	return nil
 }
 

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -85,13 +85,13 @@ func (s *StorageState) StoreTrie(ts *rtstorage.TrieState, header *types.Header) 
 	}
 
 	if header != nil {
-		insertedNodeHashes, err := ts.GetInsertedNodeHashes()
+		insertedMerkleValues, err := ts.GetInsertedMerkleValues()
 		if err != nil {
 			return fmt.Errorf("failed to get state trie inserted keys: block %s %w", header.Hash(), err)
 		}
 
-		deletedNodeHashes := ts.GetDeletedNodeHashes()
-		err = s.pruner.StoreJournalRecord(deletedNodeHashes, insertedNodeHashes, header.Hash(), int64(header.Number))
+		deletedMerkleValues := ts.GetDeletedMerkleValues()
+		err = s.pruner.StoreJournalRecord(deletedMerkleValues, insertedMerkleValues, header.Hash(), int64(header.Number))
 		if err != nil {
 			return err
 		}

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -271,18 +271,18 @@ func (s *TrieState) LoadCodeHash() (common.Hash, error) {
 	return common.Blake2bHash(code)
 }
 
-// GetInsertedNodeHashes returns a set of hashes of all nodes
-// that were inserted into state trie since the last block produced.
-func (s *TrieState) GetInsertedNodeHashes() (hashesSet map[common.Hash]struct{}, err error) {
+// GetInsertedMerkleValues returns the set of all node Merkle value inserted
+// into the state trie since the last block produced.
+func (s *TrieState) GetInsertedMerkleValues() (merkleValues map[string]struct{}, err error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return s.t.GetInsertedNodeHashes()
+	return s.t.GetInsertedMerkleValues()
 }
 
-// GetDeletedNodeHashes returns the hash of nodes that were deleted
+// GetDeletedMerkleValues returns the set of all node Merkle values deleted
 // from the state trie since the last block produced.
-func (s *TrieState) GetDeletedNodeHashes() (hashesSet map[common.Hash]struct{}) {
+func (s *TrieState) GetDeletedMerkleValues() (merkleValues map[string]struct{}) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return s.t.GetDeletedNodeHashes()
+	return s.t.GetDeletedMerkleValues()
 }

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -101,9 +101,9 @@ func updateGeneration(currentNode *Node, trieGeneration uint64,
 
 	// The hash of the node from a previous snapshotted trie
 	// is usually already computed.
-	deletedMerkleValueBytes := currentNode.MerkleValue
-	if len(deletedMerkleValueBytes) > 0 {
-		deletedMerkleValueString := string(deletedMerkleValueBytes)
+	deletedMerkleValue := currentNode.MerkleValue
+	if len(deletedMerkleValue) > 0 {
+		deletedMerkleValueString := string(deletedMerkleValue)
 		deletedMerkleValues[deletedMerkleValueString] = struct{}{}
 	}
 

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -18,10 +18,10 @@ var EmptyHash, _ = NewEmptyTrie().Hash()
 
 // Trie is a base 16 modified Merkle Patricia trie.
 type Trie struct {
-	generation  uint64
-	root        *Node
-	childTries  map[common.Hash]*Trie
-	deletedKeys map[common.Hash]struct{}
+	generation          uint64
+	root                *Node
+	childTries          map[common.Hash]*Trie
+	deletedMerkleValues map[string]struct{}
 }
 
 // NewEmptyTrie creates a trie with a nil root
@@ -32,10 +32,10 @@ func NewEmptyTrie() *Trie {
 // NewTrie creates a trie with an existing root node
 func NewTrie(root *Node) *Trie {
 	return &Trie{
-		root:        root,
-		childTries:  make(map[common.Hash]*Trie),
-		generation:  0, // Initially zero but increases after every snapshot.
-		deletedKeys: make(map[common.Hash]struct{}),
+		root:                root,
+		childTries:          make(map[common.Hash]*Trie),
+		generation:          0, // Initially zero but increases after every snapshot.
+		deletedMerkleValues: make(map[string]struct{}),
 	}
 }
 
@@ -50,17 +50,17 @@ func (t *Trie) Snapshot() (newTrie *Trie) {
 	rootCopySettings.CopyCached = true
 	for rootHash, childTrie := range t.childTries {
 		childTries[rootHash] = &Trie{
-			generation:  childTrie.generation + 1,
-			root:        childTrie.root.Copy(rootCopySettings),
-			deletedKeys: make(map[common.Hash]struct{}),
+			generation:          childTrie.generation + 1,
+			root:                childTrie.root.Copy(rootCopySettings),
+			deletedMerkleValues: make(map[string]struct{}),
 		}
 	}
 
 	return &Trie{
-		generation:  t.generation + 1,
-		root:        t.root,
-		childTries:  childTries,
-		deletedKeys: make(map[common.Hash]struct{}),
+		generation:          t.generation + 1,
+		root:                t.root,
+		childTries:          childTries,
+		deletedMerkleValues: make(map[string]struct{}),
 	}
 }
 
@@ -71,7 +71,7 @@ func (t *Trie) prepLeafForMutation(currentLeaf *Node,
 		// of current leaf.
 		newLeaf = currentLeaf
 	} else {
-		newLeaf = updateGeneration(currentLeaf, t.generation, t.deletedKeys, copySettings)
+		newLeaf = updateGeneration(currentLeaf, t.generation, t.deletedMerkleValues, copySettings)
 	}
 	newLeaf.SetDirty()
 	return newLeaf
@@ -84,7 +84,7 @@ func (t *Trie) prepBranchForMutation(currentBranch *Node,
 		// of current branch.
 		newBranch = currentBranch
 	} else {
-		newBranch = updateGeneration(currentBranch, t.generation, t.deletedKeys, copySettings)
+		newBranch = updateGeneration(currentBranch, t.generation, t.deletedMerkleValues, copySettings)
 	}
 	newBranch.SetDirty()
 	return newBranch
@@ -94,17 +94,17 @@ func (t *Trie) prepBranchForMutation(currentBranch *Node,
 // an older trie generation (snapshot) so we deep copy the
 // node and update the generation on the newer copy.
 func updateGeneration(currentNode *Node, trieGeneration uint64,
-	deletedHashes map[common.Hash]struct{}, copySettings node.CopySettings) (
+	deletedMerkleValues map[string]struct{}, copySettings node.CopySettings) (
 	newNode *Node) {
 	newNode = currentNode.Copy(copySettings)
 	newNode.Generation = trieGeneration
 
 	// The hash of the node from a previous snapshotted trie
 	// is usually already computed.
-	deletedHashBytes := currentNode.MerkleValue
-	if len(deletedHashBytes) > 0 {
-		deletedHash := common.BytesToHash(deletedHashBytes)
-		deletedHashes[deletedHash] = struct{}{}
+	deletedMerkleValueBytes := currentNode.MerkleValue
+	if len(deletedMerkleValueBytes) > 0 {
+		deletedMerkleValueString := string(deletedMerkleValueBytes)
+		deletedMerkleValues[deletedMerkleValueString] = struct{}{}
 	}
 
 	return newNode
@@ -124,10 +124,10 @@ func (t *Trie) DeepCopy() (trieCopy *Trie) {
 		generation: t.generation,
 	}
 
-	if t.deletedKeys != nil {
-		trieCopy.deletedKeys = make(map[common.Hash]struct{}, len(t.deletedKeys))
-		for k := range t.deletedKeys {
-			trieCopy.deletedKeys[k] = struct{}{}
+	if t.deletedMerkleValues != nil {
+		trieCopy.deletedMerkleValues = make(map[string]struct{}, len(t.deletedMerkleValues))
+		for k := range t.deletedMerkleValues {
+			trieCopy.deletedMerkleValues[k] = struct{}{}
 		}
 	}
 

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -292,14 +292,14 @@ func TestTrieDiff(t *testing.T) {
 	for _, test := range tests {
 		newTrie.Put(test.key, test.value)
 	}
-	deletedKeys := newTrie.deletedKeys
-	require.Len(t, deletedKeys, 3)
+	deletedMerkleValues := newTrie.deletedMerkleValues
+	require.Len(t, deletedMerkleValues, 3)
 
 	err = newTrie.WriteDirty(storageDB)
 	require.NoError(t, err)
 
-	for key := range deletedKeys {
-		err = storageDB.Del(key.ToBytes())
+	for deletedMerkleValue := range deletedMerkleValues {
+		err = storageDB.Del([]byte(deletedMerkleValue))
 		require.NoError(t, err)
 	}
 

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -18,8 +18,8 @@ import (
 
 func Test_NewEmptyTrie(t *testing.T) {
 	expectedTrie := &Trie{
-		childTries:  make(map[common.Hash]*Trie),
-		deletedKeys: map[common.Hash]struct{}{},
+		childTries:          make(map[common.Hash]*Trie),
+		deletedMerkleValues: map[string]struct{}{},
 	}
 	trie := NewEmptyTrie()
 	assert.Equal(t, expectedTrie, trie)
@@ -35,8 +35,8 @@ func Test_NewTrie(t *testing.T) {
 			Key:      []byte{0},
 			SubValue: []byte{17},
 		},
-		childTries:  make(map[common.Hash]*Trie),
-		deletedKeys: map[common.Hash]struct{}{},
+		childTries:          make(map[common.Hash]*Trie),
+		deletedMerkleValues: map[string]struct{}{},
 	}
 	trie := NewTrie(root)
 	assert.Equal(t, expectedTrie, trie)
@@ -52,21 +52,21 @@ func Test_Trie_Snapshot(t *testing.T) {
 			{1}: {
 				generation: 1,
 				root:       &Node{Key: []byte{1}, SubValue: []byte{1}},
-				deletedKeys: map[common.Hash]struct{}{
-					{1}: {},
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
 				},
 			},
 			{2}: {
 				generation: 2,
 				root:       &Node{Key: []byte{2}, SubValue: []byte{1}},
-				deletedKeys: map[common.Hash]struct{}{
-					{2}: {},
+				deletedMerkleValues: map[string]struct{}{
+					"b": {},
 				},
 			},
 		},
-		deletedKeys: map[common.Hash]struct{}{
-			{1}: {},
-			{2}: {},
+		deletedMerkleValues: map[string]struct{}{
+			"a": {},
+			"b": {},
 		},
 	}
 
@@ -75,17 +75,17 @@ func Test_Trie_Snapshot(t *testing.T) {
 		root:       &Node{Key: []byte{8}, SubValue: []byte{1}},
 		childTries: map[common.Hash]*Trie{
 			{1}: {
-				generation:  2,
-				root:        &Node{Key: []byte{1}, SubValue: []byte{1}},
-				deletedKeys: map[common.Hash]struct{}{},
+				generation:          2,
+				root:                &Node{Key: []byte{1}, SubValue: []byte{1}},
+				deletedMerkleValues: map[string]struct{}{},
 			},
 			{2}: {
-				generation:  3,
-				root:        &Node{Key: []byte{2}, SubValue: []byte{1}},
-				deletedKeys: map[common.Hash]struct{}{},
+				generation:          3,
+				root:                &Node{Key: []byte{2}, SubValue: []byte{1}},
+				deletedMerkleValues: map[string]struct{}{},
 			},
 		},
-		deletedKeys: map[common.Hash]struct{}{},
+		deletedMerkleValues: map[string]struct{}{},
 	}
 
 	newTrie := trie.Snapshot()
@@ -97,12 +97,12 @@ func Test_Trie_updateGeneration(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trieGeneration        uint64
-		node                  *Node
-		copySettings          node.CopySettings
-		newNode               *Node
-		copied                bool
-		expectedDeletedHashes map[common.Hash]struct{}
+		trieGeneration              uint64
+		node                        *Node
+		copySettings                node.CopySettings
+		newNode                     *Node
+		copied                      bool
+		expectedDeletedMerkleValues map[string]struct{}
 	}{
 		"trie generation higher and empty hash": {
 			trieGeneration: 2,
@@ -115,8 +115,8 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				Generation: 2,
 				Key:        []byte{1},
 			},
-			copied:                true,
-			expectedDeletedHashes: map[common.Hash]struct{}{},
+			copied:                      true,
+			expectedDeletedMerkleValues: map[string]struct{}{},
 		},
 		"trie generation higher and hash": {
 			trieGeneration: 2,
@@ -131,13 +131,8 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				Key:        []byte{1},
 			},
 			copied: true,
-			expectedDeletedHashes: map[common.Hash]struct{}{
-				{
-					0, 0, 0, 0, 0, 0, 0, 0, 0,
-					0, 0, 0, 0, 0, 0, 0, 0, 0,
-					0, 0, 0, 0, 0, 0, 0, 0, 0,
-					0, 0, 1, 2, 3,
-				}: {},
+			expectedDeletedMerkleValues: map[string]struct{}{
+				string([]byte{1, 2, 3}): {},
 			},
 		},
 	}
@@ -147,13 +142,13 @@ func Test_Trie_updateGeneration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			deletedHashes := make(map[common.Hash]struct{})
+			deletedMerkleValues := make(map[string]struct{})
 
 			newNode := updateGeneration(testCase.node, testCase.trieGeneration,
-				deletedHashes, testCase.copySettings)
+				deletedMerkleValues, testCase.copySettings)
 
 			assert.Equal(t, testCase.newNode, newNode)
-			assert.Equal(t, testCase.expectedDeletedHashes, deletedHashes)
+			assert.Equal(t, testCase.expectedDeletedMerkleValues, deletedMerkleValues)
 
 			// Check for deep copy
 			if newNode != nil && testCase.copied {
@@ -201,7 +196,7 @@ func testTrieForDeepCopy(t *testing.T, original, copy *Trie) {
 		return
 	}
 	assertPointersNotEqual(t, original.generation, copy.generation)
-	assertPointersNotEqual(t, original.deletedKeys, copy.deletedKeys)
+	assertPointersNotEqual(t, original.deletedMerkleValues, copy.deletedMerkleValues)
 	assertPointersNotEqual(t, original.childTries, copy.childTries)
 	for hashKey, childTrie := range copy.childTries {
 		originalChildTrie := original.childTries[hashKey]
@@ -230,15 +225,15 @@ func Test_Trie_DeepCopy(t *testing.T) {
 					{1, 2, 3}: {
 						generation: 2,
 						root:       &Node{Key: []byte{1}, SubValue: []byte{1}},
-						deletedKeys: map[common.Hash]struct{}{
-							{1, 2, 3}: {},
-							{3, 4, 5}: {},
+						deletedMerkleValues: map[string]struct{}{
+							"a": {},
+							"b": {},
 						},
 					},
 				},
-				deletedKeys: map[common.Hash]struct{}{
-					{1, 2, 3}: {},
-					{3, 4, 5}: {},
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+					"b": {},
 				},
 			},
 			trieCopy: &Trie{
@@ -248,15 +243,15 @@ func Test_Trie_DeepCopy(t *testing.T) {
 					{1, 2, 3}: {
 						generation: 2,
 						root:       &Node{Key: []byte{1}, SubValue: []byte{1}},
-						deletedKeys: map[common.Hash]struct{}{
-							{1, 2, 3}: {},
-							{3, 4, 5}: {},
+						deletedMerkleValues: map[string]struct{}{
+							"a": {},
+							"b": {},
 						},
 					},
 				},
-				deletedKeys: map[common.Hash]struct{}{
-					{1, 2, 3}: {},
-					{3, 4, 5}: {},
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+					"b": {},
 				},
 			},
 		},
@@ -648,9 +643,8 @@ func Test_Trie_Entries(t *testing.T) {
 		t.Parallel()
 
 		trie := Trie{
-			root:        nil,
-			childTries:  make(map[common.Hash]*Trie),
-			deletedKeys: make(map[common.Hash]struct{}),
+			root:       nil,
+			childTries: make(map[common.Hash]*Trie),
 		}
 
 		kv := map[string][]byte{


### PR DESCRIPTION
## Changes

The problem is as follows in this example.

For a node `A` encoding to `{1, 2}`, its database key is `{0, 0, 0, ..., 1, 2}`. Another node `B` with > 32B encoding could (unlikely but still) hash to the same value `{0, 0, 0, ..., 1, 2}` as for `A` and that would conflict in the database.

The solution is to NOT force the database key to be 32B always, and to keep it plainly as the Merkle value of the node (32B or less). This should also occupy less space in the database eventually.

- Storage KV database node key has now the length of the Merkle value and is no longer forced to 32B
- Renaming `XXXHashesSet` to `XXXMerkleValues` since it's not just hashes
- Renaming `deletedKeys` to `deletedMerkleValueToBlockNumber` in `dot/state`
- Renaming methods `XXXNodeHashes` to `XXXMerkleValues`


## Tests


```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

## Primary Reviewer

@timwu20