### PR TITLE
chore(dot/peerset): remove the time.Sleep() dependency.

### DIFF
--- a/dot/peerset/peerset_test.go
+++ b/dot/peerset/peerset_test.go
@@ -88,7 +88,6 @@ func TestAddReservedPeers(t *testing.T) {
 			waitGroup.Done()
 		}()
 		waitGroup.Wait()
-		//time.Sleep(time.Millisecond * 100)
 
 		checkReservedNodePeerExists(t, ps, peerID)
 		checkPeerIsInNoSlotsNode(t, ps.peerState, peerID, testSetID)
@@ -174,7 +173,6 @@ func TestPeerSetIncoming(t *testing.T) {
 			waitGroup.Done()
 		}()
 		waitGroup.Wait()
-		//time.Sleep(time.Millisecond * 100)
 
 		checkNodePeerExists(t, ps.peerState, tt.pid)
 
@@ -217,7 +215,6 @@ func TestPeerSetDiscovered(t *testing.T) {
 		waitGroup.Done()
 	}()
 	waitGroup.Wait()
-	//time.Sleep(200 * time.Millisecond)
 
 	checkNodePeerExists(t, ps.peerState, discovered1)
 	checkNodePeerExists(t, ps.peerState, discovered2)
@@ -259,7 +256,6 @@ func TestReAllocAfterBanned(t *testing.T) {
 		waitGroup.Done()
 	}()
 	waitGroup.Wait()
-	//time.Sleep(time.Millisecond * 100)
 
 	checkMessageStatus(t, <-ps.resultMsgCh, Drop)
 
@@ -315,7 +311,6 @@ func TestRemovePeer(t *testing.T) {
 		waitGroup.Done()
 	}()
 	waitGroup.Wait()
-	//time.Sleep(200 * time.Millisecond)
 
 	require.Len(t, ps.resultMsgCh, 2)
 	for len(ps.resultMsgCh) != 0 {
@@ -352,7 +347,6 @@ func TestSetReservePeer(t *testing.T) {
 		waitGroup.Done()
 	}()
 	waitGroup.Wait()
-	//time.Sleep(200 * time.Millisecond)
 
 	checkPeerSetReservedNodeCount(t, ps, 2)
 	for _, p := range newRsrPeerSet {


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
removed `time.Sleep()` dependency by using `sync.WaitGroup` in dot/peerset/peerset_test.go


## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/peerset
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
https://github.com/ChainSafe/gossamer/issues/2520

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
