### PR TITLE
remove the `time.Sleep()` dependency from dot/peerset/peerset_test.go

### DIFF
--- a/dot/network/helpers_test.go
+++ b/dot/network/helpers_test.go
@@ -90,7 +90,10 @@ func (s *testStreamHandler) readStream(stream libp2pnetwork.Stream,
 			return
 		} else if err != nil {
 			logger.Debugf("failed to read from stream using protocol %s: %s", stream.Protocol(), err)
-			_ = stream.Close()
+			err := stream.Close()
+			if err != nil {
+				logger.Warnf("failed to close stream: %w", err)
+			}
 			return
 		}
 
@@ -105,7 +108,10 @@ func (s *testStreamHandler) readStream(stream libp2pnetwork.Stream,
 		err = handler(stream, msg)
 		if err != nil {
 			logger.Errorf("failed to handle message %s from stream: %s", msg, err)
-			_ = stream.Close()
+			err := stream.Close()
+			if err != nil {
+				logger.Warnf("failed to close stream: %w", err)
+			}
 			return
 		}
 	}

--- a/dot/network/helpers_test.go
+++ b/dot/network/helpers_test.go
@@ -92,7 +92,7 @@ func (s *testStreamHandler) readStream(stream libp2pnetwork.Stream,
 			logger.Debugf("failed to read from stream using protocol %s: %s", stream.Protocol(), err)
 			err := stream.Close()
 			if err != nil {
-				logger.Warnf("failed to close stream: %w", err)
+				logger.Warnf("failed to close stream: %s", err)
 			}
 			return
 		}
@@ -110,7 +110,7 @@ func (s *testStreamHandler) readStream(stream libp2pnetwork.Stream,
 			logger.Errorf("failed to handle message %s from stream: %s", msg, err)
 			err := stream.Close()
 			if err != nil {
-				logger.Warnf("failed to close stream: %w", err)
+				logger.Warnf("failed to close stream: %s", err)
 			}
 			return
 		}

--- a/dot/network/light.go
+++ b/dot/network/light.go
@@ -35,7 +35,10 @@ func (s *Service) decodeLightMessage(in []byte, peer peer.ID, _ bool) (Message, 
 
 func (s *Service) handleLightMsg(stream libp2pnetwork.Stream, msg Message) (err error) {
 	defer func() {
-		_ = stream.Close()
+		err := stream.Close()
+		if err != nil {
+			logger.Warnf("failed to close stream: %w", err)
+		}
 	}()
 
 	lr, ok := msg.(*LightRequest)

--- a/dot/network/light.go
+++ b/dot/network/light.go
@@ -37,7 +37,7 @@ func (s *Service) handleLightMsg(stream libp2pnetwork.Stream, msg Message) (err 
 	defer func() {
 		err := stream.Close()
 		if err != nil {
-			logger.Warnf("failed to close stream: %w", err)
+			logger.Warnf("failed to close stream: %s", err)
 		}
 	}()
 

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -242,7 +242,10 @@ func closeOutboundStream(info *notificationsProtocol, peerID peer.ID, stream net
 	)
 
 	info.peersData.deleteOutboundHandshakeData(peerID)
-	_ = stream.Close()
+	err := stream.Close()
+	if err != nil {
+		logger.Warnf("failed to close stream: %w", err)
+	}
 }
 
 func (s *Service) sendData(peer peer.ID, hs Handshake, info *notificationsProtocol, msg NotificationsMessage) {

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -244,7 +244,7 @@ func closeOutboundStream(info *notificationsProtocol, peerID peer.ID, stream net
 	info.peersData.deleteOutboundHandshakeData(peerID)
 	err := stream.Close()
 	if err != nil {
-		logger.Warnf("failed to close stream: %w", err)
+		logger.Warnf("failed to close outbound stream: %s", err)
 	}
 }
 

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -269,7 +269,10 @@ func Test_HandshakeTimeout(t *testing.T) {
 	info.peersData.deleteOutboundHandshakeData(nodeB.host.id())
 	connAToB := nodeA.host.p2pHost.Network().ConnsToPeer(nodeB.host.id())
 	for _, stream := range connAToB[0].GetStreams() {
-		_ = stream.Close()
+		err := stream.Close()
+		if err != nil {
+			logger.Warnf("failed to close stream: %w", err)
+		}
 	}
 
 	testHandshakeMsg := &BlockAnnounceHandshake{

--- a/dot/network/notifications_test.go
+++ b/dot/network/notifications_test.go
@@ -270,9 +270,7 @@ func Test_HandshakeTimeout(t *testing.T) {
 	connAToB := nodeA.host.p2pHost.Network().ConnsToPeer(nodeB.host.id())
 	for _, stream := range connAToB[0].GetStreams() {
 		err := stream.Close()
-		if err != nil {
-			logger.Warnf("failed to close stream: %w", err)
-		}
+		require.NoError(t, err)
 	}
 
 	testHandshakeMsg := &BlockAnnounceHandshake{

--- a/dot/network/stream_manager.go
+++ b/dot/network/stream_manager.go
@@ -60,7 +60,10 @@ func (sm *streamManager) cleanupStreams() {
 		stream := data.stream
 
 		if time.Since(lastReceived) > cleanupStreamInterval {
-			_ = stream.Close()
+			err := stream.Close()
+			if err != nil {
+				logger.Warnf("failed to close stream: %w", err)
+			}
 			delete(sm.streamData, id)
 		}
 	}

--- a/dot/network/stream_manager.go
+++ b/dot/network/stream_manager.go
@@ -62,7 +62,7 @@ func (sm *streamManager) cleanupStreams() {
 		if time.Since(lastReceived) > cleanupStreamInterval {
 			err := stream.Close()
 			if err != nil {
-				logger.Warnf("failed to close stream: %w", err)
+				logger.Warnf("failed to close inactive stream: %s", err)
 			}
 			delete(sm.streamData, id)
 		}

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -35,7 +35,10 @@ func (s *Service) DoBlockRequest(to peer.ID, req *BlockRequestMessage) (*BlockRe
 	}
 
 	defer func() {
-		_ = stream.Close()
+		err := stream.Close()
+		if err != nil {
+			logger.Warnf("failed to close stream: %w", err)
+		}
 	}()
 
 	if err = s.host.writeToStream(stream, req); err != nil {
@@ -102,7 +105,10 @@ func (s *Service) handleSyncMessage(stream libp2pnetwork.Stream, msg Message) er
 	}
 
 	defer func() {
-		_ = stream.Close()
+		err := stream.Close()
+		if err != nil {
+			logger.Warnf("failed to close stream: %w", err)
+		}
 	}()
 
 	if req, ok := msg.(*BlockRequestMessage); ok {

--- a/dot/network/sync.go
+++ b/dot/network/sync.go
@@ -37,7 +37,7 @@ func (s *Service) DoBlockRequest(to peer.ID, req *BlockRequestMessage) (*BlockRe
 	defer func() {
 		err := stream.Close()
 		if err != nil {
-			logger.Warnf("failed to close stream: %w", err)
+			logger.Warnf("failed to close stream: %s", err)
 		}
 	}()
 
@@ -107,7 +107,7 @@ func (s *Service) handleSyncMessage(stream libp2pnetwork.Stream, msg Message) er
 	defer func() {
 		err := stream.Close()
 		if err != nil {
-			logger.Warnf("failed to close stream: %w", err)
+			logger.Warnf("failed to close stream: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
removed `time.Sleep()` dependency by using `sync.WaitGroup` from dot/peerset/peerset_test.go
## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/peerset
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
#2520

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
