### PR TITLE
fix(dot/core): `RuntimeInstance` interface `Version` signature

### DIFF
--- a/dot/core/interface.go
+++ b/dot/core/interface.go
@@ -29,7 +29,7 @@ type RuntimeInstance interface {
 	Exec(function string, data []byte) ([]byte, error)
 	SetContextStorage(s runtime.Storage)
 	GetCodeHash() common.Hash
-	Version() (runtime.Version, error)
+	Version() (version runtime.Version)
 	Metadata() ([]byte, error)
 	BabeConfiguration() (*types.BabeConfiguration, error)
 	GrandpaAuthorities() ([]types.Authority, error)

--- a/dot/core/mocks_test.go
+++ b/dot/core/mocks_test.go
@@ -1164,12 +1164,11 @@ func (mr *MockRuntimeInstanceMockRecorder) Validator() *gomock.Call {
 }
 
 // Version mocks base method.
-func (m *MockRuntimeInstance) Version() (runtime.Version, error) {
+func (m *MockRuntimeInstance) Version() runtime.Version {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
 	ret0, _ := ret[0].(runtime.Version)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // Version indicates an expected call of Version.


### PR DESCRIPTION
## Changes

Problem caused by merging #2747 on top of #2777 without rebasing (and there were no file conflicts)

## Tests


## Issues


## Primary Reviewer

@jimjbrettj 