### PR TITLE
feat(chain): use always the raw genesis file

### DIFF
--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -15,7 +15,7 @@ sync = ""
 digest = ""
 
 [init]
-genesis = "./chain/dev/genesis-spec.json"
+genesis = "./chain/dev/genesis.json"
 
 [account]
 key = ""

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -39,7 +39,7 @@ var (
 	// InitConfig
 
 	// DefaultGenesis is the default genesis configuration path
-	DefaultGenesis = string("./chain/dev/genesis-spec.json")
+	DefaultGenesis = string("./chain/dev/genesis.json")
 
 	// AccountConfig
 

--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -15,7 +15,7 @@ sync = ""
 digest = ""
 
 [init]
-genesis = "./chain/gssmr/genesis-spec.json"
+genesis = "./chain/gssmr/genesis.json"
 
 [account]
 key = ""

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -41,7 +41,7 @@ var (
 	// InitConfig
 
 	// DefaultGenesis is the default genesis configuration path
-	DefaultGenesis = string("./chain/gssmr/genesis-spec.json")
+	DefaultGenesis = string("./chain/gssmr/genesis.json")
 
 	// AccountConfig
 

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -45,7 +45,7 @@ func TestConfig(t *testing.T) {
 					FinalityGadgetLvl: log.Info,
 				},
 				Init: InitConfig{
-					Genesis: "./chain/dev/genesis-spec.json",
+					Genesis: "./chain/dev/genesis.json",
 				},
 				Account: AccountConfig{
 					Key: "alice",
@@ -106,7 +106,7 @@ func TestConfig(t *testing.T) {
 					FinalityGadgetLvl: log.Info,
 				},
 				Init: InitConfig{
-					Genesis: "./chain/gssmr/genesis-spec.json",
+					Genesis: "./chain/gssmr/genesis.json",
 				},
 				Account: AccountConfig{},
 				Core: CoreConfig{

--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -116,7 +116,7 @@ func TestNewTestConfig(t *testing.T) {
 					BlockProducerLvl:  3,
 					FinalityGadgetLvl: 3,
 				},
-				Init: InitConfig{Genesis: "./chain/gssmr/genesis-spec.json"},
+				Init: InitConfig{Genesis: "./chain/gssmr/genesis.json"},
 				Core: CoreConfig{
 					Roles:            4,
 					BabeAuthority:    true,


### PR DESCRIPTION
## Changes

- Change the default values to always use the raw genesis instead of the human-readable genesis file

## Tests

<!-- Detail how to run relevant tests to the changes -->

Execute `./bin/gossamer init --force` and you should be able to initialize the node

## Issues

- Closes #2770

## Primary Reviewer

@danforbes 
