### PR TITLE
chore(all): remove nil checks for constructors

### DIFF
--- a/dot/core/errors.go
+++ b/dot/core/errors.go
@@ -9,14 +9,6 @@ import (
 )
 
 var (
-	// ErrNilBlockState is returned when BlockState is nil
-	ErrNilBlockState = errors.New("cannot have nil BlockState")
-
-	// ErrNilStorageState is returned when StorageState is nil
-	ErrNilStorageState = errors.New("cannot have nil StorageState")
-
-	// ErrNilKeystore is returned when keystore is nil
-	ErrNilKeystore = errors.New("cannot have nil keystore")
 
 	// ErrServiceStopped is returned when the service has been stopped
 	ErrServiceStopped = errors.New("service has been stopped")
@@ -24,27 +16,12 @@ var (
 	// ErrInvalidBlock is returned when a block cannot be verified
 	ErrInvalidBlock = errors.New("could not verify block")
 
-	// ErrNilVerifier is returned when trying to instantiate a Syncer without a Verifier
-	ErrNilVerifier = errors.New("cannot have nil Verifier")
-
-	// ErrNilRuntime is returned when trying to instantiate a Service or Syncer without a runtime
 	ErrNilRuntime = errors.New("cannot have nil runtime")
-
-	// ErrNilBlockProducer is returned when trying to instantiate a block producing Service without a block producer
-	ErrNilBlockProducer = errors.New("cannot have nil BlockProducer")
-
-	// ErrNilConsensusMessageHandler is returned when trying to instantiate a Service without a FinalityMessageHandler
-	ErrNilConsensusMessageHandler = errors.New("cannot have nil ErrNilFinalityMessageHandler")
 
 	ErrNilBlockHandlerParameter = errors.New("unable to handle block due to nil parameter")
 
-	// ErrNilNetwork is returned when the Network interface is nil
-	ErrNilNetwork = errors.New("cannot have nil Network")
-
 	// ErrEmptyRuntimeCode is returned when the storage :code is empty
 	ErrEmptyRuntimeCode = errors.New("new :code is empty")
-
-	errNilCodeSubstitutedState = errors.New("cannot have nil CodeSubstitutedStat")
 )
 
 // ErrNilChannel is returned if a channel is nil

--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -114,10 +113,6 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 		require.NoError(t, err)
 	}
 	cfg.BlockState.StoreRuntime(cfg.BlockState.BestBlockHash(), cfg.Runtime)
-
-	if cfg.Network == nil {
-		cfg.Network = new(network.Service) // only for nil check in NewService
-	}
 
 	if cfg.CodeSubstitutes == nil {
 		cfg.CodeSubstitutes = make(map[common.Hash]string)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -77,26 +77,6 @@ type Config struct {
 // NewService returns a new core service that connects the runtime, BABE
 // session, and network service.
 func NewService(cfg *Config) (*Service, error) {
-	if cfg.Keystore == nil {
-		return nil, ErrNilKeystore
-	}
-
-	if cfg.BlockState == nil {
-		return nil, ErrNilBlockState
-	}
-
-	if cfg.StorageState == nil {
-		return nil, ErrNilStorageState
-	}
-
-	if cfg.Network == nil {
-		return nil, ErrNilNetwork
-	}
-
-	if cfg.CodeSubstitutedState == nil {
-		return nil, errNilCodeSubstitutedState
-	}
-
 	logger.Patch(log.SetLevel(cfg.LogLvl))
 
 	blockAddCh := make(chan *types.Block, 256)
@@ -137,10 +117,6 @@ func (s *Service) Stop() error {
 
 // StorageRoot returns the hash of the storage root
 func (s *Service) StorageRoot() (common.Hash, error) {
-	if s.storageState == nil {
-		return common.Hash{}, ErrNilStorageState
-	}
-
 	ts, err := s.storageState.TrieState(nil)
 	if err != nil {
 		return common.Hash{}, err

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -132,12 +132,6 @@ func Test_Service_StorageRoot(t *testing.T) {
 		expErrMsg     string
 	}{
 		{
-			name:      "nil storage state",
-			service:   &Service{},
-			expErr:    ErrNilStorageState,
-			expErrMsg: ErrNilStorageState.Error(),
-		},
-		{
 			name:          "storage trie state error",
 			service:       &Service{},
 			retErr:        errTestDummyError,

--- a/dot/mock_node_builder_test.go
+++ b/dot/mock_node_builder_test.go
@@ -63,12 +63,11 @@ func (mr *MocknodeBuilderIfaceMockRecorder) createBABEService(cfg, st, ks, cs, t
 }
 
 // createBlockVerifier mocks base method.
-func (m *MocknodeBuilderIface) createBlockVerifier(st *state.Service) (*babe.VerificationManager, error) {
+func (m *MocknodeBuilderIface) createBlockVerifier(st *state.Service) *babe.VerificationManager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "createBlockVerifier", st)
 	ret0, _ := ret[0].(*babe.VerificationManager)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // createBlockVerifier indicates an expected call of createBlockVerifier.

--- a/dot/node.go
+++ b/dot/node.go
@@ -58,7 +58,7 @@ type nodeBuilderIface interface {
 	createRuntimeStorage(st *state.Service) (*runtime.NodeStorage, error)
 	loadRuntime(cfg *Config, ns *runtime.NodeStorage, stateSrvc *state.Service, ks *keystore.GlobalKeystore,
 		net *network.Service) error
-	createBlockVerifier(st *state.Service) (*babe.VerificationManager, error)
+	createBlockVerifier(st *state.Service) *babe.VerificationManager
 	createDigestHandler(lvl log.Level, st *state.Service) (*digest.Handler, error)
 	createCoreService(cfg *Config, ks *keystore.GlobalKeystore, st *state.Service, net *network.Service,
 		dh *digest.Handler) (*core.Service, error)
@@ -324,10 +324,7 @@ func newNode(cfg *Config,
 		return nil, err
 	}
 
-	ver, err := builder.createBlockVerifier(stateSrvc)
-	if err != nil {
-		return nil, err
-	}
+	ver := builder.createBlockVerifier(stateSrvc)
 
 	dh, err := builder.createDigestHandler(cfg.Log.DigestLvl, stateSrvc)
 	if err != nil {

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -192,8 +192,8 @@ func TestNewNode(t *testing.T) {
 		NodeStorage{}, nil)
 	m.EXPECT().loadRuntime(dotConfig, &runtime.NodeStorage{}, gomock.AssignableToTypeOf(&state.Service{}),
 		ks, gomock.AssignableToTypeOf(&network.Service{})).Return(nil)
-	m.EXPECT().createBlockVerifier(gomock.AssignableToTypeOf(&state.Service{})).Return(&babe.
-		VerificationManager{}, nil)
+	m.EXPECT().createBlockVerifier(gomock.AssignableToTypeOf(&state.Service{})).
+		Return(&babe.VerificationManager{})
 	m.EXPECT().createDigestHandler(log.Critical, gomock.AssignableToTypeOf(&state.Service{})).
 		Return(&digest.Handler{}, nil)
 	m.EXPECT().createCoreService(dotConfig, ks, gomock.AssignableToTypeOf(&state.Service{}),

--- a/dot/services.go
+++ b/dot/services.go
@@ -414,13 +414,8 @@ func (nodeBuilder) createGRANDPAService(cfg *Config, st *state.Service, ks keyst
 	return grandpa.NewService(gsCfg)
 }
 
-func (nodeBuilder) createBlockVerifier(st *state.Service) (*babe.VerificationManager, error) {
-	ver, err := babe.NewVerificationManager(st.Block, st.Epoch)
-	if err != nil {
-		return nil, err
-	}
-
-	return ver, nil
+func (nodeBuilder) createBlockVerifier(st *state.Service) *babe.VerificationManager {
+	return babe.NewVerificationManager(st.Block, st.Epoch)
 }
 
 func (nodeBuilder) newSyncService(cfg *Config, st *state.Service, fg sync.FinalityGadget,

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -138,8 +138,7 @@ func TestCreateBlockVerifier(t *testing.T) {
 	require.NoError(t, err)
 	stateSrvc.Epoch = &state.EpochState{}
 
-	_, err = builder.createBlockVerifier(stateSrvc)
-	require.NoError(t, err)
+	_ = builder.createBlockVerifier(stateSrvc)
 }
 
 func TestCreateSyncService(t *testing.T) {
@@ -158,8 +157,7 @@ func TestCreateSyncService(t *testing.T) {
 	ks := keystore.NewGlobalKeystore()
 	require.NotNil(t, ks)
 
-	ver, err := builder.createBlockVerifier(stateSrvc)
-	require.NoError(t, err)
+	ver := builder.createBlockVerifier(stateSrvc)
 
 	dh, err := builder.createDigestHandler(cfg.Log.DigestLvl, stateSrvc)
 	require.NoError(t, err)

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -4,7 +4,6 @@
 package dot
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/dot/core"
@@ -184,16 +183,6 @@ func Test_nodeBuilder_createBABEService(t *testing.T) {
 			err:      ErrNoKeysProvided,
 		},
 		{
-			name: "config error",
-			args: args{
-				cfg:              cfg,
-				initStateService: false,
-				ks:               ks2.Babe,
-			},
-			expected: nil,
-			err:      babe.ErrNilBlockState,
-		},
-		{
 			name: "base case",
 			args: args{
 				cfg:              cfg,
@@ -214,9 +203,6 @@ func Test_nodeBuilder_createBABEService(t *testing.T) {
 			mockBabeBuilder.EXPECT().NewServiceIFace(
 				gomock.AssignableToTypeOf(&babe.ServiceConfig{})).DoAndReturn(func(cfg *babe.ServiceConfig) (babe.
 				ServiceIFace, error) {
-				if reflect.ValueOf(cfg.BlockState).Kind() == reflect.Ptr && reflect.ValueOf(cfg.BlockState).IsNil() {
-					return nil, babe.ErrNilBlockState
-				}
 				return mockBabeIFace, nil
 			}).AnyTimes()
 			builder := nodeBuilder{}

--- a/dot/sync/errors.go
+++ b/dot/sync/errors.go
@@ -9,14 +9,6 @@ import (
 )
 
 var (
-	errNilBlockState         = errors.New("cannot have nil BlockState")
-	errNilStorageState       = errors.New("cannot have nil StorageState")
-	errNilVerifier           = errors.New("cannot have nil Verifier")
-	errNilBlockImportHandler = errors.New("cannot have nil BlockImportHandler")
-	errNilNetwork            = errors.New("cannot have nil Network")
-	errNilFinalityGadget     = errors.New("cannot have nil FinalityGadget")
-	errNilTransactionState   = errors.New("cannot have nil TransactionState")
-
 	// ErrNilBlockData is returned when trying to process a BlockResponseMessage with nil BlockData
 	ErrNilBlockData = errors.New("got nil BlockData")
 

--- a/dot/sync/syncer.go
+++ b/dot/sync/syncer.go
@@ -41,34 +41,6 @@ type Config struct {
 
 // NewService returns a new *sync.Service
 func NewService(cfg *Config) (*Service, error) {
-	if cfg.Network == nil {
-		return nil, errNilNetwork
-	}
-
-	if cfg.BlockState == nil {
-		return nil, errNilBlockState
-	}
-
-	if cfg.StorageState == nil {
-		return nil, errNilStorageState
-	}
-
-	if cfg.FinalityGadget == nil {
-		return nil, errNilFinalityGadget
-	}
-
-	if cfg.TransactionState == nil {
-		return nil, errNilTransactionState
-	}
-
-	if cfg.BabeVerifier == nil {
-		return nil, errNilVerifier
-	}
-
-	if cfg.BlockImportHandler == nil {
-		return nil, errNilBlockImportHandler
-	}
-
 	logger.Patch(log.SetLevel(cfg.LogLvl))
 
 	readyBlocks := newBlockQueue(maxResponseSize * 30)

--- a/dot/sync/syncer_test.go
+++ b/dot/sync/syncer_test.go
@@ -27,95 +27,13 @@ func TestNewService(t *testing.T) {
 		err        error
 	}{
 		{
-			name: "nil Network",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{}
-			},
-			err: errNilNetwork,
-		},
-		{
-			name: "nil BlockState",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{
-					Network: NewMockNetwork(nil),
-				}
-			},
-			err: errNilBlockState,
-		},
-		{
-			name: "nil StorageState",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{
-					Network:    NewMockNetwork(nil),
-					BlockState: NewMockBlockState(nil),
-				}
-			},
-			err: errNilStorageState,
-		},
-		{
-			name: "nil FinalityGadget",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{
-					Network:      NewMockNetwork(nil),
-					BlockState:   NewMockBlockState(nil),
-					StorageState: NewMockStorageState(nil),
-				}
-			},
-			err: errNilFinalityGadget,
-		},
-		{
-			name: "nil TransactionState",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{
-					Network:        NewMockNetwork(nil),
-					BlockState:     NewMockBlockState(nil),
-					StorageState:   NewMockStorageState(nil),
-					FinalityGadget: NewMockFinalityGadget(nil),
-				}
-			},
-			err: errNilTransactionState,
-		},
-		{
-			name: "nil Verifier",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{
-					Network:          NewMockNetwork(nil),
-					BlockState:       NewMockBlockState(nil),
-					StorageState:     NewMockStorageState(nil),
-					FinalityGadget:   NewMockFinalityGadget(nil),
-					TransactionState: NewMockTransactionState(nil),
-				}
-			},
-			err: errNilVerifier,
-		},
-		{
-			name: "nil BlockImportHandler",
-			cfgBuilder: func(_ *gomock.Controller) *Config {
-				return &Config{
-					Network:          NewMockNetwork(nil),
-					BlockState:       NewMockBlockState(nil),
-					StorageState:     NewMockStorageState(nil),
-					FinalityGadget:   NewMockFinalityGadget(nil),
-					TransactionState: NewMockTransactionState(nil),
-					BabeVerifier:     NewMockBabeVerifier(nil),
-				}
-			},
-			err: errNilBlockImportHandler,
-		},
-		{
 			name: "working example",
 			cfgBuilder: func(ctrl *gomock.Controller) *Config {
 				blockState := NewMockBlockState(ctrl)
 				blockState.EXPECT().GetFinalisedNotifierChannel().
 					Return(make(chan *types.FinalisationInfo))
 				return &Config{
-					Network:            NewMockNetwork(nil),
-					BlockState:         blockState,
-					StorageState:       NewMockStorageState(nil),
-					FinalityGadget:     NewMockFinalityGadget(nil),
-					TransactionState:   NewMockTransactionState(nil),
-					BabeVerifier:       NewMockBabeVerifier(nil),
-					BlockImportHandler: NewMockBlockImportHandler(nil),
+					BlockState: blockState,
 				}
 			},
 			want: &Service{},

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -74,18 +74,6 @@ func (sc *ServiceConfig) Validate() error {
 		return errNoBABEAuthorityKeyProvided
 	}
 
-	if sc.BlockState == nil {
-		return ErrNilBlockState
-	}
-
-	if sc.EpochState == nil {
-		return errNilEpochState
-	}
-
-	if sc.BlockImportHandler == nil {
-		return errNilBlockImportHandler
-	}
-
 	return nil
 }
 
@@ -159,18 +147,6 @@ func (Builder) NewServiceIFace(cfg *ServiceConfig) (ServiceIFace, error) {
 func NewService(cfg *ServiceConfig) (*Service, error) {
 	if cfg.Keypair == nil && cfg.Authority {
 		return nil, errors.New("cannot create BABE service as authority; no keypair provided")
-	}
-
-	if cfg.BlockState == nil {
-		return nil, ErrNilBlockState
-	}
-
-	if cfg.EpochState == nil {
-		return nil, errNilEpochState
-	}
-
-	if cfg.BlockImportHandler == nil {
-		return nil, errNilBlockImportHandler
 	}
 
 	logger.Patch(log.SetLevel(cfg.LogLvl))
@@ -378,16 +354,6 @@ func (b *Service) getAuthorityIndex(Authorities []types.Authority) (uint32, erro
 }
 
 func (b *Service) initiate() {
-	if b.blockState == nil {
-		logger.Errorf("block authoring: %s", ErrNilBlockState)
-		return
-	}
-
-	if b.storageState == nil {
-		logger.Errorf("block authoring: %s", errNilStorageState)
-		return
-	}
-
 	// we should consider better error handling for this - we should
 	// retry to run the engine at some point (maybe the next epoch) if
 	// there's an error.

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -26,16 +26,13 @@ const (
 // construct a block for this slot with the given parent
 func (b *Service) buildBlock(parent *types.Header, slot Slot, rt runtime.Instance,
 	authorityIndex uint32, preRuntimeDigest *types.PreRuntimeDigest) (*types.Block, error) {
-	builder, err := NewBlockBuilder(
+	builder := NewBlockBuilder(
 		b.keypair,
 		b.transactionState,
 		b.blockState,
 		authorityIndex,
 		preRuntimeDigest,
 	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create block builder: %w", err)
-	}
 
 	// is necessary to enable ethmetrics to be possible register values
 	ethmetrics.Enabled = true
@@ -69,23 +66,14 @@ func NewBlockBuilder(
 	bs BlockState,
 	authidx uint32,
 	preRuntimeDigest *types.PreRuntimeDigest,
-) (*BlockBuilder, error) {
-	if ts == nil {
-		return nil, ErrNilTransactionState
-	}
-	if bs == nil {
-		return nil, ErrNilBlockState
-	}
-
-	bb := &BlockBuilder{
+) *BlockBuilder {
+	return &BlockBuilder{
 		keypair:               kp,
 		transactionState:      ts,
 		blockState:            bs,
 		currentAuthorityIndex: authidx,
 		preRuntimeDigest:      preRuntimeDigest,
 	}
-
-	return bb, nil
 }
 
 func (b *BlockBuilder) buildBlock(parent *types.Header, slot Slot, rt runtime.Instance) (*types.Block, error) {

--- a/lib/babe/build_integration_test.go
+++ b/lib/babe/build_integration_test.go
@@ -31,24 +31,9 @@ func TestSeal(t *testing.T) {
 	kp, err := sr25519.GenerateKeypair()
 	require.NoError(t, err)
 
-	cfg := &ServiceConfig{
-		Keypair: kp,
+	builder := &BlockBuilder{
+		keypair: kp,
 	}
-
-	babeService := createTestService(t, cfg)
-	babeService.epochHandler, err = babeService.initiateAndGetEpochHandler(0)
-	require.NoError(t, err)
-
-	authoringSlots := getAuthoringSlots(babeService.epochHandler.slotToPreRuntimeDigest)
-	require.NotEmpty(t, authoringSlots)
-
-	builder, _ := NewBlockBuilder(
-		babeService.keypair,
-		babeService.transactionState,
-		babeService.blockState,
-		babeService.epochHandler.epochData.authorityIndex,
-		babeService.epochHandler.slotToPreRuntimeDigest[authoringSlots[0]],
-	)
 
 	zeroHash, err := common.HexToHash("0x00")
 	require.NoError(t, err)

--- a/lib/babe/errors.go
+++ b/lib/babe/errors.go
@@ -60,13 +60,6 @@ var (
 	// ErrThresholdOneIsZero is returned when one of or both parameters to CalculateThreshold is zero
 	ErrThresholdOneIsZero = errors.New("numerator or denominator cannot be 0")
 
-	ErrNilBlockState       = errors.New("cannot have nil BlockState")
-	ErrNilTransactionState = errors.New("cannot create block builder; transaction state is nil")
-	ErrNilVRFProof         = errors.New("cannot create block builder; slot VRF proof is nil")
-
-	errNilBlockImportHandler      = errors.New("cannot have nil BlockImportHandler")
-	errNilEpochState              = errors.New("cannot have nil EpochState")
-	errNilStorageState            = errors.New("storage state is nil")
 	errNilParentHeader            = errors.New("parent header is nil")
 	errInvalidResult              = errors.New("invalid error value")
 	errFirstBlockTimeout          = errors.New("timed out waiting for first block")

--- a/lib/babe/verify.go
+++ b/lib/babe/verify.go
@@ -44,21 +44,13 @@ type VerificationManager struct {
 }
 
 // NewVerificationManager returns a new NewVerificationManager
-func NewVerificationManager(blockState BlockState, epochState EpochState) (*VerificationManager, error) {
-	if blockState == nil {
-		return nil, ErrNilBlockState
-	}
-
-	if epochState == nil {
-		return nil, errNilEpochState
-	}
-
+func NewVerificationManager(blockState BlockState, epochState EpochState) *VerificationManager {
 	return &VerificationManager{
 		epochState: epochState,
 		blockState: blockState,
 		epochInfo:  make(map[uint64]*verifierInfo),
 		onDisabled: make(map[uint64]map[uint32][]*onDisabledInfo),
-	}, nil
+	}
 }
 
 // SetOnDisabled sets the BABE authority with the given index as disabled for the rest of the epoch
@@ -188,10 +180,7 @@ func (v *VerificationManager) VerifyBlock(header *types.Header) error {
 
 	v.lock.Unlock()
 
-	verifier, err := newVerifier(v.blockState, epoch, info)
-	if err != nil {
-		return fmt.Errorf("failed to create new BABE verifier: %w", err)
-	}
+	verifier := newVerifier(v.blockState, epoch, info)
 
 	return verifier.verifyAuthorshipRight(header)
 }
@@ -231,11 +220,7 @@ type verifier struct {
 }
 
 // newVerifier returns a Verifier for the epoch described by the given descriptor
-func newVerifier(blockState BlockState, epoch uint64, info *verifierInfo) (*verifier, error) {
-	if blockState == nil {
-		return nil, ErrNilBlockState
-	}
-
+func newVerifier(blockState BlockState, epoch uint64, info *verifierInfo) *verifier {
 	return &verifier{
 		blockState:     blockState,
 		epoch:          epoch,
@@ -243,7 +228,7 @@ func newVerifier(blockState BlockState, epoch uint64, info *verifierInfo) (*veri
 		randomness:     info.randomness,
 		threshold:      info.threshold,
 		secondarySlots: info.secondarySlots,
-	}, nil
+	}
 }
 
 // verifyAuthorshipRight verifies that the authority that produced a block was authorized to produce it.

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -58,9 +58,7 @@ func newTestVerificationManager(t *testing.T, genCfg *types.BabeConfiguration) *
 
 	logger.Patch(log.SetLevel(defaultTestLogLvl))
 
-	vm, err := NewVerificationManager(dbSrv.Block, dbSrv.Epoch)
-	require.NoError(t, err)
-	return vm
+	return NewVerificationManager(dbSrv.Block, dbSrv.Epoch)
 }
 
 // TODO: add test against latest dev runtime
@@ -369,12 +367,11 @@ func TestVerifyPimarySlotWinner(t *testing.T) {
 	}
 	epochData.authorities = Authorities
 
-	verifier, err := newVerifier(babeService.blockState, testEpochIndex, &verifierInfo{
+	verifier := newVerifier(babeService.blockState, testEpochIndex, &verifierInfo{
 		authorities: epochData.authorities,
 		threshold:   epochData.threshold,
 		randomness:  epochData.randomness,
 	})
-	require.NoError(t, err)
 
 	ok, err = verifier.verifyPrimarySlotWinner(d.AuthorityIndex, slotNumber, d.VRFOutput, d.VRFProof)
 	require.NoError(t, err)
@@ -391,12 +388,11 @@ func TestVerifyAuthorshipRight(t *testing.T) {
 
 	block := createTestBlock(t, babeService, genesisHeader, [][]byte{}, 1, testEpochIndex, epochData)
 
-	verifier, err := newVerifier(babeService.blockState, testEpochIndex, &verifierInfo{
+	verifier := newVerifier(babeService.blockState, testEpochIndex, &verifierInfo{
 		authorities: epochData.authorities,
 		threshold:   epochData.threshold,
 		randomness:  epochData.randomness,
 	})
-	require.NoError(t, err)
 
 	err = verifier.verifyAuthorshipRight(&block.Header)
 	require.NoError(t, err)
@@ -430,12 +426,11 @@ func TestVerifyAuthorshipRight_Equivocation(t *testing.T) {
 	err = babeService.blockState.AddBlock(block)
 	require.NoError(t, err)
 
-	verifier, err := newVerifier(babeService.blockState, testEpochIndex, &verifierInfo{
+	verifier := newVerifier(babeService.blockState, testEpochIndex, &verifierInfo{
 		authorities: epochData.authorities,
 		threshold:   epochData.threshold,
 		randomness:  epochData.randomness,
 	})
-	require.NoError(t, err)
 
 	err = verifier.verifyAuthorshipRight(&block.Header)
 	require.NoError(t, err)
@@ -515,8 +510,7 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 
 	digestHandler.Start()
 
-	verificationManager, err := NewVerificationManager(stateService.Block, epochState)
-	require.NoError(t, err)
+	verificationManager := NewVerificationManager(stateService.Block, epochState)
 
 	/*
 	* lets issue different blocks starting from genesis (a fork)

--- a/lib/blocktree/errors.go
+++ b/lib/blocktree/errors.go
@@ -20,9 +20,6 @@ var (
 	// ErrEndNodeNotFound is returned if the end of a subchain does not exist
 	ErrEndNodeNotFound = errors.New("end node does not exist")
 
-	// ErrNilDatabase is returned in the database is nil
-	ErrNilDatabase = errors.New("blocktree database is nil")
-
 	// ErrNilDescendant is returned if calling subchain with a nil node
 	ErrNilDescendant = errors.New("descendant node is nil")
 

--- a/lib/grandpa/errors.go
+++ b/lib/grandpa/errors.go
@@ -16,12 +16,6 @@ func errRoundMismatch(got, want uint64) error {
 }
 
 var (
-	ErrNilBlockState    = errors.New("cannot have nil BlockState")
-	ErrNilGrandpaState  = errors.New("cannot have nil GrandpaState")
-	ErrNilDigestHandler = errors.New("cannot have nil DigestHandler")
-	ErrNilKeypair       = errors.New("cannot have nil keypair")
-	ErrNilNetwork       = errors.New("cannot have nil Network")
-
 	// ErrBlockDoesNotExist is returned when trying to validate a vote for a block that doesn't exist
 	ErrBlockDoesNotExist = errors.New("block does not exist")
 

--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -95,22 +95,6 @@ type Config struct {
 
 // NewService returns a new GRANDPA Service instance.
 func NewService(cfg *Config) (*Service, error) {
-	if cfg.BlockState == nil {
-		return nil, ErrNilBlockState
-	}
-
-	if cfg.GrandpaState == nil {
-		return nil, ErrNilGrandpaState
-	}
-
-	if cfg.Keypair == nil && cfg.Authority {
-		return nil, ErrNilKeypair
-	}
-
-	if cfg.Network == nil {
-		return nil, ErrNilNetwork
-	}
-
 	logger.Patch(log.SetLevel(cfg.LogLvl))
 
 	var pub string

--- a/lib/grandpa/vote_message_test.go
+++ b/lib/grandpa/vote_message_test.go
@@ -18,14 +18,9 @@ func TestCheckForEquivocation_NoEquivocation(t *testing.T) {
 	st := newTestState(t)
 	net := newTestNetwork(t)
 
-	kr, err := keystore.NewEd25519Keyring()
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
-		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -52,14 +47,9 @@ func TestCheckForEquivocation_WithEquivocation(t *testing.T) {
 	st := newTestState(t)
 	net := newTestNetwork(t)
 
-	kr, err := keystore.NewEd25519Keyring()
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
-		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -97,14 +87,9 @@ func TestCheckForEquivocation_WithExistingEquivocation(t *testing.T) {
 	st := newTestState(t)
 	net := newTestNetwork(t)
 
-	kr, err := keystore.NewEd25519Keyring()
-	require.NoError(t, err)
-
 	cfg := &Config{
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
-		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -159,7 +144,6 @@ func TestValidateMessage_Valid(t *testing.T) {
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
 		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -191,8 +175,6 @@ func TestValidateMessage_InvalidSignature(t *testing.T) {
 	cfg := &Config{
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
-		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -225,7 +207,6 @@ func TestValidateMessage_SetIDMismatch(t *testing.T) {
 	cfg := &Config{
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -259,7 +240,6 @@ func TestValidateMessage_Equivocation(t *testing.T) {
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
 		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -302,7 +282,6 @@ func TestValidateMessage_BlockDoesNotExist(t *testing.T) {
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
 		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}
@@ -336,7 +315,6 @@ func TestValidateMessage_IsNotDescendant(t *testing.T) {
 		BlockState:   st.Block,
 		GrandpaState: st.Grandpa,
 		Voters:       voters,
-		Keypair:      kr.Bob().(*ed25519.Keypair),
 		Network:      net,
 		Interval:     time.Second,
 	}


### PR DESCRIPTION
## Changes

The main reason is that adding empty fields all over in tests to pass those constructors is just plain annoying. And our production code doesn't need them at all since all of these are programming errors only.

Now if for some reason someone would use our go api and leave one of the field to nil, it would panic which is better than an error since it's really a programming error. See https://engineering-handbook.onrender.com/development/tech-stack/go#panic

Added side benefits are:

- a lot of red in this PR
- a few function signatures simplified/not returning an error anymore

This helps simplify some of the changes in tests for #2774 

## Tests

## Issues

## Primary Reviewer
