### PR TITLE
chore(runtime): move `InstanceConfig` to `lib/runtime/wasmer`

### DIFF
--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -91,7 +91,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	}
 
 	if cfg.Runtime == nil {
-		var rtCfg runtime.InstanceConfig
+		var rtCfg wasmer.InstanceConfig
 
 		rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -91,7 +91,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	}
 
 	if cfg.Runtime == nil {
-		var rtCfg wasmer.InstanceConfig
+		var rtCfg wasmer.Config
 
 		rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -261,7 +261,7 @@ func (s *Service) handleCodeSubstitution(hash common.Hash,
 
 	// this needs to create a new runtime instance, otherwise it will update
 	// the blocks that reference the current runtime version to use the code substition
-	cfg := runtime.InstanceConfig{
+	cfg := wasmer.InstanceConfig{
 		Storage:     state,
 		Keystore:    rt.Keystore(),
 		NodeStorage: rt.NodeStorage(),

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -261,7 +261,7 @@ func (s *Service) handleCodeSubstitution(hash common.Hash,
 
 	// this needs to create a new runtime instance, otherwise it will update
 	// the blocks that reference the current runtime version to use the code substition
-	cfg := wasmer.InstanceConfig{
+	cfg := wasmer.Config{
 		Storage:     state,
 		Keystore:    rt.Keystore(),
 		NodeStorage: rt.NodeStorage(),

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -63,7 +63,7 @@ func generateTestValidRemarkTxns(t *testing.T, pubKey []byte, accInfo types.Acco
 	nodeStorage := runtime.NodeStorage{
 		BaseDB: runtime.NewInMemoryDB(t),
 	}
-	cfg := runtime.InstanceConfig{
+	cfg := wasmer.InstanceConfig{
 		Storage:     genState,
 		LogLvl:      log.Error,
 		NodeStorage: nodeStorage,

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -63,7 +63,7 @@ func generateTestValidRemarkTxns(t *testing.T, pubKey []byte, accInfo types.Acco
 	nodeStorage := runtime.NodeStorage{
 		BaseDB: runtime.NewInMemoryDB(t),
 	}
-	cfg := wasmer.InstanceConfig{
+	cfg := wasmer.Config{
 		Storage:     genState,
 		LogLvl:      log.Error,
 		NodeStorage: nodeStorage,

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -413,7 +413,7 @@ func newCoreServiceTest(t *testing.T) *core.Service {
 	err = cfg.Keystore.Acco.Insert(kp)
 	require.NoError(t, err)
 
-	var rtCfg runtime.InstanceConfig
+	var rtCfg wasmer.InstanceConfig
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -413,7 +413,7 @@ func newCoreServiceTest(t *testing.T) *core.Service {
 	err = cfg.Keystore.Acco.Insert(kp)
 	require.NoError(t, err)
 
-	var rtCfg wasmer.InstanceConfig
+	var rtCfg wasmer.Config
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -40,7 +40,7 @@ type useRuntimeInstace func(*testing.T, *storage.TrieState) runtime.Instance
 func useInstanceFromGenesis(t *testing.T, rtStorage *storage.TrieState) (instance runtime.Instance) {
 	t.Helper()
 
-	cfg := runtime.InstanceConfig{
+	cfg := wasmer.InstanceConfig{
 		Storage: rtStorage,
 		LogLvl:  log.Warn,
 		NodeStorage: runtime.NodeStorage{
@@ -62,7 +62,7 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 
 	rtStorage.Set(common.CodeKey, bytes)
 
-	cfg := runtime.InstanceConfig{
+	cfg := wasmer.InstanceConfig{
 		Role:     0,
 		LogLvl:   log.Critical,
 		Storage:  rtStorage,

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -40,7 +40,7 @@ type useRuntimeInstace func(*testing.T, *storage.TrieState) runtime.Instance
 func useInstanceFromGenesis(t *testing.T, rtStorage *storage.TrieState) (instance runtime.Instance) {
 	t.Helper()
 
-	cfg := wasmer.InstanceConfig{
+	cfg := wasmer.Config{
 		Storage: rtStorage,
 		LogLvl:  log.Warn,
 		NodeStorage: runtime.NodeStorage{
@@ -62,7 +62,7 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 
 	rtStorage.Set(common.CodeKey, bytes)
 
-	cfg := wasmer.InstanceConfig{
+	cfg := wasmer.Config{
 		Role:     0,
 		LogLvl:   log.Critical,
 		Storage:  rtStorage,

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -361,7 +361,7 @@ func newTestStateService(t *testing.T) *state.Service {
 	err = stateSrvc.Start()
 	require.NoError(t, err)
 
-	var rtCfg runtime.InstanceConfig
+	var rtCfg wasmer.InstanceConfig
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -361,7 +361,7 @@ func newTestStateService(t *testing.T) *state.Service {
 	err = stateSrvc.Start()
 	require.NoError(t, err)
 
-	var rtCfg wasmer.InstanceConfig
+	var rtCfg wasmer.Config
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/services.go
+++ b/dot/services.go
@@ -134,7 +134,7 @@ func createRuntime(cfg *Config, ns runtime.NodeStorage, st *state.Service,
 	var rt runtime.Instance
 	switch cfg.Core.WasmInterpreter {
 	case wasmer.Name:
-		rtCfg := runtime.InstanceConfig{
+		rtCfg := wasmer.InstanceConfig{
 			Storage:     ts,
 			Keystore:    ks,
 			LogLvl:      cfg.Log.RuntimeLvl,

--- a/dot/services.go
+++ b/dot/services.go
@@ -134,7 +134,7 @@ func createRuntime(cfg *Config, ns runtime.NodeStorage, st *state.Service,
 	var rt runtime.Instance
 	switch cfg.Core.WasmInterpreter {
 	case wasmer.Name:
-		rtCfg := wasmer.InstanceConfig{
+		rtCfg := wasmer.Config{
 			Storage:     ts,
 			Keystore:    ks,
 			LogLvl:      cfg.Log.RuntimeLvl,

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -75,7 +75,7 @@ func newStateServiceWithoutMock(t *testing.T) *state.Service {
 
 	stateSrvc.Epoch = epochState
 
-	var rtCfg runtime.InstanceConfig
+	var rtCfg wasmer.InstanceConfig
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -75,7 +75,7 @@ func newStateServiceWithoutMock(t *testing.T) *state.Service {
 
 	stateSrvc.Epoch = epochState
 
-	var rtCfg wasmer.InstanceConfig
+	var rtCfg wasmer.Config
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -269,7 +269,7 @@ func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 
 	stateSrvc.Epoch = epochState
 
-	var rtCfg wasmer.InstanceConfig
+	var rtCfg wasmer.Config
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -269,7 +269,7 @@ func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 
 	stateSrvc.Epoch = epochState
 
-	var rtCfg runtime.InstanceConfig
+	var rtCfg wasmer.InstanceConfig
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -609,7 +609,7 @@ func (bs *BlockState) HandleRuntimeChanges(newState *rtstorage.TrieState,
 			bHash, codeHash, previousVersion.SpecVersion(), currCodeHash, newVersion.SpecVersion())
 	}
 
-	rtCfg := runtime.InstanceConfig{
+	rtCfg := wasmer.InstanceConfig{
 		Storage:     newState,
 		Keystore:    rt.Keystore(),
 		NodeStorage: rt.NodeStorage(),

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -609,7 +609,7 @@ func (bs *BlockState) HandleRuntimeChanges(newState *rtstorage.TrieState,
 			bHash, codeHash, previousVersion.SpecVersion(), currCodeHash, newVersion.SpecVersion())
 	}
 
-	rtCfg := wasmer.InstanceConfig{
+	rtCfg := wasmer.Config{
 		Storage:     newState,
 		Keystore:    rt.Keystore(),
 		NodeStorage: rt.NodeStorage(),

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -159,7 +159,7 @@ func (s *Service) CreateGenesisRuntime(t *trie.Trie, gen *genesis.Genesis) (runt
 	genTrie := rtstorage.NewTrieState(t)
 
 	// create genesis runtime
-	rtCfg := wasmer.InstanceConfig{
+	rtCfg := wasmer.Config{
 		LogLvl:  s.logLvl,
 		Storage: genTrie,
 	}

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -159,7 +159,7 @@ func (s *Service) CreateGenesisRuntime(t *trie.Trie, gen *genesis.Genesis) (runt
 	genTrie := rtstorage.NewTrieState(t)
 
 	// create genesis runtime
-	rtCfg := runtime.InstanceConfig{
+	rtCfg := wasmer.InstanceConfig{
 		LogLvl:  s.logLvl,
 		Storage: genTrie,
 	}

--- a/dot/sync/syncer_integration_test.go
+++ b/dot/sync/syncer_integration_test.go
@@ -63,7 +63,7 @@ func newTestSyncer(t *testing.T) *Service {
 	// initialise runtime
 	genState := rtstorage.NewTrieState(genTrie)
 
-	rtCfg := wasmer.InstanceConfig{
+	rtCfg := wasmer.Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}

--- a/dot/sync/syncer_integration_test.go
+++ b/dot/sync/syncer_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
-	"github.com/ChainSafe/gossamer/lib/runtime"
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
@@ -64,7 +63,7 @@ func newTestSyncer(t *testing.T) *Service {
 	// initialise runtime
 	genState := rtstorage.NewTrieState(genTrie)
 
-	rtCfg := runtime.InstanceConfig{
+	rtCfg := wasmer.InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -124,7 +124,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		cfg.EpochState = dbSrv.Epoch
 	}
 
-	var rtCfg runtime.InstanceConfig
+	var rtCfg wasmer.InstanceConfig
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	storageState := cfg.StorageState.(core.StorageState)
@@ -177,7 +177,7 @@ func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *
 		_ = dbSrv.Stop()
 	})
 
-	rtCfg := runtime.InstanceConfig{
+	rtCfg := wasmer.InstanceConfig{
 		Storage: rtstorage.NewTrieState(genTrie),
 	}
 

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -124,7 +124,7 @@ func createTestService(t *testing.T, cfg *ServiceConfig) *Service {
 		cfg.EpochState = dbSrv.Epoch
 	}
 
-	var rtCfg wasmer.InstanceConfig
+	var rtCfg wasmer.Config
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 
 	storageState := cfg.StorageState.(core.StorageState)
@@ -177,7 +177,7 @@ func newTestServiceSetupParameters(t *testing.T) (*Service, *state.EpochState, *
 		_ = dbSrv.Stop()
 	})
 
-	rtCfg := wasmer.InstanceConfig{
+	rtCfg := wasmer.Config{
 		Storage: rtstorage.NewTrieState(genTrie),
 	}
 

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/ed25519"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/keystore"
-	"github.com/ChainSafe/gossamer/lib/runtime"
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
@@ -57,7 +56,7 @@ func newTestState(t *testing.T) *state.Service {
 	block, err := state.NewBlockStateFromGenesis(db, tries, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 
-	var rtCfg runtime.InstanceConfig
+	var rtCfg wasmer.InstanceConfig
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -56,7 +56,7 @@ func newTestState(t *testing.T) *state.Service {
 	block, err := state.NewBlockStateFromGenesis(db, tries, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 
-	var rtCfg wasmer.InstanceConfig
+	var rtCfg wasmer.Config
 
 	rtCfg.Storage = rtstorage.NewTrieState(genTrie)
 

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -4,8 +4,6 @@
 package runtime
 
 import (
-	"github.com/ChainSafe/gossamer/internal/log"
-	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime/offchain"
@@ -45,18 +43,6 @@ func (n *NodeStorage) SetPersistent(k, v []byte) error {
 // GetPersistent retrieve a key and value from PERSISTENT node storage
 func (n *NodeStorage) GetPersistent(k []byte) ([]byte, error) {
 	return n.PersistentStorage.Get(k)
-}
-
-// InstanceConfig represents a runtime instance configuration
-type InstanceConfig struct {
-	Storage     Storage
-	Keystore    *keystore.GlobalKeystore
-	LogLvl      log.Level
-	Role        common.Roles
-	NodeStorage NodeStorage
-	Network     BasicNetwork
-	Transaction TransactionState
-	CodeHash    common.Hash
 }
 
 // Context is the context for the wasm interpreter's imported functions

--- a/lib/runtime/wasmer/config.go
+++ b/lib/runtime/wasmer/config.go
@@ -1,0 +1,23 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package wasmer
+
+import (
+	"github.com/ChainSafe/gossamer/internal/log"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/keystore"
+	"github.com/ChainSafe/gossamer/lib/runtime"
+)
+
+// InstanceConfig represents a runtime instance configuration
+type InstanceConfig struct {
+	Storage     runtime.Storage
+	Keystore    *keystore.GlobalKeystore
+	LogLvl      log.Level
+	Role        common.Roles
+	NodeStorage runtime.NodeStorage
+	Network     runtime.BasicNetwork
+	Transaction runtime.TransactionState
+	CodeHash    common.Hash
+}

--- a/lib/runtime/wasmer/config.go
+++ b/lib/runtime/wasmer/config.go
@@ -10,8 +10,9 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 )
 
-// InstanceConfig represents a runtime instance configuration
-type InstanceConfig struct {
+// Config is the configuration used to create a
+// Wasmer runtime instance.
+type Config struct {
 	Storage     runtime.Storage
 	Keystore    *keystore.GlobalKeystore
 	LogLvl      log.Level

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -174,7 +174,7 @@ func TestInstance_Version_KusamaRuntime(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -296,7 +296,7 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -526,7 +526,7 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -556,7 +556,7 @@ func TestInstance_ApplyExtrinsic_GossamerRuntime(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -616,7 +616,7 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -668,7 +668,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -714,7 +714,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock3784(t *testing.T) {
 	// set state to genesis state
 	state3783 := storage.NewTrieState(gossTrie3783)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: state3783,
 		LogLvl:  log.Critical,
 	}
@@ -760,7 +760,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442(t *testing.T) {
 	// set state to genesis state
 	state901441 := storage.NewTrieState(ksmTrie901441)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: state901441,
 		LogLvl:  log.Critical,
 	}
@@ -806,7 +806,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1377831(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}
@@ -852,7 +852,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1482003(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}
@@ -900,7 +900,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock4939774(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}
@@ -943,7 +943,7 @@ func TestInstance_ExecuteBlock_PolkadotBlock1089328(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(dotTrie)
 
-	cfg := InstanceConfig{
+	cfg := Config{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -174,7 +174,7 @@ func TestInstance_Version_KusamaRuntime(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -296,7 +296,7 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -526,7 +526,7 @@ func TestInstance_ExecuteBlock_GossamerRuntime(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -556,7 +556,7 @@ func TestInstance_ApplyExtrinsic_GossamerRuntime(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -616,7 +616,7 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -668,7 +668,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 	// set state to genesis state
 	genState := storage.NewTrieState(genTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: genState,
 		LogLvl:  log.Critical,
 	}
@@ -714,7 +714,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock3784(t *testing.T) {
 	// set state to genesis state
 	state3783 := storage.NewTrieState(gossTrie3783)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: state3783,
 		LogLvl:  log.Critical,
 	}
@@ -760,7 +760,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442(t *testing.T) {
 	// set state to genesis state
 	state901441 := storage.NewTrieState(ksmTrie901441)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: state901441,
 		LogLvl:  log.Critical,
 	}
@@ -806,7 +806,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1377831(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}
@@ -852,7 +852,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1482003(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}
@@ -900,7 +900,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock4939774(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}
@@ -943,7 +943,7 @@ func TestInstance_ExecuteBlock_PolkadotBlock1089328(t *testing.T) {
 	// set state to genesis state
 	state := storage.NewTrieState(dotTrie)
 
-	cfg := runtime.InstanceConfig{
+	cfg := InstanceConfig{
 		Storage: state,
 		LogLvl:  log.Critical,
 	}

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -47,7 +47,7 @@ type Instance struct {
 }
 
 // NewRuntimeFromGenesis creates a runtime instance from the genesis data
-func NewRuntimeFromGenesis(cfg InstanceConfig) (instance runtime.Instance, err error) {
+func NewRuntimeFromGenesis(cfg Config) (instance runtime.Instance, err error) {
 	if cfg.Storage == nil {
 		return nil, errors.New("storage is nil")
 	}
@@ -61,7 +61,7 @@ func NewRuntimeFromGenesis(cfg InstanceConfig) (instance runtime.Instance, err e
 }
 
 // NewInstanceFromTrie returns a new runtime instance with the code provided in the given trie
-func NewInstanceFromTrie(t *trie.Trie, cfg InstanceConfig) (*Instance, error) {
+func NewInstanceFromTrie(t *trie.Trie, cfg Config) (*Instance, error) {
 	code := t.Get(common.CodeKey)
 	if len(code) == 0 {
 		return nil, fmt.Errorf("cannot find :code in trie")
@@ -71,7 +71,7 @@ func NewInstanceFromTrie(t *trie.Trie, cfg InstanceConfig) (*Instance, error) {
 }
 
 // NewInstanceFromFile instantiates a runtime from a .wasm file
-func NewInstanceFromFile(fp string, cfg InstanceConfig) (*Instance, error) {
+func NewInstanceFromFile(fp string, cfg Config) (*Instance, error) {
 	// Reads the WebAssembly module as bytes.
 	bytes, err := wasm.ReadBytes(fp)
 	if err != nil {
@@ -82,7 +82,7 @@ func NewInstanceFromFile(fp string, cfg InstanceConfig) (*Instance, error) {
 }
 
 // NewInstance instantiates a runtime from raw wasm bytecode
-func NewInstance(code []byte, cfg InstanceConfig) (instance *Instance, err error) {
+func NewInstance(code []byte, cfg Config) (instance *Instance, err error) {
 	logger.Patch(log.SetLevel(cfg.LogLvl), log.SetCallerFunc(true))
 
 	wasmInstance, allocator, err := setupVM(code)
@@ -159,7 +159,7 @@ func (in *Instance) UpdateRuntimeCode(code []byte) (err error) {
 // GetRuntimeVersion finds the runtime version by initiating a temporary
 // runtime instance using the WASM code provided, and querying it.
 func GetRuntimeVersion(code []byte) (version runtime.Version, err error) {
-	config := runtime.InstanceConfig{
+	config := Config{
 		LogLvl: log.DoNotChange,
 	}
 	instance, err := NewInstance(code, config)

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -47,7 +47,7 @@ type Instance struct {
 }
 
 // NewRuntimeFromGenesis creates a runtime instance from the genesis data
-func NewRuntimeFromGenesis(cfg runtime.InstanceConfig) (instance runtime.Instance, err error) {
+func NewRuntimeFromGenesis(cfg InstanceConfig) (instance runtime.Instance, err error) {
 	if cfg.Storage == nil {
 		return nil, errors.New("storage is nil")
 	}
@@ -61,7 +61,7 @@ func NewRuntimeFromGenesis(cfg runtime.InstanceConfig) (instance runtime.Instanc
 }
 
 // NewInstanceFromTrie returns a new runtime instance with the code provided in the given trie
-func NewInstanceFromTrie(t *trie.Trie, cfg runtime.InstanceConfig) (*Instance, error) {
+func NewInstanceFromTrie(t *trie.Trie, cfg InstanceConfig) (*Instance, error) {
 	code := t.Get(common.CodeKey)
 	if len(code) == 0 {
 		return nil, fmt.Errorf("cannot find :code in trie")
@@ -71,7 +71,7 @@ func NewInstanceFromTrie(t *trie.Trie, cfg runtime.InstanceConfig) (*Instance, e
 }
 
 // NewInstanceFromFile instantiates a runtime from a .wasm file
-func NewInstanceFromFile(fp string, cfg runtime.InstanceConfig) (*Instance, error) {
+func NewInstanceFromFile(fp string, cfg InstanceConfig) (*Instance, error) {
 	// Reads the WebAssembly module as bytes.
 	bytes, err := wasm.ReadBytes(fp)
 	if err != nil {
@@ -82,7 +82,7 @@ func NewInstanceFromFile(fp string, cfg runtime.InstanceConfig) (*Instance, erro
 }
 
 // NewInstance instantiates a runtime from raw wasm bytecode
-func NewInstance(code []byte, cfg runtime.InstanceConfig) (instance *Instance, err error) {
+func NewInstance(code []byte, cfg InstanceConfig) (instance *Instance, err error) {
 	logger.Patch(log.SetLevel(cfg.LogLvl), log.SetCallerFunc(true))
 
 	wasmInstance, allocator, err := setupVM(code)

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -41,7 +41,7 @@ func NewTestInstanceWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie) 
 	return r
 }
 
-func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role common.Roles) runtime.InstanceConfig {
+func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role common.Roles) InstanceConfig {
 	t.Helper()
 
 	s := storage.NewTrieState(tt)
@@ -52,7 +52,7 @@ func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role common.Roles) 
 		BaseDB:            runtime.NewInMemoryDB(t), // we're using a local storage here since this is a test runtime
 	}
 
-	return runtime.InstanceConfig{
+	return InstanceConfig{
 		Storage:     s,
 		Keystore:    keystore.NewGlobalKeystore(),
 		LogLvl:      lvl,

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -41,7 +41,7 @@ func NewTestInstanceWithTrie(t *testing.T, targetRuntime string, tt *trie.Trie) 
 	return r
 }
 
-func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role common.Roles) InstanceConfig {
+func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role common.Roles) Config {
 	t.Helper()
 
 	s := storage.NewTrieState(tt)
@@ -52,7 +52,7 @@ func setupConfig(t *testing.T, tt *trie.Trie, lvl log.Level, role common.Roles) 
 		BaseDB:            runtime.NewInMemoryDB(t), // we're using a local storage here since this is a test runtime
 	}
 
-	return InstanceConfig{
+	return Config{
 		Storage:     s,
 		Keystore:    keystore.NewGlobalKeystore(),
 		LogLvl:      lvl,


### PR DESCRIPTION
## Changes

Move `InstanceConfig` from `lib/runtime` to `Config` in `lib/runtime/wasmer`

This is so private fields can be added for test-only in the wasmer package (blocks #2747)

## Tests

## Issues

#2418 

## Primary Reviewer

@timwu20