### PR TITLE
chore(config): improve `StateConfig`

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -929,9 +929,9 @@ func setDotPprofConfig(ctx *cli.Context, tomlCfg ctoml.PprofConfig, cfg *dot.Ppr
 }
 
 func setStateConfig(ctx *cli.Context, tomlCfg ctoml.StateConfig, cfg *dot.StateConfig) {
-	if tomlCfg.Rewind > 0 {
-		cfg.Rewind = tomlCfg.Rewind
-	} else if ctx.GlobalIsSet(RewindFlag.Name) {
+	if ctx.GlobalIsSet(RewindFlag.Name) {
 		cfg.Rewind = ctx.GlobalUint(RewindFlag.Name)
+	} else if tomlCfg.Rewind > 0 {
+		cfg.Rewind = tomlCfg.Rewind
 	}
 }

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -134,10 +134,7 @@ func createDotConfig(ctx *cli.Context) (*dot.Config, error) {
 	setDotNetworkConfig(ctx, tomlCfg.Network, &cfg.Network)
 	setDotRPCConfig(ctx, tomlCfg.RPC, &cfg.RPC)
 	setDotPprofConfig(ctx, tomlCfg.Pprof, &cfg.Pprof)
-
-	if rewind := ctx.GlobalUint(RewindFlag.Name); rewind != 0 {
-		cfg.State.Rewind = rewind
-	}
+	setStateConfig(ctx, tomlCfg.State, &cfg.State)
 
 	// set system info
 	setSystemInfoConfig(ctx, cfg)
@@ -929,4 +926,12 @@ func setDotPprofConfig(ctx *cli.Context, tomlCfg ctoml.PprofConfig, cfg *dot.Ppr
 	}
 
 	logger.Debug("pprof configuration: " + cfg.String())
+}
+
+func setStateConfig(ctx *cli.Context, tomlCfg ctoml.StateConfig, cfg *dot.StateConfig) {
+	if tomlCfg.Rewind > 0 {
+		cfg.Rewind = tomlCfg.Rewind
+	} else if ctx.GlobalIsSet(RewindFlag.Name) {
+		cfg.Rewind = ctx.GlobalUint(RewindFlag.Name)
+	}
 }

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -33,7 +33,7 @@ var (
 		Usage: "Roles of the gossamer node",
 	}
 	// RewindFlag rewinds the head of the chain to the given block number. Useful for development
-	RewindFlag = cli.IntFlag{
+	RewindFlag = cli.UintFlag{
 		Name:  "rewind",
 		Usage: "Rewind head of chain to the given block number",
 	}

--- a/dot/config.go
+++ b/dot/config.go
@@ -163,8 +163,7 @@ type StateConfig struct {
 }
 
 func (s *StateConfig) String() string {
-	return "" +
-		"rewind " + fmt.Sprint(s.Rewind)
+	return "rewind " + fmt.Sprint(s.Rewind)
 }
 
 // networkServiceEnabled returns true if the network service is enabled

--- a/dot/config.go
+++ b/dot/config.go
@@ -162,6 +162,11 @@ type StateConfig struct {
 	Rewind uint
 }
 
+func (s *StateConfig) String() string {
+	return "" +
+		"rewind " + fmt.Sprint(s.Rewind)
+}
+
 // networkServiceEnabled returns true if the network service is enabled
 func networkServiceEnabled(cfg *Config) bool {
 	return cfg.Core.Roles != common.NoNetworkRole

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Account AccountConfig `toml:"account,omitempty"`
 	Core    CoreConfig    `toml:"core,omitempty"`
 	Network NetworkConfig `toml:"network,omitempty"`
+	State   StateConfig   `toml:"state,omitempty"`
 	RPC     RPCConfig     `toml:"rpc,omitempty"`
 	Pprof   PprofConfig   `toml:"pprof,omitempty"`
 }
@@ -75,6 +76,11 @@ type CoreConfig struct {
 	WasmInterpreter  string `toml:"wasm-interpreter,omitempty"`
 	GrandpaInterval  uint32 `toml:"grandpa-interval,omitempty"`
 	BABELead         bool   `toml:"babe-lead,omitempty"`
+}
+
+// StateConfig contains the configuration for the state.
+type StateConfig struct {
+	Rewind uint `toml:"rewind,omitempty"`
 }
 
 // RPCConfig is to marshal/unmarshal toml RPC config vars


### PR DESCRIPTION
## Changes

Really just a tiny small thing I worked on as part of the trie versioning somewhere sometime.

- Change rewind flag to be `uint` instead of `int`
- Add `setStateConfig` with toml precedence over flags
- Add String() method to dot `StateConfig`
- Add `StateConfig` to `dot/config/toml`

## Tests

## Issues

## Primary Reviewer

@EclesioMeloJunior 