### PR TITLE
chore(dot/rpc): `NewStateRuntimeVersionResponse`

### DIFF
--- a/dot/rpc/subscription/listeners.go
+++ b/dot/rpc/subscription/listeners.go
@@ -409,16 +409,11 @@ func (l *RuntimeVersionListener) Listen() {
 	if err != nil {
 		return
 	}
-	ver := modules.StateRuntimeVersionResponse{}
-	ver.SpecName = string(rtVersion.SpecName)
-	ver.ImplName = string(rtVersion.ImplName)
-	ver.AuthoringVersion = rtVersion.AuthoringVersion
-	ver.SpecVersion = rtVersion.SpecVersion
-	ver.ImplVersion = rtVersion.ImplVersion
-	ver.TransactionVersion = rtVersion.TransactionVersion
-	ver.Apis = modules.ConvertAPIs(rtVersion.APIItems)
 
-	go l.wsconn.safeSend(newSubscriptionResponse(stateRuntimeVersionMethod, l.subID, ver))
+	versionResponse := modules.NewStateRuntimeVersionResponse(rtVersion)
+	subscriptionResponse := newSubscriptionResponse(
+		stateRuntimeVersionMethod, l.subID, versionResponse)
+	go l.wsconn.safeSend(subscriptionResponse)
 
 	// listen for runtime updates
 	go func() {
@@ -428,17 +423,10 @@ func (l *RuntimeVersionListener) Listen() {
 				return
 			}
 
-			ver := modules.StateRuntimeVersionResponse{}
-
-			ver.SpecName = string(info.SpecName)
-			ver.ImplName = string(info.ImplName)
-			ver.AuthoringVersion = info.AuthoringVersion
-			ver.SpecVersion = info.SpecVersion
-			ver.ImplVersion = info.ImplVersion
-			ver.TransactionVersion = info.TransactionVersion
-			ver.Apis = modules.ConvertAPIs(info.APIItems)
-
-			l.wsconn.safeSend(newSubscriptionResponse(stateRuntimeVersionMethod, l.subID, ver))
+			versionResponse := modules.NewStateRuntimeVersionResponse(info)
+			subscriptionResponse := newSubscriptionResponse(
+				stateRuntimeVersionMethod, l.subID, versionResponse)
+			l.wsconn.safeSend(subscriptionResponse)
 		}
 	}()
 }

--- a/dot/rpc/subscription/listeners_test.go
+++ b/dot/rpc/subscription/listeners_test.go
@@ -344,7 +344,7 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 
 	expectedInitialVersion := modules.StateRuntimeVersionResponse{
 		SpecName: "mock-spec",
-		Apis:     modules.ConvertAPIs(nil),
+		Apis:     []interface{}{},
 	}
 
 	expectedInitialResponse := newSubcriptionBaseResponseJSON()
@@ -365,7 +365,20 @@ func TestRuntimeChannelListener_Listen(t *testing.T) {
 		SpecVersion:        25,
 		ImplVersion:        0,
 		TransactionVersion: 5,
-		Apis:               modules.ConvertAPIs(version.APIItems),
+		Apis: []interface{}{
+			[]interface{}{"0xdf6acb689907609b", uint32(0x3)},
+			[]interface{}{"0x37e397fc7c91f5e4", uint32(0x1)},
+			[]interface{}{"0x40fe3ad401f8959a", uint32(0x4)},
+			[]interface{}{"0xd2bc9897eed08f15", uint32(0x2)},
+			[]interface{}{"0xf78b278be53f454c", uint32(0x2)},
+			[]interface{}{"0xaf2c0297a23e6d3d", uint32(0x1)},
+			[]interface{}{"0xed99c5acb25eedf5", uint32(0x2)},
+			[]interface{}{"0xcbca25e39f142387", uint32(0x2)},
+			[]interface{}{"0x687ad44ad37f03c2", uint32(0x1)},
+			[]interface{}{"0xab3c0572291feb8b", uint32(0x1)},
+			[]interface{}{"0xbc9d89904f5b923f", uint32(0x1)},
+			[]interface{}{"0x37c8bb1350a9a2a8", uint32(0x1)},
+		},
 	}
 
 	expectedUpdateResponse := newSubcriptionBaseResponseJSON()


### PR DESCRIPTION
## Changes

- Add new conversion function `NewStateRuntimeVersionResponse`
- Inline `modules.ConvertAPIs` content in `NewStateRuntimeVersionResponse`
- Replace all conversions with `NewStateRuntimeVersionResponse`
- Update tests to have explicit expected API items to remove `modules.ConvertAPIs`

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

Created from a comment in #2673 

## Primary Reviewer

@timwu20