### PR TITLE
fix(config): temporary fix for pprof enabled setting precedence

### DIFF
--- a/chain/dev/config.toml
+++ b/chain/dev/config.toml
@@ -52,7 +52,6 @@ modules = [
 ws-port = 8546
 
 [pprof]
-enabled = false
 listening-address = "localhost:6060"
 block-rate = 0
 mutex-rate = 0

--- a/chain/dev/defaults.go
+++ b/chain/dev/defaults.go
@@ -96,9 +96,6 @@ var (
 const (
 	// PprofConfig
 
-	// DefaultPprofEnabled to indicate the pprof http server should be enabled or not.
-	DefaultPprofEnabled = true
-
 	// DefaultPprofListeningAddress default pprof HTTP server listening address.
 	DefaultPprofListeningAddress = "localhost:6060"
 

--- a/chain/gssmr/config.toml
+++ b/chain/gssmr/config.toml
@@ -54,7 +54,6 @@ modules = [
 ws-port = 8546
 
 [pprof]
-enabled = false
 listening-address = "localhost:6060"
 block-rate = 0
 mutex-rate = 0

--- a/chain/gssmr/defaults.go
+++ b/chain/gssmr/defaults.go
@@ -104,9 +104,6 @@ var (
 const (
 	// PprofConfig
 
-	// DefaultPprofEnabled to indicate the pprof http server should be enabled or not.
-	DefaultPprofEnabled = true
-
 	// DefaultPprofListeningAddress default pprof HTTP server listening address.
 	DefaultPprofListeningAddress = "localhost:6060"
 

--- a/chain/kusama/config.toml
+++ b/chain/kusama/config.toml
@@ -42,7 +42,6 @@ ws = false
 ws-external = false
 
 [pprof]
-enabled = false
 listening-address = "localhost:6060"
 block-rate = 0
 mutex-rate = 0

--- a/chain/kusama/defaults.go
+++ b/chain/kusama/defaults.go
@@ -88,9 +88,6 @@ var (
 const (
 	// PprofConfig
 
-	// DefaultPprofEnabled to indicate the pprof http server should be enabled or not.
-	DefaultPprofEnabled = false
-
 	// DefaultPprofListeningAddress default pprof HTTP server listening address.
 	DefaultPprofListeningAddress = "localhost:6060"
 

--- a/chain/polkadot/config.toml
+++ b/chain/polkadot/config.toml
@@ -39,7 +39,6 @@ modules = ["system", "author", "chain", "state", "rpc", "grandpa", "offchain", "
 ws-port = 8546
 
 [pprof]
-enabled = false
 listening-address = "localhost:6060"
 block-rate = 0
 mutex-rate = 0

--- a/chain/polkadot/defaults.go
+++ b/chain/polkadot/defaults.go
@@ -86,9 +86,6 @@ var (
 const (
 	// PprofConfig
 
-	// DefaultPprofEnabled to indicate the pprof http server should be enabled or not.
-	DefaultPprofEnabled = false
-
 	// DefaultPprofListeningAddress default pprof HTTP server listening address.
 	DefaultPprofListeningAddress = "localhost:6060"
 

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -883,9 +883,10 @@ func updateDotConfigFromGenesisData(ctx *cli.Context, cfg *dot.Config) error {
 }
 
 func setDotPprofConfig(ctx *cli.Context, tomlCfg ctoml.PprofConfig, cfg *dot.PprofConfig) {
-	if !cfg.Enabled {
-		// only allow to enable pprof from the TOML configuration.
-		// If it is enabled by default, it cannot be disabled.
+	// Flag takes precedence over TOML config, default is ignored.
+	if ctx.GlobalIsSet(PprofServerFlag.Name) {
+		cfg.Enabled = ctx.GlobalBool(PprofServerFlag.Name)
+	} else {
 		cfg.Enabled = tomlCfg.Enabled
 	}
 
@@ -903,13 +904,6 @@ func setDotPprofConfig(ctx *cli.Context, tomlCfg ctoml.PprofConfig, cfg *dot.Ppr
 		// mutex rate must be 0 (disabled) by default, since we
 		// cannot disable it here.
 		cfg.Settings.MutexProfileRate = tomlCfg.MutexRate
-	}
-
-	// check --pprofserver flag and update node configuration
-	if enabled := ctx.GlobalBool(PprofServerFlag.Name); enabled || cfg.Enabled {
-		cfg.Enabled = true
-	} else if ctx.IsSet(PprofServerFlag.Name) && !enabled {
-		cfg.Enabled = false
 	}
 
 	// check --pprofaddress flag and update node configuration

--- a/dot/config.go
+++ b/dot/config.go
@@ -239,7 +239,6 @@ func GssmrConfig() *Config {
 			WSPort:  gssmr.DefaultRPCWSPort,
 		},
 		Pprof: PprofConfig{
-			Enabled: gssmr.DefaultPprofEnabled,
 			Settings: pprof.Settings{
 				ListeningAddress: gssmr.DefaultPprofListeningAddress,
 				BlockProfileRate: gssmr.DefaultPprofBlockRate,
@@ -297,7 +296,6 @@ func KusamaConfig() *Config {
 			WSPort:  kusama.DefaultRPCWSPort,
 		},
 		Pprof: PprofConfig{
-			Enabled: kusama.DefaultPprofEnabled,
 			Settings: pprof.Settings{
 				ListeningAddress: kusama.DefaultPprofListeningAddress,
 				BlockProfileRate: kusama.DefaultPprofBlockRate,
@@ -355,7 +353,6 @@ func PolkadotConfig() *Config {
 			WSPort:  polkadot.DefaultRPCWSPort,
 		},
 		Pprof: PprofConfig{
-			Enabled: polkadot.DefaultPprofEnabled,
 			Settings: pprof.Settings{
 				ListeningAddress: polkadot.DefaultPprofListeningAddress,
 				BlockProfileRate: polkadot.DefaultPprofBlockRate,
@@ -418,7 +415,6 @@ func DevConfig() *Config {
 			WS:      dev.DefaultWSEnabled,
 		},
 		Pprof: PprofConfig{
-			Enabled: dev.DefaultPprofEnabled,
 			Settings: pprof.Settings{
 				ListeningAddress: dev.DefaultPprofListeningAddress,
 				BlockProfileRate: dev.DefaultPprofBlockRate,

--- a/dot/config_test.go
+++ b/dot/config_test.go
@@ -74,7 +74,6 @@ func TestConfig(t *testing.T) {
 					WS:     true,
 				},
 				Pprof: PprofConfig{
-					Enabled: true,
 					Settings: pprof.Settings{
 						ListeningAddress: "localhost:6060",
 					},
@@ -134,7 +133,6 @@ func TestConfig(t *testing.T) {
 					WSUnsafeExternal: false,
 				},
 				Pprof: PprofConfig{
-					Enabled: true,
 					Settings: pprof.Settings{
 						ListeningAddress: "localhost:6060",
 						BlockProfileRate: 0,


### PR DESCRIPTION
## Changes

- Flag value is used first
- TOML config value is then used
- Default value is ignored (always `false`)
- Remove default pprof enabled values

## Tests


## Issues


## Primary Reviewer

@EclesioMeloJunior 