### PR TITLE
chore(blockstate): change `GetRuntime` to take `common.Hash` as argument

### DIFF
--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -301,5 +301,3 @@ func getGssmrRuntimeCode(t *testing.T) (code []byte) {
 
 	return trieState.LoadCode()
 }
-
-func hashPtr(h common.Hash) *common.Hash { return &h }

--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -70,7 +70,7 @@ type BlockState interface {
 	SubChain(start, end common.Hash) ([]common.Hash, error)
 	GetBlockBody(hash common.Hash) (*types.Body, error)
 	HandleRuntimeChanges(newState *rtstorage.TrieState, in runtime.Instance, bHash common.Hash) error
-	GetRuntime(*common.Hash) (runtime.Instance, error)
+	GetRuntime(blockHash common.Hash) (instance runtime.Instance, err error)
 	StoreRuntime(common.Hash, runtime.Instance)
 }
 

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -69,7 +69,7 @@ func (s *Service) HandleTransactionMessage(peerID peer.ID, msg *network.Transact
 	}
 
 	hash := head.Hash()
-	rt, err := s.blockState.GetRuntime(&hash)
+	rt, err := s.blockState.GetRuntime(hash)
 	if err != nil {
 		return false, err
 	}

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -68,8 +68,8 @@ func (s *Service) HandleTransactionMessage(peerID peer.ID, msg *network.Transact
 		return false, err
 	}
 
-	hash := head.Hash()
-	rt, err := s.blockState.GetRuntime(hash)
+	bestBlockHash := head.Hash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	if err != nil {
 		return false, err
 	}

--- a/dot/core/messages_integration_test.go
+++ b/dot/core/messages_integration_test.go
@@ -157,7 +157,8 @@ func TestService_HandleTransactionMessage(t *testing.T) {
 	genHeader, err := s.blockState.BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	ts, err := s.storageState.TrieState(nil)

--- a/dot/core/mocks_test.go
+++ b/dot/core/mocks_test.go
@@ -286,7 +286,7 @@ func (mr *MockBlockStateMockRecorder) GetImportedBlockNotifierChannel() *gomock.
 }
 
 // GetRuntime mocks base method.
-func (m *MockBlockState) GetRuntime(arg0 *common.Hash) (runtime.Instance, error) {
+func (m *MockBlockState) GetRuntime(arg0 common.Hash) (runtime.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRuntime", arg0)
 	ret0, _ := ret[0].(runtime.Instance)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -218,7 +218,7 @@ func (s *Service) handleBlock(block *types.Block, state *rtstorage.TrieState) er
 	logger.Debugf("imported block %s and stored state trie with root %s",
 		block.Header.Hash(), state.MustRoot())
 
-	rt, err := s.blockState.GetRuntime(&block.Header.ParentHash)
+	rt, err := s.blockState.GetRuntime(block.Header.ParentHash)
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func (s *Service) handleCodeSubstitution(hash common.Hash,
 		return fmt.Errorf("%w: for hash %s", ErrEmptyRuntimeCode, hash)
 	}
 
-	rt, err := s.blockState.GetRuntime(&hash)
+	rt, err := s.blockState.GetRuntime(hash)
 	if err != nil {
 		return fmt.Errorf("getting runtime from block state: %w", err)
 	}
@@ -352,7 +352,8 @@ func (s *Service) handleChainReorg(prev, curr common.Hash) error {
 	}
 
 	// Check transaction validation on the best block.
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	if err != nil {
 		return err
 	}
@@ -425,7 +426,8 @@ func (s *Service) maintainTransactionPool(block *types.Block, bestBlockHash comm
 	// re-validate transactions in the pool and move them to the queue
 	txs := s.transactionState.PendingInPool()
 	for _, tx := range txs {
-		rt, err := s.blockState.GetRuntime(&bestBlockHash)
+		bestBlockHash := s.blockState.BestBlockHash()
+		rt, err := s.blockState.GetRuntime(bestBlockHash)
 		if err != nil {
 			return fmt.Errorf("failed to get runtime to re-validate transactions in pool: %s", err)
 		}
@@ -477,7 +479,8 @@ func (s *Service) HasKey(pubKeyStr, keystoreType string) (bool, error) {
 
 // DecodeSessionKeys executes the runtime DecodeSessionKeys and return the scale encoded keys
 func (s *Service) DecodeSessionKeys(enc []byte) ([]byte, error) {
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	if err != nil {
 		return nil, err
 	}
@@ -497,6 +500,9 @@ func (s *Service) GetRuntimeVersion(bhash *common.Hash) (
 		if err != nil {
 			return version, err
 		}
+	} else {
+		bhash = new(common.Hash)
+		*bhash = s.blockState.BestBlockHash()
 	}
 
 	ts, err := s.storageState.TrieState(stateRootHash)
@@ -504,7 +510,7 @@ func (s *Service) GetRuntimeVersion(bhash *common.Hash) (
 		return version, err
 	}
 
-	rt, err := s.blockState.GetRuntime(bhash)
+	rt, err := s.blockState.GetRuntime(*bhash)
 	if err != nil {
 		return version, err
 	}
@@ -535,7 +541,7 @@ func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 		return err
 	}
 
-	rt, err := s.blockState.GetRuntime(&bestBlockHash)
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	if err != nil {
 		logger.Critical("failed to get runtime")
 		return err
@@ -576,13 +582,16 @@ func (s *Service) GetMetadata(bhash *common.Hash) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		bhash = new(common.Hash)
+		*bhash = s.blockState.BestBlockHash()
 	}
 	ts, err := s.storageState.TrieState(stateRootHash)
 	if err != nil {
 		return nil, err
 	}
 
-	rt, err := s.blockState.GetRuntime(bhash)
+	rt, err := s.blockState.GetRuntime(*bhash)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -209,7 +209,8 @@ func TestHandleChainReorg_WithReorg_Trans(t *testing.T) {
 	parent, err := bs.BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	block1 := sync.BuildBlock(t, rt, parent, nil)
@@ -299,8 +300,8 @@ func TestHandleChainReorg_WithReorg_Transactions(t *testing.T) {
 	// we prefix with []byte{2} here since that's the enum index for the old IncludeDataExt extrinsic
 	tx := append([]byte{2}, enc...)
 
-	bhash := s.blockState.BestBlockHash()
-	rt, err := s.blockState.GetRuntime(&bhash)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	validity, err := rt.ValidateTransaction(tx)
@@ -440,7 +441,8 @@ func TestMaintainTransactionPoolLatestTxnQueue_BlockWithExtrinsics(t *testing.T)
 
 func TestService_GetRuntimeVersion(t *testing.T) {
 	s := NewTestService(t, nil)
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	rtExpected := rt.Version()
@@ -461,7 +463,8 @@ func TestService_HandleSubmittedExtrinsic(t *testing.T) {
 	genHeader, err := s.blockState.BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	ts, err := s.storageState.TrieState(nil)
@@ -492,7 +495,8 @@ func TestService_HandleRuntimeChanges(t *testing.T) {
 	)
 	s := NewTestService(t, nil)
 
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	v := rt.Version()
@@ -526,7 +530,7 @@ func TestService_HandleRuntimeChanges(t *testing.T) {
 	ts, err := s.storageState.TrieState(nil) // Pass genesis root
 	require.NoError(t, err)
 
-	parentRt, err := s.blockState.GetRuntime(&hash)
+	parentRt, err := s.blockState.GetRuntime(hash)
 	require.NoError(t, err)
 
 	v = parentRt.Version()
@@ -547,13 +551,13 @@ func TestService_HandleRuntimeChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	// bhash1 runtime should not be updated
-	rt, err = s.blockState.GetRuntime(&bhash1)
+	rt, err = s.blockState.GetRuntime(bhash1)
 	require.NoError(t, err)
 
 	v = rt.Version()
 	require.Equal(t, v.SpecVersion, currSpecVersion)
 
-	rt, err = s.blockState.GetRuntime(&rtUpdateBhash)
+	rt, err = s.blockState.GetRuntime(rtUpdateBhash)
 	require.NoError(t, err)
 
 	v = rt.Version()
@@ -574,7 +578,8 @@ func TestService_HandleCodeSubstitutes(t *testing.T) {
 		blockHash: common.BytesToHex(testRuntime),
 	}
 
-	rt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	rt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	s.blockState.StoreRuntime(blockHash, rt)
@@ -589,7 +594,8 @@ func TestService_HandleCodeSubstitutes(t *testing.T) {
 func TestService_HandleRuntimeChangesAfterCodeSubstitutes(t *testing.T) {
 	s := NewTestService(t, nil)
 
-	parentRt, err := s.blockState.GetRuntime(nil)
+	bestBlockHash := s.blockState.BestBlockHash()
+	parentRt, err := s.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	codeHashBefore := parentRt.GetCodeHash()
@@ -626,7 +632,7 @@ func TestService_HandleRuntimeChangesAfterCodeSubstitutes(t *testing.T) {
 	err = s.blockState.HandleRuntimeChanges(ts, parentRt, rtUpdateBhash)
 	require.NoError(t, err)
 
-	rt, err := s.blockState.GetRuntime(&rtUpdateBhash)
+	rt, err := s.blockState.GetRuntime(rtUpdateBhash)
 	require.NoError(t, err)
 
 	// codeHash should change after runtime change

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -215,7 +215,7 @@ func Test_Service_handleCodeSubstitution(t *testing.T) {
 		"block state get runtime error": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				blockState := NewMockBlockState(ctrl)
-				blockState.EXPECT().GetRuntime(hashPtr(common.Hash{0x01})).
+				blockState.EXPECT().GetRuntime(common.Hash{0x01}).
 					Return(nil, errTest)
 				return &Service{
 					blockState: blockState,
@@ -237,7 +237,7 @@ func Test_Service_handleCodeSubstitution(t *testing.T) {
 				storedRuntime.EXPECT().Validator().Return(false)
 
 				blockState := NewMockBlockState(ctrl)
-				blockState.EXPECT().GetRuntime(hashPtr(common.Hash{0x01})).
+				blockState.EXPECT().GetRuntime(common.Hash{0x01}).
 					Return(storedRuntime, nil)
 
 				return &Service{
@@ -264,7 +264,7 @@ func Test_Service_handleCodeSubstitution(t *testing.T) {
 				storedRuntime.EXPECT().Validator().Return(true)
 
 				blockState := NewMockBlockState(ctrl)
-				blockState.EXPECT().GetRuntime(hashPtr(common.Hash{0x01})).
+				blockState.EXPECT().GetRuntime(common.Hash{0x01}).
 					Return(storedRuntime, nil)
 
 				codeSubstitutedState := NewMockCodeSubstitutedState(ctrl)
@@ -293,7 +293,7 @@ func Test_Service_handleCodeSubstitution(t *testing.T) {
 				storedRuntime.EXPECT().Validator().Return(true)
 
 				blockState := NewMockBlockState(ctrl)
-				blockState.EXPECT().GetRuntime(hashPtr(common.Hash{0x01})).
+				blockState.EXPECT().GetRuntime(common.Hash{0x01}).
 					Return(storedRuntime, nil)
 
 				codeSubstitutedState := NewMockCodeSubstitutedState(ctrl)
@@ -421,7 +421,7 @@ func Test_Service_handleBlock(t *testing.T) {
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
-		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(nil, errTestDummyError)
+		mockBlockState.EXPECT().GetRuntime(block.Header.ParentHash).Return(nil, errTestDummyError)
 
 		service := &Service{
 			storageState: mockStorageState,
@@ -444,7 +444,7 @@ func Test_Service_handleBlock(t *testing.T) {
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
-		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(runtimeMock, nil)
+		mockBlockState.EXPECT().GetRuntime(block.Header.ParentHash).Return(runtimeMock, nil)
 		mockBlockState.EXPECT().HandleRuntimeChanges(trieState, runtimeMock, block.Header.Hash()).
 			Return(errTestDummyError)
 
@@ -469,7 +469,7 @@ func Test_Service_handleBlock(t *testing.T) {
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
-		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(runtimeMock, nil)
+		mockBlockState.EXPECT().GetRuntime(block.Header.ParentHash).Return(runtimeMock, nil)
 		mockBlockState.EXPECT().HandleRuntimeChanges(trieState, runtimeMock, block.Header.Hash()).Return(nil)
 
 		service := &Service{
@@ -527,7 +527,7 @@ func Test_Service_HandleBlockProduced(t *testing.T) {
 		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
-		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(runtimeMock, nil)
+		mockBlockState.EXPECT().GetRuntime(block.Header.ParentHash).Return(runtimeMock, nil)
 		mockBlockState.EXPECT().HandleRuntimeChanges(trieState, runtimeMock, block.Header.Hash()).Return(nil)
 		mockNetwork := NewMockNetwork(ctrl)
 		mockNetwork.EXPECT().GossipMessage(msg)
@@ -590,8 +590,11 @@ func Test_Service_maintainTransactionPool(t *testing.T) {
 		mockTxnState.EXPECT().RemoveExtrinsic(types.Extrinsic{21}).Times(2)
 		mockTxnState.EXPECT().PendingInPool().Return([]*transaction.ValidTransaction{vt})
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(&common.Hash{1}).Return(runtimeMock, nil)
-		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
+		runtimeBlockHashCall := mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).
+			Return(runtimeMock, nil).After(runtimeBlockHashCall)
+		mockBlockState.EXPECT().BestBlockHash().
+			Return(common.Hash{}).After(runtimeBlockHashCall)
 
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().TrieState(&common.Hash{1}).Return(&rtstorage.TrieState{}, nil)
@@ -654,8 +657,11 @@ func Test_Service_maintainTransactionPool(t *testing.T) {
 		mockTxnState.EXPECT().RemoveExtrinsicFromPool(types.Extrinsic{21})
 
 		mockBlockStateOk := NewMockBlockState(ctrl)
-		mockBlockStateOk.EXPECT().GetRuntime(&common.Hash{1}).Return(runtimeMock, nil)
-		mockBlockStateOk.EXPECT().BestBlockHash().Return(common.Hash{})
+		runtimeBlockHashCall := mockBlockStateOk.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockStateOk.EXPECT().GetRuntime(common.Hash{1}).
+			Return(runtimeMock, nil).After(runtimeBlockHashCall)
+		mockBlockStateOk.EXPECT().BestBlockHash().
+			Return(common.Hash{}).After(runtimeBlockHashCall)
 
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().TrieState(&common.Hash{1}).Return(&rtstorage.TrieState{}, nil)
@@ -831,7 +837,8 @@ func TestService_handleChainReorg(t *testing.T) {
 		mockBlockState.EXPECT().HighestCommonAncestor(testPrevHash, testCurrentHash).
 			Return(testAncestorHash, nil)
 		mockBlockState.EXPECT().SubChain(testAncestorHash, testPrevHash).Return(testSubChain, nil)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(nil, errDummyErr)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(nil, errDummyErr)
 
 		service := &Service{
 			blockState: mockBlockState,
@@ -863,7 +870,8 @@ func TestService_handleChainReorg(t *testing.T) {
 		mockBlockState.EXPECT().HighestCommonAncestor(testPrevHash, testCurrentHash).
 			Return(testAncestorHash, nil)
 		mockBlockState.EXPECT().SubChain(testAncestorHash, testPrevHash).Return(testSubChain, nil)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMockErr, nil)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(runtimeMockErr, nil)
 		mockBlockState.EXPECT().GetBlockBody(testCurrentHash).Return(nil, errDummyErr)
 		mockBlockState.EXPECT().GetBlockBody(testAncestorHash).Return(body, nil)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
@@ -901,7 +909,8 @@ func TestService_handleChainReorg(t *testing.T) {
 		mockBlockState.EXPECT().HighestCommonAncestor(testPrevHash, testCurrentHash).
 			Return(testAncestorHash, nil)
 		mockBlockState.EXPECT().SubChain(testAncestorHash, testPrevHash).Return(testSubChain, nil)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMockOk, nil)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(runtimeMockOk, nil)
 		mockBlockState.EXPECT().GetBlockBody(testCurrentHash).Return(nil, errDummyErr)
 		mockBlockState.EXPECT().GetBlockBody(testAncestorHash).Return(body, nil)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
@@ -1048,7 +1057,8 @@ func TestService_DecodeSessionKeys(t *testing.T) {
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		runtimeMock.EXPECT().DecodeSessionKeys(testEncKeys).Return(testEncKeys, nil)
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMock, nil)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(runtimeMock, nil)
 		service := &Service{
 			blockState: mockBlockState,
 		}
@@ -1059,7 +1069,8 @@ func TestService_DecodeSessionKeys(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(nil, errDummyErr)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(nil, errDummyErr)
 		service := &Service{
 			blockState: mockBlockState,
 		}
@@ -1084,11 +1095,12 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 	emptyTrie := trie.NewEmptyTrie()
 	ts := rtstorage.NewTrieState(emptyTrie)
 
-	execTest := func(t *testing.T, s *Service, bhash *common.Hash, exp runtime.Version, expErr error) {
+	execTest := func(t *testing.T, s *Service, bhash *common.Hash, exp runtime.Version,
+		expErr error, expectedErrMessage string) {
 		res, err := s.GetRuntimeVersion(bhash)
 		assert.ErrorIs(t, err, expErr)
 		if expErr != nil {
-			assert.EqualError(t, err, expErr.Error())
+			assert.EqualError(t, err, expectedErrMessage)
 		}
 		assert.Equal(t, exp, res)
 	}
@@ -1101,7 +1113,8 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		service := &Service{
 			storageState: mockStorageState,
 		}
-		execTest(t, service, &common.Hash{}, runtime.Version{}, errDummyErr)
+		const expectedErrMessage = "setting up runtime: getting state root from block hash: dummy error for testing"
+		execTest(t, service, &common.Hash{}, runtime.Version{}, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("trie state err", func(t *testing.T) {
@@ -1113,7 +1126,8 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		service := &Service{
 			storageState: mockStorageState,
 		}
-		execTest(t, service, &common.Hash{}, runtime.Version{}, errDummyErr)
+		const expectedErrMessage = "setting up runtime: getting trie state: dummy error for testing"
+		execTest(t, service, &common.Hash{}, runtime.Version{}, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("get runtime err", func(t *testing.T) {
@@ -1124,12 +1138,13 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(ts, nil).MaxTimes(2)
 
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(nil, errDummyErr)
+		mockBlockState.EXPECT().GetRuntime(common.Hash{}).Return(nil, errDummyErr)
 		service := &Service{
 			storageState: mockStorageState,
 			blockState:   mockBlockState,
 		}
-		execTest(t, service, &common.Hash{}, runtime.Version{}, errDummyErr)
+		const expectedErrMessage = "setting up runtime: getting runtime: dummy error for testing"
+		execTest(t, service, &common.Hash{}, runtime.Version{}, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("happy path", func(t *testing.T) {
@@ -1141,14 +1156,14 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMock, nil)
+		mockBlockState.EXPECT().GetRuntime(common.Hash{}).Return(runtimeMock, nil)
 		runtimeMock.EXPECT().SetContextStorage(ts)
 		runtimeMock.EXPECT().Version().Return(rv)
 		service := &Service{
 			storageState: mockStorageState,
 			blockState:   mockBlockState,
 		}
-		execTest(t, service, &common.Hash{}, rv, nil)
+		execTest(t, service, &common.Hash{}, rv, nil, "")
 	})
 }
 
@@ -1201,7 +1216,7 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
-		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(nil, errDummyErr)
+		mockBlockState.EXPECT().GetRuntime(common.Hash{}).Return(nil, errDummyErr)
 
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(&rtstorage.TrieState{}, nil)
@@ -1224,7 +1239,7 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
 		runtimeMockErr := NewMockRuntimeInstance(ctrl)
-		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMockErr, nil).MaxTimes(2)
+		mockBlockState.EXPECT().GetRuntime(common.Hash{}).Return(runtimeMockErr, nil).MaxTimes(2)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
 
 		mockStorageState := NewMockStorageState(ctrl)
@@ -1265,7 +1280,7 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
-		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMock, nil).MaxTimes(2)
+		mockBlockState.EXPECT().GetRuntime(common.Hash{}).Return(runtimeMock, nil).MaxTimes(2)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{})
 
 		runtimeMock.EXPECT().ValidateTransaction(externalExt).Return(&transaction.Validity{Propagate: true}, nil)
@@ -1305,11 +1320,12 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 
 func TestServiceGetMetadata(t *testing.T) {
 	t.Parallel()
-	execTest := func(t *testing.T, s *Service, bhash *common.Hash, exp []byte, expErr error) {
+	execTest := func(t *testing.T, s *Service, bhash *common.Hash, exp []byte,
+		expErr error, expectedErrMessage string) {
 		res, err := s.GetMetadata(bhash)
 		assert.ErrorIs(t, err, expErr)
 		if expErr != nil {
-			assert.EqualError(t, err, expErr.Error())
+			assert.EqualError(t, err, expectedErrMessage)
 		}
 		assert.Equal(t, exp, res)
 	}
@@ -1322,7 +1338,8 @@ func TestServiceGetMetadata(t *testing.T) {
 		service := &Service{
 			storageState: mockStorageState,
 		}
-		execTest(t, service, &common.Hash{}, nil, errDummyErr)
+		const expectedErrMessage = "setting up runtime: getting state root from block hash: dummy error for testing"
+		execTest(t, service, &common.Hash{}, nil, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("trie state error", func(t *testing.T) {
@@ -1333,7 +1350,8 @@ func TestServiceGetMetadata(t *testing.T) {
 		service := &Service{
 			storageState: mockStorageState,
 		}
-		execTest(t, service, nil, nil, errDummyErr)
+		const expectedErrMessage = "setting up runtime: getting trie state: dummy error for testing"
+		execTest(t, service, nil, nil, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("get runtime error", func(t *testing.T) {
@@ -1342,12 +1360,14 @@ func TestServiceGetMetadata(t *testing.T) {
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(nil, errDummyErr)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(nil, errDummyErr)
 		service := &Service{
 			storageState: mockStorageState,
 			blockState:   mockBlockState,
 		}
-		execTest(t, service, nil, nil, errDummyErr)
+		const expectedErrMessage = "setting up runtime: getting runtime: dummy error for testing"
+		execTest(t, service, nil, nil, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("happy path", func(t *testing.T) {
@@ -1357,14 +1377,16 @@ func TestServiceGetMetadata(t *testing.T) {
 		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
 		runtimeMockOk := NewMockRuntimeInstance(ctrl)
 		mockBlockState := NewMockBlockState(ctrl)
-		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMockOk, nil)
+		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
+		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(runtimeMockOk, nil)
 		runtimeMockOk.EXPECT().SetContextStorage(&rtstorage.TrieState{})
 		runtimeMockOk.EXPECT().Metadata().Return([]byte{1, 2, 3}, nil)
 		service := &Service{
 			storageState: mockStorageState,
 			blockState:   mockBlockState,
 		}
-		execTest(t, service, nil, []byte{1, 2, 3}, nil)
+		const expectedErrMessage = "setting up runtime: getting state root from block hash: dummy error for testing"
+		execTest(t, service, nil, []byte{1, 2, 3}, nil, expectedErrMessage)
 	})
 }
 

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -50,7 +50,7 @@ type BlockAPI interface {
 	SubChain(start, end common.Hash) ([]common.Hash, error)
 	RegisterRuntimeUpdatedChannel(ch chan<- runtime.Version) (uint32, error)
 	UnregisterRuntimeUpdatedChannel(id uint32) bool
-	GetRuntime(hash *common.Hash) (runtime.Instance, error)
+	GetRuntime(blockHash common.Hash) (instance runtime.Instance, err error)
 }
 
 //go:generate mockery --name NetworkAPI --structname NetworkAPI --case underscore --keeptree

--- a/dot/rpc/modules/mocks/block_api.go
+++ b/dot/rpc/modules/mocks/block_api.go
@@ -212,13 +212,13 @@ func (_m *BlockAPI) GetJustification(hash common.Hash) ([]byte, error) {
 	return r0, r1
 }
 
-// GetRuntime provides a mock function with given fields: hash
-func (_m *BlockAPI) GetRuntime(hash *common.Hash) (runtime.Instance, error) {
-	ret := _m.Called(hash)
+// GetRuntime provides a mock function with given fields: blockHash
+func (_m *BlockAPI) GetRuntime(blockHash common.Hash) (runtime.Instance, error) {
+	ret := _m.Called(blockHash)
 
 	var r0 runtime.Instance
-	if rf, ok := ret.Get(0).(func(*common.Hash) runtime.Instance); ok {
-		r0 = rf(hash)
+	if rf, ok := ret.Get(0).(func(common.Hash) runtime.Instance); ok {
+		r0 = rf(blockHash)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(runtime.Instance)
@@ -226,8 +226,8 @@ func (_m *BlockAPI) GetRuntime(hash *common.Hash) (runtime.Instance, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*common.Hash) error); ok {
-		r1 = rf(hash)
+	if rf, ok := ret.Get(1).(func(common.Hash) error); ok {
+		r1 = rf(blockHash)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/dot/rpc/modules/mocks_test.go
+++ b/dot/rpc/modules/mocks_test.go
@@ -347,7 +347,7 @@ func (mr *MockBlockAPIMockRecorder) GetJustification(arg0 interface{}) *gomock.C
 }
 
 // GetRuntime mocks base method.
-func (m *MockBlockAPI) GetRuntime(arg0 *common.Hash) (runtime.Instance, error) {
+func (m *MockBlockAPI) GetRuntime(arg0 common.Hash) (runtime.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRuntime", arg0)
 	ret0, _ := ret[0].(runtime.Instance)

--- a/dot/rpc/modules/payment.go
+++ b/dot/rpc/modules/payment.go
@@ -45,7 +45,7 @@ func (p *PaymentModule) QueryInfo(_ *http.Request, req *PaymentQueryInfoRequest,
 		hash = *req.Hash
 	}
 
-	r, err := p.blockAPI.GetRuntime(&hash)
+	r, err := p.blockAPI.GetRuntime(hash)
 	if err != nil {
 		return err
 	}

--- a/dot/rpc/modules/payment_integration_test.go
+++ b/dot/rpc/modules/payment_integration_test.go
@@ -42,7 +42,7 @@ func TestPaymentQueryInfo(t *testing.T) {
 		blockAPIMock := mocks.NewBlockAPI(t)
 		blockAPIMock.On("BestBlockHash").Return(bestBlockHash)
 
-		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).Return(runtimeMock, nil)
+		blockAPIMock.On("GetRuntime", bestBlockHash).Return(runtimeMock, nil)
 
 		mod := &PaymentModule{
 			blockAPI: blockAPIMock,
@@ -63,7 +63,7 @@ func TestPaymentQueryInfo(t *testing.T) {
 		blockAPIMock := mocks.NewBlockAPI(t)
 		blockAPIMock.On("BestBlockHash").Return(bestBlockHash)
 
-		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).
+		blockAPIMock.On("GetRuntime", bestBlockHash).
 			Return(nil, errors.New("mocked problems"))
 
 		mod := &PaymentModule{
@@ -86,7 +86,7 @@ func TestPaymentQueryInfo(t *testing.T) {
 		runtimeMock.On("PaymentQueryInfo", mock.AnythingOfType("[]uint8")).Return(nil, errors.New("mocked error"))
 
 		blockAPIMock := mocks.NewBlockAPI(t)
-		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).Return(runtimeMock, nil)
+		blockAPIMock.On("GetRuntime", common.Hash{1, 2}).Return(runtimeMock, nil)
 
 		mod := &PaymentModule{
 			blockAPI: blockAPIMock,
@@ -109,7 +109,7 @@ func TestPaymentQueryInfo(t *testing.T) {
 		runtimeMock.On("PaymentQueryInfo", mock.AnythingOfType("[]uint8")).Return(nil, nil)
 
 		blockAPIMock := mocks.NewBlockAPI(t)
-		blockAPIMock.On("GetRuntime", mock.AnythingOfType("*common.Hash")).Return(runtimeMock, nil)
+		blockAPIMock.On("GetRuntime", common.Hash{1, 2}).Return(runtimeMock, nil)
 
 		mod := &PaymentModule{
 			blockAPI: blockAPIMock,

--- a/dot/rpc/modules/payment_test.go
+++ b/dot/rpc/modules/payment_test.go
@@ -34,13 +34,13 @@ func TestPaymentModule_QueryInfo(t *testing.T) {
 	blockErrorAPIMock2 := mocks.NewBlockAPI(t)
 
 	blockAPIMock.On("BestBlockHash").Return(testHash, nil)
-	blockAPIMock.On("GetRuntime", &testHash).Return(runtimeMock, nil)
+	blockAPIMock.On("GetRuntime", testHash).Return(runtimeMock, nil)
 
-	blockAPIMock2.On("GetRuntime", &testHash).Return(runtimeMock2, nil)
+	blockAPIMock2.On("GetRuntime", testHash).Return(runtimeMock2, nil)
 
-	blockErrorAPIMock1.On("GetRuntime", &testHash).Return(runtimeErrorMock, nil)
+	blockErrorAPIMock1.On("GetRuntime", testHash).Return(runtimeErrorMock, nil)
 
-	blockErrorAPIMock2.On("GetRuntime", &testHash).Return(nil, errors.New("GetRuntime error"))
+	blockErrorAPIMock2.On("GetRuntime", testHash).Return(nil, errors.New("GetRuntime error"))
 
 	runtimeMock.On("PaymentQueryInfo", common.MustHexToBytes("0x0000")).Return(nil, nil)
 	runtimeMock2.On("PaymentQueryInfo", common.MustHexToBytes("0x0000")).Return(&types.RuntimeDispatchInfo{

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -571,7 +571,7 @@ func setupStateModule(t *testing.T) (*StateModule, *common.Hash, *common.Hash) {
 	err = chain.Block.AddBlock(b)
 	require.NoError(t, err)
 
-	rt, err := chain.Block.GetRuntime(&b.Header.ParentHash)
+	rt, err := chain.Block.GetRuntime(b.Header.ParentHash)
 	require.NoError(t, err)
 
 	chain.Block.StoreRuntime(b.Header.Hash(), rt)

--- a/dot/services.go
+++ b/dot/services.go
@@ -376,7 +376,8 @@ func (nodeBuilder) createSystemService(cfg *types.SystemInfo, stateSrvc *state.S
 // createGRANDPAService creates a new GRANDPA service
 func (nodeBuilder) createGRANDPAService(cfg *Config, st *state.Service, ks keystore.Keystore,
 	net *network.Service, telemetryMailer telemetry.Client) (*grandpa.Service, error) {
-	rt, err := st.Block.GetRuntime(nil)
+	bestBlockHash := st.Block.BestBlockHash()
+	rt, err := st.Block.GetRuntime(bestBlockHash)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -669,17 +669,9 @@ func (bs *BlockState) HandleRuntimeChanges(newState *rtstorage.TrieState,
 	return nil
 }
 
-// GetRuntime gets the runtime for the corresponding block hash.
-func (bs *BlockState) GetRuntime(hash *common.Hash) (runtime.Instance, error) {
-	if hash == nil {
-		rt, err := bs.bt.GetBlockRuntime(bs.BestBlockHash())
-		if err != nil {
-			return nil, err
-		}
-		return rt, nil
-	}
-
-	return bs.bt.GetBlockRuntime(*hash)
+// GetRuntime gets the runtime instance pointer for the block hash given.
+func (bs *BlockState) GetRuntime(blockHash common.Hash) (instance runtime.Instance, err error) {
+	return bs.bt.GetBlockRuntime(blockHash)
 }
 
 // StoreRuntime stores the runtime for corresponding block hash.

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -152,11 +152,11 @@ func AddBlocksToState(t *testing.T, blockState *BlockState, depth uint,
 // AddBlocksToStateWithFixedBranches adds blocks to a BlockState up to depth, with fixed branches
 // branches are provided with a map of depth -> # of branches
 func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, depth uint, branches map[uint]int) {
-	previousHash := blockState.BestBlockHash()
+	bestBlockHash := blockState.BestBlockHash()
 	tb := []testBranch{}
 	arrivalTime := time.Now()
 
-	rt, err := blockState.GetRuntime(previousHash)
+	rt, err := blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	head, err := blockState.BestBlockHeader()
@@ -173,7 +173,7 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 
 		block := &types.Block{
 			Header: types.Header{
-				ParentHash: previousHash,
+				ParentHash: bestBlockHash,
 				Number:     i,
 				StateRoot:  trie.EmptyHash,
 				Digest:     digest,
@@ -187,7 +187,7 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 
 		blockState.StoreRuntime(hash, rt)
 
-		previousHash = hash
+		bestBlockHash = hash
 
 		isBranch := branches[i] > 0
 		if isBranch {
@@ -204,7 +204,7 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 
 	// create tree branches
 	for j, branch := range tb {
-		previousHash = branch.hash
+		bestBlockHash = branch.hash
 
 		for i := branch.depth; i < depth; i++ {
 			d, err := types.NewBabePrimaryPreDigest(0, uint64(i+uint(j)+99), [32]byte{}, [64]byte{}).ToPreRuntimeDigest()
@@ -215,7 +215,7 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 
 			block := &types.Block{
 				Header: types.Header{
-					ParentHash: previousHash,
+					ParentHash: bestBlockHash,
 					Number:     i + 1,
 					StateRoot:  trie.EmptyHash,
 					Digest:     digest,
@@ -229,7 +229,7 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 
 			blockState.StoreRuntime(hash, rt)
 
-			previousHash = hash
+			bestBlockHash = hash
 			arrivalTime = arrivalTime.Add(inc)
 		}
 	}

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -156,7 +156,7 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 	tb := []testBranch{}
 	arrivalTime := time.Now()
 
-	rt, err := blockState.GetRuntime(nil)
+	rt, err := blockState.GetRuntime(previousHash)
 	require.NoError(t, err)
 
 	head, err := blockState.BestBlockHeader()

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -235,8 +235,7 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 		panic("parent state root does not match snapshot state root")
 	}
 
-	hash := parent.Hash()
-	rt, err := s.blockState.GetRuntime(&hash)
+	rt, err := s.blockState.GetRuntime(parent.Hash())
 	if err != nil {
 		return err
 	}

--- a/dot/sync/chain_processor_integration_test.go
+++ b/dot/sync/chain_processor_integration_test.go
@@ -30,7 +30,8 @@ func TestChainProcessor_HandleBlockResponse_ValidChain(t *testing.T) {
 	parent, err := responder.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := responder.blockState.GetRuntime(nil)
+	bestBlockHash := responder.blockState.BestBlockHash()
+	rt, err := responder.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	for i := 0; i < maxResponseSize*2; i++ {
@@ -89,7 +90,8 @@ func TestChainProcessor_HandleBlockResponse_MissingBlocks(t *testing.T) {
 	parent, err := syncer.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := syncer.blockState.GetRuntime(nil)
+	bestBlockHash := syncer.blockState.BestBlockHash()
+	rt, err := syncer.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	for i := 0; i < 4; i++ {
@@ -104,7 +106,8 @@ func TestChainProcessor_HandleBlockResponse_MissingBlocks(t *testing.T) {
 	parent, err = responder.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err = responder.blockState.GetRuntime(nil)
+	bestBlockHash = syncer.blockState.BestBlockHash()
+	rt, err = syncer.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	for i := 0; i < 16; i++ {
@@ -166,7 +169,7 @@ func TestChainProcessor_HandleBlockResponse_BlockData(t *testing.T) {
 	parent, err := syncer.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := syncer.blockState.GetRuntime(nil)
+	rt, err := syncer.blockState.GetRuntime(parent.Hash())
 	require.NoError(t, err)
 
 	block := BuildBlock(t, rt, parent, nil)
@@ -197,7 +200,8 @@ func TestChainProcessor_ExecuteBlock(t *testing.T) {
 	parent, err := syncer.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
 
-	rt, err := syncer.blockState.GetRuntime(nil)
+	bestBlockHash := syncer.blockState.BestBlockHash()
+	rt, err := syncer.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	block := BuildBlock(t, rt, parent, nil)

--- a/dot/sync/chain_processor_integration_test.go
+++ b/dot/sync/chain_processor_integration_test.go
@@ -106,7 +106,6 @@ func TestChainProcessor_HandleBlockResponse_MissingBlocks(t *testing.T) {
 	parent, err = responder.blockState.(*state.BlockState).BestBlockHeader()
 	require.NoError(t, err)
 
-	bestBlockHash = syncer.blockState.BestBlockHash()
 	rt, err = syncer.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -64,7 +64,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
 					StateRoot: testHash,
 				}, nil)
-				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(nil, mockError)
+				mockBlockState.EXPECT().GetRuntime(testParentHash).Return(nil, mockError)
 				chainProcessor.blockState = mockBlockState
 				trieState := storage.NewTrieState(nil)
 				mockStorageState := NewMockStorageState(ctrl)
@@ -89,7 +89,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockRuntimeInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(trieState)
 				mockInstance.EXPECT().ExecuteBlock(&types.Block{Body: types.Body{}}).Return(nil, mockError)
-				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(mockInstance, nil)
+				mockBlockState.EXPECT().GetRuntime(testParentHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
 				mockStorageState.EXPECT().Lock()
@@ -114,7 +114,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockRuntimeInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(trieState)
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(mockInstance, nil)
+				mockBlockState.EXPECT().GetRuntime(testParentHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
 				mockStorageState.EXPECT().Lock()
@@ -149,7 +149,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockRuntimeInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(trieState)
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState.EXPECT().GetRuntime(&mockHeaderHash).Return(mockInstance, nil)
+				mockBlockState.EXPECT().GetRuntime(mockHeaderHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
 				mockStorageState.EXPECT().Lock()
@@ -189,7 +189,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockRuntimeInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(trieState)
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState.EXPECT().GetRuntime(&mockHeaderHash).Return(mockInstance, nil)
+				mockBlockState.EXPECT().GetRuntime(mockHeaderHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
 				mockStorageState.EXPECT().Lock()
@@ -802,7 +802,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					StateRoot: stateRootHash,
 				}, nil)
 				mockBlockState.EXPECT().CompareAndSetBlockData(&types.BlockData{Header: &types.Header{}, Body: &types.Body{}})
-				mockBlockState.EXPECT().GetRuntime(&runtimeHash).Return(mockInstance, nil)
+				mockBlockState.EXPECT().GetRuntime(runtimeHash).Return(mockInstance, nil)
 
 				mockBabeVerifier := NewMockBabeVerifier(ctrl)
 				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{}).Return(nil)
@@ -856,7 +856,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 				mockBlockState.EXPECT().SetJustification(
 					common.MustHexToHash("0xdcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a"), justification)
 				mockBlockState.EXPECT().CompareAndSetBlockData(gomock.AssignableToTypeOf(&types.BlockData{}))
-				mockBlockState.EXPECT().GetRuntime(&runtimeHash).Return(mockInstance, nil)
+				mockBlockState.EXPECT().GetRuntime(runtimeHash).Return(mockInstance, nil)
 				mockBabeVerifier := NewMockBabeVerifier(ctrl)
 				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{})
 				mockStorageState := NewMockStorageState(ctrl)

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -68,7 +68,7 @@ type BlockState interface {
 	AddBlockToBlockTree(block *types.Block) error
 	GetHashByNumber(blockNumber uint) (common.Hash, error)
 	GetBlockByHash(common.Hash) (*types.Block, error)
-	GetRuntime(*common.Hash) (runtime.Instance, error)
+	GetRuntime(blockHash common.Hash) (instance runtime.Instance, err error)
 	StoreRuntime(common.Hash, runtime.Instance)
 	GetHighestFinalisedHeader() (*types.Header, error)
 	GetFinalisedNotifierChannel() chan *types.FinalisationInfo

--- a/dot/sync/mocks_test.go
+++ b/dot/sync/mocks_test.go
@@ -308,7 +308,7 @@ func (mr *MockBlockStateMockRecorder) GetReceipt(arg0 interface{}) *gomock.Call 
 }
 
 // GetRuntime mocks base method.
-func (m *MockBlockState) GetRuntime(arg0 *common.Hash) (runtime.Instance, error) {
+func (m *MockBlockState) GetRuntime(arg0 common.Hash) (runtime.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRuntime", arg0)
 	ret0, _ := ret[0].(runtime.Instance)

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -524,8 +524,7 @@ func (b *Service) handleSlot(epoch, slotNum uint64,
 		return err
 	}
 
-	hash := parent.Hash()
-	rt, err := b.blockState.GetRuntime(&hash)
+	rt, err := b.blockState.GetRuntime(parent.Hash())
 	if err != nil {
 		return err
 	}

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -316,7 +316,8 @@ func TestService_HandleSlotWithLaggingSlot(t *testing.T) {
 
 	// add a block
 	parentHash := babeService.blockState.GenesisHash()
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	epochData, err := babeService.initiateEpoch(testEpochIndex)

--- a/lib/babe/build_integration_test.go
+++ b/lib/babe/build_integration_test.go
@@ -70,7 +70,8 @@ func createTestBlock(t *testing.T, babeService *Service, parent *types.Header,
 		number:   slotNumber,
 	}
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	preRuntimeDigest, err := claimSlot(epoch, slotNumber, epochData, babeService.keypair)
@@ -89,7 +90,8 @@ func TestBuildBlock_ok(t *testing.T) {
 	babeService := createTestService(t, ServiceConfig{})
 
 	parentHash := babeService.blockState.GenesisHash()
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
@@ -149,7 +151,8 @@ func TestApplyExtrinsic(t *testing.T) {
 	parentHeader, err := babeService.blockState.GetHeader(parentHash)
 	require.NoError(t, err)
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	ts, err := babeService.storageState.TrieState(nil)
@@ -210,7 +213,8 @@ func TestBuildAndApplyExtrinsic(t *testing.T) {
 	parentHash := common.MustHexToHash("0x35a28a7dbaf0ba07d1485b0f3da7757e3880509edc8c31d0850cb6dd6219361d")
 	header := types.NewHeader(parentHash, common.Hash{}, common.Hash{}, 1, types.NewDigest())
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	//initialise block header
@@ -327,7 +331,8 @@ func TestBuildBlock_failing(t *testing.T) {
 		number:   1000,
 	}
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	const authorityIndex uint32 = 0

--- a/lib/babe/mock_state_test.go
+++ b/lib/babe/mock_state_test.go
@@ -257,7 +257,7 @@ func (mr *MockBlockStateMockRecorder) GetImportedBlockNotifierChannel() *gomock.
 }
 
 // GetRuntime mocks base method.
-func (m *MockBlockState) GetRuntime(arg0 *common.Hash) (runtime.Instance, error) {
+func (m *MockBlockState) GetRuntime(arg0 common.Hash) (runtime.Instance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRuntime", arg0)
 	ret0, _ := ret[0].(runtime.Instance)

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -35,7 +35,7 @@ type BlockState interface {
 	GetFinalisedHeader(uint64, uint64) (*types.Header, error)
 	IsDescendantOf(parent, child common.Hash) (bool, error)
 	NumberIsFinalised(blockNumber uint) (bool, error)
-	GetRuntime(*common.Hash) (runtime.Instance, error)
+	GetRuntime(blockHash common.Hash) (instance runtime.Instance, err error)
 	StoreRuntime(common.Hash, runtime.Instance)
 	ImportedBlockNotifierManager
 }

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -160,7 +160,8 @@ func TestVerificationManager_VerifyBlock_Ok(t *testing.T) {
 	}
 	babeService := createTestService(t, serviceConfig)
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	cfg, err := rt.BabeConfiguration()
@@ -188,7 +189,8 @@ func TestVerificationManager_VerifyBlock_Secondary(t *testing.T) {
 	}
 	babeService := createTestService(t, serviceConfig)
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	cfg, err := rt.BabeConfiguration()
@@ -254,7 +256,8 @@ func TestVerificationManager_VerifyBlock_MultipleEpochs(t *testing.T) {
 	}
 	babeService := createTestService(t, serviceConfig)
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	cfg, err := rt.BabeConfiguration()
@@ -304,7 +307,8 @@ func TestVerificationManager_VerifyBlock_InvalidBlockOverThreshold(t *testing.T)
 	}
 	babeService := createTestService(t, serviceConfig)
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	cfg, err := rt.BabeConfiguration()
@@ -333,7 +337,8 @@ func TestVerificationManager_VerifyBlock_InvalidBlockAuthority(t *testing.T) {
 	}
 	babeService := createTestService(t, serviceConfig)
 
-	rt, err := babeService.blockState.GetRuntime(nil)
+	bestBlockHash := babeService.blockState.BestBlockHash()
+	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	cfg, err := rt.BabeConfiguration()

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -1178,8 +1178,7 @@ func addBlocksToState(t *testing.T, blockState *state.BlockState, depth uint) {
 	t.Helper()
 
 	previousHash := blockState.BestBlockHash()
-
-	rt, err := blockState.GetRuntime(nil)
+	rt, err := blockState.GetRuntime(previousHash)
 	require.NoError(t, err)
 
 	head, err := blockState.BestBlockHeader()


### PR DESCRIPTION
## Changes

The aim was to better see the use of the blockstate `GetRuntime` method.

There is no hurry to merge this, but it could be a nice addition imo.

- No longer a mix of passing best block hashes and nils
- Force the caller to get the best block hash (also to reduce getting the best block hash N times in loops)
- Rename some hash variable names
- Deduplicate copied-pasted code in dot/core.

## Tests

## Issues


## Primary Reviewer

@EclesioMeloJunior 