### PR TITLE
chore(dot/state): `newTestStorageState` does not take `tries` argument

### DIFF
--- a/dot/state/block_data_test.go
+++ b/dot/state/block_data_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGetSet_ReceiptMessageQueue_Justification(t *testing.T) {
-	s := newTestBlockState(t, nil, newTriesEmpty())
+	s := newTestBlockState(t, newTriesEmpty())
 
 	var genesisHeader = &types.Header{
 		Number:    0,

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHighestRoundAndSetID(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 	round, setID, err := bs.GetHighestRoundAndSetID()
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), round)
@@ -62,7 +62,7 @@ func TestHighestRoundAndSetID(t *testing.T) {
 }
 
 func TestBlockState_SetFinalisedHash(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 	h, err := bs.GetFinalisedHash(0, 0)
 	require.NoError(t, err)
 	require.Equal(t, testGenesisHeader.Hash(), h)
@@ -104,7 +104,7 @@ func TestBlockState_SetFinalisedHash(t *testing.T) {
 }
 
 func TestSetFinalisedHash_setFirstSlotOnFinalisation(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 	firstSlot := uint64(42069)
 
 	digest := types.NewDigest()

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -16,7 +16,7 @@ import (
 var testMessageTimeout = time.Second * 3
 
 func TestImportChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 	ch := bs.GetImportedBlockNotifierChannel()
 
 	defer bs.FreeImportedBlockNotifierChannel(ch)
@@ -33,7 +33,7 @@ func TestImportChannel(t *testing.T) {
 }
 
 func TestFreeImportedBlockNotifierChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 	ch := bs.GetImportedBlockNotifierChannel()
 	require.Equal(t, 1, len(bs.imported))
 
@@ -42,7 +42,7 @@ func TestFreeImportedBlockNotifierChannel(t *testing.T) {
 }
 
 func TestFinalizedChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 
 	ch := bs.GetFinalisedNotifierChannel()
 
@@ -64,7 +64,7 @@ func TestFinalizedChannel(t *testing.T) {
 }
 
 func TestImportChannel_Multi(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 
 	num := 5
 	chs := make([]chan *types.Block, num)
@@ -96,7 +96,7 @@ func TestImportChannel_Multi(t *testing.T) {
 }
 
 func TestFinalizedChannel_Multi(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 
 	num := 5
 	chs := make([]chan *types.FinalisationInfo, num)
@@ -133,7 +133,7 @@ func TestFinalizedChannel_Multi(t *testing.T) {
 }
 
 func TestService_RegisterUnRegisterRuntimeUpdatedChannel(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 	ch := make(chan<- runtime.Version)
 	chID, err := bs.RegisterRuntimeUpdatedChannel(ch)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestService_RegisterUnRegisterRuntimeUpdatedChannel(t *testing.T) {
 }
 
 func TestService_RegisterUnRegisterConcurrentCalls(t *testing.T) {
-	bs := newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	bs := newTestBlockState(t, newTriesEmpty())
 
 	go func() {
 		for i := 0; i < 100; i++ {

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -30,12 +30,9 @@ func newTestBlockState(t *testing.T, tries *Tries) *BlockState {
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 	db := NewInMemoryDB(t)
-	header := types.Header{
-		StateRoot: trie.EmptyHash,
-		Digest:    types.NewDigest(),
-	}
+	header := testGenesisHeader
 
-	bs, err := NewBlockStateFromGenesis(db, tries, &header, telemetryMock)
+	bs, err := NewBlockStateFromGenesis(db, tries, header, telemetryMock)
 	require.NoError(t, err)
 
 	// loads in-memory tries with genesis state root, should be deleted

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -29,7 +29,7 @@ var genesisBABEConfig = &types.BabeConfiguration{
 
 func newEpochStateFromGenesis(t *testing.T) *EpochState {
 	db := NewInMemoryDB(t)
-	blockState := newTestBlockState(t, nil, newTriesEmpty())
+	blockState := newTestBlockState(t, newTriesEmpty())
 	s, err := NewEpochStateFromGenesis(db, blockState, genesisBABEConfig)
 	require.NoError(t, err)
 	return s
@@ -183,7 +183,7 @@ func TestEpochState_SetAndGetSlotDuration(t *testing.T) {
 
 func TestEpochState_GetEpochFromTime(t *testing.T) {
 	s := newEpochStateFromGenesis(t)
-	s.blockState = newTestBlockState(t, testGenesisHeader, newTriesEmpty())
+	s.blockState = newTestBlockState(t, newTriesEmpty())
 
 	epochDuration, err := time.ParseDuration(
 		fmt.Sprintf("%dms",

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestStorageState_RegisterStorageObserver(t *testing.T) {
-	ss := newTestStorageState(t, newTriesEmpty())
+	ss := newTestStorageState(t)
 
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 }
 
 func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
-	ss := newTestStorageState(t, newTriesEmpty())
+	ss := newTestStorageState(t)
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 
 func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 	t.Skip() // this seems to fail often on CI
-	ss := newTestStorageState(t, newTriesEmpty())
+	ss := newTestStorageState(t)
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
 

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -20,9 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestStorageState(t *testing.T, tries *Tries) *StorageState {
+func newTestStorageState(t *testing.T) *StorageState {
 	db := NewInMemoryDB(t)
 
+	tries := newTriesEmpty()
 	bs := newTestBlockState(t, testGenesisHeader, tries)
 
 	s, err := NewStorageState(db, bs, tries, pruner.Config{})
@@ -31,7 +32,7 @@ func newTestStorageState(t *testing.T, tries *Tries) *StorageState {
 }
 
 func TestStorage_StoreAndLoadTrie(t *testing.T) {
-	storage := newTestStorageState(t, newTriesEmpty())
+	storage := newTestStorageState(t)
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -50,7 +51,7 @@ func TestStorage_StoreAndLoadTrie(t *testing.T) {
 }
 
 func TestStorage_GetStorageByBlockHash(t *testing.T) {
-	storage := newTestStorageState(t, newTriesEmpty())
+	storage := newTestStorageState(t)
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -85,7 +86,7 @@ func TestStorage_GetStorageByBlockHash(t *testing.T) {
 }
 
 func TestStorage_TrieState(t *testing.T) {
-	storage := newTestStorageState(t, newTriesEmpty())
+	storage := newTestStorageState(t)
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 	ts.Set([]byte("noot"), []byte("washere"))
@@ -105,7 +106,7 @@ func TestStorage_TrieState(t *testing.T) {
 }
 
 func TestStorage_LoadFromDB(t *testing.T) {
-	storage := newTestStorageState(t, newTriesEmpty())
+	storage := newTestStorageState(t)
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 
@@ -150,7 +151,7 @@ func TestStorage_LoadFromDB(t *testing.T) {
 }
 
 func TestStorage_StoreTrie_NotSyncing(t *testing.T) {
-	storage := newTestStorageState(t, newTriesEmpty())
+	storage := newTestStorageState(t)
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
 

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -24,7 +24,7 @@ func newTestStorageState(t *testing.T) *StorageState {
 	db := NewInMemoryDB(t)
 
 	tries := newTriesEmpty()
-	bs := newTestBlockState(t, testGenesisHeader, tries)
+	bs := newTestBlockState(t, tries)
 
 	s, err := NewStorageState(db, bs, tries, pruner.Config{})
 	require.NoError(t, err)


### PR DESCRIPTION
Tiny simplification for test helper always taking `newEmptyTries()` argument

