### PR TITLE
chore(dot/state): refactor `NewTries`

### DIFF
--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -42,8 +42,7 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 	db := state.NewInMemoryDB(t)
 
 	_, genesisTrie, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
-	tries, err := state.NewTries(genesisTrie)
-	require.NoError(t, err)
+	tries := state.NewTries(genesisTrie)
 	bs, err := state.NewBlockStateFromGenesis(db, tries, genesisHeader, telemetryMock)
 	require.NoError(t, err)
 	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -42,7 +42,8 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 	db := state.NewInMemoryDB(t)
 
 	_, genesisTrie, genesisHeader := genesis.NewTestGenesisWithTrieAndHeader(t)
-	tries := state.NewTries(genesisTrie)
+	tries := state.NewTries()
+	tries.SetTrie(genesisTrie)
 	bs, err := state.NewBlockStateFromGenesis(db, tries, genesisHeader, telemetryMock)
 	require.NoError(t, err)
 	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -63,10 +63,7 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to write genesis values to database: %s", err)
 	}
 
-	tries, err := NewTries(t)
-	if err != nil {
-		return fmt.Errorf("cannot setup tries: %w", err)
-	}
+	tries := NewTries(t)
 
 	// create block state from genesis block
 	blockState, err := NewBlockStateFromGenesis(db, tries, header, s.Telemetry)

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -63,7 +63,8 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to write genesis values to database: %s", err)
 	}
 
-	tries := NewTries(t)
+	tries := NewTries()
+	tries.SetTrie(t)
 
 	// create block state from genesis block
 	blockState, err := NewBlockStateFromGenesis(db, tries, header, s.Telemetry)

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -41,10 +41,7 @@ func NewOfflinePruner(inputDBPath, prunedDBPath string, bloomSize uint64,
 		return nil, fmt.Errorf("failed to load DB %w", err)
 	}
 
-	tries, err := NewTries(trie.NewEmptyTrie())
-	if err != nil {
-		return nil, fmt.Errorf("cannot setup tries: %w", err)
-	}
+	tries := NewTries(trie.NewEmptyTrie())
 
 	// create blockState state
 	// NewBlockState on pruner execution does not use telemetry

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -41,7 +41,8 @@ func NewOfflinePruner(inputDBPath, prunedDBPath string, bloomSize uint64,
 		return nil, fmt.Errorf("failed to load DB %w", err)
 	}
 
-	tries := NewTries(trie.NewEmptyTrie())
+	tries := NewTries()
+	tries.SetEmptyTrie()
 
 	// create blockState state
 	// NewBlockState on pruner execution does not use telemetry

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -113,7 +113,8 @@ func (s *Service) Start() (err error) {
 		return nil
 	}
 
-	tries := NewTries(trie.NewEmptyTrie())
+	tries := NewTries()
+	tries.SetEmptyTrie()
 
 	// create block state
 	s.Block, err = NewBlockState(s.db, tries, s.Telemetry)

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -108,15 +108,12 @@ func (s *Service) SetupBase() error {
 }
 
 // Start initialises the Storage database and the Block database.
-func (s *Service) Start() error {
+func (s *Service) Start() (err error) {
 	if !s.isMemDB && (s.Storage != nil || s.Block != nil || s.Epoch != nil || s.Grandpa != nil) {
 		return nil
 	}
 
-	tries, err := NewTries(trie.NewEmptyTrie())
-	if err != nil {
-		return fmt.Errorf("cannot create tries: %w", err)
-	}
+	tries := NewTries(trie.NewEmptyTrie())
 
 	// create block state
 	s.Block, err = NewBlockState(s.db, tries, s.Telemetry)

--- a/dot/state/tries.go
+++ b/dot/state/tries.go
@@ -51,10 +51,14 @@ func NewTries() (tries *Tries) {
 	}
 }
 
+// SetEmptyTrie sets the empty trie in the tries.
+// Note the empty trie is the same for the v0 and the v1
+// state trie versions.
 func (t *Tries) SetEmptyTrie() {
 	t.softSet(trie.EmptyHash, trie.NewEmptyTrie())
 }
 
+// SetTrie sets the trie at its root hash in the tries map.
 func (t *Tries) SetTrie(trie *trie.Trie) {
 	t.softSet(trie.MustHash(), trie)
 }

--- a/dot/state/tries.go
+++ b/dot/state/tries.go
@@ -41,12 +41,10 @@ type Tries struct {
 }
 
 // NewTries creates a new thread safe map of root hash
-// to trie using the trie given as a first trie.
-func NewTries(t *trie.Trie) (tries *Tries) {
+// to trie.
+func NewTries() (tries *Tries) {
 	return &Tries{
-		rootToTrie: map[common.Hash]*trie.Trie{
-			t.MustHash(): t,
-		},
+		rootToTrie:    make(map[common.Hash]*trie.Trie),
 		triesGauge:    triesGauge,
 		setCounter:    setCounter,
 		deleteCounter: deleteCounter,

--- a/dot/state/tries.go
+++ b/dot/state/tries.go
@@ -42,7 +42,7 @@ type Tries struct {
 
 // NewTries creates a new thread safe map of root hash
 // to trie using the trie given as a first trie.
-func NewTries(t *trie.Trie) (trs *Tries, err error) {
+func NewTries(t *trie.Trie) (tries *Tries) {
 	return &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{
 			t.MustHash(): t,
@@ -50,7 +50,7 @@ func NewTries(t *trie.Trie) (trs *Tries, err error) {
 		triesGauge:    triesGauge,
 		setCounter:    setCounter,
 		deleteCounter: deleteCounter,
-	}, nil
+	}
 }
 
 // softSet sets the given trie at the given root hash

--- a/dot/state/tries.go
+++ b/dot/state/tries.go
@@ -53,6 +53,14 @@ func NewTries(t *trie.Trie) (tries *Tries) {
 	}
 }
 
+func (t *Tries) SetEmptyTrie() {
+	t.softSet(trie.EmptyHash, trie.NewEmptyTrie())
+}
+
+func (t *Tries) SetTrie(trie *trie.Trie) {
+	t.softSet(trie.MustHash(), trie)
+}
+
 // softSet sets the given trie at the given root hash
 // in the memory map only if it is not already set.
 func (t *Tries) softSet(root common.Hash, trie *trie.Trie) {

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -32,6 +32,49 @@ func Test_NewTries(t *testing.T) {
 	assert.Equal(t, expectedTries, rootToTrie)
 }
 
+func Test_Tries_SetEmptyTrie(t *testing.T) {
+	t.Parallel()
+
+	tr := trie.NewTrie(&node.Node{Key: []byte{1}})
+
+	tries := NewTries(tr)
+	tries.SetEmptyTrie()
+
+	expectedTries := &Tries{
+		rootToTrie: map[common.Hash]*trie.Trie{
+			tr.MustHash():  tr,
+			trie.EmptyHash: trie.NewEmptyTrie(),
+		},
+		triesGauge:    triesGauge,
+		setCounter:    setCounter,
+		deleteCounter: deleteCounter,
+	}
+
+	assert.Equal(t, expectedTries, tries)
+}
+
+func Test_Tries_SetTrie(t *testing.T) {
+	t.Parallel()
+
+	trieA := trie.NewTrie(&node.Node{Key: []byte{1}})
+	trieB := trie.NewTrie(&node.Node{Key: []byte{2}})
+
+	tries := NewTries(trieA)
+	tries.SetTrie(trieB)
+
+	expectedTries := &Tries{
+		rootToTrie: map[common.Hash]*trie.Trie{
+			trieA.MustHash(): trieA,
+			trieB.MustHash(): trieB,
+		},
+		triesGauge:    triesGauge,
+		setCounter:    setCounter,
+		deleteCounter: deleteCounter,
+	}
+
+	assert.Equal(t, expectedTries, tries)
+}
+
 //go:generate mockgen -destination=mock_gauge_test.go -package $GOPACKAGE github.com/prometheus/client_golang/prometheus Gauge
 //go:generate mockgen -destination=mock_counter_test.go -package $GOPACKAGE github.com/prometheus/client_golang/prometheus Counter
 

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -16,14 +16,10 @@ import (
 func Test_NewTries(t *testing.T) {
 	t.Parallel()
 
-	tr := trie.NewEmptyTrie()
-
-	rootToTrie := NewTries(tr)
+	rootToTrie := NewTries()
 
 	expectedTries := &Tries{
-		rootToTrie: map[common.Hash]*trie.Trie{
-			tr.MustHash(): tr,
-		},
+		rootToTrie:    map[common.Hash]*trie.Trie{},
 		triesGauge:    triesGauge,
 		setCounter:    setCounter,
 		deleteCounter: deleteCounter,
@@ -35,14 +31,11 @@ func Test_NewTries(t *testing.T) {
 func Test_Tries_SetEmptyTrie(t *testing.T) {
 	t.Parallel()
 
-	tr := trie.NewTrie(&node.Node{Key: []byte{1}})
-
-	tries := NewTries(tr)
+	tries := NewTries()
 	tries.SetEmptyTrie()
 
 	expectedTries := &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{
-			tr.MustHash():  tr,
 			trie.EmptyHash: trie.NewEmptyTrie(),
 		},
 		triesGauge:    triesGauge,
@@ -56,16 +49,14 @@ func Test_Tries_SetEmptyTrie(t *testing.T) {
 func Test_Tries_SetTrie(t *testing.T) {
 	t.Parallel()
 
-	trieA := trie.NewTrie(&node.Node{Key: []byte{1}})
-	trieB := trie.NewTrie(&node.Node{Key: []byte{2}})
+	tr := trie.NewTrie(&node.Node{Key: []byte{1}})
 
-	tries := NewTries(trieA)
-	tries.SetTrie(trieB)
+	tries := NewTries()
+	tries.SetTrie(tr)
 
 	expectedTries := &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{
-			trieA.MustHash(): trieA,
-			trieB.MustHash(): trieB,
+			tr.MustHash(): tr,
 		},
 		triesGauge:    triesGauge,
 		setCounter:    setCounter,

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_NewTries(t *testing.T) {
@@ -19,8 +18,7 @@ func Test_NewTries(t *testing.T) {
 
 	tr := trie.NewEmptyTrie()
 
-	rootToTrie, err := NewTries(tr)
-	require.NoError(t, err)
+	rootToTrie := NewTries(tr)
 
 	expectedTries := &Tries{
 		rootToTrie: map[common.Hash]*trie.Trie{

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -51,8 +51,7 @@ func newTestState(t *testing.T) *state.Service {
 	t.Cleanup(func() { db.Close() })
 
 	_, genTrie, _ := genesis.NewTestGenesisWithTrieAndHeader(t)
-	tries, err := state.NewTries(genTrie)
-	require.NoError(t, err)
+	tries := state.NewTries(genTrie)
 	block, err := state.NewBlockStateFromGenesis(db, tries, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 

--- a/lib/grandpa/grandpa_test.go
+++ b/lib/grandpa/grandpa_test.go
@@ -51,7 +51,8 @@ func newTestState(t *testing.T) *state.Service {
 	t.Cleanup(func() { db.Close() })
 
 	_, genTrie, _ := genesis.NewTestGenesisWithTrieAndHeader(t)
-	tries := state.NewTries(genTrie)
+	tries := state.NewTries()
+	tries.SetTrie(genTrie)
 	block, err := state.NewBlockStateFromGenesis(db, tries, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Changes

- `NewTries` does not return an error (always nil)
- `NewTries` does not take an initial as argument (which won't get versioned)
- Add `(*Tries) SetEmptyTrie()` method (which won't get versioned)
- Add `(*Tries) SetTrie(*trie.Trie)` method (which **will** get versioned)

This PR is because the empty trie is the same for v0 and v1 state versions.
So we want a method `SetEmptyTrie` on Tries which doesn't require a state version, and another method `SetTrie` which does.

This allows to have way less code changes in the next chunky PR versioning trie calls.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

#2418 

## Primary Reviewer

@kishansagathiya 