### PR TITLE
chore(all): version trie calls

### DIFF
--- a/dot/build_spec.go
+++ b/dot/build_spec.go
@@ -112,8 +112,19 @@ func BuildFromDB(path string) (*BuildSpec, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot start state service: %w", err)
 	}
+
+	bestBlockStateRoot, err := stateSrvc.Block.BestBlockStateRoot()
+	if err != nil {
+		return nil, fmt.Errorf("getting best block state root: %w", err)
+	}
+
+	instance, err := stateSrvc.Block.GetRuntime(&bestBlockStateRoot)
+	if err != nil {
+		return nil, fmt.Errorf("getting runtime instance for best block state root: %w", err)
+	}
+
 	// set genesis fields data
-	ent, err := stateSrvc.Storage.Entries(nil)
+	ent, err := stateSrvc.Storage.Entries(&bestBlockStateRoot, instance.StateVersion())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage trie entries: %w", err)
 	}

--- a/dot/build_spec_test.go
+++ b/dot/build_spec_test.go
@@ -155,7 +155,7 @@ func TestBuildFromDB(t *testing.T) {
 			if tt.err != nil {
 				assert.EqualError(t, err, tt.err.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			if tt.want != nil {
 				got.genesis.Genesis.Raw = map[string]map[string]string{}

--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -146,11 +146,14 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	require.NoError(t, err)
 	gen = *genPtr
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -19,7 +19,11 @@ func (s *Service) validateTransaction(head *types.Header, rt RuntimeInstance,
 	tx types.Extrinsic) (validity *transaction.Validity, err error) {
 	s.storageState.Lock()
 
-	ts, err := s.storageState.TrieState(&head.StateRoot)
+	// Note this is a cheap call getting the runtime cached version
+	// so we can call this in this function and not pass it as argument.
+	stateVersion := rt.StateVersion()
+
+	ts, err := s.storageState.TrieState(&head.StateRoot, stateVersion)
 	s.storageState.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("cannot get trie state from storage for root %s: %w", head.StateRoot, err)

--- a/dot/core/messages_integration_test.go
+++ b/dot/core/messages_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
 	"github.com/golang/mock/gomock"
@@ -107,7 +108,8 @@ func TestService_HandleBlockProduced(t *testing.T) {
 
 	net.EXPECT().GossipMessage(expected)
 
-	state, err := s.storageState.TrieState(nil)
+	const stateVersion = trie.V0 // TODO should we get this from something?
+	state, err := s.storageState.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 
 	err = s.HandleBlockProduced(&newBlock, state)
@@ -153,7 +155,8 @@ func TestService_HandleTransactionMessage(t *testing.T) {
 	rt, err := s.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
-	ts, err := s.storageState.TrieState(nil)
+	const stateVersion = trie.V0 // TODO should we get this from something?
+	ts, err := s.storageState.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 	rt.SetContextStorage(ts)
 

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/transaction"
+	"github.com/ChainSafe/gossamer/lib/trie"
 
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -350,7 +351,8 @@ func TestServiceHandleTransactionMessage(t *testing.T) {
 				storageState := NewMockStorageState(ctrl)
 				storageState.EXPECT().Lock()
 				storageState.EXPECT().Unlock()
-				storageState.EXPECT().TrieState(tt.mockStorageState.input).Return(
+				const stateVersion = trie.V0
+				storageState.EXPECT().TrieState(tt.mockStorageState.input, stateVersion).Return(
 					tt.mockStorageState.trieState,
 					tt.mockStorageState.err)
 				s.storageState = storageState

--- a/dot/core/mocks_test.go
+++ b/dot/core/mocks_test.go
@@ -15,6 +15,7 @@ import (
 	runtime "github.com/ChainSafe/gossamer/lib/runtime"
 	storage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	transaction "github.com/ChainSafe/gossamer/lib/transaction"
+	trie "github.com/ChainSafe/gossamer/lib/trie"
 	gomock "github.com/golang/mock/gomock"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -395,18 +396,18 @@ func (m *MockStorageState) EXPECT() *MockStorageStateMockRecorder {
 }
 
 // GenerateTrieProof mocks base method.
-func (m *MockStorageState) GenerateTrieProof(arg0 common.Hash, arg1 [][]byte) ([][]byte, error) {
+func (m *MockStorageState) GenerateTrieProof(arg0 common.Hash, arg1 [][]byte, arg2 trie.Version) ([][]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateTrieProof", arg0, arg1)
+	ret := m.ctrl.Call(m, "GenerateTrieProof", arg0, arg1, arg2)
 	ret0, _ := ret[0].([][]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateTrieProof indicates an expected call of GenerateTrieProof.
-func (mr *MockStorageStateMockRecorder) GenerateTrieProof(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStorageStateMockRecorder) GenerateTrieProof(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTrieProof", reflect.TypeOf((*MockStorageState)(nil).GenerateTrieProof), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTrieProof", reflect.TypeOf((*MockStorageState)(nil).GenerateTrieProof), arg0, arg1, arg2)
 }
 
 // GetStateRootFromBlock mocks base method.
@@ -482,32 +483,32 @@ func (mr *MockStorageStateMockRecorder) Lock() *gomock.Call {
 }
 
 // StoreTrie mocks base method.
-func (m *MockStorageState) StoreTrie(arg0 *storage.TrieState, arg1 *types.Header) error {
+func (m *MockStorageState) StoreTrie(arg0 *storage.TrieState, arg1 *types.Header, arg2 trie.Version) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreTrie", arg0, arg1)
+	ret := m.ctrl.Call(m, "StoreTrie", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreTrie indicates an expected call of StoreTrie.
-func (mr *MockStorageStateMockRecorder) StoreTrie(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStorageStateMockRecorder) StoreTrie(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreTrie", reflect.TypeOf((*MockStorageState)(nil).StoreTrie), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreTrie", reflect.TypeOf((*MockStorageState)(nil).StoreTrie), arg0, arg1, arg2)
 }
 
 // TrieState mocks base method.
-func (m *MockStorageState) TrieState(arg0 *common.Hash) (*storage.TrieState, error) {
+func (m *MockStorageState) TrieState(arg0 *common.Hash, arg1 trie.Version) (*storage.TrieState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TrieState", arg0)
+	ret := m.ctrl.Call(m, "TrieState", arg0, arg1)
 	ret0, _ := ret[0].(*storage.TrieState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TrieState indicates an expected call of TrieState.
-func (mr *MockStorageStateMockRecorder) TrieState(arg0 interface{}) *gomock.Call {
+func (mr *MockStorageStateMockRecorder) TrieState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieState", reflect.TypeOf((*MockStorageState)(nil).TrieState), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieState", reflect.TypeOf((*MockStorageState)(nil).TrieState), arg0, arg1)
 }
 
 // Unlock mocks base method.
@@ -1106,6 +1107,20 @@ func (m *MockRuntimeInstance) SetContextStorage(arg0 runtime.Storage) {
 func (mr *MockRuntimeInstanceMockRecorder) SetContextStorage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextStorage", reflect.TypeOf((*MockRuntimeInstance)(nil).SetContextStorage), arg0)
+}
+
+// StateVersion mocks base method.
+func (m *MockRuntimeInstance) StateVersion() trie.Version {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateVersion")
+	ret0, _ := ret[0].(trie.Version)
+	return ret0
+}
+
+// StateVersion indicates an expected call of StateVersion.
+func (mr *MockRuntimeInstanceMockRecorder) StateVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateVersion", reflect.TypeOf((*MockRuntimeInstance)(nil).StateVersion))
 }
 
 // Stop mocks base method.

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -127,6 +127,7 @@ func Test_Service_StorageRoot(t *testing.T) {
 		exp           common.Hash
 		retTrieState  *rtstorage.TrieState
 		trieStateCall bool
+		stateVersion  trie.Version
 		retErr        error
 		expErr        error
 		expErrMsg     string
@@ -146,6 +147,7 @@ func Test_Service_StorageRoot(t *testing.T) {
 				0x62, 0xb1, 0x57, 0xe7, 0x87, 0x86, 0xd8, 0xc0, 0x82, 0xf2, 0x9d, 0xcf, 0x4c, 0x11, 0x13, 0x14},
 			retTrieState:  ts,
 			trieStateCall: true,
+			stateVersion:  trie.V0,
 		},
 	}
 	for _, tt := range tests {
@@ -156,11 +158,12 @@ func Test_Service_StorageRoot(t *testing.T) {
 			if tt.trieStateCall {
 				ctrl := gomock.NewController(t)
 				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().TrieState(nil).Return(tt.retTrieState, tt.retErr)
+				mockStorageState.EXPECT().TrieState(nil, tt.stateVersion).
+					Return(tt.retTrieState, tt.retErr)
 				service.storageState = mockStorageState
 			}
 
-			res, err := service.StorageRoot()
+			res, err := service.StorageRoot(tt.stateVersion)
 			assert.ErrorIs(t, err, tt.expErr)
 			if tt.expErr != nil {
 				assert.EqualError(t, err, tt.expErrMsg)
@@ -354,7 +357,9 @@ func Test_Service_handleBlock(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(errTestDummyError)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(errTestDummyError)
 
 		service := &Service{storageState: mockStorageState}
 		execTest(t, service, &block, trieState, errTestDummyError)
@@ -370,7 +375,9 @@ func Test_Service_handleBlock(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(errTestDummyError)
 
@@ -391,7 +398,9 @@ func Test_Service_handleBlock(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrParentNotFound)
 
@@ -412,7 +421,9 @@ func Test_Service_handleBlock(t *testing.T) {
 
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
 		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(nil, errTestDummyError)
@@ -435,7 +446,9 @@ func Test_Service_handleBlock(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
 		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(runtimeMock, nil)
@@ -460,7 +473,9 @@ func Test_Service_handleBlock(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
 		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(runtimeMock, nil)
@@ -518,7 +533,9 @@ func Test_Service_HandleBlockProduced(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header).Return(nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().StoreTrie(trieState, &block.Header, stateVersion).
+			Return(nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().AddBlock(&block).Return(blocktree.ErrBlockExists)
 		mockBlockState.EXPECT().GetRuntime(&block.Header.ParentHash).Return(runtimeMock, nil)
@@ -1044,7 +1061,9 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, errDummyErr)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(nil, errDummyErr)
 		service := &Service{
 			storageState: mockStorageState,
 		}
@@ -1056,7 +1075,9 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(ts, nil).MaxTimes(2)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(ts, nil).MaxTimes(2)
 
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(nil, errDummyErr)
@@ -1072,7 +1093,9 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil).MaxTimes(2)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(ts, nil).MaxTimes(2)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(ts, nil).MaxTimes(2)
 
 		runtimeMock := NewMockRuntimeInstance(ctrl)
 		mockBlockState := NewMockBlockState(ctrl)
@@ -1110,7 +1133,9 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, errDummyErr)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(nil, errDummyErr)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
 
 		mockBlockState := NewMockBlockState(ctrl)
@@ -1135,7 +1160,9 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(nil, errDummyErr)
 
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(&rtstorage.TrieState{}, nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(&rtstorage.TrieState{}, nil)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
 
 		mockTxnState := NewMockTransactionState(ctrl)
@@ -1158,7 +1185,9 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		mockBlockState.EXPECT().GetRuntime(&common.Hash{}).Return(runtimeMockErr, nil).MaxTimes(2)
 
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(&rtstorage.TrieState{}, nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(&rtstorage.TrieState{}, nil)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
 
 		mockTxnState := NewMockTransactionState(ctrl)
@@ -1187,7 +1216,9 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		runtimeMock.EXPECT().ValidateTransaction(externalExt).Return(&transaction.Validity{Propagate: true}, nil)
 
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(&rtstorage.TrieState{}, nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(&common.Hash{}, stateVersion).
+			Return(&rtstorage.TrieState{}, nil)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
 
 		mockTxnState := NewMockTransactionState(ctrl)
@@ -1231,7 +1262,8 @@ func TestServiceGetMetadata(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(nil).Return(nil, errDummyErr)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(nil, stateVersion).Return(nil, errDummyErr)
 		service := &Service{
 			storageState: mockStorageState,
 		}
@@ -1242,7 +1274,8 @@ func TestServiceGetMetadata(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(nil, stateVersion).Return(&rtstorage.TrieState{}, nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(nil).Return(nil, errDummyErr)
 		service := &Service{
@@ -1256,7 +1289,8 @@ func TestServiceGetMetadata(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().TrieState(nil, stateVersion).Return(&rtstorage.TrieState{}, nil)
 		runtimeMockOk := NewMockRuntimeInstance(ctrl)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(nil).Return(runtimeMockOk, nil)
@@ -1302,7 +1336,8 @@ func TestService_GetReadProofAt(t *testing.T) {
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{2})
 		mockBlockState.EXPECT().GetBlockStateRoot(common.Hash{2}).Return(common.Hash{3}, nil)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().GenerateTrieProof(common.Hash{3}, [][]byte{{1}}).
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().GenerateTrieProof(common.Hash{3}, [][]byte{{1}}, stateVersion).
 			Return([][]byte{}, errDummyErr)
 		service := &Service{
 			blockState:   mockBlockState,
@@ -1318,7 +1353,8 @@ func TestService_GetReadProofAt(t *testing.T) {
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{2})
 		mockBlockState.EXPECT().GetBlockStateRoot(common.Hash{2}).Return(common.Hash{3}, nil)
 		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().GenerateTrieProof(common.Hash{3}, [][]byte{{1}}).
+		const stateVersion = trie.V0
+		mockStorageState.EXPECT().GenerateTrieProof(common.Hash{3}, [][]byte{{1}}, stateVersion).
 			Return([][]byte{{2}}, nil)
 		service := &Service{
 			blockState:   mockBlockState,

--- a/dot/digest/helpers_test.go
+++ b/dot/digest/helpers_test.go
@@ -27,8 +27,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()

--- a/dot/helpers_test.go
+++ b/dot/helpers_test.go
@@ -41,8 +41,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()

--- a/dot/import_integration_test.go
+++ b/dot/import_integration_test.go
@@ -17,15 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewTrieFromPairs(t *testing.T) {
-	fp := setupStateFile(t)
-	trie, err := newTrieFromPairs(fp)
-	require.NoError(t, err)
-
-	expectedRoot := common.MustHexToHash("0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb")
-	require.Equal(t, expectedRoot, trie.MustHash())
-}
-
 func TestNewHeaderFromFile(t *testing.T) {
 	fp := setupHeaderFile(t)
 	header, err := newHeaderFromFile(fp)

--- a/dot/import_test.go
+++ b/dot/import_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -197,20 +198,23 @@ func Test_newTrieFromPairs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		filename string
-		want     common.Hash
-		err      error
+		name         string
+		filename     string
+		stateVersion trie.Version
+		want         common.Hash
+		err          error
 	}{
 		{
-			name: "no arguments",
-			err:  errors.New("read .: is a directory"),
-			want: common.Hash{},
+			name:         "no arguments",
+			stateVersion: trie.V0,
+			err:          errors.New("read .: is a directory"),
+			want:         common.Hash{},
 		},
 		{
-			name:     "working example",
-			filename: setupStateFile(t),
-			want:     common.MustHexToHash("0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb"),
+			name:         "working example",
+			stateVersion: trie.V0,
+			filename:     setupStateFile(t),
+			want:         common.MustHexToHash("0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb"),
 		},
 	}
 	for _, tt := range tests {
@@ -218,7 +222,7 @@ func Test_newTrieFromPairs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := newTrieFromPairs(tt.filename)
+			got, err := newTrieFromPairs(tt.filename, tt.stateVersion)
 			if tt.err != nil {
 				assert.EqualError(t, err, tt.err.Error())
 			} else {
@@ -227,7 +231,7 @@ func Test_newTrieFromPairs(t *testing.T) {
 			if tt.want.IsEmpty() {
 				assert.Nil(t, got)
 			} else {
-				assert.Equal(t, tt.want, got.MustHash())
+				assert.Equal(t, tt.want, got.MustHash(tt.stateVersion))
 			}
 		})
 	}

--- a/dot/node.go
+++ b/dot/node.go
@@ -144,6 +144,11 @@ func (*nodeBuilder) initNode(cfg *Config) error {
 		}
 	}
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(*gen)
+	if err != nil {
+		return fmt.Errorf("getting genesis state version: %w", err)
+	}
+
 	// create trie from genesis
 	t, err := wasmer.NewTrieFromGenesis(*gen)
 	if err != nil {
@@ -151,7 +156,7 @@ func (*nodeBuilder) initNode(cfg *Config) error {
 	}
 
 	// create genesis block from trie
-	header, err := t.GenesisBlock()
+	header, err := t.GenesisBlock(stateVersion)
 	if err != nil {
 		return fmt.Errorf("failed to create genesis block from trie: %w", err)
 	}

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -170,8 +170,11 @@ func TestNewNode(t *testing.T) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create trie from genesis: %w", err)
 		}
-		// create genesis block from trie
-		header, err := trie.GenesisBlock()
+
+		stateVersion, err := wasmer.StateVersionFromGenesis(*gen)
+		require.NoError(t, err)
+
+		header, err := trie.GenesisBlock(stateVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create genesis block from trie: %w", err)
 		}

--- a/dot/rpc/helpers_test.go
+++ b/dot/rpc/helpers_test.go
@@ -27,8 +27,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -21,13 +21,13 @@ import (
 // StorageAPI is the interface for the storage state
 type StorageAPI interface {
 	GetStorage(root *common.Hash, key []byte) ([]byte, error)
-	GetStorageChild(root *common.Hash, keyToChild []byte) (*trie.Trie, error)
-	GetStorageFromChild(root *common.Hash, keyToChild, key []byte) ([]byte, error)
+	GetStorageChild(root *common.Hash, keyToChild []byte, stateVersion trie.Version) (*trie.Trie, error)
+	GetStorageFromChild(root *common.Hash, keyToChild, key []byte, stateVersion trie.Version) ([]byte, error)
 	GetStorageByBlockHash(bhash *common.Hash, key []byte) ([]byte, error)
-	Entries(root *common.Hash) (map[string][]byte, error)
+	Entries(root *common.Hash, stateVersion trie.Version) (map[string][]byte, error)
 	GetStateRootFromBlock(bhash *common.Hash) (*common.Hash, error)
-	GetKeysWithPrefix(root *common.Hash, prefix []byte) ([][]byte, error)
-	RegisterStorageObserver(observer state.Observer)
+	GetKeysWithPrefix(root *common.Hash, prefix []byte, stateVersion trie.Version) ([][]byte, error)
+	RegisterStorageObserver(observer state.Observer) (err error)
 	UnregisterStorageObserver(observer state.Observer)
 }
 
@@ -101,7 +101,8 @@ type CoreAPI interface {
 	HandleSubmittedExtrinsic(types.Extrinsic) error
 	GetMetadata(bhash *common.Hash) ([]byte, error)
 	DecodeSessionKeys(enc []byte) ([]byte, error)
-	GetReadProofAt(block common.Hash, keys [][]byte) (common.Hash, [][]byte, error)
+	GetReadProofAt(block common.Hash, keys [][]byte) (
+		blockHash common.Hash, encodedNodes [][]byte, err error)
 }
 
 //go:generate mockery --name RPCAPI --structname RPCAPI --case underscore --keeptree

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -59,7 +59,9 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 	bytes, err := os.ReadFile(testRuntimeFilePath)
 	require.NoError(t, err)
 
-	rtStorage.Set(common.CodeKey, bytes)
+	// Runtime v0910 uses state version v0 only.
+	const stateVersion = trie.V0
+	rtStorage.Set(common.CodeKey, bytes, stateVersion)
 
 	cfg := wasmer.Config{
 		Role:     0,
@@ -81,6 +83,7 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 
 func TestAuthorModule_Pending_Integration(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), nil)
 
 	auth := newAuthorModule(t, integrationTestController)
@@ -107,6 +110,7 @@ func TestAuthorModule_Pending_Integration(t *testing.T) {
 
 func TestAuthorModule_SubmitExtrinsic_Integration(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndPopulateTrieState(t, t.TempDir(), useInstanceFromGenesis)
 
 	ctrl := gomock.NewController(t)
@@ -162,6 +166,7 @@ func TestAuthorModule_SubmitExtrinsic_Integration(t *testing.T) {
 
 func TestAuthorModule_SubmitExtrinsic_invalid(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), useInstanceFromGenesis)
 
 	genesisHash := integrationTestController.genesisHeader.Hash()
@@ -202,6 +207,7 @@ func TestAuthorModule_SubmitExtrinsic_invalid_input(t *testing.T) {
 
 func TestAuthorModule_SubmitExtrinsic_AlreadyInPool(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), useInstanceFromGenesis)
 
 	ctrl := gomock.NewController(t)
@@ -250,6 +256,7 @@ func TestAuthorModule_SubmitExtrinsic_AlreadyInPool(t *testing.T) {
 
 func TestAuthorModule_InsertKey_Integration(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), useInstanceFromGenesis)
 	auth := newAuthorModule(t, integrationTestController)
 
@@ -332,6 +339,7 @@ func TestAuthorModule_InsertKey_Integration(t *testing.T) {
 
 func TestAuthorModule_HasKey_Integration(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), useInstanceFromGenesis)
 
 	ks := keystore.NewGlobalKeystore()
@@ -400,6 +408,7 @@ func TestAuthorModule_HasKey_Integration(t *testing.T) {
 
 func TestAuthorModule_HasSessionKeys_Integration(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndRuntime(t, t.TempDir(), useInstanceFromGenesis)
 	auth := newAuthorModule(t, integrationTestController)
 
@@ -498,6 +507,7 @@ func TestAuthorModule_HasSessionKeys_Integration(t *testing.T) {
 
 func TestAuthorModule_SubmitExtrinsic_WithVersion_V0910(t *testing.T) {
 	t.Parallel()
+
 	integrationTestController := setupStateAndPopulateTrieState(t, t.TempDir(), useInstanceFromRuntimeV0910)
 
 	ctrl := gomock.NewController(t)
@@ -568,10 +578,11 @@ type integrationTestController struct {
 	keystore      *keystore.GlobalKeystore
 }
 
-func setupStateAndRuntime(t *testing.T, basepath string, useInstance useRuntimeInstace) *integrationTestController {
+func setupStateAndRuntime(t *testing.T, basepath string,
+	useInstance useRuntimeInstace) *integrationTestController {
 	t.Helper()
 
-	gen, genesisTrie, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	gen, genesisTrie, genesisHeader, stateVersion := newTestGenesisWithTrieAndHeader(t)
 
 	ctrl := gomock.NewController(t)
 	telemetryMock := NewMockClient(ctrl)
@@ -614,7 +625,7 @@ func setupStateAndRuntime(t *testing.T, basepath string, useInstance useRuntimeI
 	}
 
 	if useInstance != nil {
-		rtStorage, err := state2test.Storage.TrieState(nil)
+		rtStorage, err := state2test.Storage.TrieState(nil, stateVersion)
 		require.NoError(t, err)
 
 		rt := useInstance(t, rtStorage)
@@ -631,7 +642,7 @@ func setupStateAndPopulateTrieState(t *testing.T, basepath string,
 	useInstance useRuntimeInstace) *integrationTestController {
 	t.Helper()
 
-	gen, genesisTrie, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	gen, genesisTrie, genesisHeader, stateVersion := newTestGenesisWithTrieAndHeader(t)
 
 	ctrl := gomock.NewController(t)
 	telemetryMock := NewMockClient(ctrl)
@@ -675,10 +686,11 @@ func setupStateAndPopulateTrieState(t *testing.T, basepath string,
 	}
 
 	if useInstance != nil {
-		rtStorage, err := state2test.Storage.TrieState(nil)
+		rtStorage, err := state2test.Storage.TrieState(nil, stateVersion)
 		require.NoError(t, err)
 
 		rt := useInstance(t, rtStorage)
+		stateVersion = rt.StateVersion()
 
 		integrationTestController.runtime = rt
 
@@ -690,7 +702,7 @@ func setupStateAndPopulateTrieState(t *testing.T, basepath string,
 		err = state2test.Block.AddBlock(b)
 		require.NoError(t, err)
 
-		err = state2test.Storage.StoreTrie(rtStorage, &b.Header)
+		err = state2test.Storage.StoreTrie(rtStorage, &b.Header, stateVersion)
 		require.NoError(t, err)
 
 		state2test.Block.StoreRuntime(b.Header.Hash(), rt)

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -289,7 +289,7 @@ func TestChainGetBlockHash_Array(t *testing.T) {
 func TestChainGetFinalizedHead(t *testing.T) {
 	state := newTestStateService(t)
 	svc := NewChainModule(state.Block)
-	_, _, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	_, _, genesisHeader, _ := newTestGenesisWithTrieAndHeader(t)
 	var res ChainHashResponse
 	err := svc.GetFinalizedHead(nil, &EmptyRequest{}, &res)
 	require.NoError(t, err)
@@ -307,7 +307,7 @@ func TestChainGetFinalizedHeadByRound(t *testing.T) {
 	err := svc.GetFinalizedHeadByRound(nil, &req, &res)
 	require.NoError(t, err)
 
-	_, _, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	_, _, genesisHeader, _ := newTestGenesisWithTrieAndHeader(t)
 	expected := genesisHeader.Hash()
 	require.Equal(t, common.BytesToHex(expected[:]), res)
 
@@ -352,7 +352,7 @@ func newTestStateService(t *testing.T) *state.Service {
 	stateSrvc := state.NewService(config)
 	stateSrvc.UseMemDB()
 
-	gen, genesisTrie, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	gen, genesisTrie, genesisHeader, _ := newTestGenesisWithTrieAndHeader(t)
 
 	err := stateSrvc.Initialise(&gen, &genesisHeader, &genesisTrie)
 	require.NoError(t, err)

--- a/dot/rpc/modules/childstate.go
+++ b/dot/rpc/modules/childstate.go
@@ -4,6 +4,7 @@
 package modules
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -66,7 +67,13 @@ func (cs *ChildStateModule) GetKeys(_ *http.Request, req *GetKeysRequest, res *[
 		return err
 	}
 
-	trie, err := cs.storageAPI.GetStorageChild(stateRoot, req.Key)
+	instance, err := cs.blockAPI.GetRuntime(&hash)
+	if err != nil {
+		return fmt.Errorf("getting runtime instance: %w", err)
+	}
+	stateVersion := instance.StateVersion()
+
+	trie, err := cs.storageAPI.GetStorageChild(stateRoot, req.Key, stateVersion)
 	if err != nil {
 		return err
 	}
@@ -96,7 +103,14 @@ func (cs *ChildStateModule) GetStorageSize(_ *http.Request, req *GetChildStorage
 		return err
 	}
 
-	item, err := cs.storageAPI.GetStorageFromChild(stateRoot, req.KeyChild, req.EntryKey)
+	instance, err := cs.blockAPI.GetRuntime(&hash)
+	if err != nil {
+		return fmt.Errorf("getting runtime instance: %w", err)
+	}
+	stateVersion := instance.StateVersion()
+
+	item, err := cs.storageAPI.GetStorageFromChild(stateRoot,
+		req.KeyChild, req.EntryKey, stateVersion)
 	if err != nil {
 		return err
 	}
@@ -123,7 +137,14 @@ func (cs *ChildStateModule) GetStorageHash(_ *http.Request, req *GetStorageHash,
 		return err
 	}
 
-	item, err := cs.storageAPI.GetStorageFromChild(stateRoot, req.KeyChild, req.EntryKey)
+	instance, err := cs.blockAPI.GetRuntime(&hash)
+	if err != nil {
+		return fmt.Errorf("getting runtime instance: %w", err)
+	}
+	stateVersion := instance.StateVersion()
+
+	item, err := cs.storageAPI.GetStorageFromChild(stateRoot,
+		req.KeyChild, req.EntryKey, stateVersion)
 	if err != nil {
 		return err
 	}
@@ -155,7 +176,14 @@ func (cs *ChildStateModule) GetStorage(
 		return err
 	}
 
-	item, err = cs.storageAPI.GetStorageFromChild(stateRoot, req.ChildStorageKey, req.Key)
+	instance, err := cs.blockAPI.GetRuntime(&hash)
+	if err != nil {
+		return fmt.Errorf("getting runtime instance: %w", err)
+	}
+	stateVersion := instance.StateVersion()
+
+	item, err = cs.storageAPI.GetStorageFromChild(stateRoot,
+		req.ChildStorageKey, req.Key, stateVersion)
 	if err != nil {
 		return err
 	}

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -20,21 +20,22 @@ import (
 func createTestTrieState(t *testing.T) (*trie.Trie, common.Hash) {
 	t.Helper()
 
-	_, genesisTrie, _ := newTestGenesisWithTrieAndHeader(t)
-	tr := rtstorage.NewTrieState(&genesisTrie)
+	_, genTrie, _, stateVersion := newTestGenesisWithTrieAndHeader(t)
 
-	tr.Set([]byte(":first_key"), []byte(":value1"))
-	tr.Set([]byte(":second_key"), []byte(":second_value"))
+	tr := rtstorage.NewTrieState(&genTrie)
+
+	tr.Set([]byte(":first_key"), []byte(":value1"), stateVersion)
+	tr.Set([]byte(":second_key"), []byte(":second_value"), stateVersion)
 
 	childTr := trie.NewEmptyTrie()
-	childTr.Put([]byte(":child_first"), []byte(":child_first_value"))
-	childTr.Put([]byte(":child_second"), []byte(":child_second_value"))
-	childTr.Put([]byte(":another_child"), []byte("value"))
+	childTr.Put([]byte(":child_first"), []byte(":child_first_value"), stateVersion)
+	childTr.Put([]byte(":child_second"), []byte(":child_second_value"), stateVersion)
+	childTr.Put([]byte(":another_child"), []byte("value"), stateVersion)
 
-	err := tr.SetChild([]byte(":child_storage_key"), childTr)
+	err := tr.SetChild([]byte(":child_storage_key"), childTr, stateVersion)
 	require.NoError(t, err)
 
-	stateRoot, err := tr.Root()
+	stateRoot, err := tr.Root(stateVersion)
 	require.NoError(t, err)
 
 	return tr.Trie(), stateRoot

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -40,9 +40,9 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 
 	db := state.NewInMemoryDB(t)
 
-	_, genesisTrie, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	_, genesisTrie, genesisHeader, stateVersion := newTestGenesisWithTrieAndHeader(t)
 	tries := state.NewTries()
-	tries.SetTrie(&genesisTrie)
+	tries.SetTrie(&genesisTrie, stateVersion)
 	bs, err := state.NewBlockStateFromGenesis(db, tries, &genesisHeader, telemetryMock)
 	require.NoError(t, err)
 	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)
@@ -57,6 +57,9 @@ func newBABEService(t *testing.T) *babe.Service {
 	bs, es := newState(t)
 	tt := trie.NewEmptyTrie()
 	rt := wasmer.NewTestInstanceWithTrie(t, runtime.NODE_RUNTIME, tt)
+
+	stateVersion := rt.StateVersion()
+
 	bs.StoreRuntime(bs.GenesisHash(), rt)
 	tt.Put(
 		common.MustHexToBytes("0x886726f904d8372fdabb7707870c2fad"),
@@ -67,7 +70,7 @@ func newBABEService(t *testing.T) *babe.Service {
 			"0d4a9e054df4e01000000000000001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c010000"+
 			"00000000004603307f855321776922daeea21ee31720388d097cdaac66f05a6f8462b317570100000000000000be1d9d59d"+
 			"e1283380100550a7b024501cb62d6cc40e3db35fcc5cf341814986e01000000000000001206960f920a23f7f4c43cc9081"+
-			"ec2ed0721f31a9bef2c10fd7602e16e08a32c0100000000000000"))
+			"ec2ed0721f31a9bef2c10fd7602e16e08a32c0100000000000000"), stateVersion)
 
 	cfg := &babe.ServiceConfig{
 		BlockState:         bs,

--- a/dot/rpc/modules/helpers_test.go
+++ b/dot/rpc/modules/helpers_test.go
@@ -23,7 +23,8 @@ func makeChange(keyHex, valueHex string) [2]*string {
 }
 
 func newTestGenesisWithTrieAndHeader(t *testing.T) (
-	gen genesis.Genesis, genesisTrie trie.Trie, genesisHeader types.Header) {
+	gen genesis.Genesis, genesisTrie trie.Trie, genesisHeader types.Header,
+	stateVersion trie.Version) {
 	t.Helper()
 
 	genesisPath := utils.GetGssmrV3SubstrateGenesisRawPathTest(t)
@@ -34,8 +35,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err = wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()
@@ -44,5 +48,5 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	require.NoError(t, err)
 	genesisHeader = *genesisHeaderPtr
 
-	return gen, genesisTrie, genesisHeader
+	return gen, genesisTrie, genesisHeader, stateVersion
 }

--- a/dot/rpc/modules/mocks/storage_api.go
+++ b/dot/rpc/modules/mocks/storage_api.go
@@ -16,13 +16,13 @@ type StorageAPI struct {
 	mock.Mock
 }
 
-// Entries provides a mock function with given fields: root
-func (_m *StorageAPI) Entries(root *common.Hash) (map[string][]byte, error) {
-	ret := _m.Called(root)
+// Entries provides a mock function with given fields: root, stateVersion
+func (_m *StorageAPI) Entries(root *common.Hash, stateVersion trie.Version) (map[string][]byte, error) {
+	ret := _m.Called(root, stateVersion)
 
 	var r0 map[string][]byte
-	if rf, ok := ret.Get(0).(func(*common.Hash) map[string][]byte); ok {
-		r0 = rf(root)
+	if rf, ok := ret.Get(0).(func(*common.Hash, trie.Version) map[string][]byte); ok {
+		r0 = rf(root, stateVersion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string][]byte)
@@ -30,8 +30,8 @@ func (_m *StorageAPI) Entries(root *common.Hash) (map[string][]byte, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*common.Hash) error); ok {
-		r1 = rf(root)
+	if rf, ok := ret.Get(1).(func(*common.Hash, trie.Version) error); ok {
+		r1 = rf(root, stateVersion)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -39,13 +39,13 @@ func (_m *StorageAPI) Entries(root *common.Hash) (map[string][]byte, error) {
 	return r0, r1
 }
 
-// GetKeysWithPrefix provides a mock function with given fields: root, prefix
-func (_m *StorageAPI) GetKeysWithPrefix(root *common.Hash, prefix []byte) ([][]byte, error) {
-	ret := _m.Called(root, prefix)
+// GetKeysWithPrefix provides a mock function with given fields: root, prefix, stateVersion
+func (_m *StorageAPI) GetKeysWithPrefix(root *common.Hash, prefix []byte, stateVersion trie.Version) ([][]byte, error) {
+	ret := _m.Called(root, prefix, stateVersion)
 
 	var r0 [][]byte
-	if rf, ok := ret.Get(0).(func(*common.Hash, []byte) [][]byte); ok {
-		r0 = rf(root, prefix)
+	if rf, ok := ret.Get(0).(func(*common.Hash, []byte, trie.Version) [][]byte); ok {
+		r0 = rf(root, prefix, stateVersion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([][]byte)
@@ -53,8 +53,8 @@ func (_m *StorageAPI) GetKeysWithPrefix(root *common.Hash, prefix []byte) ([][]b
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*common.Hash, []byte) error); ok {
-		r1 = rf(root, prefix)
+	if rf, ok := ret.Get(1).(func(*common.Hash, []byte, trie.Version) error); ok {
+		r1 = rf(root, prefix, stateVersion)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -131,13 +131,13 @@ func (_m *StorageAPI) GetStorageByBlockHash(bhash *common.Hash, key []byte) ([]b
 	return r0, r1
 }
 
-// GetStorageChild provides a mock function with given fields: root, keyToChild
-func (_m *StorageAPI) GetStorageChild(root *common.Hash, keyToChild []byte) (*trie.Trie, error) {
-	ret := _m.Called(root, keyToChild)
+// GetStorageChild provides a mock function with given fields: root, keyToChild, stateVersion
+func (_m *StorageAPI) GetStorageChild(root *common.Hash, keyToChild []byte, stateVersion trie.Version) (*trie.Trie, error) {
+	ret := _m.Called(root, keyToChild, stateVersion)
 
 	var r0 *trie.Trie
-	if rf, ok := ret.Get(0).(func(*common.Hash, []byte) *trie.Trie); ok {
-		r0 = rf(root, keyToChild)
+	if rf, ok := ret.Get(0).(func(*common.Hash, []byte, trie.Version) *trie.Trie); ok {
+		r0 = rf(root, keyToChild, stateVersion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*trie.Trie)
@@ -145,8 +145,8 @@ func (_m *StorageAPI) GetStorageChild(root *common.Hash, keyToChild []byte) (*tr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*common.Hash, []byte) error); ok {
-		r1 = rf(root, keyToChild)
+	if rf, ok := ret.Get(1).(func(*common.Hash, []byte, trie.Version) error); ok {
+		r1 = rf(root, keyToChild, stateVersion)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -154,13 +154,13 @@ func (_m *StorageAPI) GetStorageChild(root *common.Hash, keyToChild []byte) (*tr
 	return r0, r1
 }
 
-// GetStorageFromChild provides a mock function with given fields: root, keyToChild, key
-func (_m *StorageAPI) GetStorageFromChild(root *common.Hash, keyToChild []byte, key []byte) ([]byte, error) {
-	ret := _m.Called(root, keyToChild, key)
+// GetStorageFromChild provides a mock function with given fields: root, keyToChild, key, stateVersion
+func (_m *StorageAPI) GetStorageFromChild(root *common.Hash, keyToChild []byte, key []byte, stateVersion trie.Version) ([]byte, error) {
+	ret := _m.Called(root, keyToChild, key, stateVersion)
 
 	var r0 []byte
-	if rf, ok := ret.Get(0).(func(*common.Hash, []byte, []byte) []byte); ok {
-		r0 = rf(root, keyToChild, key)
+	if rf, ok := ret.Get(0).(func(*common.Hash, []byte, []byte, trie.Version) []byte); ok {
+		r0 = rf(root, keyToChild, key, stateVersion)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
@@ -168,8 +168,8 @@ func (_m *StorageAPI) GetStorageFromChild(root *common.Hash, keyToChild []byte, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*common.Hash, []byte, []byte) error); ok {
-		r1 = rf(root, keyToChild, key)
+	if rf, ok := ret.Get(1).(func(*common.Hash, []byte, []byte, trie.Version) error); ok {
+		r1 = rf(root, keyToChild, key, stateVersion)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -178,8 +178,17 @@ func (_m *StorageAPI) GetStorageFromChild(root *common.Hash, keyToChild []byte, 
 }
 
 // RegisterStorageObserver provides a mock function with given fields: observer
-func (_m *StorageAPI) RegisterStorageObserver(observer state.Observer) {
-	_m.Called(observer)
+func (_m *StorageAPI) RegisterStorageObserver(observer state.Observer) error {
+	ret := _m.Called(observer)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(state.Observer) error); ok {
+		r0 = rf(observer)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // UnregisterStorageObserver provides a mock function with given fields: observer

--- a/dot/rpc/modules/mocks_test.go
+++ b/dot/rpc/modules/mocks_test.go
@@ -39,33 +39,33 @@ func (m *MockStorageAPI) EXPECT() *MockStorageAPIMockRecorder {
 }
 
 // Entries mocks base method.
-func (m *MockStorageAPI) Entries(arg0 *common.Hash) (map[string][]byte, error) {
+func (m *MockStorageAPI) Entries(arg0 *common.Hash, arg1 trie.Version) (map[string][]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Entries", arg0)
+	ret := m.ctrl.Call(m, "Entries", arg0, arg1)
 	ret0, _ := ret[0].(map[string][]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Entries indicates an expected call of Entries.
-func (mr *MockStorageAPIMockRecorder) Entries(arg0 interface{}) *gomock.Call {
+func (mr *MockStorageAPIMockRecorder) Entries(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Entries", reflect.TypeOf((*MockStorageAPI)(nil).Entries), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Entries", reflect.TypeOf((*MockStorageAPI)(nil).Entries), arg0, arg1)
 }
 
 // GetKeysWithPrefix mocks base method.
-func (m *MockStorageAPI) GetKeysWithPrefix(arg0 *common.Hash, arg1 []byte) ([][]byte, error) {
+func (m *MockStorageAPI) GetKeysWithPrefix(arg0 *common.Hash, arg1 []byte, arg2 trie.Version) ([][]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKeysWithPrefix", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetKeysWithPrefix", arg0, arg1, arg2)
 	ret0, _ := ret[0].([][]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetKeysWithPrefix indicates an expected call of GetKeysWithPrefix.
-func (mr *MockStorageAPIMockRecorder) GetKeysWithPrefix(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStorageAPIMockRecorder) GetKeysWithPrefix(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeysWithPrefix", reflect.TypeOf((*MockStorageAPI)(nil).GetKeysWithPrefix), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeysWithPrefix", reflect.TypeOf((*MockStorageAPI)(nil).GetKeysWithPrefix), arg0, arg1, arg2)
 }
 
 // GetStateRootFromBlock mocks base method.
@@ -114,39 +114,41 @@ func (mr *MockStorageAPIMockRecorder) GetStorageByBlockHash(arg0, arg1 interface
 }
 
 // GetStorageChild mocks base method.
-func (m *MockStorageAPI) GetStorageChild(arg0 *common.Hash, arg1 []byte) (*trie.Trie, error) {
+func (m *MockStorageAPI) GetStorageChild(arg0 *common.Hash, arg1 []byte, arg2 trie.Version) (*trie.Trie, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStorageChild", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetStorageChild", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*trie.Trie)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStorageChild indicates an expected call of GetStorageChild.
-func (mr *MockStorageAPIMockRecorder) GetStorageChild(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStorageAPIMockRecorder) GetStorageChild(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageChild", reflect.TypeOf((*MockStorageAPI)(nil).GetStorageChild), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageChild", reflect.TypeOf((*MockStorageAPI)(nil).GetStorageChild), arg0, arg1, arg2)
 }
 
 // GetStorageFromChild mocks base method.
-func (m *MockStorageAPI) GetStorageFromChild(arg0 *common.Hash, arg1, arg2 []byte) ([]byte, error) {
+func (m *MockStorageAPI) GetStorageFromChild(arg0 *common.Hash, arg1, arg2 []byte, arg3 trie.Version) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStorageFromChild", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetStorageFromChild", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStorageFromChild indicates an expected call of GetStorageFromChild.
-func (mr *MockStorageAPIMockRecorder) GetStorageFromChild(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockStorageAPIMockRecorder) GetStorageFromChild(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageFromChild", reflect.TypeOf((*MockStorageAPI)(nil).GetStorageFromChild), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageFromChild", reflect.TypeOf((*MockStorageAPI)(nil).GetStorageFromChild), arg0, arg1, arg2, arg3)
 }
 
 // RegisterStorageObserver mocks base method.
-func (m *MockStorageAPI) RegisterStorageObserver(arg0 state.Observer) {
+func (m *MockStorageAPI) RegisterStorageObserver(arg0 state.Observer) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterStorageObserver", arg0)
+	ret := m.ctrl.Call(m, "RegisterStorageObserver", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // RegisterStorageObserver indicates an expected call of RegisterStorageObserver.

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -539,17 +539,23 @@ func setupStateModule(t *testing.T) (*StateModule, *common.Hash, *common.Hash) {
 	// setup service
 	net := newNetworkService(t)
 	chain := newTestStateService(t)
+
+	bestBlockHash := chain.Block.BestBlockHash()
+	instance, err := chain.Block.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
 	// init storage with test data
-	ts, err := chain.Storage.TrieState(nil)
+	ts, err := chain.Storage.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 
-	ts.Set([]byte(`:key2`), []byte(`value2`))
-	ts.Set([]byte(`:key1`), []byte(`value1`))
-	ts.SetChildStorage([]byte(`:child1`), []byte(`:key1`), []byte(`:childValue1`))
+	ts.Set([]byte(`:key2`), []byte(`value2`), stateVersion)
+	ts.Set([]byte(`:key1`), []byte(`value1`), stateVersion)
+	ts.SetChildStorage([]byte(`:child1`), []byte(`:key1`), []byte(`:childValue1`), stateVersion)
 
-	sr1, err := ts.Root()
+	sr1, err := ts.Root(stateVersion)
 	require.NoError(t, err)
-	err = chain.Storage.StoreTrie(ts, nil)
+	err = chain.Storage.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	digest := types.NewDigest()

--- a/dot/rpc/modules/sync_state.go
+++ b/dot/rpc/modules/sync_state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/trie"
 )
 
 // GenSyncSpecRequest represents request to get chain specification.
@@ -43,21 +44,17 @@ type syncState struct {
 }
 
 // NewStateSync creates an instance of SyncStateAPI given a chain specification.
-func NewStateSync(gData *genesis.Data, storageAPI StorageAPI) (SyncStateAPI, error) {
+func NewStateSync(gData *genesis.Data, storageAPI StorageAPI,
+	stateVersion trie.Version) (stateSync SyncStateAPI, err error) {
 	tmpGen := &genesis.Genesis{
-		Name:       "",
-		ID:         "",
-		Bootnodes:  nil,
-		ProtocolID: "",
 		Genesis: genesis.Fields{
-			Runtime: nil,
+			Raw:     make(map[string]map[string]string),
+			Runtime: make(map[string]map[string]interface{}),
 		},
 	}
-	tmpGen.Genesis.Raw = make(map[string]map[string]string)
-	tmpGen.Genesis.Runtime = make(map[string]map[string]interface{})
 
 	// set genesis fields data
-	ent, err := storageAPI.Entries(nil)
+	ent, err := storageAPI.Entries(nil, stateVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/rpc/subscription/websocket.go
+++ b/dot/rpc/subscription/websocket.go
@@ -203,7 +203,11 @@ func (c *WSConn) initStorageChangeListener(reqID float64, params interface{}) (L
 
 	c.mu.Unlock()
 
-	c.StorageAPI.RegisterStorageObserver(stgobs)
+	err := c.StorageAPI.RegisterStorageObserver(stgobs)
+	if err != nil {
+		return nil, fmt.Errorf("registering storage observer: %w", err)
+	}
+
 	initRes := NewSubscriptionResponseJSON(stgobs.id, reqID)
 	c.safeSend(initRes)
 

--- a/dot/state/base_test.go
+++ b/dot/state/base_test.go
@@ -21,23 +21,25 @@ func TestTrie_StoreAndLoadFromDB(t *testing.T) {
 	const size = 500
 	kv := generateKeyValues(t, generator, size)
 
+	const stateVersion = trie.V0
+
 	for keyString, value := range kv {
 		key := []byte(keyString)
-		tt.Put(key, value)
+		tt.Put(key, value, stateVersion)
 	}
 
 	err := tt.Store(db)
 	require.NoError(t, err)
 
-	encroot, err := tt.Hash()
+	encroot, err := tt.Hash(stateVersion)
 	require.NoError(t, err)
 
-	expected := tt.MustHash()
+	expected := tt.MustHash(stateVersion)
 
 	tt = trie.NewEmptyTrie()
-	err = tt.Load(db, encroot)
+	err = tt.Load(db, encroot, stateVersion)
 	require.NoError(t, err)
-	require.Equal(t, expected, tt.MustHash())
+	require.Equal(t, expected, tt.MustHash(stateVersion))
 }
 
 func TestStoreAndLoadGenesisData(t *testing.T) {

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -35,10 +35,15 @@ func newTestBlockState(t *testing.T, tries *Tries) *BlockState {
 	bs, err := NewBlockStateFromGenesis(db, tries, header, telemetryMock)
 	require.NoError(t, err)
 
+	bestBlockHash := bs.BestBlockHash()
+	instance, err := bs.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
 	// loads in-memory tries with genesis state root, should be deleted
 	// after another block is finalised
 	tr := trie.NewEmptyTrie()
-	err = tr.Load(bs.db, header.StateRoot)
+	err = tr.Load(bs.db, header.StateRoot, stateVersion)
 	require.NoError(t, err)
 	bs.tries.softSet(header.StateRoot, tr)
 
@@ -349,6 +354,7 @@ func TestGetHashByNumber(t *testing.T) {
 
 func TestAddBlock_WithReOrg(t *testing.T) {
 	t.Skip() // TODO: this should be fixed after state refactor PR
+
 	bs := newTestBlockState(t, newTriesEmpty())
 
 	header1a := &types.Header{
@@ -479,7 +485,6 @@ func TestAddBlockToBlockTree(t *testing.T) {
 
 func TestNumberIsFinalised(t *testing.T) {
 	tries := newTriesEmpty()
-
 	bs := newTestBlockState(t, tries)
 	fin, err := bs.NumberIsFinalised(0)
 	require.NoError(t, err)

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -35,10 +35,6 @@ func newEpochStateFromGenesis(t *testing.T) *EpochState {
 	return s
 }
 
-func TestNewEpochStateFromGenesis(t *testing.T) {
-	_ = newEpochStateFromGenesis(t)
-}
-
 func TestEpochState_CurrentEpoch(t *testing.T) {
 	s := newEpochStateFromGenesis(t)
 	epoch, err := s.GetCurrentEpoch()

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -132,10 +132,13 @@ func testBlockState(t *testing.T, db chaindb.Database) *BlockState {
 	bs, err := NewBlockStateFromGenesis(db, newTriesEmpty(), header, telemetryMock)
 	require.NoError(t, err)
 
+	runtime, err := bs.GetRuntime(nil)
+	require.NoError(t, err)
+
 	// loads in-memory tries with genesis state root, should be deleted
 	// after another block is finalised
 	tr := trie.NewEmptyTrie()
-	err = tr.Load(bs.db, header.StateRoot)
+	err = tr.Load(bs.db, header.StateRoot, runtime.StateVersion())
 	require.NoError(t, err)
 	bs.tries.softSet(header.StateRoot, tr)
 

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -90,7 +90,8 @@ func generateRandBytes(tb testing.TB, size int,
 }
 
 func newTestGenesisWithTrieAndHeader(t *testing.T) (
-	gen genesis.Genesis, genesisTrie trie.Trie, genesisHeader types.Header) {
+	gen genesis.Genesis, genesisTrie trie.Trie, genesisHeader types.Header,
+	stateVersion trie.Version) {
 	t.Helper()
 
 	genesisPath := utils.GetGssmrV3SubstrateGenesisRawPathTest(t)
@@ -101,8 +102,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err = wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()
@@ -111,5 +115,5 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	require.NoError(t, err)
 	genesisHeader = *genesisHeaderPtr
 
-	return gen, genesisTrie, genesisHeader
+	return gen, genesisTrie, genesisHeader, stateVersion
 }

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -53,6 +53,8 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return err
 	}
 
+	stateVersion := rt.StateVersion()
+
 	babeCfg, err := s.loadBabeConfigurationFromRuntime(rt)
 	if err != nil {
 		return err
@@ -65,7 +67,7 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 	}
 
 	tries := NewTries()
-	tries.SetTrie(t)
+	tries.SetTrie(t, stateVersion)
 
 	// create block state from genesis block
 	blockState, err := NewBlockStateFromGenesis(db, tries, header, s.Telemetry)

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -120,6 +120,9 @@ func (s *StorageState) TrieState(root *common.Hash, version trie.Version) (*rtst
 		root = &sr
 	}
 
+	// TODO get state version from runtime corresponding to block hash corresponding to state root given?
+	// Or keep it injected?
+
 	t := s.tries.get(*root)
 	if t == nil {
 		var err error

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -20,7 +20,12 @@ import (
 func TestStorageState_RegisterStorageObserver(t *testing.T) {
 	ss := newTestStorageState(t)
 
-	ts, err := ss.TrieState(nil)
+	bestBlockHash := ss.blockState.BestBlockHash()
+	instance, err := ss.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
+	ts, err := ss.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 
 	mockfilter := map[string][]byte{}
@@ -46,8 +51,8 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 	ss.RegisterStorageObserver(mockobs)
 	defer ss.UnregisterStorageObserver(mockobs)
 
-	ts.Set([]byte("mackcom"), []byte("wuz here"))
-	err = ss.StoreTrie(ts, nil)
+	ts.Set([]byte("mackcom"), []byte("wuz here"), stateVersion)
+	err = ss.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	// We need to wait since GetFilter and Update are called
@@ -58,7 +63,13 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 
 func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 	ss := newTestStorageState(t)
-	ts, err := ss.TrieState(nil)
+
+	bestBlockHash := ss.blockState.BestBlockHash()
+	runtime, err := ss.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := runtime.StateVersion()
+
+	ts, err := ss.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 
 	num := 5
@@ -74,16 +85,16 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 		mockobs.On("GetFilter").Return(mockfilter).Times(2)
 
 		mocks = append(mocks, mockobs)
-		ss.RegisterStorageObserver(mockobs)
+		err = ss.RegisterStorageObserver(mockobs)
 		require.NoError(t, err)
 	}
 
 	key1 := []byte("key1")
 	value1 := []byte("value1")
 
-	ts.Set(key1, value1)
+	ts.Set(key1, value1, stateVersion)
 
-	err = ss.StoreTrie(ts, nil)
+	err = ss.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	time.Sleep(time.Millisecond * 10)
@@ -96,7 +107,13 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 	t.Skip() // this seems to fail often on CI
 	ss := newTestStorageState(t)
-	ts, err := ss.TrieState(nil)
+
+	bestBlockHash := ss.blockState.BestBlockHash()
+	instance, err := ss.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
+	ts, err := ss.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 
 	key1 := []byte("key1")
@@ -115,11 +132,12 @@ func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 		mockobs.On("GetFilter").Return(filter).Times(len(filter) + 3)
 
 		mocks = append(mocks, mockobs)
-		ss.RegisterStorageObserver(mockobs)
+		err = ss.RegisterStorageObserver(mockobs)
+		require.NoError(t, err)
 	}
 
-	ts.Set(key1, value1)
-	err = ss.StoreTrie(ts, nil)
+	ts.Set(key1, value1, stateVersion)
+	err = ss.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	time.Sleep(time.Millisecond * 10)

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -33,17 +33,23 @@ func newTestStorageState(t *testing.T) *StorageState {
 
 func TestStorage_StoreAndLoadTrie(t *testing.T) {
 	storage := newTestStorageState(t)
-	ts, err := storage.TrieState(&trie.EmptyHash)
+
+	bestBlockHash := storage.blockState.BestBlockHash()
+	instance, err := storage.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
+	ts, err := storage.TrieState(&trie.EmptyHash, stateVersion)
 	require.NoError(t, err)
 
-	root, err := ts.Root()
+	root, err := ts.Root(stateVersion)
 	require.NoError(t, err)
-	err = storage.StoreTrie(ts, nil)
+	err = storage.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	time.Sleep(time.Millisecond * 100)
 
-	trie, err := storage.LoadFromDB(root)
+	trie, err := storage.LoadFromDB(root, stateVersion)
 	require.NoError(t, err)
 	ts2 := runtime.NewTrieState(trie)
 	new := ts2.Snapshot()
@@ -52,16 +58,22 @@ func TestStorage_StoreAndLoadTrie(t *testing.T) {
 
 func TestStorage_GetStorageByBlockHash(t *testing.T) {
 	storage := newTestStorageState(t)
-	ts, err := storage.TrieState(&trie.EmptyHash)
+
+	bestBlockHash := storage.blockState.BestBlockHash()
+	instance, err := storage.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
+	ts, err := storage.TrieState(&trie.EmptyHash, stateVersion)
 	require.NoError(t, err)
 
 	key := []byte("testkey")
 	value := []byte("testvalue")
-	ts.Set(key, value)
+	ts.Set(key, value, stateVersion)
 
-	root, err := ts.Root()
+	root, err := ts.Root(stateVersion)
 	require.NoError(t, err)
-	err = storage.StoreTrie(ts, nil)
+	err = storage.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	body, err := types.NewBodyFromBytes([]byte{})
@@ -87,27 +99,39 @@ func TestStorage_GetStorageByBlockHash(t *testing.T) {
 
 func TestStorage_TrieState(t *testing.T) {
 	storage := newTestStorageState(t)
-	ts, err := storage.TrieState(&trie.EmptyHash)
-	require.NoError(t, err)
-	ts.Set([]byte("noot"), []byte("washere"))
 
-	root, err := ts.Root()
+	bestBlockHash := storage.blockState.BestBlockHash()
+	instance, err := storage.blockState.GetRuntime(&bestBlockHash)
 	require.NoError(t, err)
-	err = storage.StoreTrie(ts, nil)
+	stateVersion := instance.StateVersion()
+
+	ts, err := storage.TrieState(&trie.EmptyHash, stateVersion)
+	require.NoError(t, err)
+	ts.Set([]byte("noot"), []byte("washere"), stateVersion)
+
+	root, err := ts.Root(stateVersion)
+	require.NoError(t, err)
+	err = storage.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	time.Sleep(time.Millisecond * 100)
 
 	// get trie from db
 	storage.blockState.tries.delete(root)
-	ts3, err := storage.TrieState(&root)
+	ts3, err := storage.TrieState(&root, stateVersion)
 	require.NoError(t, err)
-	require.Equal(t, ts.Trie().MustHash(), ts3.Trie().MustHash())
+	require.Equal(t, ts.Trie().MustHash(stateVersion), ts3.Trie().MustHash(stateVersion))
 }
 
 func TestStorage_LoadFromDB(t *testing.T) {
 	storage := newTestStorageState(t)
-	ts, err := storage.TrieState(&trie.EmptyHash)
+
+	bestBlockHash := storage.blockState.BestBlockHash()
+	instance, err := storage.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
+	ts, err := storage.TrieState(&trie.EmptyHash, stateVersion)
 	require.NoError(t, err)
 
 	trieKV := []struct {
@@ -120,14 +144,14 @@ func TestStorage_LoadFromDB(t *testing.T) {
 	}
 
 	for _, kv := range trieKV {
-		ts.Set(kv.key, kv.value)
+		ts.Set(kv.key, kv.value, stateVersion)
 	}
 
-	root, err := ts.Root()
+	root, err := ts.Root(stateVersion)
 	require.NoError(t, err)
 
 	// Write trie to disk.
-	err = storage.StoreTrie(ts, nil)
+	err = storage.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 
 	// Clear trie from cache and fetch data from disk.
@@ -139,27 +163,33 @@ func TestStorage_LoadFromDB(t *testing.T) {
 
 	storage.blockState.tries.delete(root)
 
-	prefixKeys, err := storage.GetKeysWithPrefix(&root, []byte("ke"))
+	prefixKeys, err := storage.GetKeysWithPrefix(&root, []byte("ke"), stateVersion)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(prefixKeys))
 
 	storage.blockState.tries.delete(root)
 
-	entries, err := storage.Entries(&root)
+	entries, err := storage.Entries(&root, stateVersion)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(entries))
 }
 
 func TestStorage_StoreTrie_NotSyncing(t *testing.T) {
 	storage := newTestStorageState(t)
-	ts, err := storage.TrieState(&trie.EmptyHash)
+
+	bestBlockHash := storage.blockState.BestBlockHash()
+	instance, err := storage.blockState.GetRuntime(&bestBlockHash)
+	require.NoError(t, err)
+	stateVersion := instance.StateVersion()
+
+	ts, err := storage.TrieState(&trie.EmptyHash, stateVersion)
 	require.NoError(t, err)
 
 	key := []byte("testkey")
 	value := []byte("testvalue")
-	ts.Set(key, value)
+	ts.Set(key, value, stateVersion)
 
-	err = storage.StoreTrie(ts, nil)
+	err = storage.StoreTrie(ts, nil, stateVersion)
 	require.NoError(t, err)
 	require.Equal(t, 2, storage.blockState.tries.len())
 }
@@ -170,7 +200,7 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	db, err := utils.SetupDatabase(basepath, false)
 	require.NoError(t, err)
 
-	_, genTrie, genHeader := newTestGenesisWithTrieAndHeader(t)
+	_, genTrie, genHeader, stateVersion := newTestGenesisWithTrieAndHeader(t)
 
 	ctrl := gomock.NewController(t)
 	telemetryMock := NewMockClient(ctrl)
@@ -186,9 +216,9 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	}
 	testChildTrie := trie.NewTrie(trieRoot)
 
-	testChildTrie.Put([]byte("keyInsidechild"), []byte("voila"))
+	testChildTrie.Put([]byte("keyInsidechild"), []byte("voila"), stateVersion)
 
-	err = genTrie.PutChild([]byte("keyToChild"), testChildTrie)
+	err = genTrie.PutChild([]byte("keyToChild"), testChildTrie, stateVersion)
 	require.NoError(t, err)
 
 	tries := newTriesEmpty()
@@ -201,26 +231,26 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 
 	trieState := runtime.NewTrieState(&genTrie)
 
-	header, err := types.NewHeader(blockState.GenesisHash(), trieState.MustRoot(),
+	header, err := types.NewHeader(blockState.GenesisHash(), trieState.MustRoot(stateVersion),
 		common.Hash{}, 1, types.NewDigest())
 	require.NoError(t, err)
 
-	err = storage.StoreTrie(trieState, header)
+	err = storage.StoreTrie(trieState, header, stateVersion)
 	require.NoError(t, err)
 
-	rootHash, err := genTrie.Hash()
+	rootHash, err := genTrie.Hash(stateVersion)
 	require.NoError(t, err)
 
-	_, err = storage.GetStorageChild(&rootHash, []byte("keyToChild"))
+	_, err = storage.GetStorageChild(&rootHash, []byte("keyToChild"), stateVersion)
 	require.NoError(t, err)
 
 	// Clear trie from cache and fetch data from disk.
 	storage.blockState.tries.delete(rootHash)
 
-	_, err = storage.GetStorageChild(&rootHash, []byte("keyToChild"))
+	_, err = storage.GetStorageChild(&rootHash, []byte("keyToChild"), stateVersion)
 	require.NoError(t, err)
 
-	value, err := storage.GetStorageFromChild(&rootHash, []byte("keyToChild"), []byte("keyInsidechild"))
+	value, err := storage.GetStorageFromChild(&rootHash, []byte("keyToChild"), []byte("keyInsidechild"), stateVersion)
 	require.NoError(t, err)
 
 	require.Equal(t, []byte("voila"), value)

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -236,17 +236,18 @@ func AddBlocksToStateWithFixedBranches(t *testing.T, blockState *BlockState, dep
 }
 
 func generateBlockWithRandomTrie(t *testing.T, serv *Service,
-	parent *common.Hash, bNum uint) (*types.Block, *runtime.TrieState) {
-	trieState, err := serv.Storage.TrieState(nil)
+	parent *common.Hash, bNum uint, stateVersion trie.Version) (
+	block *types.Block, trieState *runtime.TrieState) {
+	trieState, err := serv.Storage.TrieState(nil, stateVersion)
 	require.NoError(t, err)
 
 	// Generate random data for trie state.
 	rand := time.Now().UnixNano()
 	key := []byte("testKey" + fmt.Sprint(rand))
 	value := []byte("testValue" + fmt.Sprint(rand))
-	trieState.Set(key, value)
+	trieState.Set(key, value, stateVersion)
 
-	trieStateRoot, err := trieState.Root()
+	trieStateRoot, err := trieState.Root(stateVersion)
 	require.NoError(t, err)
 
 	if parent == nil {
@@ -257,7 +258,7 @@ func generateBlockWithRandomTrie(t *testing.T, serv *Service,
 	body, err := types.NewBodyFromBytes([]byte{})
 	require.NoError(t, err)
 
-	block := &types.Block{
+	block = &types.Block{
 		Header: types.Header{
 			ParentHash: *parent,
 			Number:     bNum,

--- a/dot/state/tries.go
+++ b/dot/state/tries.go
@@ -59,8 +59,8 @@ func (t *Tries) SetEmptyTrie() {
 }
 
 // SetTrie sets the trie at its root hash in the tries map.
-func (t *Tries) SetTrie(trie *trie.Trie) {
-	t.softSet(trie.MustHash(), trie)
+func (t *Tries) SetTrie(trie *trie.Trie, stateVersion trie.Version) {
+	t.softSet(trie.MustHash(stateVersion), trie)
 }
 
 // softSet sets the given trie at the given root hash

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -49,14 +49,16 @@ func Test_Tries_SetEmptyTrie(t *testing.T) {
 func Test_Tries_SetTrie(t *testing.T) {
 	t.Parallel()
 
+	const stateVersion = trie.V0
+
 	tr := trie.NewTrie(&node.Node{Key: []byte{1}})
 
 	tries := NewTries()
-	tries.SetTrie(tr)
+	tries.SetTrie(tr, stateVersion)
 
 	expectedTries := &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{
-			tr.MustHash(): tr,
+			tr.MustHash(stateVersion): tr,
 		},
 		triesGauge:    triesGauge,
 		setCounter:    setCounter,

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -4,7 +4,6 @@
 package sync
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +11,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/telemetry"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
+	"github.com/ChainSafe/gossamer/lib/trie"
 )
 
 // ChainProcessor processes ready blocks.
@@ -140,10 +140,16 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 			}
 		}
 
+		instance, err := s.blockState.GetRuntime(&block.Header.ParentHash)
+		if err != nil {
+			return fmt.Errorf("getting runtime instance: %w", err)
+		}
+		stateVersion := instance.StateVersion()
+
 		// TODO: this is probably unnecessary, since the state is already in the database
 		// however, this case shouldn't be hit often, since it's only hit if the node state
 		// is rewinded or if the node shuts down unexpectedly (#1784)
-		state, err := s.storageState.TrieState(&block.Header.StateRoot)
+		state, err := s.storageState.TrieState(&block.Header.StateRoot, stateVersion)
 		if err != nil {
 			logger.Warnf("failed to load state for block with hash %s: %s", block.Header.Hash(), err)
 			return err
@@ -200,30 +206,34 @@ func (s *chainProcessor) handleBody(body *types.Body) {
 	}
 }
 
-// handleHeader handles blocks (header+body) included in BlockResponses
+// handleBlock handles blocks (header+body) included in BlockResponses
 func (s *chainProcessor) handleBlock(block *types.Block) error {
 	parent, err := s.blockState.GetHeader(block.Header.ParentHash)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errFailedToGetParent, err)
 	}
 
-	s.storageState.Lock()
-	defer s.storageState.Unlock()
-
-	ts, err := s.storageState.TrieState(&parent.StateRoot)
-	if err != nil {
-		return err
-	}
-
-	root := ts.MustRoot()
-	if !bytes.Equal(parent.StateRoot[:], root[:]) {
-		panic("parent state root does not match snapshot state root")
-	}
-
 	hash := parent.Hash()
 	rt, err := s.blockState.GetRuntime(&hash)
 	if err != nil {
+		return fmt.Errorf("getting runtime for parent hash: %w", err)
+	}
+
+	stateVersion := rt.StateVersion()
+
+	s.storageState.Lock()
+	defer s.storageState.Unlock()
+
+	ts, err := s.storageState.TrieState(&parent.StateRoot, stateVersion)
+	if err != nil {
 		return err
+	}
+
+	// TODO shall we remove this? Both are coming from the internal state
+	rootV0 := ts.MustRoot(trie.V0)
+	if !rootV0.Equal(parent.StateRoot) {
+		// TODO add extra check with rootV1 when v1 is supported
+		panic("parent state root does not match snapshot state root")
 	}
 
 	rt.SetContextStorage(ts)
@@ -234,7 +244,7 @@ func (s *chainProcessor) handleBlock(block *types.Block) error {
 	}
 
 	if err = s.blockImportHandler.HandleBlockImport(block, ts); err != nil {
-		return err
+		return fmt.Errorf("handling block import: %w", err)
 	}
 
 	logger.Debugf("🔗 imported block number %d with hash %s", block.Header.Number, block.Header.Hash())

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -97,16 +97,17 @@ func (s *chainProcessor) processReadyBlocks() {
 // or the index of the block data that errored on failure.
 func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 	if bd == nil {
-		return ErrNilBlockData
+		return fmt.Errorf("%w", ErrNilBlockData)
 	}
 
 	hasHeader, err := s.blockState.HasHeader(bd.Hash)
 	if err != nil {
-		return fmt.Errorf("failed to check if block state has header for hash %s: %w", bd.Hash, err)
+		return fmt.Errorf("checking header in block state: %w", err)
 	}
+
 	hasBody, err := s.blockState.HasBlockBody(bd.Hash)
 	if err != nil {
-		return fmt.Errorf("failed to check block state has body for hash %s: %w", bd.Hash, err)
+		return fmt.Errorf("checking block body in block state: %w", err)
 	}
 
 	if hasHeader && hasBody {
@@ -116,8 +117,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		// code block can be removed (#1784)
 		block, err := s.blockState.GetBlockByHash(bd.Hash)
 		if err != nil {
-			logger.Debugf("failed to get block header for hash %s: %s", bd.Hash, err)
-			return err
+			return fmt.Errorf("getting block by hash from block state: %w", err)
 		}
 
 		logger.Debugf(
@@ -128,8 +128,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		if errors.Is(err, blocktree.ErrBlockExists) {
 			return nil
 		} else if err != nil {
-			logger.Warnf("failed to add block with hash %s to blocktree: %s", bd.Hash, err)
-			return err
+			return fmt.Errorf("adding block to block tree: %w", err)
 		}
 
 		if bd.Justification != nil {
@@ -151,12 +150,11 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		// is rewinded or if the node shuts down unexpectedly (#1784)
 		state, err := s.storageState.TrieState(&block.Header.StateRoot, stateVersion)
 		if err != nil {
-			logger.Warnf("failed to load state for block with hash %s: %s", block.Header.Hash(), err)
-			return err
+			return fmt.Errorf("running trie state: %w", err)
 		}
 
 		if err := s.blockImportHandler.HandleBlockImport(block, state); err != nil {
-			logger.Warnf("failed to handle block import: %s", err)
+			return fmt.Errorf("handling block import: %w", err)
 		}
 
 		return nil
@@ -166,7 +164,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 
 	if bd.Header != nil && bd.Body != nil {
 		if err := s.babeVerifier.VerifyBlock(bd.Header); err != nil {
-			return err
+			return fmt.Errorf("babe verifying block: %w", err)
 		}
 
 		s.handleBody(bd.Body)

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -174,9 +174,9 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 			Body:   *bd.Body,
 		}
 
-		if err := s.handleBlock(block); err != nil {
-			logger.Debugf("failed to handle block number %d: %s", block.Header.Number, err)
-			return err
+		err = s.handleBlock(block)
+		if err != nil {
+			return fmt.Errorf("handling block: %w", err)
 		}
 
 		logger.Debugf("block with hash %s processed", bd.Hash)
@@ -191,7 +191,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 	}
 
 	if err := s.blockState.CompareAndSetBlockData(bd); err != nil {
-		return fmt.Errorf("failed to compare and set data: %w", err)
+		return fmt.Errorf("comparing and setting block data: %w", err)
 	}
 
 	return nil
@@ -224,7 +224,7 @@ func (s *chainProcessor) handleBlock(block *types.Block) error {
 
 	ts, err := s.storageState.TrieState(&parent.StateRoot, stateVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("trie state: %w", err)
 	}
 
 	// TODO shall we remove this? Both are coming from the internal state

--- a/dot/sync/chain_processor_integration_test.go
+++ b/dot/sync/chain_processor_integration_test.go
@@ -194,16 +194,18 @@ func TestChainProcessor_HandleBlockResponse_BlockData(t *testing.T) {
 func TestChainProcessor_ExecuteBlock(t *testing.T) {
 	syncer := newTestSyncer(t)
 
-	parent, err := syncer.blockState.(*state.BlockState).BestBlockHeader()
+	parent, err := syncer.blockState.BestBlockHeader()
 	require.NoError(t, err)
 
 	rt, err := syncer.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
+	stateVersion := rt.StateVersion()
+
 	block := BuildBlock(t, rt, parent, nil)
 
 	// reset parentState
-	parentState, err := syncer.chainProcessor.(*chainProcessor).storageState.TrieState(&parent.StateRoot)
+	parentState, err := syncer.chainProcessor.(*chainProcessor).storageState.TrieState(&parent.StateRoot, stateVersion)
 	require.NoError(t, err)
 	rt.SetContextStorage(parentState)
 

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -6,8 +6,10 @@ package sync
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/dot/telemetry"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -20,154 +22,235 @@ import (
 func Test_chainProcessor_handleBlock(t *testing.T) {
 	t.Parallel()
 	mockError := errors.New("test mock error")
-	testHash := common.MustHexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-	testParentHash := common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a")
 
 	tests := map[string]struct {
 		chainProcessorBuilder func(ctrl *gomock.Controller) chainProcessor
 		block                 *types.Block
 		wantErr               error
+		errMessage            string
 	}{
-		"handle getHeader error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(nil, mockError)
-				chainProcessor.blockState = mockBlockState
-				return
-			},
-			block: &types.Block{
-				Body: types.Body{},
-			},
-			wantErr: errFailedToGetParent,
-		},
-		"handle trieState error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{}, nil)
-				chainProcessor.blockState = mockBlockState
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, mockError)
-				mockStorageState.EXPECT().Unlock()
-				chainProcessor.storageState = mockStorageState
-				return
-			},
-			block: &types.Block{
-				Body: types.Body{},
-			},
-			wantErr: mockError,
-		},
-		"handle getRuntime error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
-					StateRoot: testHash,
-				}, nil)
-				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(nil, mockError)
-				chainProcessor.blockState = mockBlockState
-				trieState := storage.NewTrieState(nil)
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().TrieState(&testHash).Return(trieState, nil)
-				mockStorageState.EXPECT().Unlock()
-				chainProcessor.storageState = mockStorageState
-				return
-			},
-			block: &types.Block{
-				Body: types.Body{},
-			},
-			wantErr: mockError,
-		},
-		"handle runtime ExecuteBlock error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				trieState := storage.NewTrieState(nil)
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
-					StateRoot: testHash,
-				}, nil)
-				mockInstance := NewMockRuntimeInstance(ctrl)
-				mockInstance.EXPECT().SetContextStorage(trieState)
-				mockInstance.EXPECT().ExecuteBlock(&types.Block{Body: types.Body{}}).Return(nil, mockError)
-				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(mockInstance, nil)
-				chainProcessor.blockState = mockBlockState
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().TrieState(&testHash).Return(trieState, nil)
-				mockStorageState.EXPECT().Unlock()
-				chainProcessor.storageState = mockStorageState
-				return
-			},
-			block: &types.Block{
-				Body: types.Body{},
-			},
-			wantErr: mockError,
-		},
-		"handle block import error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				trieState := storage.NewTrieState(nil)
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
-					StateRoot: testHash,
-				}, nil)
-				mockBlock := &types.Block{Body: types.Body{}}
-				mockInstance := NewMockRuntimeInstance(ctrl)
-				mockInstance.EXPECT().SetContextStorage(trieState)
-				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState.EXPECT().GetRuntime(&testParentHash).Return(mockInstance, nil)
-				chainProcessor.blockState = mockBlockState
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().TrieState(&testHash).Return(trieState, nil)
-				mockStorageState.EXPECT().Unlock()
-				chainProcessor.storageState = mockStorageState
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(mockBlock,
-					trieState).Return(mockError)
-				chainProcessor.blockImportHandler = mockBlockImportHandler
-				return
-			},
-			block: &types.Block{
-				Body: types.Body{},
-			},
-			wantErr: mockError,
-		},
-		"base case": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) (chainProcessor chainProcessor) {
-				mockBlock := &types.Block{
-					Body: types.Body{}, // empty slice of extrinsics
+		"block state GetHeader error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().GetHeader(common.Hash{1}).
+					Return(nil, mockError)
+				return chainProcessor{
+					blockState: blockState,
 				}
-				trieState := storage.NewTrieState(nil)
-				mockBlockState := NewMockBlockState(ctrl)
-				mockHeader := &types.Header{
-					Number:    0,
-					StateRoot: trie.EmptyHash,
-				}
-				mockHeaderHash := mockHeader.Hash()
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(mockHeader, nil)
+			},
+			block: &types.Block{
+				Header: types.Header{ParentHash: common.Hash{1}},
+			},
+			wantErr:    errFailedToGetParent,
+			errMessage: "failed to get parent header: test mock error",
+		},
+		"block state GetRuntime error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				blockState := NewMockBlockState(ctrl)
+				parentHeader := &types.Header{Number: 1}
+				blockState.EXPECT().GetHeader(common.Hash{1}).
+					Return(parentHeader, nil)
 
-				mockInstance := NewMockRuntimeInstance(ctrl)
-				mockInstance.EXPECT().SetContextStorage(trieState)
-				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState.EXPECT().GetRuntime(&mockHeaderHash).Return(mockInstance, nil)
-				chainProcessor.blockState = mockBlockState
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().Unlock()
-				mockStorageState.EXPECT().TrieState(&trie.EmptyHash).Return(trieState, nil)
-				chainProcessor.storageState = mockStorageState
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(mockBlock, trieState).Return(nil)
-				chainProcessor.blockImportHandler = mockBlockImportHandler
-				mockTelemetry := NewMockClient(ctrl)
-				mockTelemetry.EXPECT().SendMessage(gomock.Any())
-				chainProcessor.telemetry = mockTelemetry
-				return
+				parentHash := parentHeader.Hash()
+				blockState.EXPECT().GetRuntime(&parentHash).
+					Return(nil, mockError)
+
+				return chainProcessor{
+					blockState: blockState,
+				}
+			},
+			block: &types.Block{
+				Header: types.Header{ParentHash: common.Hash{1}},
+			},
+			wantErr:    mockError,
+			errMessage: "getting runtime for parent hash: test mock error",
+		},
+		"storage state TrieState error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				blockState := NewMockBlockState(ctrl)
+				parentHeader := &types.Header{Number: 1, StateRoot: common.Hash{2}}
+				blockState.EXPECT().GetHeader(common.Hash{1}).
+					Return(parentHeader, nil)
+
+				parentHash := parentHeader.Hash()
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(&parentHash).
+					Return(runtimeInstance, nil)
+
+				runtimeInstance.EXPECT().StateVersion().Return(trie.V0)
+
+				storageState := NewMockStorageState(ctrl)
+				lockCall := storageState.EXPECT().Lock()
+				storageState.EXPECT().Unlock().After(lockCall)
+				storageState.EXPECT().TrieState(&common.Hash{2}, trie.V0).
+					Return(nil, mockError)
+
+				return chainProcessor{
+					blockState:   blockState,
+					storageState: storageState,
+				}
+			},
+			block: &types.Block{
+				Header: types.Header{ParentHash: common.Hash{1}},
+			},
+			wantErr:    mockError,
+			errMessage: "trie state: test mock error",
+		},
+		"runtime ExecuteBlock error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				blockState := NewMockBlockState(ctrl)
+				parentHeader := &types.Header{Number: 1, StateRoot: trie.EmptyHash}
+				blockState.EXPECT().GetHeader(common.Hash{1}).
+					Return(parentHeader, nil)
+
+				parentHash := parentHeader.Hash()
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(&parentHash).
+					Return(runtimeInstance, nil)
+
+				runtimeInstance.EXPECT().StateVersion().Return(trie.V0)
+
+				storageState := NewMockStorageState(ctrl)
+				lockCall := storageState.EXPECT().Lock()
+				storageState.EXPECT().Unlock().After(lockCall)
+
+				trieState := storage.NewTrieState(nil)
+				storageState.EXPECT().TrieState(&trie.EmptyHash, trie.V0).
+					Return(trieState, nil)
+
+				runtimeInstance.EXPECT().SetContextStorage(trieState)
+
+				expectedBlockArgument := &types.Block{
+					Header: types.Header{
+						Number:     1,
+						ParentHash: common.Hash{1},
+					},
+				}
+				runtimeInstance.EXPECT().ExecuteBlock(expectedBlockArgument).
+					Return(nil, mockError)
+
+				return chainProcessor{
+					blockState:   blockState,
+					storageState: storageState,
+				}
 			},
 			block: &types.Block{
 				Header: types.Header{
-					Number: 0,
+					Number:     1,
+					ParentHash: common.Hash{1},
 				},
-				Body: types.Body{},
+			},
+			wantErr:    mockError,
+			errMessage: "failed to execute block 1: test mock error",
+		},
+		"handle block import error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				blockState := NewMockBlockState(ctrl)
+				parentHeader := &types.Header{Number: 1, StateRoot: trie.EmptyHash}
+				blockState.EXPECT().GetHeader(common.Hash{1}).
+					Return(parentHeader, nil)
+
+				parentHash := parentHeader.Hash()
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(&parentHash).
+					Return(runtimeInstance, nil)
+
+				runtimeInstance.EXPECT().StateVersion().Return(trie.V0)
+
+				storageState := NewMockStorageState(ctrl)
+				lockCall := storageState.EXPECT().Lock()
+				storageState.EXPECT().Unlock().After(lockCall)
+
+				trieState := storage.NewTrieState(nil)
+				storageState.EXPECT().TrieState(&trie.EmptyHash, trie.V0).
+					Return(trieState, nil)
+
+				runtimeInstance.EXPECT().SetContextStorage(trieState)
+
+				expectedBlockArgument := &types.Block{
+					Header: types.Header{ParentHash: common.Hash{1}},
+				}
+				runtimeInstance.EXPECT().ExecuteBlock(expectedBlockArgument).
+					Return(nil, nil)
+
+				blockImportHandler := NewMockBlockImportHandler(ctrl)
+				blockImportHandler.EXPECT().HandleBlockImport(expectedBlockArgument, trieState).
+					Return(mockError)
+
+				return chainProcessor{
+					blockState:         blockState,
+					storageState:       storageState,
+					blockImportHandler: blockImportHandler,
+				}
+			},
+			block: &types.Block{
+				Header: types.Header{ParentHash: common.Hash{1}},
+			},
+			wantErr:    mockError,
+			errMessage: "handling block import: test mock error",
+		},
+		"success": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				blockState := NewMockBlockState(ctrl)
+				parentHeader := &types.Header{Number: 1, StateRoot: trie.EmptyHash}
+				blockState.EXPECT().GetHeader(common.Hash{1}).
+					Return(parentHeader, nil)
+
+				parentHash := parentHeader.Hash()
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(&parentHash).
+					Return(runtimeInstance, nil)
+
+				runtimeInstance.EXPECT().StateVersion().Return(trie.V0)
+
+				storageState := NewMockStorageState(ctrl)
+				lockCall := storageState.EXPECT().Lock()
+				storageState.EXPECT().Unlock().After(lockCall)
+
+				trieState := storage.NewTrieState(nil)
+				storageState.EXPECT().TrieState(&trie.EmptyHash, trie.V0).
+					Return(trieState, nil)
+
+				runtimeInstance.EXPECT().SetContextStorage(trieState)
+
+				expectedBlockArgument := &types.Block{
+					Header: types.Header{
+						ParentHash: common.Hash{1},
+						Number:     3,
+					},
+				}
+				runtimeInstance.EXPECT().ExecuteBlock(expectedBlockArgument).
+					Return(nil, nil)
+
+				blockImportHandler := NewMockBlockImportHandler(ctrl)
+				blockImportHandler.EXPECT().HandleBlockImport(expectedBlockArgument, trieState).
+					Return(nil)
+
+				telemetryClient := NewMockClient(ctrl)
+				blockHeader := types.Header{
+					ParentHash: common.Hash{1},
+					Number:     3,
+				}
+				blockHash := blockHeader.Hash()
+				telemetryBlockImport := &telemetry.BlockImport{
+					BestHash: &blockHash,
+					Height:   3,
+					Origin:   "NetworkInitialSync",
+				}
+				telemetryClient.EXPECT().SendMessage(telemetryBlockImport)
+
+				return chainProcessor{
+					blockState:         blockState,
+					storageState:       storageState,
+					blockImportHandler: blockImportHandler,
+					telemetry:          telemetryClient,
+				}
+			},
+			block: &types.Block{
+				Header: types.Header{
+					ParentHash: common.Hash{1},
+					Number:     3,
+				},
 			},
 		},
 	}
@@ -176,36 +259,52 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			s := tt.chainProcessorBuilder(ctrl)
+			processor := tt.chainProcessorBuilder(ctrl)
 
-			err := s.handleBlock(tt.block)
+			err := processor.handleBlock(tt.block)
 			assert.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErr != nil {
+				assert.EqualError(t, err, tt.errMessage)
+			}
 		})
 	}
+
 	t.Run("panics on different parent state root", func(t *testing.T) {
 		t.Parallel()
+
 		ctrl := gomock.NewController(t)
-		bock := &types.Block{
-			Header: types.Header{
-				ParentHash: common.Hash{1},
-			},
-		}
+
 		blockState := NewMockBlockState(ctrl)
+		parentHeader := &types.Header{Number: 1, StateRoot: common.Hash{2}}
 		blockState.EXPECT().GetHeader(common.Hash{1}).
-			Return(&types.Header{StateRoot: common.Hash{2}}, nil)
-		trieState := storage.NewTrieState(nil)
+			Return(parentHeader, nil)
+
+		parentHash := parentHeader.Hash()
+		runtimeInstance := NewMockRuntimeInstance(ctrl)
+		blockState.EXPECT().GetRuntime(&parentHash).
+			Return(runtimeInstance, nil)
+
+		runtimeInstance.EXPECT().StateVersion().Return(trie.V0)
+
 		storageState := NewMockStorageState(ctrl)
 		lockCall := storageState.EXPECT().Lock()
-		trieStateCall := storageState.EXPECT().TrieState(&common.Hash{2}).
-			Return(trieState, nil).After(lockCall)
-		storageState.EXPECT().Unlock().After(trieStateCall)
-		chainProcessor := &chainProcessor{
+		storageState.EXPECT().Unlock().After(lockCall)
+		trieState := storage.NewTrieState(nil)
+		storageState.EXPECT().TrieState(&common.Hash{2}, trie.V0).
+			Return(trieState, nil)
+
+		processor := chainProcessor{
 			blockState:   blockState,
 			storageState: storageState,
 		}
+
+		block := &types.Block{
+			Header: types.Header{ParentHash: common.Hash{1}},
+		}
+
 		const expectedPanicValue = "parent state root does not match snapshot state root"
 		assert.PanicsWithValue(t, expectedPanicValue, func() {
-			_ = chainProcessor.handleBlock(bock)
+			_ = processor.handleBlock(block)
 		})
 	})
 }
@@ -328,84 +427,114 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 	t.Parallel()
 
 	mockError := errors.New("mock test error")
-	justification := []byte{0, 1, 2}
 
 	tests := map[string]struct {
 		chainProcessorBuilder func(ctrl *gomock.Controller) chainProcessor
 		blockData             *types.BlockData
-		expectedError         error
+		errSentinel           error
+		errString             string
 	}{
 		"nil block data": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+			chainProcessorBuilder: func(_ *gomock.Controller) chainProcessor {
 				return chainProcessor{}
 			},
-			blockData:     nil,
-			expectedError: ErrNilBlockData,
+			errSentinel: ErrNilBlockData,
+			errString:   "got nil BlockData",
 		},
-		"handle has header error": {
+		"has header error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, mockError)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(false, mockError)
 				return chainProcessor{
 					blockState: mockBlockState,
-				}
-			},
-			blockData:     &types.BlockData{},
-			expectedError: mockError,
-		},
-		"handle has block body error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, mockError)
-				return chainProcessor{
-					blockState: mockBlockState,
-				}
-			},
-			blockData:     &types.BlockData{},
-			expectedError: mockError,
-		},
-		"handle getBlockByHash error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{}).Return(nil, mockError)
-				return chainProcessor{
-					blockState: mockBlockState,
-				}
-			},
-			blockData:     &types.BlockData{},
-			expectedError: mockError,
-		},
-		"handle AddBlockToBlockTree error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlock := &types.Block{
-					Header: types.Header{
-						Number: uint(1),
-					},
-				}
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{}).Return(mockBlock, nil)
-				mockBlockState.EXPECT().AddBlockToBlockTree(&types.Block{
-					Header: types.Header{Number: 1}}).Return(blocktree.ErrBlockExists)
-				mockFinalityGadget := NewMockFinalityGadget(ctrl)
-				mockStorageState := NewMockStorageState(ctrl)
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				return chainProcessor{
-					blockState:         mockBlockState,
-					finalityGadget:     mockFinalityGadget,
-					storageState:       mockStorageState,
-					blockImportHandler: mockBlockImportHandler,
 				}
 			},
 			blockData: &types.BlockData{
-				Justification: &[]byte{1, 2, 3},
+				Hash: common.Hash{1},
+			},
+			errSentinel: mockError,
+			errString:   "checking header in block state: mock test error",
+		},
+		"has block body error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				mockBlockState := NewMockBlockState(ctrl)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(false, mockError)
+				return chainProcessor{
+					blockState: mockBlockState,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
+			},
+			errSentinel: mockError,
+			errString:   "checking block body in block state: mock test error",
+		},
+		"has header and body - GetBlockByHash error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				mockBlockState := NewMockBlockState(ctrl)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).Return(nil, mockError)
+				return chainProcessor{
+					blockState: mockBlockState,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
+			},
+			errSentinel: mockError,
+			errString:   "getting block by hash from block state: mock test error",
+		},
+		"has header and body - block exists in blocktree": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				mockBlock := &types.Block{
+					Header: types.Header{
+						ParentHash: common.Hash{2},
+					},
+				}
+				mockBlockState := NewMockBlockState(ctrl)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).
+					Return(mockBlock, nil)
+				mockBlockState.EXPECT().AddBlockToBlockTree(mockBlock).
+					Return(fmt.Errorf("%w", blocktree.ErrBlockExists))
+				return chainProcessor{
+					blockState: mockBlockState,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
 			},
 		},
-		"header and body - fail to handle justification": {
+		"has header and body - fail to add block to block tree": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				header := types.Header{
+					Number: uint(1),
+				}
+				block := &types.Block{
+					Header: header,
+				}
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				blockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				blockState.EXPECT().GetBlockByHash(common.Hash{1}).
+					Return(block, nil)
+				blockState.EXPECT().AddBlockToBlockTree(block).Return(mockError)
+
+				return chainProcessor{
+					blockState: blockState,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
+			},
+			errSentinel: mockError,
+			errString:   "adding block to block tree: mock test error",
+		},
+		"has header and body - fail to handle justification": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				header := types.Header{
 					Number: uint(1),
@@ -436,217 +565,268 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 				Hash:          common.Hash{1},
 				Justification: &[]byte{1, 2, 3},
 			},
-			expectedError: mockError,
+			errSentinel: mockError,
+			errString: "handling justification: " +
+				"verifying block number 1 justification: mock test error",
 		},
-		"handle block data justification != nil": {
+		"has header and body - get runtime error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlock := &types.Block{
-					Header: types.Header{
-						Number: uint(1),
-					},
+				expectedJustification := []byte{1, 2, 3}
+				blockHeader := types.Header{
+					ParentHash: common.Hash{2},
+					StateRoot:  common.Hash{3},
+				}
+				block := &types.Block{
+					Header: blockHeader,
 				}
 				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{}).Return(mockBlock, nil)
-				mockBlockState.EXPECT().AddBlockToBlockTree(&types.Block{
-					Header: types.Header{Number: 1}}).Return(nil)
-				mockBlockState.EXPECT().SetJustification(common.MustHexToHash(
-					"0x6443a0b46e0412e626363028115a9f2cf963eeed526b8b33e5316f08b50d0dc3"), []byte{1, 2, 3})
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).Return(block, nil)
+				mockBlockState.EXPECT().AddBlockToBlockTree(block).Return(nil)
+
 				mockFinalityGadget := NewMockFinalityGadget(ctrl)
-				mockFinalityGadget.EXPECT().VerifyBlockJustification(common.MustHexToHash(
-					"0x6443a0b46e0412e626363028115a9f2cf963eeed526b8b33e5316f08b50d0dc3"), []byte{1, 2,
-					3}).Return([]byte{1, 2, 3}, nil)
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, nil)
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(mockBlock,
-					nil).Return(nil)
-				return chainProcessor{
-					blockState:         mockBlockState,
-					finalityGadget:     mockFinalityGadget,
-					storageState:       mockStorageState,
-					blockImportHandler: mockBlockImportHandler,
-				}
-			},
-			blockData: &types.BlockData{
-				Justification: &[]byte{1, 2, 3},
-			},
-		},
-		"handle trie state error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlock := &types.Block{
-					Header: types.Header{
-						Number: uint(1),
-					},
-				}
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{}).Return(mockBlock, nil)
-				mockBlockState.EXPECT().AddBlockToBlockTree(&types.Block{
-					Header: types.Header{Number: 1}}).Return(nil)
-				mockBlockState.EXPECT().SetJustification(common.MustHexToHash(
-					"0x6443a0b46e0412e626363028115a9f2cf963eeed526b8b33e5316f08b50d0dc3"), []byte{1, 2, 3})
-				mockFinalityGadget := NewMockFinalityGadget(ctrl)
-				mockFinalityGadget.EXPECT().VerifyBlockJustification(common.MustHexToHash(
-					"0x6443a0b46e0412e626363028115a9f2cf963eeed526b8b33e5316f08b50d0dc3"), []byte{1, 2,
-					3}).Return([]byte{1, 2, 3}, nil)
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, mockError)
+				mockFinalityGadget.EXPECT().
+					VerifyBlockJustification(blockHeader.Hash(), expectedJustification).
+					Return(expectedJustification, nil)
+
+				mockBlockState.EXPECT().
+					SetJustification(blockHeader.Hash(), expectedJustification).
+					Return(nil)
+
+				mockBlockState.EXPECT().GetRuntime(&common.Hash{2}).
+					Return(nil, mockError)
+
 				return chainProcessor{
 					blockState:     mockBlockState,
 					finalityGadget: mockFinalityGadget,
-					storageState:   mockStorageState,
 				}
 			},
 			blockData: &types.BlockData{
+				Hash:          common.Hash{1},
 				Justification: &[]byte{1, 2, 3},
 			},
-			expectedError: mockError,
+			errSentinel: mockError,
+			errString:   "getting runtime instance: mock test error",
 		},
-		"handle block import handler error": {
+		"has header and body - trie state error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlock := &types.Block{
-					Header: types.Header{
-						Number: uint(1),
-					},
+				expectedJustification := []byte{1, 2, 3}
+				blockHeader := types.Header{
+					ParentHash: common.Hash{2},
+					StateRoot:  common.Hash{3},
+				}
+				block := &types.Block{
+					Header: blockHeader,
 				}
 				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{}).Return(mockBlock, nil)
-				mockBlockState.EXPECT().AddBlockToBlockTree(&types.Block{
-					Header: types.Header{Number: 1}}).Return(nil)
-				mockBlockState.EXPECT().SetJustification(common.MustHexToHash(
-					"0x6443a0b46e0412e626363028115a9f2cf963eeed526b8b33e5316f08b50d0dc3"), []byte{1, 2, 3})
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).Return(block, nil)
+				mockBlockState.EXPECT().AddBlockToBlockTree(block).Return(nil)
+
 				mockFinalityGadget := NewMockFinalityGadget(ctrl)
-				mockFinalityGadget.EXPECT().VerifyBlockJustification(common.MustHexToHash(
-					"0x6443a0b46e0412e626363028115a9f2cf963eeed526b8b33e5316f08b50d0dc3"), []byte{1, 2,
-					3}).Return([]byte{1, 2, 3}, nil)
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, nil)
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(mockBlock,
-					nil).Return(mockError)
+				mockFinalityGadget.EXPECT().
+					VerifyBlockJustification(blockHeader.Hash(), expectedJustification).
+					Return(expectedJustification, nil)
+
+				mockBlockState.EXPECT().
+					SetJustification(blockHeader.Hash(), expectedJustification).
+					Return(nil)
+
+				mockInstance := NewMockRuntimeInstance(ctrl)
+				mockBlockState.EXPECT().GetRuntime(&common.Hash{2}).
+					Return(mockInstance, nil)
+				const stateVersion = trie.V0
+				mockInstance.EXPECT().StateVersion().Return(stateVersion)
+
+				storageState := NewMockStorageState(ctrl)
+				storageState.EXPECT().TrieState(&common.Hash{3}, stateVersion).
+					Return(nil, mockError)
+
+				return chainProcessor{
+					blockState:     mockBlockState,
+					finalityGadget: mockFinalityGadget,
+					storageState:   storageState,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash:          common.Hash{1},
+				Justification: &[]byte{1, 2, 3},
+			},
+			errSentinel: mockError,
+			errString:   "running trie state: mock test error",
+		},
+		"has header and body - block import error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				expectedJustification := []byte{1, 2, 3}
+				blockHeader := types.Header{
+					ParentHash: common.Hash{2},
+					StateRoot:  common.Hash{3},
+				}
+				block := &types.Block{
+					Header: blockHeader,
+				}
+				mockBlockState := NewMockBlockState(ctrl)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).Return(block, nil)
+				mockBlockState.EXPECT().AddBlockToBlockTree(block).Return(nil)
+
+				mockFinalityGadget := NewMockFinalityGadget(ctrl)
+				mockFinalityGadget.EXPECT().
+					VerifyBlockJustification(blockHeader.Hash(), expectedJustification).
+					Return(expectedJustification, nil)
+
+				mockBlockState.EXPECT().
+					SetJustification(blockHeader.Hash(), expectedJustification).
+					Return(nil)
+
+				mockInstance := NewMockRuntimeInstance(ctrl)
+				mockBlockState.EXPECT().GetRuntime(&common.Hash{2}).
+					Return(mockInstance, nil)
+				const stateVersion = trie.V0
+				mockInstance.EXPECT().StateVersion().Return(stateVersion)
+
+				storageState := NewMockStorageState(ctrl)
+				someTrie := trie.NewEmptyTrie()
+				someTrie.Put([]byte{1}, []byte{2}, stateVersion)
+				trieState := storage.NewTrieState(someTrie)
+				storageState.EXPECT().TrieState(&common.Hash{3}, stateVersion).
+					Return(trieState, nil)
+
+				blockImportHandler := NewMockBlockImportHandler(ctrl)
+				blockImportHandler.EXPECT().HandleBlockImport(block, trieState).
+					Return(mockError)
+
 				return chainProcessor{
 					blockState:         mockBlockState,
 					finalityGadget:     mockFinalityGadget,
-					storageState:       mockStorageState,
-					blockImportHandler: mockBlockImportHandler,
+					storageState:       storageState,
+					blockImportHandler: blockImportHandler,
 				}
 			},
 			blockData: &types.BlockData{
+				Hash:          common.Hash{1},
+				Justification: &[]byte{1, 2, 3},
+			},
+			errSentinel: mockError,
+			errString:   "handling block import: mock test error",
+		},
+		"has header and body - success": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				expectedJustification := []byte{1, 2, 3}
+				blockHeader := types.Header{
+					ParentHash: common.Hash{2},
+					StateRoot:  common.Hash{3},
+				}
+				block := &types.Block{
+					Header: blockHeader,
+				}
+				mockBlockState := NewMockBlockState(ctrl)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).Return(block, nil)
+				mockBlockState.EXPECT().AddBlockToBlockTree(block).Return(nil)
+
+				mockFinalityGadget := NewMockFinalityGadget(ctrl)
+				mockFinalityGadget.EXPECT().
+					VerifyBlockJustification(blockHeader.Hash(), expectedJustification).
+					Return(expectedJustification, nil)
+
+				mockBlockState.EXPECT().
+					SetJustification(blockHeader.Hash(), expectedJustification).
+					Return(nil)
+
+				mockInstance := NewMockRuntimeInstance(ctrl)
+				mockBlockState.EXPECT().GetRuntime(&common.Hash{2}).
+					Return(mockInstance, nil)
+				const stateVersion = trie.V0
+				mockInstance.EXPECT().StateVersion().Return(stateVersion)
+
+				storageState := NewMockStorageState(ctrl)
+				someTrie := trie.NewEmptyTrie()
+				someTrie.Put([]byte{1}, []byte{2}, stateVersion)
+				trieState := storage.NewTrieState(someTrie)
+				storageState.EXPECT().TrieState(&common.Hash{3}, stateVersion).
+					Return(trieState, nil)
+
+				blockImportHandler := NewMockBlockImportHandler(ctrl)
+				blockImportHandler.EXPECT().HandleBlockImport(block, trieState).
+					Return(nil)
+
+				return chainProcessor{
+					blockState:         mockBlockState,
+					finalityGadget:     mockFinalityGadget,
+					storageState:       storageState,
+					blockImportHandler: blockImportHandler,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash:          common.Hash{1},
 				Justification: &[]byte{1, 2, 3},
 			},
 		},
-		"has header body false": {
+		"block data has header and body - verify block error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().CompareAndSetBlockData(&types.BlockData{}).Return(nil)
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				blockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+
+				babeVerifier := NewMockBabeVerifier(ctrl)
+				babeVerifier.EXPECT().VerifyBlock(&types.Header{ParentHash: common.Hash{2}}).
+					Return(mockError)
+
 				return chainProcessor{
-					blockState: mockBlockState,
-				}
-			},
-			blockData: &types.BlockData{},
-		},
-		"handle babe verify block error": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{}).Return(mockError)
-				return chainProcessor{
-					blockState:   mockBlockState,
-					babeVerifier: mockBabeVerifier,
+					blockState:   blockState,
+					babeVerifier: babeVerifier,
 				}
 			},
 			blockData: &types.BlockData{
-				Header: &types.Header{},
+				Header: &types.Header{ParentHash: common.Hash{2}},
 				Body:   &types.Body{},
+				Hash:   common.Hash{1},
 			},
-			expectedError: mockError,
+			errSentinel: mockError,
+			errString:   "babe verifying block: mock test error",
 		},
-		"handle error with handleBlock": {
+		"block data has header and body - handle block error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(nil, mockError)
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{}).Return(nil)
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				blockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+
+				babeVerifier := NewMockBabeVerifier(ctrl)
+				babeVerifier.EXPECT().VerifyBlock(&types.Header{ParentHash: common.Hash{2}}).
+					Return(nil)
+
+				blockState.EXPECT().GetHeader(common.Hash{2}).
+					Return(nil, mockError)
+
 				return chainProcessor{
-					blockState:   mockBlockState,
-					babeVerifier: mockBabeVerifier,
+					blockState:   blockState,
+					babeVerifier: babeVerifier,
 				}
 			},
 			blockData: &types.BlockData{
-				Header: &types.Header{},
+				Header: &types.Header{ParentHash: common.Hash{2}},
 				Body:   &types.Body{},
+				Hash:   common.Hash{1},
 			},
-			expectedError: errFailedToGetParent,
+			errSentinel: errFailedToGetParent,
+			errString:   "handling block: failed to get parent header: mock test error",
 		},
-		"error adding block": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{1, 2, 3}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{1, 2, 3}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1, 2, 3}).Return(&types.Block{
-					Header: types.Header{
-						Number: uint(1),
-					},
-				}, nil)
-				mockBlockState.EXPECT().AddBlockToBlockTree(&types.Block{
-					Header: types.Header{Number: 1}}).Return(mockError)
-				return chainProcessor{
-					blockState: mockBlockState,
-				}
-			},
-			blockData: &types.BlockData{
-				Hash: common.Hash{1, 2, 3},
-			},
-			expectedError: mockError,
-		},
-		"handle block import": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockTrieState := storage.NewTrieState(nil)
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{1, 2, 3}).Return(true, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{1, 2, 3}).Return(true, nil)
-				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1, 2, 3}).Return(&types.Block{
-					Header: types.Header{
-						Number: uint(1),
-					},
-				}, nil)
-				mockBlockState.EXPECT().AddBlockToBlockTree(&types.Block{Header: types.Header{Number: 1}}).Return(nil)
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(mockTrieState, nil)
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(&types.Block{Header: types.Header{Number: 1}}, mockTrieState)
-				return chainProcessor{
-					blockState:         mockBlockState,
-					storageState:       mockStorageState,
-					blockImportHandler: mockBlockImportHandler,
-				}
-			},
-			blockData: &types.BlockData{
-				Hash: common.Hash{1, 2, 3},
-			},
-		},
-		"no header and body - fail to handle justification": {
+		"has no header - handle justification error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				blockState := NewMockBlockState(ctrl)
 				blockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
 				blockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
 
 				finalityGadget := NewMockFinalityGadget(ctrl)
-				expectedBlockDataHeader := &types.Header{Number: 2}
-				expectedBlockDataHeaderHash := expectedBlockDataHeader.Hash()
+				header := types.Header{ParentHash: common.Hash{2}}
+				headerHash := header.Hash()
 				finalityGadget.EXPECT().
-					VerifyBlockJustification(expectedBlockDataHeaderHash, []byte{1, 2, 3}).
+					VerifyBlockJustification(headerHash, []byte{1, 2, 3}).
 					Return(nil, mockError)
 
 				return chainProcessor{
@@ -655,119 +835,141 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 				}
 			},
 			blockData: &types.BlockData{
+				Header:        &types.Header{ParentHash: common.Hash{2}},
 				Hash:          common.Hash{1},
-				Header:        &types.Header{Number: 2},
 				Justification: &[]byte{1, 2, 3},
 			},
-			expectedError: mockError,
+			errSentinel: mockError,
+			errString: "handling justification: " +
+				"verifying block number 0 justification: mock test error",
 		},
-		"handle compareAndSetBlockData error": {
+		"compare and set block data error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().CompareAndSetBlockData(&types.BlockData{}).Return(mockError)
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				blockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+
+				blockState.EXPECT().CompareAndSetBlockData(&types.BlockData{Hash: common.Hash{1}}).
+					Return(mockError)
+
 				return chainProcessor{
-					blockState: mockBlockState,
+					blockState: blockState,
 				}
 			},
-			blockData:     &types.BlockData{},
-			expectedError: mockError,
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
+			},
+			errSentinel: mockError,
+			errString: "comparing and setting block data: " +
+				"mock test error",
 		},
-		"handle header": {
+		"shortest success code path": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				stateRootHash := common.MustHexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-				mockTrieState := storage.NewTrieState(nil)
-				runtimeHash := common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a")
-				mockBlock := &types.Block{Header: types.Header{}, Body: types.Body{}}
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				blockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
 
-				mockInstance := NewMockRuntimeInstance(ctrl)
-				mockInstance.EXPECT().SetContextStorage(mockTrieState)
-				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
-					Number:    0,
-					StateRoot: stateRootHash,
-				}, nil)
-				mockBlockState.EXPECT().CompareAndSetBlockData(&types.BlockData{Header: &types.Header{}, Body: &types.Body{}})
-				mockBlockState.EXPECT().GetRuntime(&runtimeHash).Return(mockInstance, nil)
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{})
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().TrieState(&stateRootHash).Return(mockTrieState, nil)
-				mockStorageState.EXPECT().Unlock()
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(mockBlock, mockTrieState)
-				mockTelemetry := NewMockClient(ctrl)
-				mockTelemetry.EXPECT().SendMessage(gomock.Any()).AnyTimes()
+				blockState.EXPECT().CompareAndSetBlockData(&types.BlockData{Hash: common.Hash{1}}).
+					Return(nil)
+
 				return chainProcessor{
-					blockState:         mockBlockState,
-					babeVerifier:       mockBabeVerifier,
-					storageState:       mockStorageState,
-					blockImportHandler: mockBlockImportHandler,
-					telemetry:          mockTelemetry,
+					blockState: blockState,
+				}
+			},
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
+			},
+		},
+		"longest success code path": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
+				expectedBlockData := &types.BlockData{
+					Header: &types.Header{
+						Number:     6,
+						ParentHash: common.Hash{2},
+					},
+					Body:          &types.Body{{3}},
+					Hash:          common.Hash{1},
+					Justification: &[]byte{4},
+				}
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().HasHeader(expectedBlockData.Hash).Return(false, nil)
+				blockState.EXPECT().HasBlockBody(expectedBlockData.Hash).Return(true, nil)
+
+				babeVerifier := NewMockBabeVerifier(ctrl)
+				blockDataHeader := &types.Header{
+					Number:     6,
+					ParentHash: common.Hash{2},
+				}
+				babeVerifier.EXPECT().VerifyBlock(blockDataHeader).Return(nil)
+
+				transactionState := NewMockTransactionState(ctrl)
+				transactionState.EXPECT().RemoveExtrinsic(types.Extrinsic{3})
+
+				parentStateRoot := trie.EmptyHash
+				parentHeader := &types.Header{StateRoot: parentStateRoot}
+				blockState.EXPECT().GetHeader(common.Hash{2}).
+					Return(parentHeader, nil)
+				parentHeaderHash := parentHeader.Hash()
+				instance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(&parentHeaderHash).
+					Return(instance, nil)
+				instance.EXPECT().StateVersion().Return(trie.V0)
+
+				storageState := NewMockStorageState(ctrl)
+				lockCall := storageState.EXPECT().Lock()
+				storageState.EXPECT().Unlock().After(lockCall)
+				trieState := storage.NewTrieState(nil)
+				trieStateCall := storageState.EXPECT().
+					TrieState(&parentStateRoot, trie.V0).
+					Return(trieState, nil).After(lockCall)
+
+				instance.EXPECT().SetContextStorage(trieState).After(trieStateCall)
+				block := &types.Block{
+					Header: *expectedBlockData.Header,
+					Body:   *expectedBlockData.Body,
+				}
+				instance.EXPECT().ExecuteBlock(block).Return(nil, nil)
+
+				blockImportHandler := NewMockBlockImportHandler(ctrl)
+				blockImportHandler.EXPECT().HandleBlockImport(block, trieState).
+					Return(nil)
+
+				telemetryClient := NewMockClient(ctrl)
+				blockHeaderHash := expectedBlockData.Header.Hash()
+				blockNumber := expectedBlockData.Header.Number
+				telemetryMessage := telemetry.NewBlockImport(
+					&blockHeaderHash, blockNumber, "NetworkInitialSync")
+				telemetryClient.EXPECT().SendMessage(telemetryMessage)
+
+				finalityGadget := NewMockFinalityGadget(ctrl)
+				finalityGadget.EXPECT().
+					VerifyBlockJustification(blockHeaderHash, []byte{4}).
+					Return([]byte{5}, nil)
+				blockState.EXPECT().SetJustification(blockHeaderHash, []byte{5}).
+					Return(nil)
+
+				blockState.EXPECT().CompareAndSetBlockData(expectedBlockData).
+					Return(nil)
+
+				return chainProcessor{
+					blockState:         blockState,
+					babeVerifier:       babeVerifier,
+					transactionState:   transactionState,
+					storageState:       storageState,
+					blockImportHandler: blockImportHandler,
+					telemetry:          telemetryClient,
+					finalityGadget:     finalityGadget,
 				}
 			},
 			blockData: &types.BlockData{
 				Header: &types.Header{
-					Number: 0,
+					Number:     6,
+					ParentHash: common.Hash{2},
 				},
-				Body: &types.Body{},
-			},
-		},
-		"handle justification": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				stateRootHash := common.MustHexToHash("0x03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314")
-				runtimeHash := common.MustHexToHash("0x7db9db5ed9967b80143100189ba69d9e4deab85ac3570e5df25686cabe32964a")
-				mockTrieState := storage.NewTrieState(nil)
-				mockBlock := &types.Block{Header: types.Header{}, Body: types.Body{}}
-
-				mockInstance := NewMockRuntimeInstance(ctrl)
-				mockInstance.EXPECT().SetContextStorage(mockTrieState)
-				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{
-					Number:    0,
-					StateRoot: stateRootHash,
-				}, nil)
-				mockBlockState.EXPECT().SetJustification(
-					common.MustHexToHash("0xdcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a"), justification)
-				mockBlockState.EXPECT().CompareAndSetBlockData(gomock.AssignableToTypeOf(&types.BlockData{}))
-				mockBlockState.EXPECT().GetRuntime(&runtimeHash).Return(mockInstance, nil)
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{})
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().TrieState(&stateRootHash).Return(mockTrieState, nil)
-				mockStorageState.EXPECT().Unlock()
-				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				mockBlockImportHandler.EXPECT().HandleBlockImport(mockBlock, mockTrieState)
-				mockTelemetry := NewMockClient(ctrl)
-				mockTelemetry.EXPECT().SendMessage(gomock.Any()).AnyTimes()
-				mockFinalityGadget := NewMockFinalityGadget(ctrl)
-				mockFinalityGadget.EXPECT().VerifyBlockJustification(
-					common.MustHexToHash("0xdcdd89927d8a348e00257e1ecc8617f45edb5118efff3ea2f9961b2ad9b7690a"),
-					justification).Return(justification, nil)
-				return chainProcessor{
-					blockState:         mockBlockState,
-					babeVerifier:       mockBabeVerifier,
-					storageState:       mockStorageState,
-					blockImportHandler: mockBlockImportHandler,
-					telemetry:          mockTelemetry,
-					finalityGadget:     mockFinalityGadget,
-				}
-			},
-			blockData: &types.BlockData{
-				Header: &types.Header{
-					Number: 0,
-				},
-				Body:          &types.Body{},
-				Justification: &justification,
+				Body:          &types.Body{{3}},
+				Hash:          common.Hash{1},
+				Justification: &[]byte{4},
 			},
 		},
 	}
@@ -778,144 +980,177 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			processor := tt.chainProcessorBuilder(ctrl)
+
 			err := processor.processBlockData(tt.blockData)
-			assert.ErrorIs(t, err, tt.expectedError)
+
+			assert.ErrorIs(t, err, tt.errSentinel)
+			if tt.errSentinel != nil {
+				assert.EqualError(t, err, tt.errString)
+			}
 		})
 	}
 }
 
 func Test_chainProcessor_processReadyBlocks(t *testing.T) {
 	t.Parallel()
+
 	mockError := errors.New("test mock error")
+
 	tests := map[string]struct {
-		blockStateBuilder   func(ctrl *gomock.Controller, done chan struct{}) BlockState
-		blockData           *types.BlockData
-		babeVerifierBuilder func(ctrl *gomock.Controller) BabeVerifier
-		pendingBlockBuilder func(ctrl *gomock.Controller, done chan struct{}) DisjointBlockSet
-		storageStateBuilder func(ctrl *gomock.Controller, done chan struct{}) StorageState
+		chainProcessorBuilder func(ctrl *gomock.Controller, done chan<- struct{}) chainProcessor
+		blockData             *types.BlockData
 	}{
-		"base case": {
-			blockStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) BlockState {
+		"context canceled": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller, done chan<- struct{}) chainProcessor {
+				defer close(done)
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				<-ctx.Done()
+				return chainProcessor{
+					ctx:         ctx,
+					cancel:      cancel,
+					readyBlocks: newBlockQueue(1),
+				}
+			},
+			blockData: &types.BlockData{
+				Hash: common.Hash{1},
+			},
+		},
+		"process block data success": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller, done chan<- struct{}) chainProcessor {
 				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().CompareAndSetBlockData(&types.BlockData{}).DoAndReturn(func(*types.
-					BlockData) error {
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(false, nil)
+				mockBlockState.EXPECT().CompareAndSetBlockData(&types.BlockData{
+					Hash: common.Hash{1},
+				}).DoAndReturn(func(*types.BlockData) error {
 					close(done)
 					return nil
 				})
-				return mockBlockState
+
+				ctx, cancel := context.WithCancel(context.Background())
+				return chainProcessor{
+					ctx:         ctx,
+					cancel:      cancel,
+					readyBlocks: newBlockQueue(1),
+					blockState:  mockBlockState,
+				}
 			},
 			blockData: &types.BlockData{
-				Hash: common.Hash{},
-			},
-			babeVerifierBuilder: func(ctrl *gomock.Controller) BabeVerifier {
-				return nil
-			},
-			pendingBlockBuilder: func(ctrl *gomock.Controller, done chan struct{}) DisjointBlockSet {
-				return nil
-			},
-			storageStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) StorageState {
-				return nil
+				Hash: common.Hash{1},
 			},
 		},
-		"add block": {
-			blockStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) BlockState {
+		"process block data error": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller, done chan<- struct{}) chainProcessor {
 				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(nil, mockError)
-				return mockBlockState
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(true, nil)
+				mockBlockState.EXPECT().GetBlockByHash(common.Hash{1}).
+					DoAndReturn(func(_ common.Hash) (block *types.Block, err error) {
+						defer close(done)
+						return nil, mockError
+					})
+
+				ctx, cancel := context.WithCancel(context.Background())
+				return chainProcessor{
+					ctx:         ctx,
+					cancel:      cancel,
+					readyBlocks: newBlockQueue(1),
+					blockState:  mockBlockState,
+				}
 			},
 			blockData: &types.BlockData{
-				Hash:   common.Hash{},
-				Header: &types.Header{},
-				Body:   &types.Body{},
-			},
-			babeVerifierBuilder: func(ctrl *gomock.Controller) BabeVerifier {
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{}).Return(nil)
-				return mockBabeVerifier
-			},
-			pendingBlockBuilder: func(ctrl *gomock.Controller, done chan struct{}) DisjointBlockSet {
-				mockDisjointBlockSet := NewMockDisjointBlockSet(ctrl)
-				mockDisjointBlockSet.EXPECT().addBlock(&types.Block{
-					Header: types.Header{},
-					Body:   types.Body{},
-				}).DoAndReturn(func(block *types.Block) error {
-					close(done)
-					return nil
-				})
-				return mockDisjointBlockSet
-			},
-			storageStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) StorageState {
-				return nil
-			},
-		},
-		"error in process block": {
-			blockStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) BlockState {
-				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(&types.Header{}, nil)
-				return mockBlockState
-			},
-			blockData: &types.BlockData{
-				Hash:   common.Hash{},
-				Header: &types.Header{},
-				Body:   &types.Body{},
-			},
-			babeVerifierBuilder: func(ctrl *gomock.Controller) BabeVerifier {
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{}).Return(nil)
-				return mockBabeVerifier
-			},
-			pendingBlockBuilder: func(ctrl *gomock.Controller, done chan struct{}) DisjointBlockSet {
-				return nil
-			},
-			storageStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) StorageState {
-				mockStorageState := NewMockStorageState(ctrl)
-				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().Unlock()
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).DoAndReturn(func(hash *common.Hash) (*storage.
-					TrieState, error) {
-					close(done)
-					return nil, mockError
-				})
-				return mockStorageState
+				Hash: common.Hash{1},
 			},
 		},
 		"add block error": {
-			blockStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) BlockState {
+			chainProcessorBuilder: func(ctrl *gomock.Controller, done chan<- struct{}) chainProcessor {
 				mockBlockState := NewMockBlockState(ctrl)
-				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
-				mockBlockState.EXPECT().GetHeader(common.Hash{}).Return(nil, mockError)
-				return mockBlockState
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(false, nil)
+
+				babeVerifier := NewMockBabeVerifier(ctrl)
+				babeVerifier.EXPECT().
+					VerifyBlock(&types.Header{ParentHash: common.Hash{2}}).
+					Return(nil)
+
+				transactionState := NewMockTransactionState(ctrl)
+				transactionState.EXPECT().RemoveExtrinsic(types.Extrinsic{3})
+
+				mockBlockState.EXPECT().GetHeader(common.Hash{2}).
+					Return(nil, mockError)
+
+				pendingBlocks := NewMockDisjointBlockSet(ctrl)
+				block := &types.Block{
+					Header: types.Header{ParentHash: common.Hash{2}},
+					Body:   types.Body{{3}},
+				}
+				pendingBlocks.EXPECT().addBlock(block).
+					DoAndReturn(func(block *types.Block) error {
+						defer close(done)
+						return mockError
+					})
+
+				ctx, cancel := context.WithCancel(context.Background())
+				return chainProcessor{
+					ctx:              ctx,
+					cancel:           cancel,
+					readyBlocks:      newBlockQueue(1),
+					blockState:       mockBlockState,
+					babeVerifier:     babeVerifier,
+					transactionState: transactionState,
+					pendingBlocks:    pendingBlocks,
+				}
 			},
 			blockData: &types.BlockData{
-				Hash:   common.Hash{},
-				Header: &types.Header{},
-				Body:   &types.Body{},
+				Hash:   common.Hash{1},
+				Header: &types.Header{ParentHash: common.Hash{2}},
+				Body:   &types.Body{{3}},
 			},
-			babeVerifierBuilder: func(ctrl *gomock.Controller) BabeVerifier {
-				mockBabeVerifier := NewMockBabeVerifier(ctrl)
-				mockBabeVerifier.EXPECT().VerifyBlock(&types.Header{}).Return(nil)
-				return mockBabeVerifier
+		},
+		"add block success": {
+			chainProcessorBuilder: func(ctrl *gomock.Controller, done chan<- struct{}) chainProcessor {
+				mockBlockState := NewMockBlockState(ctrl)
+				mockBlockState.EXPECT().HasHeader(common.Hash{1}).Return(false, nil)
+				mockBlockState.EXPECT().HasBlockBody(common.Hash{1}).Return(false, nil)
+
+				babeVerifier := NewMockBabeVerifier(ctrl)
+				babeVerifier.EXPECT().
+					VerifyBlock(&types.Header{ParentHash: common.Hash{2}}).
+					Return(nil)
+
+				transactionState := NewMockTransactionState(ctrl)
+				transactionState.EXPECT().RemoveExtrinsic(types.Extrinsic{3})
+
+				mockBlockState.EXPECT().GetHeader(common.Hash{2}).
+					Return(nil, mockError)
+
+				pendingBlocks := NewMockDisjointBlockSet(ctrl)
+				block := &types.Block{
+					Header: types.Header{ParentHash: common.Hash{2}},
+					Body:   types.Body{{3}},
+				}
+				pendingBlocks.EXPECT().addBlock(block).
+					DoAndReturn(func(block *types.Block) error {
+						defer close(done)
+						return nil
+					})
+
+				ctx, cancel := context.WithCancel(context.Background())
+				return chainProcessor{
+					ctx:              ctx,
+					cancel:           cancel,
+					readyBlocks:      newBlockQueue(1),
+					blockState:       mockBlockState,
+					babeVerifier:     babeVerifier,
+					transactionState: transactionState,
+					pendingBlocks:    pendingBlocks,
+				}
 			},
-			pendingBlockBuilder: func(ctrl *gomock.Controller, done chan struct{}) DisjointBlockSet {
-				mockDisjointBlockSet := NewMockDisjointBlockSet(ctrl)
-				mockDisjointBlockSet.EXPECT().addBlock(&types.Block{
-					Header: types.Header{},
-					Body:   types.Body{},
-				}).DoAndReturn(func(block *types.Block) error {
-					close(done)
-					return mockError
-				})
-				return mockDisjointBlockSet
-			},
-			storageStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) StorageState {
-				return nil
+			blockData: &types.BlockData{
+				Hash:   common.Hash{1},
+				Header: &types.Header{ParentHash: common.Hash{2}},
+				Body:   &types.Body{{3}},
 			},
 		},
 	}
@@ -924,25 +1159,15 @@ func Test_chainProcessor_processReadyBlocks(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			ctx, cancel := context.WithCancel(context.Background())
-			readyBlock := newBlockQueue(5)
-			done := make(chan struct{})
+			lastMockCalled := make(chan struct{})
 
-			s := &chainProcessor{
-				ctx:           ctx,
-				cancel:        cancel,
-				readyBlocks:   readyBlock,
-				blockState:    tt.blockStateBuilder(ctrl, done),
-				babeVerifier:  tt.babeVerifierBuilder(ctrl),
-				pendingBlocks: tt.pendingBlockBuilder(ctrl, done),
-				storageState:  tt.storageStateBuilder(ctrl, done),
-			}
+			processor := tt.chainProcessorBuilder(ctrl, lastMockCalled)
 
-			go s.processReadyBlocks()
+			go processor.processReadyBlocks()
 
-			readyBlock.push(tt.blockData)
-			<-done
-			s.cancel()
+			processor.readyBlocks.push(tt.blockData)
+			<-lastMockCalled
+			processor.cancel()
 		})
 	}
 }

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/transaction"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -79,7 +80,7 @@ type BlockState interface {
 
 // StorageState is the interface for the storage state
 type StorageState interface {
-	TrieState(root *common.Hash) (*rtstorage.TrieState, error)
+	TrieState(root *common.Hash, stateVersion trie.Version) (*rtstorage.TrieState, error)
 	LoadCodeHash(*common.Hash) (common.Hash, error)
 	sync.Locker
 }

--- a/dot/sync/interface.go
+++ b/dot/sync/interface.go
@@ -30,6 +30,7 @@ type RuntimeInstance interface {
 	SetContextStorage(s runtime.Storage)
 	GetCodeHash() common.Hash
 	Version() runtime.Version
+	StateVersion() (stateVersion trie.Version)
 	Metadata() ([]byte, error)
 	BabeConfiguration() (*types.BabeConfiguration, error)
 	GrandpaAuthorities() ([]types.Authority, error)

--- a/dot/sync/mocks_test.go
+++ b/dot/sync/mocks_test.go
@@ -15,6 +15,7 @@ import (
 	runtime "github.com/ChainSafe/gossamer/lib/runtime"
 	storage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	transaction "github.com/ChainSafe/gossamer/lib/transaction"
+	trie "github.com/ChainSafe/gossamer/lib/trie"
 	gomock "github.com/golang/mock/gomock"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -487,18 +488,18 @@ func (mr *MockStorageStateMockRecorder) Lock() *gomock.Call {
 }
 
 // TrieState mocks base method.
-func (m *MockStorageState) TrieState(arg0 *common.Hash) (*storage.TrieState, error) {
+func (m *MockStorageState) TrieState(arg0 *common.Hash, arg1 trie.Version) (*storage.TrieState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TrieState", arg0)
+	ret := m.ctrl.Call(m, "TrieState", arg0, arg1)
 	ret0, _ := ret[0].(*storage.TrieState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TrieState indicates an expected call of TrieState.
-func (mr *MockStorageStateMockRecorder) TrieState(arg0 interface{}) *gomock.Call {
+func (mr *MockStorageStateMockRecorder) TrieState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieState", reflect.TypeOf((*MockStorageState)(nil).TrieState), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieState", reflect.TypeOf((*MockStorageState)(nil).TrieState), arg0, arg1)
 }
 
 // Unlock mocks base method.

--- a/dot/sync/mocks_test.go
+++ b/dot/sync/mocks_test.go
@@ -1079,6 +1079,20 @@ func (mr *MockRuntimeInstanceMockRecorder) SetContextStorage(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextStorage", reflect.TypeOf((*MockRuntimeInstance)(nil).SetContextStorage), arg0)
 }
 
+// StateVersion mocks base method.
+func (m *MockRuntimeInstance) StateVersion() trie.Version {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateVersion")
+	ret0, _ := ret[0].(trie.Version)
+	return ret0
+}
+
+// StateVersion indicates an expected call of StateVersion.
+func (mr *MockRuntimeInstanceMockRecorder) StateVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateVersion", reflect.TypeOf((*MockRuntimeInstance)(nil).StateVersion))
+}
+
 // Stop mocks base method.
 func (m *MockRuntimeInstance) Stop() {
 	m.ctrl.T.Helper()

--- a/dot/types/header.go
+++ b/dot/types/header.go
@@ -80,8 +80,10 @@ func (bh *Header) DeepCopy() (*Header, error) {
 
 // String returns the formatted header as a string
 func (bh *Header) String() string {
-	return fmt.Sprintf("ParentHash=%s Number=%d StateRoot=%s ExtrinsicsRoot=%s Digest=%v Hash=%s",
-		bh.ParentHash, bh.Number, bh.StateRoot, bh.ExtrinsicsRoot, bh.Digest, bh.Hash())
+	return fmt.Sprintf("{ParentHash: %s, Number: %d, StateRoot: %s, "+
+		"ExtrinsicsRoot: %s, Digest: %#v, hash: %s}",
+		bh.ParentHash, bh.Number, bh.StateRoot, bh.ExtrinsicsRoot, bh.Digest,
+		bh.hash)
 }
 
 // Hash returns the hash of the block header

--- a/dot/utils_integration_test.go
+++ b/dot/utils_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/genesis"
+	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/stretchr/testify/require"
 )
@@ -21,13 +22,16 @@ func TestTrieSnapshot(t *testing.T) {
 	genRaw, err := genesis.NewGenesisFromJSONRaw(genRawFile)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(*genRaw)
+	require.NoError(t, err)
+
 	tri := trie.NewEmptyTrie()
 	key := []byte("key")
 	value := []byte("value")
 
 	for k, v := range genRaw.Genesis.Raw["top"] {
 		val := []byte(v)
-		tri.Put([]byte(k), val)
+		tri.Put([]byte(k), val, stateVersion)
 	}
 
 	deepCopyTrie := tri.DeepCopy()
@@ -36,13 +40,13 @@ func TestTrieSnapshot(t *testing.T) {
 	newTrie := tri.Snapshot()
 
 	// Get the Trie root hash for all the 3 tries.
-	tHash, err := tri.Hash()
+	tHash, err := tri.Hash(stateVersion)
 	require.NoError(t, err)
 
-	dcTrieHash, err := deepCopyTrie.Hash()
+	dcTrieHash, err := deepCopyTrie.Hash(stateVersion)
 	require.NoError(t, err)
 
-	newTrieHash, err := newTrie.Hash()
+	newTrieHash, err := newTrie.Hash(stateVersion)
 	require.NoError(t, err)
 
 	// Root hash for the 3 tries should be equal.
@@ -51,16 +55,16 @@ func TestTrieSnapshot(t *testing.T) {
 
 	// Modify the current trie.
 	value[0] = 'w'
-	newTrie.Put(key, value)
+	newTrie.Put(key, value, stateVersion)
 
 	// Get the updated root hash of all tries.
-	tHash, err = tri.Hash()
+	tHash, err = tri.Hash(stateVersion)
 	require.NoError(t, err)
 
-	dcTrieHash, err = deepCopyTrie.Hash()
+	dcTrieHash, err = deepCopyTrie.Hash(stateVersion)
 	require.NoError(t, err)
 
-	newTrieHash, err = newTrie.Hash()
+	newTrieHash, err = newTrie.Hash(stateVersion)
 	require.NoError(t, err)
 
 	// Only the current trie should have a different root hash since it is updated.

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -483,17 +483,19 @@ func (b *Service) handleSlot(epoch, slotNum uint64,
 	b.storageState.Lock()
 	defer b.storageState.Unlock()
 
-	// set runtime trie before building block
-	// if block building is successful, store the resulting trie in the storage state
-	ts, err := b.storageState.TrieState(&parent.StateRoot)
-	if err != nil || ts == nil {
-		logger.Errorf("failed to get parent trie with parent state root %s: %s", parent.StateRoot, err)
-		return err
-	}
-
 	hash := parent.Hash()
 	rt, err := b.blockState.GetRuntime(&hash)
 	if err != nil {
+		return fmt.Errorf("getting runtime: %w", err)
+	}
+
+	stateVersion := rt.StateVersion()
+
+	// set runtime trie before building block
+	// if block building is successful, store the resulting trie in the storage state
+	ts, err := b.storageState.TrieState(&parent.StateRoot, stateVersion)
+	if err != nil || ts == nil {
+		logger.Errorf("failed to get parent trie with parent state root %s: %s", parent.StateRoot, err)
 		return err
 	}
 

--- a/lib/babe/build_integration_test.go
+++ b/lib/babe/build_integration_test.go
@@ -167,7 +167,7 @@ func TestApplyExtrinsic(t *testing.T) {
 	rt, err := babeService.blockState.GetRuntime(nil)
 	require.NoError(t, err)
 
-	ts, err := babeService.storageState.TrieState(nil)
+	ts, err := babeService.storageState.TrieState(nil, rt.StateVersion())
 	require.NoError(t, err)
 	rt.SetContextStorage(ts)
 

--- a/lib/babe/helpers_test.go
+++ b/lib/babe/helpers_test.go
@@ -28,8 +28,11 @@ func newDevGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	genesisHeaderPtr, err := types.NewHeader(common.NewHash([]byte{0}),
-		genesisTrie.MustHash(), trie.EmptyHash, 0, types.NewDigest())
+		genesisTrie.MustHash(stateVersion), trie.EmptyHash, 0, types.NewDigest())
 	require.NoError(t, err)
 	genesisHeader = *genesisHeaderPtr
 
@@ -48,8 +51,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()

--- a/lib/babe/mock_state_test.go
+++ b/lib/babe/mock_state_test.go
@@ -13,6 +13,7 @@ import (
 	runtime "github.com/ChainSafe/gossamer/lib/runtime"
 	storage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	transaction "github.com/ChainSafe/gossamer/lib/transaction"
+	trie "github.com/ChainSafe/gossamer/lib/trie"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -413,18 +414,18 @@ func (mr *MockStorageStateMockRecorder) Lock() *gomock.Call {
 }
 
 // TrieState mocks base method.
-func (m *MockStorageState) TrieState(arg0 *common.Hash) (*storage.TrieState, error) {
+func (m *MockStorageState) TrieState(arg0 *common.Hash, arg1 trie.Version) (*storage.TrieState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TrieState", arg0)
+	ret := m.ctrl.Call(m, "TrieState", arg0, arg1)
 	ret0, _ := ret[0].(*storage.TrieState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TrieState indicates an expected call of TrieState.
-func (mr *MockStorageStateMockRecorder) TrieState(arg0 interface{}) *gomock.Call {
+func (mr *MockStorageStateMockRecorder) TrieState(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieState", reflect.TypeOf((*MockStorageState)(nil).TrieState), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrieState", reflect.TypeOf((*MockStorageState)(nil).TrieState), arg0, arg1)
 }
 
 // Unlock mocks base method.

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/transaction"
+	"github.com/ChainSafe/gossamer/lib/trie"
 )
 
 //go:generate mockgen -destination=./mock_state_test.go -package $GOPACKAGE . BlockState,ImportedBlockNotifierManager,StorageState,TransactionState,EpochState,DigestHandler,BlockImportHandler
@@ -47,7 +48,7 @@ type ImportedBlockNotifierManager interface {
 
 // StorageState interface for storage state methods
 type StorageState interface {
-	TrieState(hash *common.Hash) (*rtstorage.TrieState, error)
+	TrieState(hash *common.Hash, stateVersion trie.Version) (*rtstorage.TrieState, error)
 	sync.Locker
 }
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -414,7 +414,8 @@ func (bt *BlockTree) StoreRuntime(hash common.Hash, in runtime.Instance) {
 func (bt *BlockTree) GetBlockRuntime(hash common.Hash) (runtime.Instance, error) {
 	ins := bt.runtimes.get(hash)
 	if ins == nil {
-		return nil, ErrFailedToGetRuntime
+		return nil, fmt.Errorf("%w: for hash %s in %d instances",
+			ErrFailedToGetRuntime, hash, bt.runtimes.len())
 	}
 	return ins, nil
 }

--- a/lib/blocktree/hashtoruntime.go
+++ b/lib/blocktree/hashtoruntime.go
@@ -37,3 +37,9 @@ func (h *hashToRuntime) delete(hash Hash) {
 	defer h.mutex.Unlock()
 	delete(h.mapping, hash)
 }
+
+func (h *hashToRuntime) len() (length int) {
+	h.mutex.RLock()
+	defer h.mutex.RUnlock()
+	return len(h.mapping)
+}

--- a/lib/blocktree/mock_instance_test.go
+++ b/lib/blocktree/mock_instance_test.go
@@ -12,6 +12,7 @@ import (
 	keystore "github.com/ChainSafe/gossamer/lib/keystore"
 	runtime "github.com/ChainSafe/gossamer/lib/runtime"
 	transaction "github.com/ChainSafe/gossamer/lib/transaction"
+	trie "github.com/ChainSafe/gossamer/lib/trie"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -316,6 +317,20 @@ func (m *MockInstance) SetContextStorage(arg0 runtime.Storage) {
 func (mr *MockInstanceMockRecorder) SetContextStorage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextStorage", reflect.TypeOf((*MockInstance)(nil).SetContextStorage), arg0)
+}
+
+// StateVersion mocks base method.
+func (m *MockInstance) StateVersion() trie.Version {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StateVersion")
+	ret0, _ := ret[0].(trie.Version)
+	return ret0
+}
+
+// StateVersion indicates an expected call of StateVersion.
+func (mr *MockInstanceMockRecorder) StateVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateVersion", reflect.TypeOf((*MockInstance)(nil).StateVersion))
 }
 
 // Stop mocks base method.

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -4,6 +4,9 @@
 package genesis
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
@@ -92,6 +95,24 @@ func (g *Genesis) ToRaw() error {
 	g.Genesis.Raw = make(map[string]map[string]string)
 	g.Genesis.Raw["top"] = res
 	return nil
+}
+
+var ErrRuntimeCodeNotFound = errors.New("runtime code not found")
+
+// RuntimeCode returns the runtime bytes stored in the ":code" key.
+func (g *Genesis) RuntimeCode() (runtimeCode []byte, err error) {
+	const hexCodeTrieKey = "0x3a636f6465" // :code in hexadecimal
+	hexRuntimeCode, ok := g.Genesis.Raw["top"][hexCodeTrieKey]
+	if !ok {
+		return nil, fmt.Errorf("%w", ErrRuntimeCodeNotFound)
+	}
+
+	runtimeCode, err = common.HexToBytes(hexRuntimeCode)
+	if err != nil {
+		return nil, fmt.Errorf("converting runtime code hex to bytes: %w", err)
+	}
+
+	return runtimeCode, nil
 }
 
 func interfaceToTelemetryEndpoint(endpoints []interface{}) []*TelemetryEndpoint {

--- a/lib/grandpa/helpers_test.go
+++ b/lib/grandpa/helpers_test.go
@@ -27,8 +27,11 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	genesisTrie, err = wasmer.NewTrieFromGenesis(gen)
 	require.NoError(t, err)
 
+	stateVersion, err := wasmer.StateVersionFromGenesis(gen)
+	require.NoError(t, err)
+
 	parentHash := common.NewHash([]byte{0})
-	stateRoot := genesisTrie.MustHash()
+	stateRoot := genesisTrie.MustHash(stateVersion)
 	extrinsicRoot := trie.EmptyHash
 	const number = 0
 	digest := types.NewDigest()

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -28,6 +28,7 @@ type Instance interface {
 	// Version returns the version from the runtime.
 	// This should return the cached version and be cheap to execute.
 	Version() (version Version)
+	StateVersion() (stateVersion trie.Version)
 	Metadata() ([]byte, error)
 	BabeConfiguration() (*types.BabeConfiguration, error)
 	GrandpaAuthorities() ([]types.Authority, error)
@@ -50,11 +51,11 @@ type Instance interface {
 
 // Storage interface
 type Storage interface {
-	Set(key []byte, value []byte)
+	Set(key []byte, value []byte, stateVersion trie.Version)
 	Get(key []byte) []byte
-	Root() (common.Hash, error)
-	SetChild(keyToChild []byte, child *trie.Trie) error
-	SetChildStorage(keyToChild, key, value []byte) error
+	Root(stateVersion trie.Version) (common.Hash, error)
+	SetChild(keyToChild []byte, child *trie.Trie, stateVersion trie.Version) error
+	SetChildStorage(keyToChild, key, value []byte, stateVersion trie.Version) error
 	GetChildStorage(keyToChild, key []byte) ([]byte, error)
 	Delete(key []byte)
 	DeleteChild(keyToChild []byte)

--- a/lib/runtime/mocks/instance.go
+++ b/lib/runtime/mocks/instance.go
@@ -12,6 +12,8 @@ import (
 
 	transaction "github.com/ChainSafe/gossamer/lib/transaction"
 
+	trie "github.com/ChainSafe/gossamer/lib/trie"
+
 	types "github.com/ChainSafe/gossamer/dot/types"
 )
 
@@ -349,6 +351,20 @@ func (_m *Instance) RandomSeed() {
 // SetContextStorage provides a mock function with given fields: s
 func (_m *Instance) SetContextStorage(s runtime.Storage) {
 	_m.Called(s)
+}
+
+// StateVersion provides a mock function with given fields:
+func (_m *Instance) StateVersion() trie.Version {
+	ret := _m.Called()
+
+	var r0 trie.Version
+	if rf, ok := ret.Get(0).(func() trie.Version); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(trie.Version)
+	}
+
+	return r0
 }
 
 // Stop provides a mock function with given fields:

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -68,10 +68,10 @@ func (s *TrieState) RollbackStorageTransaction() {
 }
 
 // Set sets a key-value pair in the trie
-func (s *TrieState) Set(key, value []byte) {
+func (s *TrieState) Set(key, value []byte, version trie.Version) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.t.Put(key, value)
+	s.t.Put(key, value, version)
 }
 
 // Get gets a value from the trie
@@ -82,13 +82,13 @@ func (s *TrieState) Get(key []byte) []byte {
 }
 
 // MustRoot returns the trie's root hash. It panics if it fails to compute the root.
-func (s *TrieState) MustRoot() common.Hash {
-	return s.t.MustHash()
+func (s *TrieState) MustRoot(version trie.Version) common.Hash {
+	return s.t.MustHash(version)
 }
 
 // Root returns the trie's root hash
-func (s *TrieState) Root() (common.Hash, error) {
-	return s.t.Hash()
+func (s *TrieState) Root(version trie.Version) (common.Hash, error) {
+	return s.t.Hash(version)
 }
 
 // Has returns whether or not a key exists
@@ -139,17 +139,19 @@ func (s *TrieState) TrieEntries() map[string][]byte {
 }
 
 // SetChild sets the child trie at the given key
-func (s *TrieState) SetChild(keyToChild []byte, child *trie.Trie) error {
+func (s *TrieState) SetChild(keyToChild []byte, child *trie.Trie,
+	version trie.Version) (err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	return s.t.PutChild(keyToChild, child)
+	return s.t.PutChild(keyToChild, child, version)
 }
 
 // SetChildStorage sets a key-value pair in a child trie
-func (s *TrieState) SetChildStorage(keyToChild, key, value []byte) error {
+func (s *TrieState) SetChildStorage(keyToChild, key, value []byte,
+	version trie.Version) (err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	return s.t.PutIntoChild(keyToChild, key, value)
+	return s.t.PutIntoChild(keyToChild, key, value, version)
 }
 
 // GetChild returns the child trie at the given key

--- a/lib/runtime/types.go
+++ b/lib/runtime/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime/offchain"
+	"github.com/ChainSafe/gossamer/lib/trie"
 )
 
 // NodeStorageType type to identify offchain storage type
@@ -57,4 +58,8 @@ type Context struct {
 	SigVerifier     *crypto.SignatureVerifier
 	OffchainHTTPSet *offchain.HTTPSet
 	Version         Version
+	// StateVersion is the cached state version parsed
+	// from the core version. It is cached on top of the
+	// Version field so it doesn't need to be parsed every time.
+	StateVersion trie.Version
 }

--- a/lib/runtime/wasmer/exports.go
+++ b/lib/runtime/wasmer/exports.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/transaction"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
 
@@ -47,6 +48,12 @@ func (in *Instance) version() (version runtime.Version, err error) {
 	}
 
 	return version, nil
+}
+
+// StateVersion returns the typed instance state version.
+// This is cheap to call since the instance state version is cached.
+func (in *Instance) StateVersion() (stateVersion trie.Version) {
+	return in.ctx.StateVersion
 }
 
 // Metadata calls runtime function Metadata_metadata

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -332,13 +332,13 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	encBal, err := scale.Marshal(accInfo)
 	require.NoError(t, err)
 
-	rt.(*Instance).ctx.Storage.Set(aliceBalanceKey, encBal)
+	rt.(*Instance).ctx.Storage.Set(aliceBalanceKey, encBal, rt.StateVersion())
 	// this key is System.UpgradedToDualRefCount -> set to true since all accounts have been upgraded to v0.9 format
-	rt.(*Instance).ctx.Storage.Set(common.UpgradedToDualRefKey, []byte{1})
+	rt.(*Instance).ctx.Storage.Set(common.UpgradedToDualRefKey, []byte{1}, rt.StateVersion())
 
 	genesisHeader := &types.Header{
 		Number:    0,
-		StateRoot: genTrie.MustHash(),
+		StateRoot: genTrie.MustHash(trie.V0),
 	}
 
 	extHex := runtime.NewTestExtrinsic(t, rt, genesisHeader.Hash(), genesisHeader.Hash(),
@@ -354,14 +354,13 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 
 func TestInstance_GrandpaAuthorities_NodeRuntime(t *testing.T) {
 	tt := trie.NewEmptyTrie()
+	rt := NewTestInstanceWithTrie(t, runtime.NODE_RUNTIME, tt)
 
 	value, err := common.HexToBytes("0x0108eea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d714103640100000000000000b64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d7170100000000000000") //nolint:lll
 	require.NoError(t, err)
 
 	key := common.MustHexToBytes(genesis.GrandpaAuthoritiesKeyHex)
-	tt.Put(key, value)
-
-	rt := NewTestInstanceWithTrie(t, runtime.NODE_RUNTIME, tt)
+	tt.Put(key, value, rt.StateVersion())
 
 	auths, err := rt.GrandpaAuthorities()
 	require.NoError(t, err)
@@ -382,14 +381,13 @@ func TestInstance_GrandpaAuthorities_NodeRuntime(t *testing.T) {
 
 func TestInstance_GrandpaAuthorities_PolkadotRuntime(t *testing.T) {
 	tt := trie.NewEmptyTrie()
+	rt := NewTestInstanceWithTrie(t, runtime.POLKADOT_RUNTIME, tt)
 
 	value, err := common.HexToBytes("0x0108eea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d714103640100000000000000b64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d7170100000000000000") //nolint:lll
 	require.NoError(t, err)
 
 	key := common.MustHexToBytes(genesis.GrandpaAuthoritiesKeyHex)
-	tt.Put(key, value)
-
-	rt := NewTestInstanceWithTrie(t, runtime.POLKADOT_RUNTIME, tt)
+	tt.Put(key, value, rt.StateVersion())
 
 	auths, err := rt.GrandpaAuthorities()
 	require.NoError(t, err)
@@ -446,19 +444,18 @@ func TestInstance_BabeConfiguration_DevRuntime_NoAuthorities(t *testing.T) {
 
 func TestInstance_BabeConfiguration_NodeRuntime_WithAuthorities(t *testing.T) {
 	tt := trie.NewEmptyTrie()
+	rt := NewTestInstanceWithTrie(t, runtime.NODE_RUNTIME, tt)
 
 	rvalue, err := common.HexToHash("0x01")
 	require.NoError(t, err)
 	key := common.MustHexToBytes(genesis.BABERandomnessKeyHex)
-	tt.Put(key, rvalue[:])
+	tt.Put(key, rvalue[:], rt.StateVersion())
 
 	avalue, err := common.HexToBytes("0x08eea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d714103640100000000000000b64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d7170100000000000000") //nolint:lll
 	require.NoError(t, err)
 
 	key = common.MustHexToBytes(genesis.BABEAuthoritiesKeyHex)
-	tt.Put(key, avalue)
-
-	rt := NewTestInstanceWithTrie(t, runtime.NODE_RUNTIME, tt)
+	tt.Put(key, avalue, rt.StateVersion())
 
 	cfg, err := rt.BabeConfiguration()
 	require.NoError(t, err)
@@ -617,7 +614,7 @@ func TestInstance_ExecuteBlock_PolkadotRuntime_PolkadotBlock1(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedGenesisRoot := common.MustHexToHash("0x29d0d972cd27cbc511e9589fcb7a4506d5eb6a9e8df205f00472e5ab354a4e17")
-	require.Equal(t, expectedGenesisRoot, genTrie.MustHash())
+	require.Equal(t, expectedGenesisRoot, genTrie.MustHash(trie.V0))
 
 	// set state to genesis state
 	genState := storage.NewTrieState(&genTrie)
@@ -667,7 +664,7 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedGenesisRoot := common.MustHexToHash("0xb0006203c3a6e6bd2c6a17b1d4ae8ca49a31da0f4579da950b127774b44aef6b")
-	require.Equal(t, expectedGenesisRoot, genTrie.MustHash())
+	require.Equal(t, expectedGenesisRoot, genTrie.MustHash(trie.V0))
 
 	// set state to genesis state
 	genState := storage.NewTrieState(&genTrie)
@@ -711,9 +708,10 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock3784(t *testing.T) {
-	gossTrie3783 := newTrieFromPairs(t, "../test_data/kusama/block3783.out")
+	const stateVersion = trie.V0 // block3783 was using v0 state trie
+	gossTrie3783 := newTrieFromPairs(t, "../test_data/kusama/block3783.out", stateVersion)
 	expectedRoot := common.MustHexToHash("0x948338bc0976aee78879d559a1f42385407e5a481b05a91d2a9386aa7507e7a0")
-	require.Equal(t, expectedRoot, gossTrie3783.MustHash())
+	require.Equal(t, expectedRoot, gossTrie3783.MustHash(trie.V0))
 
 	// set state to genesis state
 	state3783 := storage.NewTrieState(gossTrie3783)
@@ -757,9 +755,10 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock3784(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442(t *testing.T) {
-	ksmTrie901441 := newTrieFromPairs(t, "../test_data/kusama/block901441.out")
+	const stateVersion = trie.V0 // block901441 was using v0 state trie
+	ksmTrie901441 := newTrieFromPairs(t, "../test_data/kusama/block901441.out", stateVersion)
 	expectedRoot := common.MustHexToHash("0x3a2ef7ee032f5810160bb8f3ffe3e3377bb6f2769ee9f79a5425973347acd504")
-	require.Equal(t, expectedRoot, ksmTrie901441.MustHash())
+	require.Equal(t, expectedRoot, ksmTrie901441.MustHash(trie.V0))
 
 	// set state to genesis state
 	state901441 := storage.NewTrieState(ksmTrie901441)
@@ -803,9 +802,10 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock901442(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1377831(t *testing.T) {
-	ksmTrie := newTrieFromPairs(t, "../test_data/kusama/block1377830.out")
+	const stateVersion = trie.V0 // block1377830 was using v0 state trie
+	ksmTrie := newTrieFromPairs(t, "../test_data/kusama/block1377830.out", stateVersion)
 	expectedRoot := common.MustHexToHash("0xe4de6fecda9e9e35f937d159665cf984bc1a68048b6c78912de0aeb6bd7f7e99")
-	require.Equal(t, expectedRoot, ksmTrie.MustHash())
+	require.Equal(t, expectedRoot, ksmTrie.MustHash(trie.V0))
 
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
@@ -849,9 +849,10 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1377831(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1482003(t *testing.T) {
-	ksmTrie := newTrieFromPairs(t, "../test_data/kusama/block1482002.out")
+	const stateVersion = trie.V0 // block1482002 was using v0 state trie
+	ksmTrie := newTrieFromPairs(t, "../test_data/kusama/block1482002.out", stateVersion)
 	expectedRoot := common.MustHexToHash("0x09f9ca28df0560c2291aa16b56e15e07d1e1927088f51356d522722aa90ca7cb")
-	require.Equal(t, expectedRoot, ksmTrie.MustHash())
+	require.Equal(t, expectedRoot, ksmTrie.MustHash(trie.V0))
 
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
@@ -897,9 +898,10 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock1482003(t *testing.T) {
 
 func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock4939774(t *testing.T) {
 	t.Skip("skip for now as block4939773 is too large")
-	ksmTrie := newTrieFromPairs(t, "../test_data/kusama/block4939773.out")
+	const stateVersion = trie.V0 // block4939773 was using v0 state trie
+	ksmTrie := newTrieFromPairs(t, "../test_data/kusama/block4939773.out", stateVersion)
 	expectedRoot := common.MustHexToHash("0xc45748e6e8632b44fc32b04cc4380098a9584cbd63ffbc59adce189574fc36fe")
-	require.Equal(t, expectedRoot, ksmTrie.MustHash())
+	require.Equal(t, expectedRoot, ksmTrie.MustHash(trie.V0))
 
 	// set state to genesis state
 	state := storage.NewTrieState(ksmTrie)
@@ -940,9 +942,10 @@ func TestInstance_ExecuteBlock_KusamaRuntime_KusamaBlock4939774(t *testing.T) {
 }
 
 func TestInstance_ExecuteBlock_PolkadotBlock1089328(t *testing.T) {
-	dotTrie := newTrieFromPairs(t, "../test_data/polkadot/block1089327.json")
+	const stateVersion = trie.V0 // block1089327 was using v0 state trie
+	dotTrie := newTrieFromPairs(t, "../test_data/polkadot/block1089327.json", stateVersion)
 	expectedRoot := common.MustHexToHash("0x87ed9ebe7fb645d3b5b0255cc16e78ed022d9fbb52486105436e15a74557535b")
-	require.Equal(t, expectedRoot, dotTrie.MustHash())
+	require.Equal(t, expectedRoot, dotTrie.MustHash(trie.V0))
 
 	// set state to genesis state
 	state := storage.NewTrieState(dotTrie)
@@ -1069,7 +1072,7 @@ func TestInstance_PaymentQueryInfo(t *testing.T) {
 	}
 }
 
-func newTrieFromPairs(t *testing.T, filename string) *trie.Trie {
+func newTrieFromPairs(t *testing.T, filename string, stateVersion trie.Version) *trie.Trie { //nolint:unparam
 	data, err := os.ReadFile(filename)
 	require.NoError(t, err)
 
@@ -1085,7 +1088,7 @@ func newTrieFromPairs(t *testing.T, filename string) *trie.Trie {
 	}
 
 	tr := trie.NewEmptyTrie()
-	err = tr.LoadFromMap(entries)
+	err = tr.LoadFromMap(entries, stateVersion)
 	require.NoError(t, err)
 	return tr
 }

--- a/lib/runtime/wasmer/genesis.go
+++ b/lib/runtime/wasmer/genesis.go
@@ -15,8 +15,14 @@ var (
 	ErrGenesisTopNotFound = errors.New("genesis top not found")
 )
 
-// NewTrieFromGenesis creates a new trie from the raw genesis data
+// NewTrieFromGenesis creates a new trie from the raw genesis data.
+// TODO inject state version perhaps? Check usages
 func NewTrieFromGenesis(gen genesis.Genesis) (tr trie.Trie, err error) {
+	stateVersion, err := StateVersionFromGenesis(gen)
+	if err != nil {
+		return tr, fmt.Errorf("getting genesis state version: %w", err)
+	}
+
 	triePtr := trie.NewEmptyTrie()
 	tr = *triePtr
 	genesisFields := gen.GenesisFields()
@@ -26,10 +32,28 @@ func NewTrieFromGenesis(gen genesis.Genesis) (tr trie.Trie, err error) {
 			ErrGenesisTopNotFound, gen.Name)
 	}
 
-	err = tr.LoadFromMap(keyValues)
+	err = tr.LoadFromMap(keyValues, stateVersion)
 	if err != nil {
 		return tr, fmt.Errorf("loading genesis top key values into trie: %w", err)
 	}
 
 	return tr, nil
+}
+
+// StateVersionFromGenesis returns the state version from the genesis data.
+// Note this is an expensive call since it instantiates a full runtime from
+// the genesis runtime blob.
+func StateVersionFromGenesis(genesis genesis.Genesis) (
+	stateVersion trie.Version, err error) {
+	runtimeCode, err := genesis.RuntimeCode()
+	if err != nil {
+		return stateVersion, fmt.Errorf("getting genesis runtime code: %w", err)
+	}
+
+	stateVersion, err = GetRuntimeStateVersion(runtimeCode)
+	if err != nil {
+		return stateVersion, fmt.Errorf("getting genesis runtime state version: %w", err)
+	}
+
+	return stateVersion, nil
 }

--- a/lib/runtime/wasmer/helpers.go
+++ b/lib/runtime/wasmer/helpers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/lib/common/types"
 	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/wasmerio/go-ext-wasm/wasmer"
 )
@@ -159,7 +160,8 @@ func toWasmMemoryFixedSizeOptional(context wasmer.InstanceContext, data []byte) 
 	return toWasmMemory(context, encodedOptionalFixedSize)
 }
 
-func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
+func storageAppend(storage runtime.Storage, key, valueToAppend []byte,
+	version trie.Version) error {
 	// this function assumes the item in storage is a SCALE encoded array of items
 	// the valueToAppend is a new item, so it appends the item and increases the length prefix by 1
 	currentValue := storage.Get(key)
@@ -211,6 +213,6 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 	}
 
 	logger.Debugf("resulting value: 0x%x", value)
-	storage.Set(key, value)
+	storage.Set(key, value, version)
 	return nil
 }

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -187,7 +187,7 @@ func Test_ext_storage_clear_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Set(testkey, []byte{1}, inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -372,10 +372,10 @@ func Test_ext_storage_clear_prefix_version_1_hostAPI(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("static")
-	inst.ctx.Storage.Set(testkey, []byte("Inverse"))
+	inst.ctx.Storage.Set(testkey, []byte("Inverse"), inst.StateVersion())
 
 	testkey2 := []byte("even-keeled")
-	inst.ctx.Storage.Set(testkey2, []byte("Future-proofed"))
+	inst.ctx.Storage.Set(testkey2, []byte("Future-proofed"), inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey[:3])
 	require.NoError(t, err)
@@ -395,10 +395,10 @@ func Test_ext_storage_clear_prefix_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Set(testkey, []byte{1}, inst.StateVersion())
 
 	testkey2 := []byte("spaghet")
-	inst.ctx.Storage.Set(testkey2, []byte{2})
+	inst.ctx.Storage.Set(testkey2, []byte{2}, inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey[:3])
 	require.NoError(t, err)
@@ -418,20 +418,20 @@ func Test_ext_storage_clear_prefix_version_2(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Set(testkey, []byte{1}, inst.StateVersion())
 
 	testkey2 := []byte("noot1")
-	inst.ctx.Storage.Set(testkey2, []byte{1})
+	inst.ctx.Storage.Set(testkey2, []byte{1}, inst.StateVersion())
 
 	testkey3 := []byte("noot2")
-	inst.ctx.Storage.Set(testkey3, []byte{1})
+	inst.ctx.Storage.Set(testkey3, []byte{1}, inst.StateVersion())
 
 	testkey4 := []byte("noot3")
-	inst.ctx.Storage.Set(testkey4, []byte{1})
+	inst.ctx.Storage.Set(testkey4, []byte{1}, inst.StateVersion())
 
 	testkey5 := []byte("spaghet")
 	testValue5 := []byte{2}
-	inst.ctx.Storage.Set(testkey5, testValue5)
+	inst.ctx.Storage.Set(testkey5, testValue5, inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey[:3])
 	require.NoError(t, err)
@@ -492,7 +492,7 @@ func Test_ext_storage_get_version_1(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte{1, 2}
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Set(testkey, testvalue, inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -513,7 +513,7 @@ func Test_ext_storage_exists_version_1(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte{1, 2}
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Set(testkey, testvalue, inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -536,10 +536,10 @@ func Test_ext_storage_next_key_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Set(testkey, []byte{1}, inst.StateVersion())
 
 	nextkey := []byte("oot")
-	inst.ctx.Storage.Set(nextkey, []byte{1})
+	inst.ctx.Storage.Set(nextkey, []byte{1}, inst.StateVersion())
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -560,7 +560,7 @@ func Test_ext_storage_read_version_1(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte("washere")
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Set(testkey, testvalue, inst.StateVersion())
 
 	testoffset := uint32(2)
 	testBufferSize := uint32(100)
@@ -589,7 +589,7 @@ func Test_ext_storage_read_version_1_again(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte("_was_here_")
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Set(testkey, testvalue, inst.StateVersion())
 
 	testoffset := uint32(8)
 	testBufferSize := uint32(5)
@@ -619,7 +619,7 @@ func Test_ext_storage_read_version_1_OffsetLargerThanValue(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte("washere")
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Set(testkey, testvalue, inst.StateVersion())
 
 	testoffset := uint32(len(testvalue))
 	testBufferSize := uint32(8)
@@ -1192,10 +1192,10 @@ func Test_ext_default_child_storage_read_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
-	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue)
+	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue, trie.V0)
 	require.NoError(t, err)
 
 	testOffset := uint32(2)
@@ -1232,10 +1232,10 @@ func Test_ext_default_child_storage_clear_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
-	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue)
+	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue, trie.V0)
 	require.NoError(t, err)
 
 	// Confirm if value is set
@@ -1272,11 +1272,11 @@ func Test_ext_default_child_storage_clear_prefix_version_1(t *testing.T) {
 		{[]byte("keyThree"), []byte("value3")},
 	}
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
 	for _, kv := range testKeyValuePair {
-		err = inst.ctx.Storage.SetChildStorage(testChildKey, kv.key, kv.value)
+		err = inst.ctx.Storage.SetChildStorage(testChildKey, kv.key, kv.value, trie.V0)
 		require.NoError(t, err)
 	}
 
@@ -1303,10 +1303,10 @@ func Test_ext_default_child_storage_exists_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
-	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue)
+	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue, trie.V0)
 	require.NoError(t, err)
 
 	encChildKey, err := scale.Marshal(testChildKey)
@@ -1328,10 +1328,10 @@ func Test_ext_default_child_storage_get_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
-	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue)
+	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue, trie.V0)
 	require.NoError(t, err)
 
 	encChildKey, err := scale.Marshal(testChildKey)
@@ -1363,11 +1363,11 @@ func Test_ext_default_child_storage_next_key_version_1(t *testing.T) {
 
 	key := testKeyValuePair[0].key
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
 	for _, kv := range testKeyValuePair {
-		err = inst.ctx.Storage.SetChildStorage(testChildKey, kv.key, kv.value)
+		err = inst.ctx.Storage.SetChildStorage(testChildKey, kv.key, kv.value, trie.V0)
 		require.NoError(t, err)
 	}
 
@@ -1391,16 +1391,16 @@ func Test_ext_default_child_storage_root_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
-	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue)
+	err = inst.ctx.Storage.SetChildStorage(testChildKey, testKey, testValue, trie.V0)
 	require.NoError(t, err)
 
 	child, err := inst.ctx.Storage.GetChild(testChildKey)
 	require.NoError(t, err)
 
-	rootHash, err := child.Hash()
+	rootHash, err := child.Hash(trie.V0)
 	require.NoError(t, err)
 
 	encChildKey, err := scale.Marshal(testChildKey)
@@ -1424,7 +1424,7 @@ func Test_ext_default_child_storage_set_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
 	// Check if value is not set
@@ -1453,7 +1453,7 @@ func Test_ext_default_child_storage_storage_kill_version_1(t *testing.T) {
 	t.Parallel()
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+	err := inst.ctx.Storage.SetChild(testChildKey, trie.NewEmptyTrie(), trie.V0)
 	require.NoError(t, err)
 
 	// Confirm if value is set
@@ -1476,9 +1476,9 @@ func Test_ext_default_child_storage_storage_kill_version_2_limit_all(t *testing.
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	tr := trie.NewEmptyTrie()
-	tr.Put([]byte(`key2`), []byte(`value2`))
-	tr.Put([]byte(`key1`), []byte(`value1`))
-	err := inst.ctx.Storage.SetChild(testChildKey, tr)
+	tr.Put([]byte(`key2`), []byte(`value2`), inst.StateVersion())
+	tr.Put([]byte(`key1`), []byte(`value1`), inst.StateVersion())
+	err := inst.ctx.Storage.SetChild(testChildKey, tr, trie.V0)
 	require.NoError(t, err)
 
 	// Confirm if value is set
@@ -1510,9 +1510,9 @@ func Test_ext_default_child_storage_storage_kill_version_2_limit_1(t *testing.T)
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	tr := trie.NewEmptyTrie()
-	tr.Put([]byte(`key2`), []byte(`value2`))
-	tr.Put([]byte(`key1`), []byte(`value1`))
-	err := inst.ctx.Storage.SetChild(testChildKey, tr)
+	tr.Put([]byte(`key2`), []byte(`value2`), inst.StateVersion())
+	tr.Put([]byte(`key1`), []byte(`value1`), inst.StateVersion())
+	err := inst.ctx.Storage.SetChild(testChildKey, tr, trie.V0)
 	require.NoError(t, err)
 
 	// Confirm if value is set
@@ -1544,9 +1544,9 @@ func Test_ext_default_child_storage_storage_kill_version_2_limit_none(t *testing
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	tr := trie.NewEmptyTrie()
-	tr.Put([]byte(`key2`), []byte(`value2`))
-	tr.Put([]byte(`key1`), []byte(`value1`))
-	err := inst.ctx.Storage.SetChild(testChildKey, tr)
+	tr.Put([]byte(`key2`), []byte(`value2`), inst.StateVersion())
+	tr.Put([]byte(`key1`), []byte(`value1`), inst.StateVersion())
+	err := inst.ctx.Storage.SetChild(testChildKey, tr, trie.V0)
 	require.NoError(t, err)
 
 	// Confirm if value is set
@@ -1575,10 +1575,10 @@ func Test_ext_default_child_storage_storage_kill_version_3(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	tr := trie.NewEmptyTrie()
-	tr.Put([]byte(`key2`), []byte(`value2`))
-	tr.Put([]byte(`key1`), []byte(`value1`))
-	tr.Put([]byte(`key3`), []byte(`value3`))
-	err := inst.ctx.Storage.SetChild(testChildKey, tr)
+	tr.Put([]byte(`key2`), []byte(`value2`), inst.StateVersion())
+	tr.Put([]byte(`key1`), []byte(`value1`), inst.StateVersion())
+	tr.Put([]byte(`key3`), []byte(`value3`), inst.StateVersion())
+	err := inst.ctx.Storage.SetChild(testChildKey, tr, trie.V0)
 	require.NoError(t, err)
 
 	testLimitBytes := make([]byte, 4)
@@ -1758,15 +1758,18 @@ func Test_ext_trie_blake2_256_root_version_1(t *testing.T) {
 	require.NoError(t, err)
 
 	tt := trie.NewEmptyTrie()
-	tt.Put([]byte("noot"), []byte("was"))
-	tt.Put([]byte("here"), []byte("??"))
+	tt.Put([]byte("noot"), []byte("was"), inst.StateVersion())
+	tt.Put([]byte("here"), []byte("??"), inst.StateVersion())
 
-	expected := tt.MustHash()
+	expected := tt.MustHash(trie.V0)
 	require.Equal(t, expected[:], hash)
 }
 
 func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	t.Parallel()
+
+	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
+	stateVersion := inst.StateVersion()
 
 	tmp := t.TempDir()
 
@@ -1777,22 +1780,22 @@ func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	require.NoError(t, err)
 
 	otherTrie := trie.NewEmptyTrie()
-	otherTrie.Put([]byte("simple"), []byte("cat"))
+	otherTrie.Put([]byte("simple"), []byte("cat"), stateVersion)
 
-	otherHash, err := otherTrie.Hash()
+	otherHash, err := otherTrie.Hash(trie.V0)
 	require.NoError(t, err)
 
 	tr := trie.NewEmptyTrie()
-	tr.Put([]byte("do"), []byte("verb"))
-	tr.Put([]byte("domain"), []byte("website"))
-	tr.Put([]byte("other"), []byte("random"))
-	tr.Put([]byte("otherwise"), []byte("randomstuff"))
-	tr.Put([]byte("cat"), []byte("another animal"))
+	tr.Put([]byte("do"), []byte("verb"), stateVersion)
+	tr.Put([]byte("domain"), []byte("website"), stateVersion)
+	tr.Put([]byte("other"), []byte("random"), stateVersion)
+	tr.Put([]byte("otherwise"), []byte("randomstuff"), stateVersion)
+	tr.Put([]byte("cat"), []byte("another animal"), stateVersion)
 
 	err = tr.Store(memdb)
 	require.NoError(t, err)
 
-	hash, err := tr.Hash()
+	hash, err := tr.Hash(trie.V0)
 	require.NoError(t, err)
 
 	keys := [][]byte{
@@ -1806,7 +1809,7 @@ func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	root := hash.ToBytes()
 	otherRoot := otherHash.ToBytes()
 
-	allProofs, err := proof.Generate(root, keys, memdb)
+	allProofs, err := proof.Generate(root, keys, memdb, trie.V0)
 	require.NoError(t, err)
 
 	testcases := map[string]struct {
@@ -1829,8 +1832,6 @@ func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 		"Empty proof, should be false": {
 			root: root, key: []byte("do"), proof: [][]byte{}, value: nil, expect: false},
 	}
-
-	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	for name, testcase := range testcases {
 		testcase := testcase

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -200,6 +200,23 @@ func GetRuntimeVersion(code []byte) (version runtime.Version, err error) {
 	return version, nil
 }
 
+// GetRuntimeStateVersion finds the runtime version by initiating a temporary
+// runtime instance using the WASM code provided, and returns its typed
+// state version.
+func GetRuntimeStateVersion(code []byte) (stateVersion trie.Version, err error) {
+	coreVersion, err := GetRuntimeVersion(code)
+	if err != nil {
+		return stateVersion, fmt.Errorf("getting runtime version: %w", err)
+	}
+
+	stateVersion, err = trie.ParseVersion(coreVersion.StateVersion)
+	if err != nil {
+		return stateVersion, fmt.Errorf("parsing state version: %w", err)
+	}
+
+	return stateVersion, nil
+}
+
 var (
 	ErrCodeEmpty      = errors.New("code is empty")
 	ErrWASMDecompress = errors.New("wasm decompression failed")

--- a/lib/runtime/wasmer/instance.go
+++ b/lib/runtime/wasmer/instance.go
@@ -119,6 +119,12 @@ func NewInstance(code []byte, cfg Config) (instance *Instance, err error) {
 		}
 	}
 
+	instance.ctx.StateVersion, err = trie.ParseVersion(instance.ctx.Version.StateVersion)
+	if err != nil {
+		instance.close()
+		return nil, fmt.Errorf("parsing state version: %w", err)
+	}
+
 	wasmInstance.SetContextData(instance.ctx)
 
 	return instance, nil
@@ -175,6 +181,13 @@ func (in *Instance) UpdateRuntimeCode(code []byte) (err error) {
 		return fmt.Errorf("getting instance version: %w", err)
 	}
 	in.ctx.Version = version
+
+	in.ctx.StateVersion, err = trie.ParseVersion(in.ctx.Version.StateVersion)
+	if err != nil {
+		in.close()
+		return fmt.Errorf("parsing state version: %w", err)
+	}
+
 	wasmInstance.SetContextData(in.ctx)
 
 	return nil

--- a/lib/trie/child_storage_test.go
+++ b/lib/trie/child_storage_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestPutAndGetChild(t *testing.T) {
 	childKey := []byte("default")
-	childTrie := buildSmallTrie()
+	childTrie := buildSmallTrie(V0)
 	parentTrie := NewEmptyTrie()
 
-	err := parentTrie.PutChild(childKey, childTrie)
+	err := parentTrie.PutChild(childKey, childTrie, V0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,17 +31,17 @@ func TestPutAndGetChild(t *testing.T) {
 
 func TestPutAndGetFromChild(t *testing.T) {
 	childKey := []byte("default")
-	childTrie := buildSmallTrie()
+	childTrie := buildSmallTrie(V0)
 	parentTrie := NewEmptyTrie()
 
-	err := parentTrie.PutChild(childKey, childTrie)
+	err := parentTrie.PutChild(childKey, childTrie, V0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	testKey := []byte("child_key")
 	testValue := []byte("child_value")
-	err = parentTrie.PutIntoChild(childKey, testKey, testValue)
+	err = parentTrie.PutIntoChild(childKey, testKey, testValue, V0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestPutAndGetFromChild(t *testing.T) {
 
 	testKey = []byte("child_key_again")
 	testValue = []byte("child_value_again")
-	err = parentTrie.PutIntoChild(childKey, testKey, testValue)
+	err = parentTrie.PutIntoChild(childKey, testKey, testValue, V0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/trie/genesis.go
+++ b/lib/trie/genesis.go
@@ -11,8 +11,8 @@ import (
 )
 
 // GenesisBlock creates a genesis block from the trie.
-func (t *Trie) GenesisBlock() (genesisHeader types.Header, err error) {
-	rootHash, err := t.Hash()
+func (t *Trie) GenesisBlock(stateVersion Version) (genesisHeader types.Header, err error) {
+	rootHash, err := t.Hash(stateVersion)
 	if err != nil {
 		return genesisHeader, fmt.Errorf("root hashing trie: %w", err)
 	}

--- a/lib/trie/genesis_test.go
+++ b/lib/trie/genesis_test.go
@@ -22,11 +22,13 @@ func Test_Trie_GenesisBlock(t *testing.T) {
 
 	testCases := map[string]struct {
 		trie          Trie
+		stateVersion  Version
 		genesisHeader types.Header
 		errSentinel   error
 		errMessage    string
 	}{
 		"empty trie": {
+			stateVersion: V0,
 			genesisHeader: withHash(types.Header{
 				ParentHash:     common.Hash{0},
 				StateRoot:      EmptyHash,
@@ -41,6 +43,7 @@ func Test_Trie_GenesisBlock(t *testing.T) {
 					SubValue: []byte{4, 5, 6},
 				},
 			},
+			stateVersion: V0,
 			genesisHeader: withHash(types.Header{
 				ParentHash: common.Hash{0},
 				StateRoot: common.Hash{
@@ -61,7 +64,7 @@ func Test_Trie_GenesisBlock(t *testing.T) {
 
 			trie := testCase.trie
 
-			genesisHeader, err := trie.GenesisBlock()
+			genesisHeader, err := trie.GenesisBlock(testCase.stateVersion)
 
 			assert.ErrorIs(t, err, testCase.errSentinel)
 			if testCase.errSentinel != nil {

--- a/lib/trie/helpers_test.go
+++ b/lib/trie/helpers_test.go
@@ -22,9 +22,10 @@ type writeCall struct {
 var errTest = errors.New("test error")
 
 type keyValues struct {
-	key   []byte
-	value []byte
-	op    int
+	key     []byte
+	value   []byte
+	version Version
+	op      int
 }
 
 // newGenerator creates a new PRNG seeded with the
@@ -99,7 +100,8 @@ func makeSeededTrie(t *testing.T, size int) (
 
 	for keyString, value := range keyValues {
 		key := []byte(keyString)
-		trie.Put(key, value)
+		const version = V0
+		trie.Put(key, value, version)
 	}
 
 	return trie, keyValues

--- a/lib/trie/mem_test.go
+++ b/lib/trie/mem_test.go
@@ -93,7 +93,8 @@ func populateTrieAtPrefix(trie *Trie,
 	for keyString, value := range kv {
 		key := append(prefix, []byte(keyString)...) //skipcq: CRT-D0001
 
-		trie.Put(key, value)
+		const version = V0
+		trie.Put(key, value, version)
 	}
 }
 
@@ -109,6 +110,7 @@ func mutateTrieLeavesAtPrefix(trie *Trie,
 			newValue[i], newValue[j] = newValue[j], newValue[i]
 		}
 
-		trie.Put(key, value)
+		const version = V0
+		trie.Put(key, value, version)
 	}
 }

--- a/lib/trie/proof/generate.go
+++ b/lib/trie/proof/generate.go
@@ -29,10 +29,11 @@ type Database interface {
 // for the trie corresponding to the root hash given, and for
 // the slice of (Little Endian) full keys given. The database given
 // is used to load the trie using the root hash given.
-func Generate(rootHash []byte, fullKeys [][]byte, database Database) (
-	encodedProofNodes [][]byte, err error) {
+func Generate(rootHash []byte, fullKeys [][]byte, database Database,
+	stateVersion trie.Version) (encodedProofNodes [][]byte, err error) {
 	trie := trie.NewEmptyTrie()
-	if err := trie.Load(database, common.BytesToHash(rootHash)); err != nil {
+	err = trie.Load(database, common.BytesToHash(rootHash), stateVersion)
+	if err != nil {
 		return nil, fmt.Errorf("loading trie: %w", err)
 	}
 	rootNode := trie.RootNode()

--- a/lib/trie/proof/proof_test.go
+++ b/lib/trie/proof/proof_test.go
@@ -15,6 +15,8 @@ import (
 func Test_Generate_Verify(t *testing.T) {
 	t.Parallel()
 
+	const version = trie.V0
+
 	keys := []string{
 		"cat",
 		"catapulta",
@@ -23,30 +25,30 @@ func Test_Generate_Verify(t *testing.T) {
 		"doguinho",
 	}
 
-	trie := trie.NewEmptyTrie()
+	testTrie := trie.NewEmptyTrie()
 
 	for i, key := range keys {
 		value := fmt.Sprintf("%x-%d", key, i)
-		trie.Put([]byte(key), []byte(value))
+		testTrie.Put([]byte(key), []byte(value), version)
 	}
 
-	rootHash, err := trie.Hash()
+	rootHash, err := testTrie.Hash(version)
 	require.NoError(t, err)
 
 	database, err := chaindb.NewBadgerDB(&chaindb.Config{
 		InMemory: true,
 	})
 	require.NoError(t, err)
-	err = trie.Store(database)
+	err = testTrie.Store(database)
 	require.NoError(t, err)
 
 	for i, key := range keys {
 		fullKeys := [][]byte{[]byte(key)}
-		proof, err := Generate(rootHash.ToBytes(), fullKeys, database)
+		proof, err := Generate(rootHash.ToBytes(), fullKeys, database, version)
 		require.NoError(t, err)
 
 		expectedValue := fmt.Sprintf("%x-%d", key, i)
-		err = Verify(proof, rootHash.ToBytes(), []byte(key), []byte(expectedValue))
+		err = Verify(proof, rootHash.ToBytes(), []byte(key), []byte(expectedValue), version)
 		require.NoError(t, err)
 	}
 }

--- a/lib/trie/proof/verify.go
+++ b/lib/trie/proof/verify.go
@@ -25,7 +25,8 @@ var (
 // A nil error is returned on success.
 // Note this is exported because it is imported and used by:
 // https://github.com/ComposableFi/ibc-go/blob/6d62edaa1a3cb0768c430dab81bb195e0b0c72db/modules/light-clients/11-beefy/types/client_state.go#L78
-func Verify(encodedProofNodes [][]byte, rootHash, key, value []byte) (err error) {
+func Verify(encodedProofNodes [][]byte, rootHash, key, value []byte,
+	stateVersion trie.Version) (err error) {
 	proofTrie, err := buildTrie(encodedProofNodes, rootHash)
 	if err != nil {
 		return fmt.Errorf("building trie from proof encoded nodes: %w", err)

--- a/lib/trie/proof/verify.go
+++ b/lib/trie/proof/verify.go
@@ -18,6 +18,7 @@ import (
 var (
 	ErrKeyNotFoundInProofTrie = errors.New("key not found in proof trie")
 	ErrValueMismatchProofTrie = errors.New("value found in proof trie does not match")
+	ErrVersionNotSupported    = errors.New("version not supported")
 )
 
 // Verify verifies a given key and value belongs to the trie by creating
@@ -27,6 +28,10 @@ var (
 // https://github.com/ComposableFi/ibc-go/blob/6d62edaa1a3cb0768c430dab81bb195e0b0c72db/modules/light-clients/11-beefy/types/client_state.go#L78
 func Verify(encodedProofNodes [][]byte, rootHash, key, value []byte,
 	stateVersion trie.Version) (err error) {
+	if stateVersion != trie.V0 {
+		return fmt.Errorf("%w: %d", ErrVersionNotSupported, stateVersion)
+	}
+
 	proofTrie, err := buildTrie(encodedProofNodes, rootHash)
 	if err != nil {
 		return fmt.Errorf("building trie from proof encoded nodes: %w", err)

--- a/lib/trie/proof/verify_test.go
+++ b/lib/trie/proof/verify_test.go
@@ -44,6 +44,7 @@ func Test_Verify(t *testing.T) {
 		rootHash          []byte
 		keyLE             []byte
 		value             []byte
+		version           trie.Version
 		errWrapped        error
 		errMessage        string
 	}{
@@ -61,6 +62,7 @@ func Test_Verify(t *testing.T) {
 			},
 			rootHash:   blake2bNode(t, branch),
 			keyLE:      []byte{1, 1}, // nil child of branch
+			version:    trie.V0,
 			errWrapped: ErrKeyNotFoundInProofTrie,
 			errMessage: "key not found in proof trie: " +
 				"0x0101 in proof trie for root hash " +
@@ -74,6 +76,7 @@ func Test_Verify(t *testing.T) {
 			},
 			rootHash: blake2bNode(t, branch),
 			keyLE:    []byte{0x34, 0x21}, // inlined short leaf of branch
+			version:  trie.V0,
 		},
 		"key found with mismatching value": {
 			encodedProofNodes: [][]byte{
@@ -84,6 +87,7 @@ func Test_Verify(t *testing.T) {
 			rootHash:   blake2bNode(t, branch),
 			keyLE:      []byte{0x34, 0x21}, // inlined short leaf of branch
 			value:      []byte{2},
+			version:    trie.V0,
 			errWrapped: ErrValueMismatchProofTrie,
 			errMessage: "value found in proof trie does not match: " +
 				"expected value 0x02 but got value 0x01 from proof trie",
@@ -97,6 +101,7 @@ func Test_Verify(t *testing.T) {
 			rootHash: blake2bNode(t, branch),
 			keyLE:    []byte{0x34, 0x32}, // large hash-referenced leaf of branch
 			value:    generateBytes(t, 40),
+			version:  trie.V0,
 		},
 	}
 
@@ -105,7 +110,8 @@ func Test_Verify(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			err := Verify(testCase.encodedProofNodes, testCase.rootHash, testCase.keyLE, testCase.value)
+			err := Verify(testCase.encodedProofNodes, testCase.rootHash,
+				testCase.keyLE, testCase.value, testCase.version)
 
 			assert.ErrorIs(t, err, testCase.errWrapped)
 			if testCase.errWrapped != nil {

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -155,7 +155,8 @@ func (t *Trie) RootNode() *Node {
 }
 
 // encodeRoot writes the encoding of the root node to the buffer.
-func encodeRoot(root *Node, buffer node.Buffer) (err error) {
+func encodeRoot(root *Node, version Version, buffer node.Buffer) (err error) {
+	enforceValidVersion(version)
 	if root == nil {
 		_, err = buffer.Write([]byte{0})
 		if err != nil {
@@ -183,7 +184,7 @@ func (t *Trie) Hash(version Version) (rootHash common.Hash, err error) {
 	buffer.Reset()
 	defer pools.EncodingBuffers.Put(buffer)
 
-	err = encodeRoot(t.root, buffer)
+	err = encodeRoot(t.root, version, buffer)
 	if err != nil {
 		return [32]byte{}, err
 	}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -13,8 +13,9 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
-// EmptyHash is the empty trie hash.
-var EmptyHash, _ = NewEmptyTrie().Hash()
+// EmptyHash is the empty trie hash, which is the same for
+// both the V0 and V1 state trie versions
+var EmptyHash, _ = NewEmptyTrie().Hash(V0)
 
 // Trie is a base 16 modified Merkle Patricia trie.
 type Trie struct {
@@ -167,8 +168,8 @@ func encodeRoot(root *Node, buffer node.Buffer) (err error) {
 
 // MustHash returns the hashed root of the trie.
 // It panics if it fails to hash the root node.
-func (t *Trie) MustHash() common.Hash {
-	h, err := t.Hash()
+func (t *Trie) MustHash(version Version) common.Hash {
+	h, err := t.Hash(version)
 	if err != nil {
 		panic(err)
 	}
@@ -177,7 +178,7 @@ func (t *Trie) MustHash() common.Hash {
 }
 
 // Hash returns the hashed root of the trie.
-func (t *Trie) Hash() (rootHash common.Hash, err error) {
+func (t *Trie) Hash(version Version) (rootHash common.Hash, err error) {
 	buffer := pools.EncodingBuffers.Get().(*bytes.Buffer)
 	buffer.Reset()
 	defer pools.EncodingBuffers.Put(buffer)
@@ -317,14 +318,15 @@ func findNextKeyChild(children []*Node, startIndex byte,
 
 // Put inserts a value into the trie at the
 // key specified in little Endian format.
-func (t *Trie) Put(keyLE, value []byte) {
+func (t *Trie) Put(keyLE, value []byte, version Version) {
 	nibblesKey := codec.KeyLEToNibbles(keyLE)
-	t.root, _ = t.insert(t.root, nibblesKey, value)
+	t.root, _ = t.insert(t.root, nibblesKey, value, version)
 }
 
 // insert inserts a value in the trie at the key specified.
 // It may create one or more new nodes or update an existing node.
-func (t *Trie) insert(parent *Node, key, value []byte) (newParent *Node, nodesCreated uint32) {
+func (t *Trie) insert(parent *Node, key, value []byte, version Version) (
+	newParent *Node, nodesCreated uint32) {
 	if parent == nil {
 		const nodesCreated = 1
 		return &Node{
@@ -338,13 +340,14 @@ func (t *Trie) insert(parent *Node, key, value []byte) (newParent *Node, nodesCr
 	// TODO ensure all values have dirty set to true
 
 	if parent.Kind() == node.Branch {
-		return t.insertInBranch(parent, key, value)
+		return t.insertInBranch(parent, key, value, version)
 	}
-	return t.insertInLeaf(parent, key, value)
+	return t.insertInLeaf(parent, key, value, version)
 }
 
-func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte) (
+func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte, version Version) (
 	newParent *Node, nodesCreated uint32) {
+	enforceValidVersion(version)
 	if bytes.Equal(parentLeaf.Key, key) {
 		nodesCreated = 0
 		if bytes.Equal(value, parentLeaf.SubValue) {
@@ -413,8 +416,9 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte) (
 	return newBranchParent, nodesCreated
 }
 
-func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte) (
+func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte, version Version) (
 	newParent *Node, nodesCreated uint32) {
+	enforceValidVersion(version)
 	copySettings := node.DefaultCopySettings
 	parentBranch = t.prepBranchForMutation(parentBranch, copySettings)
 
@@ -439,7 +443,7 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte) (
 			}
 			nodesCreated = 1
 		} else {
-			child, nodesCreated = t.insert(child, remainingKey, value)
+			child, nodesCreated = t.insert(child, remainingKey, value, version)
 		}
 
 		parentBranch.Children[childIndex] = child
@@ -471,7 +475,7 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte) (
 		childIndex := key[commonPrefixLength]
 		remainingKey := key[commonPrefixLength+1:]
 		var additionalNodesCreated uint32
-		newParentBranch.Children[childIndex], additionalNodesCreated = t.insert(nil, remainingKey, value)
+		newParentBranch.Children[childIndex], additionalNodesCreated = t.insert(nil, remainingKey, value, version)
 		nodesCreated += additionalNodesCreated
 		newParentBranch.Descendants += additionalNodesCreated
 	}
@@ -482,7 +486,7 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte) (
 // LoadFromMap loads the given data mapping of key to value into the trie.
 // The keys are in hexadecimal little Endian encoding and the values
 // are hexadecimal encoded.
-func (t *Trie) LoadFromMap(data map[string]string) (err error) {
+func (t *Trie) LoadFromMap(data map[string]string, version Version) (err error) {
 	for key, value := range data {
 		keyLEBytes, err := common.HexToBytes(key)
 		if err != nil {
@@ -494,7 +498,7 @@ func (t *Trie) LoadFromMap(data map[string]string) (err error) {
 			return fmt.Errorf("cannot convert value hex to bytes: %w", err)
 		}
 
-		t.Put(keyLEBytes, valueBytes)
+		t.Put(keyLEBytes, valueBytes, version)
 	}
 
 	return nil

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -27,7 +27,7 @@ const (
 	getLeaf
 )
 
-func buildSmallTrie() *Trie {
+func buildSmallTrie(version Version) *Trie { //nolint:unparam
 	trie := NewEmptyTrie()
 
 	tests := []keyValues{
@@ -40,7 +40,7 @@ func buildSmallTrie() *Trie {
 	}
 
 	for _, test := range tests {
-		trie.Put(test.key, test.value)
+		trie.Put(test.key, test.value, version)
 	}
 
 	return trie
@@ -50,7 +50,7 @@ func runTests(t *testing.T, trie *Trie, tests []keyValues) {
 	for _, test := range tests {
 		switch test.op {
 		case put:
-			trie.Put(test.key, test.value)
+			trie.Put(test.key, test.value, test.version)
 		case get:
 			val := trie.Get(test.key)
 			assert.Equal(t, test.value, val)
@@ -67,16 +67,16 @@ func TestPutAndGetBranch(t *testing.T) {
 	trie := NewEmptyTrie()
 
 	tests := []keyValues{
-		{key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: put},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: put},
-		{key: []byte{0x07}, value: []byte("ramen"), op: put},
-		{key: []byte{0xf2}, value: []byte("pho"), op: put},
-		{key: []byte("noot"), value: nil, op: get},
-		{key: []byte{0}, value: nil, op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: get},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: get},
-		{key: []byte{0x07}, value: []byte("ramen"), op: get},
-		{key: []byte{0xf2}, value: []byte("pho"), op: get},
+		{version: V0, key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: put},
+		{version: V0, key: []byte{0x07}, value: []byte("ramen"), op: put},
+		{version: V0, key: []byte{0xf2}, value: []byte("pho"), op: put},
+		{version: V0, key: []byte("noot"), value: nil, op: get},
+		{version: V0, key: []byte{0}, value: nil, op: get},
+		{version: V0, key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: get},
+		{version: V0, key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: get},
+		{version: V0, key: []byte{0x07}, value: []byte("ramen"), op: get},
+		{version: V0, key: []byte{0xf2}, value: []byte("pho"), op: get},
 	}
 
 	runTests(t, trie, tests)
@@ -86,28 +86,29 @@ func TestPutAndGetOddKeyLengths(t *testing.T) {
 	trie := NewEmptyTrie()
 
 	tests := []keyValues{
-		{key: []byte{0x43, 0xc1}, value: []byte("noot"), op: put},
-		{key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: put},
-		{key: []byte{0x43, 0x0c}, value: []byte("odd"), op: put},
-		{key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: put},
-		{key: []byte{0x4f, 0xbc}, value: []byte("stuffagain"), op: put},
-		{key: []byte{0x43, 0xc1}, value: []byte("noot"), op: get},
-		{key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: get},
-		{key: []byte{0x43, 0x0c}, value: []byte("odd"), op: get},
-		{key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: get},
-		{key: []byte{0x4f, 0xbc}, value: []byte("stuffagain"), op: get},
+		{version: V0, key: []byte{0x43, 0xc1}, value: []byte("noot"), op: put},
+		{version: V0, key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: put},
+		{version: V0, key: []byte{0x43, 0x0c}, value: []byte("odd"), op: put},
+		{version: V0, key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: put},
+		{version: V0, key: []byte{0x4f, 0xbc}, value: []byte("stuffagain"), op: put},
+		{version: V0, key: []byte{0x43, 0xc1}, value: []byte("noot"), op: get},
+		{version: V0, key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: get},
+		{version: V0, key: []byte{0x43, 0x0c}, value: []byte("odd"), op: get},
+		{version: V0, key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: get},
+		{version: V0, key: []byte{0x4f, 0xbc}, value: []byte("stuffagain"), op: get},
 	}
 
 	runTests(t, trie, tests)
 }
 
 func Fuzz_Trie_PutAndGet(f *testing.F) {
+	const stateVersion = V0
 	trie := NewEmptyTrie()
 	var trieMutex sync.Mutex
 
 	f.Fuzz(func(t *testing.T, key, value []byte) {
 		trieMutex.Lock()
-		trie.Put(key, value)
+		trie.Put(key, value, stateVersion)
 		retrievedValue := trie.Get(key)
 		trieMutex.Unlock()
 		assert.Equal(t, retrievedValue, value)
@@ -118,79 +119,81 @@ func TestGetPartialKey(t *testing.T) {
 	trie := NewEmptyTrie()
 
 	tests := []keyValues{
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: put},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: put},
-		{key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: put},
-		{key: []byte{}, value: []byte("floof"), op: put},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: getLeaf},
-		{key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: del},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: getLeaf},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: getLeaf},
-		{key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: put},
-		{key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: getLeaf},
-		{key: []byte{0xf2}, value: []byte("pen"), op: put},
-		{key: []byte{0x09, 0xd3}, value: []byte("noot"), op: put},
-		{key: []byte{}, value: []byte("floof"), op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: getLeaf},
-		{key: []byte{0xf2}, value: []byte("pen"), op: getLeaf},
-		{key: []byte{0x09, 0xd3}, value: []byte("noot"), op: getLeaf},
+		{version: V0, key: []byte{0x01, 0x35}, value: []byte("pen"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: put},
+		{version: V0, key: []byte{}, value: []byte("floof"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: getLeaf},
+		{version: V0, key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: del},
+		{version: V0, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: getLeaf},
+		{version: V0, key: []byte{0x01, 0x35}, value: []byte("pen"), op: getLeaf},
+		{version: V0, key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: getLeaf},
+		{version: V0, key: []byte{0xf2}, value: []byte("pen"), op: put},
+		{version: V0, key: []byte{0x09, 0xd3}, value: []byte("noot"), op: put},
+		{version: V0, key: []byte{}, value: []byte("floof"), op: get},
+		{version: V0, key: []byte{0x01, 0x35}, value: []byte("pen"), op: getLeaf},
+		{version: V0, key: []byte{0xf2}, value: []byte("pen"), op: getLeaf},
+		{version: V0, key: []byte{0x09, 0xd3}, value: []byte("noot"), op: getLeaf},
 	}
 
 	runTests(t, trie, tests)
 }
 
 func TestDeleteSmall(t *testing.T) {
-	trie := buildSmallTrie()
+	const stateVersion = V0
+	trie := buildSmallTrie(stateVersion)
 
 	tests := []keyValues{
-		{key: []byte{}, value: []byte("floof"), op: del},
-		{key: []byte{}, value: nil, op: get},
-		{key: []byte{}, value: []byte("floof"), op: put},
+		{version: stateVersion, key: []byte{}, value: []byte("floof"), op: del},
+		{version: stateVersion, key: []byte{}, value: nil, op: get},
+		{version: stateVersion, key: []byte{}, value: []byte("floof"), op: put},
 
-		{key: []byte{0x09, 0xd3}, value: []byte("noot"), op: del},
-		{key: []byte{0x09, 0xd3}, value: nil, op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
-		{key: []byte{0x09, 0xd3}, value: []byte("noot"), op: put},
+		{version: stateVersion, key: []byte{0x09, 0xd3}, value: []byte("noot"), op: del},
+		{version: stateVersion, key: []byte{0x09, 0xd3}, value: nil, op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
+		{version: stateVersion, key: []byte{0x09, 0xd3}, value: []byte("noot"), op: put},
 
-		{key: []byte{0xf2}, value: []byte("feather"), op: del},
-		{key: []byte{0xf2}, value: nil, op: get},
-		{key: []byte{0xf2}, value: []byte("feather"), op: put},
+		{version: stateVersion, key: []byte{0xf2}, value: []byte("feather"), op: del},
+		{version: stateVersion, key: []byte{0xf2}, value: nil, op: get},
+		{version: stateVersion, key: []byte{0xf2}, value: []byte("feather"), op: put},
 
-		{key: []byte{}, value: []byte("floof"), op: del},
-		{key: []byte{0xf2}, value: []byte("feather"), op: del},
-		{key: []byte{}, value: nil, op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
-		{key: []byte{}, value: []byte("floof"), op: put},
-		{key: []byte{0xf2}, value: []byte("feather"), op: put},
+		{version: stateVersion, key: []byte{}, value: []byte("floof"), op: del},
+		{version: stateVersion, key: []byte{0xf2}, value: []byte("feather"), op: del},
+		{version: stateVersion, key: []byte{}, value: nil, op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
+		{version: stateVersion, key: []byte{}, value: []byte("floof"), op: put},
+		{version: stateVersion, key: []byte{0xf2}, value: []byte("feather"), op: put},
 
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: del},
-		{key: []byte{0x01, 0x35, 0x79}, value: nil, op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: put},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: del},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: nil, op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: put},
 
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: del},
-		{key: []byte{0x01, 0x35}, value: nil, op: get},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: put},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: []byte("pen"), op: del},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: nil, op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: []byte("pen"), op: put},
 
-		{key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: del},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
-		{key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x07}, value: []byte("odd"), op: del},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35}, value: []byte("pen"), op: get},
 	}
 
 	runTests(t, trie, tests)
 }
 
 func TestDeleteCombineBranch(t *testing.T) {
-	trie := buildSmallTrie()
+	const stateVersion = V0
+	trie := buildSmallTrie(stateVersion)
 
 	tests := []keyValues{
-		{key: []byte{0x01, 0x35, 0x46}, value: []byte("raccoon"), op: put},
-		{key: []byte{0x01, 0x35, 0x46, 0x77}, value: []byte("rat"), op: put},
-		{key: []byte{0x09, 0xd3}, value: []byte("noot"), op: del},
-		{key: []byte{0x09, 0xd3}, value: nil, op: get},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x46}, value: []byte("raccoon"), op: put},
+		{version: stateVersion, key: []byte{0x01, 0x35, 0x46, 0x77}, value: []byte("rat"), op: put},
+		{version: stateVersion, key: []byte{0x09, 0xd3}, value: []byte("noot"), op: del},
+		{version: stateVersion, key: []byte{0x09, 0xd3}, value: nil, op: get},
 	}
 
 	runTests(t, trie, tests)
@@ -200,22 +203,22 @@ func TestDeleteFromBranch(t *testing.T) {
 	trie := NewEmptyTrie()
 
 	tests := []keyValues{
-		{key: []byte{0x06, 0x15, 0xfc}, value: []byte("noot"), op: put},
-		{key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: put},
-		{key: []byte{0x06, 0xaf, 0xb1}, value: []byte("odd"), op: put},
-		{key: []byte{0x06, 0xa3, 0xff}, value: []byte("stuff"), op: put},
-		{key: []byte{0x43, 0x21}, value: []byte("stuffagain"), op: put},
-		{key: []byte{0x06, 0x15, 0xfc}, value: []byte("noot"), op: get},
-		{key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
-		{key: []byte{0x06, 0x15, 0xfc}, value: []byte("noot"), op: del},
-		{key: []byte{0x06, 0x15, 0xfc}, value: nil, op: get},
-		{key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
-		{key: []byte{0x06, 0xaf, 0xb1}, value: []byte("odd"), op: get},
-		{key: []byte{0x06, 0xaf, 0xb1}, value: []byte("odd"), op: del},
-		{key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
-		{key: []byte{0x06, 0xa3, 0xff}, value: []byte("stuff"), op: get},
-		{key: []byte{0x06, 0xa3, 0xff}, value: []byte("stuff"), op: del},
-		{key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
+		{version: V0, key: []byte{0x06, 0x15, 0xfc}, value: []byte("noot"), op: put},
+		{version: V0, key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: put},
+		{version: V0, key: []byte{0x06, 0xaf, 0xb1}, value: []byte("odd"), op: put},
+		{version: V0, key: []byte{0x06, 0xa3, 0xff}, value: []byte("stuff"), op: put},
+		{version: V0, key: []byte{0x43, 0x21}, value: []byte("stuffagain"), op: put},
+		{version: V0, key: []byte{0x06, 0x15, 0xfc}, value: []byte("noot"), op: get},
+		{version: V0, key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
+		{version: V0, key: []byte{0x06, 0x15, 0xfc}, value: []byte("noot"), op: del},
+		{version: V0, key: []byte{0x06, 0x15, 0xfc}, value: nil, op: get},
+		{version: V0, key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
+		{version: V0, key: []byte{0x06, 0xaf, 0xb1}, value: []byte("odd"), op: get},
+		{version: V0, key: []byte{0x06, 0xaf, 0xb1}, value: []byte("odd"), op: del},
+		{version: V0, key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
+		{version: V0, key: []byte{0x06, 0xa3, 0xff}, value: []byte("stuff"), op: get},
+		{version: V0, key: []byte{0x06, 0xa3, 0xff}, value: []byte("stuff"), op: del},
+		{version: V0, key: []byte{0x06, 0x2b, 0xa9}, value: []byte("nootagain"), op: get},
 	}
 
 	runTests(t, trie, tests)
@@ -225,20 +228,20 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 	trie := NewEmptyTrie()
 
 	tests := []keyValues{
-		{key: []byte{0x43, 0xc1}, value: []byte("noot"), op: put},
-		{key: []byte{0x43, 0xc1}, value: []byte("noot"), op: get},
-		{key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: put},
-		{key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: get},
-		{key: []byte{0x43, 0x0c}, value: []byte("odd"), op: put},
-		{key: []byte{0x43, 0x0c}, value: []byte("odd"), op: get},
-		{key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: put},
-		{key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: get},
-		{key: []byte{0x43, 0x0c}, value: []byte("odd"), op: del},
-		{key: []byte{0x43, 0x0c}, value: nil, op: get},
-		{key: []byte{0xf4, 0xbc}, value: []byte("spaghetti"), op: put},
-		{key: []byte{0xf4, 0xbc}, value: []byte("spaghetti"), op: get},
-		{key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: get},
-		{key: []byte{0x43, 0xc1}, value: []byte("noot"), op: get},
+		{version: V0, key: []byte{0x43, 0xc1}, value: []byte("noot"), op: put},
+		{version: V0, key: []byte{0x43, 0xc1}, value: []byte("noot"), op: get},
+		{version: V0, key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: put},
+		{version: V0, key: []byte{0x49, 0x29}, value: []byte("nootagain"), op: get},
+		{version: V0, key: []byte{0x43, 0x0c}, value: []byte("odd"), op: put},
+		{version: V0, key: []byte{0x43, 0x0c}, value: []byte("odd"), op: get},
+		{version: V0, key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: put},
+		{version: V0, key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: get},
+		{version: V0, key: []byte{0x43, 0x0c}, value: []byte("odd"), op: del},
+		{version: V0, key: []byte{0x43, 0x0c}, value: nil, op: get},
+		{version: V0, key: []byte{0xf4, 0xbc}, value: []byte("spaghetti"), op: put},
+		{version: V0, key: []byte{0xf4, 0xbc}, value: []byte("spaghetti"), op: get},
+		{version: V0, key: []byte{0x4f, 0x4d}, value: []byte("stuff"), op: get},
+		{version: V0, key: []byte{0x43, 0xc1}, value: []byte("noot"), op: get},
 	}
 
 	runTests(t, trie, tests)
@@ -268,13 +271,13 @@ func TestTrieDiff(t *testing.T) {
 	var testKey = []byte("testKey")
 
 	tests := []keyValues{
-		{key: testKey, value: testKey},
-		{key: []byte("testKey1"), value: []byte("testKey1")},
-		{key: []byte("testKey2"), value: []byte("testKey2")},
+		{version: V0, key: testKey, value: testKey},
+		{version: V0, key: []byte("testKey1"), value: []byte("testKey1")},
+		{version: V0, key: []byte("testKey2"), value: []byte("testKey2")},
 	}
 
 	for _, test := range tests {
-		trie.Put(test.key, test.value)
+		trie.Put(test.key, test.value, test.version)
 	}
 
 	newTrie := trie.Snapshot()
@@ -282,15 +285,15 @@ func TestTrieDiff(t *testing.T) {
 	require.NoError(t, err)
 
 	tests = []keyValues{
-		{key: testKey, value: []byte("newTestKey2")},
-		{key: []byte("testKey2"), value: []byte("newKey")},
-		{key: []byte("testKey3"), value: []byte("testKey3")},
-		{key: []byte("testKey4"), value: []byte("testKey2")},
-		{key: []byte("testKey5"), value: []byte("testKey5")},
+		{version: V0, key: testKey, value: []byte("newTestKey2")},
+		{version: V0, key: []byte("testKey2"), value: []byte("newKey")},
+		{version: V0, key: []byte("testKey3"), value: []byte("testKey3")},
+		{version: V0, key: []byte("testKey4"), value: []byte("testKey2")},
+		{version: V0, key: []byte("testKey5"), value: []byte("testKey5")},
 	}
 
 	for _, test := range tests {
-		newTrie.Put(test.key, test.value)
+		newTrie.Put(test.key, test.value, test.version)
 	}
 	deletedMerkleValues := newTrie.deletedMerkleValues
 	require.Len(t, deletedMerkleValues, 3)
@@ -304,7 +307,9 @@ func TestTrieDiff(t *testing.T) {
 	}
 
 	dbTrie := NewEmptyTrie()
-	err = dbTrie.Load(storageDB, common.BytesToHash(newTrie.root.MerkleValue))
+	err = dbTrie.Load(storageDB,
+		common.BytesToHash(newTrie.root.MerkleValue),
+		V0)
 	require.NoError(t, err)
 }
 
@@ -316,8 +321,9 @@ func TestDelete(t *testing.T) {
 	kv := generateKeyValues(t, generator, kvSize)
 
 	for keyString, value := range kv {
+		const stateVersion = V0
 		key := []byte(keyString)
-		trie.Put(key, value)
+		trie.Put(key, value, stateVersion)
 	}
 
 	dcTrie := trie.DeepCopy()
@@ -326,13 +332,13 @@ func TestDelete(t *testing.T) {
 	ssTrie := trie.Snapshot()
 
 	// Get the Trie root hash for all the 3 tries.
-	tHash, err := trie.Hash()
+	tHash, err := trie.Hash(V0)
 	require.NoError(t, err)
 
-	dcTrieHash, err := dcTrie.Hash()
+	dcTrieHash, err := dcTrie.Hash(V0)
 	require.NoError(t, err)
 
-	ssTrieHash, err := ssTrie.Hash()
+	ssTrieHash, err := ssTrie.Hash(V0)
 	require.NoError(t, err)
 
 	// Root hash for all the 3 tries should be equal.
@@ -353,13 +359,13 @@ func TestDelete(t *testing.T) {
 	}
 
 	// Get the updated root hash of all tries.
-	tHash, err = trie.Hash()
+	tHash, err = trie.Hash(V0)
 	require.NoError(t, err)
 
-	dcTrieHash, err = dcTrie.Hash()
+	dcTrieHash, err = dcTrie.Hash(V0)
 	require.NoError(t, err)
 
-	ssTrieHash, err = ssTrie.Hash()
+	ssTrieHash, err = ssTrie.Hash(V0)
 	require.NoError(t, err)
 
 	// Only the current trie should have a different root hash since it is updated.
@@ -369,15 +375,15 @@ func TestDelete(t *testing.T) {
 
 func TestClearPrefix(t *testing.T) {
 	tests := []keyValues{
-		{key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: put},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: put},
-		{key: []byte{0x01, 0x35, 0x79, 0xab}, value: []byte("spaghetti"), op: put},
-		{key: []byte{0x01, 0x35, 0x79, 0xab, 0x9}, value: []byte("gnocchi"), op: put},
-		{key: []byte{0x07, 0x3a}, value: []byte("ramen"), op: put},
-		{key: []byte{0x07, 0x3b}, value: []byte("noodles"), op: put},
-		{key: []byte{0xf2}, value: []byte("pho"), op: put},
-		{key: []byte{0xff, 0xee, 0xdd, 0xcc, 0xbb, 0x11}, value: []byte("asd"), op: put},
-		{key: []byte{0xff, 0xee, 0xdd, 0xcc, 0xaa, 0x11}, value: []byte("fgh"), op: put},
+		{version: V0, key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x79, 0xab}, value: []byte("spaghetti"), op: put},
+		{version: V0, key: []byte{0x01, 0x35, 0x79, 0xab, 0x9}, value: []byte("gnocchi"), op: put},
+		{version: V0, key: []byte{0x07, 0x3a}, value: []byte("ramen"), op: put},
+		{version: V0, key: []byte{0x07, 0x3b}, value: []byte("noodles"), op: put},
+		{version: V0, key: []byte{0xf2}, value: []byte("pho"), op: put},
+		{version: V0, key: []byte{0xff, 0xee, 0xdd, 0xcc, 0xbb, 0x11}, value: []byte("asd"), op: put},
+		{version: V0, key: []byte{0xff, 0xee, 0xdd, 0xcc, 0xaa, 0x11}, value: []byte("fgh"), op: put},
 	}
 
 	// prefix to clear cases
@@ -400,7 +406,7 @@ func TestClearPrefix(t *testing.T) {
 		trie := NewEmptyTrie()
 
 		for _, test := range tests {
-			trie.Put(test.key, test.value)
+			trie.Put(test.key, test.value, test.version)
 		}
 
 		dcTrie := trie.DeepCopy()
@@ -409,13 +415,13 @@ func TestClearPrefix(t *testing.T) {
 		ssTrie := trie.Snapshot()
 
 		// Get the Trie root hash for all the 3 tries.
-		tHash, err := trie.Hash()
+		tHash, err := trie.Hash(V0)
 		require.NoError(t, err)
 
-		dcTrieHash, err := dcTrie.Hash()
+		dcTrieHash, err := dcTrie.Hash(V0)
 		require.NoError(t, err)
 
-		ssTrieHash, err := ssTrie.Hash()
+		ssTrieHash, err := ssTrie.Hash(V0)
 		require.NoError(t, err)
 
 		// Root hash for all the 3 tries should be equal.
@@ -441,13 +447,13 @@ func TestClearPrefix(t *testing.T) {
 		}
 
 		// Get the updated root hash of all tries.
-		tHash, err = trie.Hash()
+		tHash, err = trie.Hash(V0)
 		require.NoError(t, err)
 
-		dcTrieHash, err = dcTrie.Hash()
+		dcTrieHash, err = dcTrie.Hash(V0)
 		require.NoError(t, err)
 
-		ssTrieHash, err = ssTrie.Hash()
+		ssTrieHash, err = ssTrie.Hash(V0)
 		require.NoError(t, err)
 
 		// Only the current trie should have a different root hash since it is updated.
@@ -466,13 +472,13 @@ func TestClearPrefix_Small(t *testing.T) {
 	ssTrie := trie.Snapshot()
 
 	// Get the Trie root hash for all the 3 tries.
-	tHash, err := trie.Hash()
+	tHash, err := trie.Hash(V0)
 	require.NoError(t, err)
 
-	dcTrieHash, err := dcTrie.Hash()
+	dcTrieHash, err := dcTrie.Hash(V0)
 	require.NoError(t, err)
 
-	ssTrieHash, err := ssTrie.Hash()
+	ssTrieHash, err := ssTrie.Hash(V0)
 	require.NoError(t, err)
 
 	// Root hash for all the 3 tries should be equal.
@@ -485,7 +491,8 @@ func TestClearPrefix_Small(t *testing.T) {
 		"other",
 	}
 	for _, key := range keys {
-		ssTrie.Put([]byte(key), []byte(key))
+		const stateVersion = V0
+		ssTrie.Put([]byte(key), []byte(key), stateVersion)
 	}
 
 	ssTrie.ClearPrefix([]byte("noo"))
@@ -499,13 +506,13 @@ func TestClearPrefix_Small(t *testing.T) {
 	require.Equal(t, expectedRoot, ssTrie.root)
 
 	// Get the updated root hash of all tries.
-	tHash, err = trie.Hash()
+	tHash, err = trie.Hash(V0)
 	require.NoError(t, err)
 
-	dcTrieHash, err = dcTrie.Hash()
+	dcTrieHash, err = dcTrie.Hash(V0)
 	require.NoError(t, err)
 
-	ssTrieHash, err = ssTrie.Hash()
+	ssTrieHash, err = ssTrie.Hash(V0)
 	require.NoError(t, err)
 
 	require.Equal(t, tHash, dcTrieHash)
@@ -531,32 +538,32 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 
 	cases := [][]keyValues{
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g")},
-			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h")},
-			{key: []byte{0xf2}, value: []byte("feather")},
-			{key: []byte{0xf2, 0x3}, value: []byte("f")},
-			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-			{key: []byte{0x07}, value: []byte("ramen")},
-			{key: []byte{0}, value: nil},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), version: V0},
+			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g"), version: V0},
+			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h"), version: V0},
+			{key: []byte{0xf2}, value: []byte("feather"), version: V0},
+			{key: []byte{0xf2, 0x3}, value: []byte("f"), version: V0},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot"), version: V0},
+			{key: []byte{0x07}, value: []byte("ramen"), version: V0},
+			{key: []byte{0}, value: nil, version: V0},
 		},
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g")},
-			{key: []byte{0xf2}, value: []byte("feather")},
-			{key: []byte{0xf2, 0x30}, value: []byte("f")},
-			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-			{key: []byte{0x07}, value: []byte("ramen")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), version: V0},
+			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g"), version: V0},
+			{key: []byte{0xf2}, value: []byte("feather"), version: V0},
+			{key: []byte{0xf2, 0x30}, value: []byte("f"), version: V0},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot"), version: V0},
+			{key: []byte{0x07}, value: []byte("ramen"), version: V0},
 		},
 		{
-			{key: []byte("asdf"), value: []byte("asdf")},
-			{key: []byte("ghjk"), value: []byte("ghjk")},
-			{key: []byte("qwerty"), value: []byte("qwerty")},
-			{key: []byte("uiopl"), value: []byte("uiopl")},
-			{key: []byte("zxcv"), value: []byte("zxcv")},
-			{key: []byte("bnm"), value: []byte("bnm")},
+			{key: []byte("asdf"), value: []byte("asdf"), version: V0},
+			{key: []byte("ghjk"), value: []byte("ghjk"), version: V0},
+			{key: []byte("qwerty"), value: []byte("qwerty"), version: V0},
+			{key: []byte("uiopl"), value: []byte("uiopl"), version: V0},
+			{key: []byte("zxcv"), value: []byte("zxcv"), version: V0},
+			{key: []byte("bnm"), value: []byte("bnm"), version: V0},
 		},
 	}
 
@@ -566,8 +573,8 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 			trieClearPrefix := NewEmptyTrie()
 
 			for _, test := range testCase {
-				trieDelete.Put(test.key, test.value)
-				trieClearPrefix.Put(test.key, test.value)
+				trieDelete.Put(test.key, test.value, test.version)
+				trieClearPrefix.Put(test.key, test.value, test.version)
 			}
 
 			prefixedKeys := trieDelete.GetKeysWithPrefix(prefix)
@@ -577,25 +584,25 @@ func TestTrie_ClearPrefixVsDelete(t *testing.T) {
 
 			trieClearPrefix.ClearPrefix(prefix)
 
-			require.Equal(t, trieClearPrefix.MustHash(), trieDelete.MustHash())
+			require.Equal(t, trieClearPrefix.MustHash(V0), trieDelete.MustHash(V0))
 		}
 	}
 }
 
 func TestSnapshot(t *testing.T) {
 	tests := []keyValues{
-		{key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: put},
-		{key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: put},
-		{key: []byte{0x01, 0x35, 0x79, 0xab}, value: []byte("spaghetti"), op: put},
-		{key: []byte{0x01, 0x35, 0x79, 0xab, 0x9}, value: []byte("gnocchi"), op: put},
-		{key: []byte{0x07, 0x3a}, value: []byte("ramen"), op: put},
-		{key: []byte{0x07, 0x3b}, value: []byte("noodles"), op: put},
-		{key: []byte{0xf2}, value: []byte("pho"), op: put},
+		{key: []byte{0x01, 0x35}, value: []byte("spaghetti"), op: put, version: V0},
+		{key: []byte{0x01, 0x35, 0x79}, value: []byte("gnocchi"), op: put, version: V0},
+		{key: []byte{0x01, 0x35, 0x79, 0xab}, value: []byte("spaghetti"), op: put, version: V0},
+		{key: []byte{0x01, 0x35, 0x79, 0xab, 0x9}, value: []byte("gnocchi"), op: put, version: V0},
+		{key: []byte{0x07, 0x3a}, value: []byte("ramen"), op: put, version: V0},
+		{key: []byte{0x07, 0x3b}, value: []byte("noodles"), op: put, version: V0},
+		{key: []byte{0xf2}, value: []byte("pho"), op: put, version: V0},
 	}
 
 	expectedTrie := NewEmptyTrie()
 	for _, test := range tests {
-		expectedTrie.Put(test.key, test.value)
+		expectedTrie.Put(test.key, test.value, test.version)
 	}
 
 	// put all keys except first
@@ -604,14 +611,14 @@ func TestSnapshot(t *testing.T) {
 		if i == 0 {
 			continue
 		}
-		parentTrie.Put(test.key, test.value)
+		parentTrie.Put(test.key, test.value, test.version)
 	}
 
 	newTrie := parentTrie.Snapshot()
-	newTrie.Put(tests[0].key, tests[0].value)
+	newTrie.Put(tests[0].key, tests[0].value, tests[0].version)
 
-	require.Equal(t, expectedTrie.MustHash(), newTrie.MustHash())
-	require.NotEqual(t, parentTrie.MustHash(), newTrie.MustHash())
+	require.Equal(t, expectedTrie.MustHash(V0), newTrie.MustHash(V0))
+	require.NotEqual(t, parentTrie.MustHash(V0), newTrie.MustHash(V0))
 }
 
 func Test_Trie_NextKey_Random(t *testing.T) {
@@ -635,7 +642,8 @@ func Test_Trie_NextKey_Random(t *testing.T) {
 
 	for _, key := range sortedKeys {
 		value := []byte{1}
-		trie.Put(key, value)
+		const stateVersion = V0
+		trie.Put(key, value, stateVersion)
 	}
 
 	for i, key := range sortedKeys {
@@ -659,11 +667,12 @@ func Benchmark_Trie_Hash(b *testing.B) {
 	trie := NewEmptyTrie()
 	for keyString, value := range kv {
 		key := []byte(keyString)
-		trie.Put(key, value)
+		const stateVersion = V0
+		trie.Put(key, value, stateVersion)
 	}
 
 	b.StartTimer()
-	_, err := trie.Hash()
+	_, err := trie.Hash(V0)
 	b.StopTimer()
 
 	require.NoError(b, err)
@@ -689,9 +698,10 @@ func TestTrie_ConcurrentSnapshotWrites(t *testing.T) {
 	testCases := make([][]keyValues, workers)
 	expectedTries := make([]*Trie, workers)
 
+	const stateVersion = V0
 	for i := 0; i < workers; i++ {
 		testCases[i] = make([]keyValues, size)
-		expectedTries[i] = buildSmallTrie()
+		expectedTries[i] = buildSmallTrie(stateVersion)
 		for j := 0; j < size; j++ {
 			k := make([]byte, 2)
 			_, err := generator.Read(k)
@@ -700,7 +710,7 @@ func TestTrie_ConcurrentSnapshotWrites(t *testing.T) {
 
 			switch op {
 			case put:
-				expectedTries[i].Put(k, k)
+				expectedTries[i].Put(k, k, stateVersion)
 			case del:
 				expectedTries[i].Delete(k)
 			case clearPrefix:
@@ -721,7 +731,7 @@ func TestTrie_ConcurrentSnapshotWrites(t *testing.T) {
 	snapshotedTries := make([]*Trie, workers)
 
 	for i := 0; i < workers; i++ {
-		snapshotedTries[i] = buildSmallTrie().Snapshot()
+		snapshotedTries[i] = buildSmallTrie(stateVersion).Snapshot()
 
 		go func(trie *Trie, operations []keyValues,
 			startWg, finishWg *sync.WaitGroup) {
@@ -731,7 +741,7 @@ func TestTrie_ConcurrentSnapshotWrites(t *testing.T) {
 			for _, operation := range operations {
 				switch operation.op {
 				case put:
-					trie.Put(operation.key, operation.key)
+					trie.Put(operation.key, operation.key, stateVersion)
 				case del:
 					trie.Delete(operation.key)
 				case clearPrefix:
@@ -745,8 +755,8 @@ func TestTrie_ConcurrentSnapshotWrites(t *testing.T) {
 
 	for i := 0; i < workers; i++ {
 		assert.Equal(t,
-			expectedTries[i].MustHash(),
-			snapshotedTries[i].MustHash())
+			expectedTries[i].MustHash(V0),
+			snapshotedTries[i].MustHash(V0))
 	}
 }
 
@@ -768,37 +778,37 @@ func TestTrie_ClearPrefixLimit(t *testing.T) {
 
 	cases := [][]keyValues{
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x36}, value: []byte("pencil")},
-			{key: []byte{0x02}, value: []byte("feather")},
-			{key: []byte{0x03}, value: []byte("birds")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x36}, value: []byte("pencil"), version: V0},
+			{key: []byte{0x02}, value: []byte("feather"), version: V0},
+			{key: []byte{0x03}, value: []byte("birds"), version: V0},
 		},
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g")},
-			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h")},
-			{key: []byte{0xf2}, value: []byte("feather")},
-			{key: []byte{0xf2, 0x3}, value: []byte("f")},
-			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-			{key: []byte{0x07}, value: []byte("ramen")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), version: V0},
+			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g"), version: V0},
+			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h"), version: V0},
+			{key: []byte{0xf2}, value: []byte("feather"), version: V0},
+			{key: []byte{0xf2, 0x3}, value: []byte("f"), version: V0},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot"), version: V0},
+			{key: []byte{0x07}, value: []byte("ramen"), version: V0},
 		},
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g")},
-			{key: []byte{0xf2}, value: []byte("feather")},
-			{key: []byte{0xf2, 0x30}, value: []byte("f")},
-			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-			{key: []byte{0x07}, value: []byte("ramen")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), version: V0},
+			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g"), version: V0},
+			{key: []byte{0xf2}, value: []byte("feather"), version: V0},
+			{key: []byte{0xf2, 0x30}, value: []byte("f"), version: V0},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot"), version: V0},
+			{key: []byte{0x07}, value: []byte("ramen"), version: V0},
 		},
 		{
-			{key: []byte("asdf"), value: []byte("asdf")},
-			{key: []byte("ghjk"), value: []byte("ghjk")},
-			{key: []byte("qwerty"), value: []byte("qwerty")},
-			{key: []byte("uiopl"), value: []byte("uiopl")},
-			{key: []byte("zxcv"), value: []byte("zxcv")},
-			{key: []byte("bnm"), value: []byte("bnm")},
+			{key: []byte("asdf"), value: []byte("asdf"), version: V0},
+			{key: []byte("ghjk"), value: []byte("ghjk"), version: V0},
+			{key: []byte("qwerty"), value: []byte("qwerty"), version: V0},
+			{key: []byte("uiopl"), value: []byte("uiopl"), version: V0},
+			{key: []byte("zxcv"), value: []byte("zxcv"), version: V0},
+			{key: []byte("bnm"), value: []byte("bnm"), version: V0},
 		},
 	}
 
@@ -812,7 +822,7 @@ func TestTrie_ClearPrefixLimit(t *testing.T) {
 			trieClearPrefix := NewEmptyTrie()
 
 			for _, test := range testCase {
-				trieClearPrefix.Put(test.key, test.value)
+				trieClearPrefix.Put(test.key, test.value, test.version)
 			}
 
 			num, allDeleted := trieClearPrefix.ClearPrefixLimit(prefix, uint32(lim))
@@ -869,40 +879,40 @@ func TestTrie_ClearPrefixLimitSnapshot(t *testing.T) {
 
 	cases := [][]keyValues{
 		{
-			{key: []byte{0x01}, value: []byte("feather")},
+			{key: []byte{0x01}, value: []byte("feather"), version: V0},
 		},
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x36}, value: []byte("pencil")},
-			{key: []byte{0x02}, value: []byte("feather")},
-			{key: []byte{0x03}, value: []byte("birds")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x36}, value: []byte("pencil"), version: V0},
+			{key: []byte{0x02}, value: []byte("feather"), version: V0},
+			{key: []byte{0x03}, value: []byte("birds"), version: V0},
 		},
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g")},
-			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h")},
-			{key: []byte{0xf2}, value: []byte("feather")},
-			{key: []byte{0xf2, 0x3}, value: []byte("f")},
-			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-			{key: []byte{0x07}, value: []byte("ramen")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), version: V0},
+			{key: []byte{0x01, 0x35, 0x7}, value: []byte("g"), version: V0},
+			{key: []byte{0x01, 0x35, 0x99}, value: []byte("h"), version: V0},
+			{key: []byte{0xf2}, value: []byte("feather"), version: V0},
+			{key: []byte{0xf2, 0x3}, value: []byte("f"), version: V0},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot"), version: V0},
+			{key: []byte{0x07}, value: []byte("ramen"), version: V0},
 		},
 		{
-			{key: []byte{0x01, 0x35}, value: []byte("pen")},
-			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin")},
-			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g")},
-			{key: []byte{0xf2}, value: []byte("feather")},
-			{key: []byte{0xf2, 0x30}, value: []byte("f")},
-			{key: []byte{0x09, 0xd3}, value: []byte("noot")},
-			{key: []byte{0x07}, value: []byte("ramen")},
+			{key: []byte{0x01, 0x35}, value: []byte("pen"), version: V0},
+			{key: []byte{0x01, 0x35, 0x79}, value: []byte("penguin"), version: V0},
+			{key: []byte{0x01, 0x35, 0x70}, value: []byte("g"), version: V0},
+			{key: []byte{0xf2}, value: []byte("feather"), version: V0},
+			{key: []byte{0xf2, 0x30}, value: []byte("f"), version: V0},
+			{key: []byte{0x09, 0xd3}, value: []byte("noot"), version: V0},
+			{key: []byte{0x07}, value: []byte("ramen"), version: V0},
 		},
 		{
-			{key: []byte("asdf"), value: []byte("asdf")},
-			{key: []byte("ghjk"), value: []byte("ghjk")},
-			{key: []byte("qwerty"), value: []byte("qwerty")},
-			{key: []byte("uiopl"), value: []byte("uiopl")},
-			{key: []byte("zxcv"), value: []byte("zxcv")},
-			{key: []byte("bnm"), value: []byte("bnm")},
+			{key: []byte("asdf"), value: []byte("asdf"), version: V0},
+			{key: []byte("ghjk"), value: []byte("ghjk"), version: V0},
+			{key: []byte("qwerty"), value: []byte("qwerty"), version: V0},
+			{key: []byte("uiopl"), value: []byte("uiopl"), version: V0},
+			{key: []byte("zxcv"), value: []byte("zxcv"), version: V0},
+			{key: []byte("bnm"), value: []byte("bnm"), version: V0},
 		},
 	}
 
@@ -917,7 +927,7 @@ func TestTrie_ClearPrefixLimitSnapshot(t *testing.T) {
 				trieClearPrefix := NewEmptyTrie()
 
 				for _, test := range testCase {
-					trieClearPrefix.Put(test.key, test.value)
+					trieClearPrefix.Put(test.key, test.value, test.version)
 				}
 
 				dcTrie := trieClearPrefix.DeepCopy()
@@ -926,13 +936,13 @@ func TestTrie_ClearPrefixLimitSnapshot(t *testing.T) {
 				ssTrie := trieClearPrefix.Snapshot()
 
 				// Get the Trie root hash for all the 3 tries.
-				tHash, err := trieClearPrefix.Hash()
+				tHash, err := trieClearPrefix.Hash(V0)
 				require.NoError(t, err)
 
-				dcTrieHash, err := dcTrie.Hash()
+				dcTrieHash, err := dcTrie.Hash(V0)
 				require.NoError(t, err)
 
-				ssTrieHash, err := ssTrie.Hash()
+				ssTrieHash, err := ssTrie.Hash(V0)
 				require.NoError(t, err)
 
 				// Root hash for all the 3 tries should be equal.
@@ -967,13 +977,13 @@ func TestTrie_ClearPrefixLimitSnapshot(t *testing.T) {
 				}
 
 				// Get the updated root hash of all tries.
-				tHash, err = trieClearPrefix.Hash()
+				tHash, err = trieClearPrefix.Hash(V0)
 				require.NoError(t, err)
 
-				dcTrieHash, err = dcTrie.Hash()
+				dcTrieHash, err = dcTrie.Hash(V0)
 				require.NoError(t, err)
 
-				ssTrieHash, err = ssTrie.Hash()
+				ssTrieHash, err = ssTrie.Hash(V0)
 				require.NoError(t, err)
 
 				// If node got deleted then root hash must be updated else it has same root hash.
@@ -997,12 +1007,13 @@ func Test_encodeRoot_fuzz(t *testing.T) {
 
 	const randomBatches = 3
 
+	const stateVersion = V0
 	for i := 0; i < randomBatches; i++ {
 		const kvSize = 16
 		kv := generateKeyValues(t, generator, kvSize)
 		for keyString, value := range kv {
 			key := []byte(keyString)
-			trie.Put(key, value)
+			trie.Put(key, value, stateVersion)
 
 			retrievedValue := trie.Get(key)
 			assert.Equal(t, value, retrievedValue)
@@ -1056,8 +1067,9 @@ func Test_Trie_Descendants_Fuzz(t *testing.T) {
 		return bytes.Compare(keys[i], keys[j]) < 0
 	})
 
+	const stateVersion = V0
 	for _, key := range keys {
-		trie.Put(key, kv[string(key)])
+		trie.Put(key, kv[string(key)], stateVersion)
 	}
 
 	testDescendants(t, trie.root)

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -305,12 +305,14 @@ func Test_encodeRoot(t *testing.T) {
 
 	testCases := map[string]struct {
 		root         *Node
+		version      Version
 		bufferCalls  bufferCalls
 		errWrapped   error
 		errMessage   string
 		expectedRoot *Node
 	}{
 		"nil root and no error": {
+			version: V0,
 			bufferCalls: bufferCalls{
 				writeCalls: []writeCall{
 					{written: []byte{0}},
@@ -318,6 +320,7 @@ func Test_encodeRoot(t *testing.T) {
 			},
 		},
 		"nil root and write error": {
+			version: V0,
 			bufferCalls: bufferCalls{
 				writeCalls: []writeCall{
 					{
@@ -334,6 +337,7 @@ func Test_encodeRoot(t *testing.T) {
 				Key:      []byte{1, 2},
 				SubValue: []byte{1},
 			},
+			version: V0,
 			bufferCalls: bufferCalls{
 				writeCalls: []writeCall{
 					{
@@ -354,6 +358,7 @@ func Test_encodeRoot(t *testing.T) {
 				Key:      []byte{1, 2},
 				SubValue: []byte{1},
 			},
+			version: V0,
 			bufferCalls: bufferCalls{
 				writeCalls: []writeCall{
 					{written: []byte{66}},
@@ -401,7 +406,7 @@ func Test_encodeRoot(t *testing.T) {
 					Return(testCase.bufferCalls.bytesReturn)
 			}
 
-			err := encodeRoot(testCase.root, buffer)
+			err := encodeRoot(testCase.root, testCase.version, buffer)
 
 			assert.ErrorIs(t, err, testCase.errWrapped)
 			if testCase.errWrapped != nil {

--- a/lib/trie/version.go
+++ b/lib/trie/version.go
@@ -30,15 +30,30 @@ func (v Version) String() string {
 	}
 }
 
-var ErrParseVersion = errors.New("parsing version failed")
+var ErrVersionNotValid = errors.New("version not valid")
 
-// ParseVersion parses a state trie version string.
-func ParseVersion(s string) (version Version, err error) {
+// ParseVersion parses a state trie version string or uint32.
+func ParseVersion[T string | uint32](x T) (version Version, err error) {
+	var s string
+	switch value := any(x).(type) {
+	case string:
+		s = value
+	case uint32:
+		s = fmt.Sprintf("V%d", value)
+	default:
+		panic(fmt.Sprintf("unsupported type %T", x))
+	}
+
 	switch {
 	case strings.EqualFold(s, V0.String()):
 		return V0, nil
 	default:
-		return version, fmt.Errorf("%w: %q must be %s",
-			ErrParseVersion, s, V0)
+		return version, fmt.Errorf("%w: %s", ErrVersionNotValid, s)
+	}
+}
+
+func enforceValidVersion(version Version) {
+	if version != V0 {
+		panic(fmt.Sprintf("unsupported version %d", version))
 	}
 }

--- a/lib/trie/version_test.go
+++ b/lib/trie/version_test.go
@@ -66,7 +66,7 @@ func Test_ParseVersion(t *testing.T) {
 		"invalid string": {
 			x:          "xyz",
 			errWrapped: ErrVersionNotValid,
-			errMessage: "parsing version failed: xyz",
+			errMessage: "version not valid: xyz",
 		},
 		"0 uint32": {
 			x:       uint32(0),
@@ -75,7 +75,7 @@ func Test_ParseVersion(t *testing.T) {
 		"invalid uint32": {
 			x:          uint32(100),
 			errWrapped: ErrVersionNotValid,
-			errMessage: "parsing version failed: v100",
+			errMessage: "version not valid: V100",
 		},
 	}
 


### PR DESCRIPTION
## Changes

- [x] Version relevant trie calls (Put, Hash)
- [x] Convert wasmer Core_version `Version` to typed `trie.Version`
- [x] Adapt tests/test helpers to read the state version from the genesis runtime code
- [ ] Fix unit tests
- [ ] Fix integration tests

## Tests

Entire codebase test suite

## Issues

#2418 

## Primary Reviewer

@edwardmack 
