### PR TITLE
chore(dot/sync): `handleJustification` returns errors

### DIFF
--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -134,7 +134,10 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 
 		if bd.Justification != nil {
 			logger.Debugf("handling Justification for block number %d with hash %s...", block.Header.Number, bd.Hash)
-			s.handleJustification(&block.Header, *bd.Justification)
+			err = s.handleJustification(&block.Header, *bd.Justification)
+			if err != nil {
+				return fmt.Errorf("handling justification: %w", err)
+			}
 		}
 
 		// TODO: this is probably unnecessary, since the state is already in the database
@@ -177,7 +180,10 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 
 	if bd.Justification != nil && bd.Header != nil {
 		logger.Debugf("handling Justification for block number %d with hash %s...", bd.Number(), bd.Hash)
-		s.handleJustification(bd.Header, *bd.Justification)
+		err = s.handleJustification(bd.Header, *bd.Justification)
+		if err != nil {
+			return fmt.Errorf("handling justification: %w", err)
+		}
 	}
 
 	if err := s.blockState.CompareAndSetBlockData(bd); err != nil {
@@ -242,22 +248,22 @@ func (s *chainProcessor) handleBlock(block *types.Block) error {
 	return nil
 }
 
-func (s *chainProcessor) handleJustification(header *types.Header, justification []byte) {
-	if len(justification) == 0 || header == nil {
-		return
+func (s *chainProcessor) handleJustification(header *types.Header, justification []byte) (err error) {
+	if len(justification) == 0 {
+		return nil
 	}
 
-	returnedJustification, err := s.finalityGadget.VerifyBlockJustification(header.Hash(), justification)
+	headerHash := header.Hash()
+	returnedJustification, err := s.finalityGadget.VerifyBlockJustification(headerHash, justification)
 	if err != nil {
-		logger.Warnf("failed to verify block number %d and hash %s justification: %s", header.Number, header.Hash(), err)
-		return
+		return fmt.Errorf("verifying block number %d justification: %w", header.Number, err)
 	}
 
-	err = s.blockState.SetJustification(header.Hash(), returnedJustification)
+	err = s.blockState.SetJustification(headerHash, returnedJustification)
 	if err != nil {
-		logger.Errorf("failed tostore justification: %s", err)
-		return
+		return fmt.Errorf("setting justification for block number %d: %w", header.Number, err)
 	}
 
-	logger.Infof("🔨 finalised block number %d with hash %s", header.Number, header.Hash())
+	logger.Infof("🔨 finalised block number %d with hash %s", header.Number, headerHash)
+	return nil
 }

--- a/dot/sync/chain_processor_integration_test.go
+++ b/dot/sync/chain_processor_integration_test.go
@@ -234,7 +234,8 @@ func TestChainProcessor_HandleJustification(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	syncer.chainProcessor.(*chainProcessor).handleJustification(header, just)
+	err = syncer.chainProcessor.(*chainProcessor).handleJustification(header, just)
+	require.NoError(t, err)
 
 	res, err := syncer.blockState.GetJustification(header.Hash())
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

- Remove nil check on header and justification (unused, see caller checks - and caller should be the ones checking what they pass down)
- Return wrapped errors to callers
- Change callers to handle non-nil errors and return them up the call stack
- Adapt tests

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer/dot/sync/...
```

## Issues

## Primary Reviewer

@noot 