### PR TITLE
chore(dot/sync): simplify `processBlockData` and associated tests

### DIFF
--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -82,9 +82,12 @@ func (s *chainProcessor) stop() {
 
 func (s *chainProcessor) processReadyBlocks() {
 	for {
-		bd := s.readyBlocks.pop(s.ctx)
-		if bd == nil { // context was canceled
-			return
+		bd, err := s.readyBlocks.pop(s.ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+			panic(fmt.Sprintf("unhandled error: %s", err))
 		}
 
 		if err := s.processBlockData(*bd); err != nil {

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -156,8 +156,9 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 			return fmt.Errorf("loading trie state: %w", err)
 		}
 
-		if err := s.blockImportHandler.HandleBlockImport(block, state, announceImportedBlock); err != nil {
-			logger.Warnf("failed to handle block import: %s", err)
+		err = s.blockImportHandler.HandleBlockImport(block, state, announceImportedBlock)
+		if err != nil {
+			return fmt.Errorf("handling block import: %w", err)
 		}
 
 		return nil

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -109,6 +109,8 @@ func (s *chainProcessor) processReadyBlocks() {
 // returns the index of the last BlockData it handled on success,
 // or the index of the block data that errored on failure.
 func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
+	logger.Debugf("processing block data with hash %s", bd.Hash)
+
 	hasHeader, err := s.blockState.HasHeader(bd.Hash)
 	if err != nil {
 		return fmt.Errorf("checking if block state has header: %w", err)
@@ -162,8 +164,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 
 		return nil
 	}
-
-	logger.Debugf("processing block data with hash %s", bd.Hash)
 
 	if bd.Header != nil && bd.Body != nil {
 		if err := s.babeVerifier.VerifyBlock(bd.Header); err != nil {

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -140,7 +140,7 @@ func (c *chainProcessor) processBlockData(blockData types.BlockData) error { //n
 		logger.Debugf("block with hash %s processed", blockData.Hash)
 	}
 
-	if blockData.Justification != nil && blockData.Header != nil {
+	if blockData.Justification != nil && len(*blockData.Justification) > 0 && blockData.Header != nil {
 		err = c.handleJustification(blockData.Header, *blockData.Justification)
 		if err != nil {
 			return fmt.Errorf("handling justification: %w", err)
@@ -175,7 +175,7 @@ func (c *chainProcessor) processBlockDataWithStateHeaderAndBody(blockData types.
 		return fmt.Errorf("adding block to blocktree: %w", err)
 	}
 
-	if blockData.Justification != nil {
+	if blockData.Justification != nil && len(*blockData.Justification) > 0 {
 		err = c.handleJustification(&block.Header, *blockData.Justification)
 		if err != nil {
 			return fmt.Errorf("handling justification: %w", err)

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -127,7 +127,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		// code block can be removed (#1784)
 		block, err := s.blockState.GetBlockByHash(bd.Hash)
 		if err != nil {
-			logger.Debugf("failed to get block header for hash %s: %s", bd.Hash, err)
 			return fmt.Errorf("getting block by hash: %w", err)
 		}
 
@@ -139,7 +138,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		if errors.Is(err, blocktree.ErrBlockExists) {
 			return nil
 		} else if err != nil {
-			logger.Warnf("failed to add block with hash %s to blocktree: %s", bd.Hash, err)
 			return fmt.Errorf("adding block to blocktree: %w", err)
 		}
 
@@ -156,7 +154,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		// is rewinded or if the node shuts down unexpectedly (#1784)
 		state, err := s.storageState.TrieState(&block.Header.StateRoot)
 		if err != nil {
-			logger.Warnf("failed to load state for block with hash %s: %s", block.Header.Hash(), err)
 			return fmt.Errorf("loading trie state: %w", err)
 		}
 
@@ -182,7 +179,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		}
 
 		if err := s.handleBlock(block, announceImportedBlock); err != nil {
-			logger.Debugf("failed to handle block number %d: %s", block.Header.Number, err)
 			return fmt.Errorf("handling block: %w", err)
 		}
 

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -87,7 +87,7 @@ func (s *chainProcessor) processReadyBlocks() {
 			return
 		}
 
-		if err := s.processBlockData(bd); err != nil {
+		if err := s.processBlockData(*bd); err != nil {
 			// depending on the error, we might want to save this block for later
 			if !errors.Is(err, errFailedToGetParent) {
 				logger.Errorf("block data processing for block with hash %s failed: %s", bd.Hash, err)
@@ -108,7 +108,7 @@ func (s *chainProcessor) processReadyBlocks() {
 // processBlockData processes the BlockData from a BlockResponse and
 // returns the index of the last BlockData it handled on success,
 // or the index of the block data that errored on failure.
-func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
+func (s *chainProcessor) processBlockData(bd types.BlockData) error {
 	logger.Debugf("processing block data with hash %s", bd.Hash)
 
 	hasHeader, err := s.blockState.HasHeader(bd.Hash)
@@ -123,7 +123,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 	// while in bootstrap mode we don't need to broadcast block announcements
 	announceImportedBlock := s.chainSync.syncState() == tip
 	if hasHeader && hasBody {
-		err = s.processBlockDataWithStateHeaderAndBody(*bd, announceImportedBlock)
+		err = s.processBlockDataWithStateHeaderAndBody(bd, announceImportedBlock)
 		if err != nil {
 			return fmt.Errorf("processing block data with header and "+
 				"body in block state: %w", err)
@@ -132,7 +132,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 	}
 
 	if bd.Header != nil && bd.Body != nil {
-		err = s.processBlockDataWithHeaderAndBody(*bd, announceImportedBlock)
+		err = s.processBlockDataWithHeaderAndBody(bd, announceImportedBlock)
 		if err != nil {
 			return fmt.Errorf("processing block data with header and body: %w", err)
 		}
@@ -146,7 +146,7 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		}
 	}
 
-	if err := s.blockState.CompareAndSetBlockData(bd); err != nil {
+	if err := s.blockState.CompareAndSetBlockData(&bd); err != nil {
 		return fmt.Errorf("comparing and setting block data: %w", err)
 	}
 

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -109,10 +109,6 @@ func (s *chainProcessor) processReadyBlocks() {
 // returns the index of the last BlockData it handled on success,
 // or the index of the block data that errored on failure.
 func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
-	if bd == nil {
-		return ErrNilBlockData
-	}
-
 	hasHeader, err := s.blockState.HasHeader(bd.Hash)
 	if err != nil {
 		return fmt.Errorf("failed to check if block state has header for hash %s: %w", bd.Hash, err)

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -263,10 +263,6 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 }
 
 func (s *chainProcessor) handleJustification(header *types.Header, justification []byte) (err error) {
-	if len(justification) == 0 {
-		return nil
-	}
-
 	headerHash := header.Hash()
 	returnedJustification, err := s.finalityGadget.VerifyBlockJustification(headerHash, justification)
 	if err != nil {

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -142,7 +142,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 		}
 
 		if bd.Justification != nil {
-			logger.Debugf("handling Justification for block number %d with hash %s...", block.Header.Number, bd.Hash)
 			err = s.handleJustification(&block.Header, *bd.Justification)
 			if err != nil {
 				return fmt.Errorf("handling justification: %w", err)
@@ -186,7 +185,6 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 	}
 
 	if bd.Justification != nil && bd.Header != nil {
-		logger.Debugf("handling Justification for block number %d with hash %s...", bd.Number(), bd.Hash)
 		err = s.handleJustification(bd.Header, *bd.Justification)
 		if err != nil {
 			return fmt.Errorf("handling justification: %w", err)
@@ -255,6 +253,8 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 }
 
 func (s *chainProcessor) handleJustification(header *types.Header, justification []byte) (err error) {
+	logger.Debugf("handling justification for block %d...", header.Number)
+
 	headerHash := header.Hash()
 	returnedJustification, err := s.finalityGadget.VerifyBlockJustification(headerHash, justification)
 	if err != nil {

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -130,12 +130,11 @@ func (s *chainProcessor) processBlockData(bd *types.BlockData) error {
 			return fmt.Errorf("getting block by hash: %w", err)
 		}
 
-		logger.Debugf(
-			"skipping block number %d with hash %s, already have",
-			block.Header.Number, bd.Hash) // TODO is this valid?
-
 		err = s.blockState.AddBlockToBlockTree(block)
 		if errors.Is(err, blocktree.ErrBlockExists) {
+			logger.Debugf(
+				"block number %d with hash %s already exists in block tree, skipping it.",
+				block.Header.Number, bd.Hash)
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("adding block to blocktree: %w", err)

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -157,8 +157,8 @@ func (c *chainProcessor) processBlockData(blockData types.BlockData) error { //n
 	return nil
 }
 
-func (c *chainProcessor) processBlockDataWithStateHeaderAndBody(blockData types.BlockData,
-	announceImportedBlock bool) (err error) { //nolint:revive
+func (c *chainProcessor) processBlockDataWithStateHeaderAndBody(blockData types.BlockData, //nolint:revive
+	announceImportedBlock bool) (err error) {
 	// TODO: fix this; sometimes when the node shuts down the "best block" isn't stored properly,
 	// so when the node restarts it has blocks higher than what it thinks is the best, causing it not to sync
 	// if we update the node to only store finalised blocks in the database, this should be fixed and the entire
@@ -201,8 +201,8 @@ func (c *chainProcessor) processBlockDataWithStateHeaderAndBody(blockData types.
 	return nil
 }
 
-func (c *chainProcessor) processBlockDataWithHeaderAndBody(blockData types.BlockData,
-	announceImportedBlock bool) (err error) { //nolint:revive
+func (c *chainProcessor) processBlockDataWithHeaderAndBody(blockData types.BlockData, //nolint:revive
+	announceImportedBlock bool) (err error) {
 	err = c.babeVerifier.VerifyBlock(blockData.Header)
 	if err != nil {
 		return fmt.Errorf("babe verifying block: %w", err)

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -108,22 +108,22 @@ func (s *chainProcessor) processReadyBlocks() {
 // processBlockData processes the BlockData from a BlockResponse and
 // returns the index of the last BlockData it handled on success,
 // or the index of the block data that errored on failure.
-func (s *chainProcessor) processBlockData(bd types.BlockData) error {
+func (c *chainProcessor) processBlockData(bd types.BlockData) error { //nolint:revive
 	logger.Debugf("processing block data with hash %s", bd.Hash)
 
-	hasHeader, err := s.blockState.HasHeader(bd.Hash)
+	hasHeader, err := c.blockState.HasHeader(bd.Hash)
 	if err != nil {
 		return fmt.Errorf("checking if block state has header: %w", err)
 	}
-	hasBody, err := s.blockState.HasBlockBody(bd.Hash)
+	hasBody, err := c.blockState.HasBlockBody(bd.Hash)
 	if err != nil {
 		return fmt.Errorf("checking if block state has body: %w", err)
 	}
 
 	// while in bootstrap mode we don't need to broadcast block announcements
-	announceImportedBlock := s.chainSync.syncState() == tip
+	announceImportedBlock := c.chainSync.syncState() == tip
 	if hasHeader && hasBody {
-		err = s.processBlockDataWithStateHeaderAndBody(bd, announceImportedBlock)
+		err = c.processBlockDataWithStateHeaderAndBody(bd, announceImportedBlock)
 		if err != nil {
 			return fmt.Errorf("processing block data with header and "+
 				"body in block state: %w", err)
@@ -132,7 +132,7 @@ func (s *chainProcessor) processBlockData(bd types.BlockData) error {
 	}
 
 	if bd.Header != nil && bd.Body != nil {
-		err = s.processBlockDataWithHeaderAndBody(bd, announceImportedBlock)
+		err = c.processBlockDataWithHeaderAndBody(bd, announceImportedBlock)
 		if err != nil {
 			return fmt.Errorf("processing block data with header and body: %w", err)
 		}
@@ -140,13 +140,13 @@ func (s *chainProcessor) processBlockData(bd types.BlockData) error {
 	}
 
 	if bd.Justification != nil && bd.Header != nil {
-		err = s.handleJustification(bd.Header, *bd.Justification)
+		err = c.handleJustification(bd.Header, *bd.Justification)
 		if err != nil {
 			return fmt.Errorf("handling justification: %w", err)
 		}
 	}
 
-	if err := s.blockState.CompareAndSetBlockData(&bd); err != nil {
+	if err := c.blockState.CompareAndSetBlockData(&bd); err != nil {
 		return fmt.Errorf("comparing and setting block data: %w", err)
 	}
 

--- a/dot/sync/chain_processor_integration_test.go
+++ b/dot/sync/chain_processor_integration_test.go
@@ -57,7 +57,7 @@ func TestChainProcessor_HandleBlockResponse_ValidChain(t *testing.T) {
 
 	// process response
 	for _, bd := range resp.BlockData {
-		err = syncer.chainProcessor.(*chainProcessor).processBlockData(bd)
+		err = syncer.chainProcessor.(*chainProcessor).processBlockData(*bd)
 		require.NoError(t, err)
 	}
 
@@ -77,7 +77,7 @@ func TestChainProcessor_HandleBlockResponse_ValidChain(t *testing.T) {
 
 	// process response
 	for _, bd := range resp.BlockData {
-		err = syncer.chainProcessor.(*chainProcessor).processBlockData(bd)
+		err = syncer.chainProcessor.(*chainProcessor).processBlockData(*bd)
 		require.NoError(t, err)
 	}
 }
@@ -130,7 +130,7 @@ func TestChainProcessor_HandleBlockResponse_MissingBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, bd := range resp.BlockData {
-		err = syncer.chainProcessor.(*chainProcessor).processBlockData(bd)
+		err = syncer.chainProcessor.(*chainProcessor).processBlockData(*bd)
 		require.True(t, errors.Is(err, errFailedToGetParent))
 	}
 }
@@ -180,7 +180,7 @@ func TestChainProcessor_HandleBlockResponse_BlockData(t *testing.T) {
 	}
 
 	for _, bd := range msg.BlockData {
-		err = syncer.chainProcessor.(*chainProcessor).processBlockData(bd)
+		err = syncer.chainProcessor.(*chainProcessor).processBlockData(*bd)
 		require.NoError(t, err)
 	}
 }

--- a/dot/sync/chain_processor_integration_test.go
+++ b/dot/sync/chain_processor_integration_test.go
@@ -154,12 +154,6 @@ func TestChainProcessor_handleBody_ShouldRemoveIncludedExtrinsics(t *testing.T) 
 	require.Nil(t, inQueue, "queue should be empty")
 }
 
-func TestChainProcessor_HandleBlockResponse_NoBlockData(t *testing.T) {
-	syncer := newTestSyncer(t)
-	err := syncer.chainProcessor.(*chainProcessor).processBlockData(nil)
-	require.Equal(t, ErrNilBlockData, err)
-}
-
 // TODO: add test against latest gssmr runtime
 // See https://github.com/ChainSafe/gossamer/issues/2703
 func TestChainProcessor_HandleBlockResponse_BlockData(t *testing.T) {

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -602,6 +602,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 			blockData: &types.BlockData{
 				Justification: &[]byte{1, 2, 3},
 			},
+			expectedError: mockError,
 		},
 		"has header body false": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -371,13 +371,6 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 		blockData             *types.BlockData
 		expectedError         error
 	}{
-		"nil block data": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				return chainProcessor{}
-			},
-			blockData:     nil,
-			expectedError: ErrNilBlockData,
-		},
 		"handle has header error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				mockBlockState := NewMockBlockState(ctrl)

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -368,7 +368,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 
 	tests := map[string]struct {
 		chainProcessorBuilder func(ctrl *gomock.Controller) chainProcessor
-		blockData             *types.BlockData
+		blockData             types.BlockData
 		expectedError         error
 	}{
 		"handle has header error": {
@@ -380,7 +380,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockState: mockBlockState,
 				}
 			},
-			blockData:     &types.BlockData{},
+			blockData:     types.BlockData{},
 			expectedError: mockError,
 		},
 		"handle has block body error": {
@@ -392,7 +392,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockState: mockBlockState,
 				}
 			},
-			blockData:     &types.BlockData{},
+			blockData:     types.BlockData{},
 			expectedError: mockError,
 		},
 		"handle getBlockByHash error": {
@@ -409,7 +409,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					chainSync:  mockChainSync,
 				}
 			},
-			blockData:     &types.BlockData{},
+			blockData:     types.BlockData{},
 			expectedError: mockError,
 		},
 		"handle AddBlockToBlockTree error": {
@@ -439,7 +439,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockImportHandler: mockBlockImportHandler,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Justification: &[]byte{1, 2, 3},
 			},
 		},
@@ -474,7 +474,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					finalityGadget: finalityGadget,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Hash:          common.Hash{1},
 				Justification: &[]byte{1, 2, 3},
 			},
@@ -520,7 +520,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockImportHandler: mockBlockImportHandler,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Justification: &[]byte{1, 2, 3},
 			},
 		},
@@ -555,7 +555,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					storageState:   mockStorageState,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Justification: &[]byte{1, 2, 3},
 			},
 			expectedError: mockError,
@@ -599,7 +599,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockImportHandler: mockBlockImportHandler,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Justification: &[]byte{1, 2, 3},
 			},
 			expectedError: mockError,
@@ -619,7 +619,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockState: mockBlockState,
 				}
 			},
-			blockData: &types.BlockData{},
+			blockData: types.BlockData{},
 		},
 		"handle babe verify block error": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
@@ -638,7 +638,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					babeVerifier: mockBabeVerifier,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Header: &types.Header{},
 				Body:   &types.Body{},
 			},
@@ -662,7 +662,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					babeVerifier: mockBabeVerifier,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Header: &types.Header{},
 				Body:   &types.Body{},
 			},
@@ -688,7 +688,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockState: mockBlockState,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Hash: common.Hash{1, 2, 3},
 			},
 			expectedError: mockError,
@@ -722,7 +722,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockImportHandler: mockBlockImportHandler,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Hash: common.Hash{1, 2, 3},
 			},
 		},
@@ -748,7 +748,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					finalityGadget: finalityGadget,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Hash:          common.Hash{1},
 				Header:        &types.Header{Number: 2},
 				Justification: &[]byte{1, 2, 3},
@@ -769,7 +769,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					blockState: mockBlockState,
 				}
 			},
-			blockData:     &types.BlockData{},
+			blockData:     types.BlockData{},
 			expectedError: mockError,
 		},
 		"handle header": {
@@ -818,7 +818,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					telemetry:          mockTelemetry,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Header: &types.Header{
 					Number: 0,
 				},
@@ -875,7 +875,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 					finalityGadget:     mockFinalityGadget,
 				}
 			},
-			blockData: &types.BlockData{
+			blockData: types.BlockData{
 				Header: &types.Header{
 					Number: 0,
 				},

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -291,11 +291,6 @@ func Test_chainProcessor_handleJustification(t *testing.T) {
 		sentinelError         error
 		errorMessage          string
 	}{
-		"nil justification and header": {
-			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
-				return chainProcessor{}
-			},
-		},
 		"invalid justification": {
 			chainProcessorBuilder: func(ctrl *gomock.Controller) chainProcessor {
 				mockFinalityGadget := NewMockFinalityGadget(ctrl)

--- a/dot/sync/chain_sync_test.go
+++ b/dot/sync/chain_sync_test.go
@@ -951,8 +951,9 @@ func TestChainSync_doSync(t *testing.T) {
 
 	workerErr = cs.doSync(req, make(map[peer.ID]struct{}))
 	require.Nil(t, workerErr)
-	bd := readyBlocks.pop(context.Background())
+	bd, err := readyBlocks.pop(context.Background())
 	require.NotNil(t, bd)
+	require.NoError(t, err)
 	require.Equal(t, resp.BlockData[0], bd)
 
 	parent := (&types.Header{
@@ -992,13 +993,15 @@ func TestChainSync_doSync(t *testing.T) {
 	workerErr = cs.doSync(req, make(map[peer.ID]struct{}))
 	require.Nil(t, workerErr)
 
-	bd = readyBlocks.pop(context.Background())
+	bd, err = readyBlocks.pop(context.Background())
 	require.NotNil(t, bd)
 	require.Equal(t, resp.BlockData[0], bd)
+	require.NoError(t, err)
 
-	bd = readyBlocks.pop(context.Background())
+	bd, err = readyBlocks.pop(context.Background())
 	require.NotNil(t, bd)
 	require.Equal(t, resp.BlockData[1], bd)
+	require.NoError(t, err)
 }
 
 func TestHandleReadyBlock(t *testing.T) {
@@ -1054,9 +1057,17 @@ func TestHandleReadyBlock(t *testing.T) {
 	require.False(t, cs.pendingBlocks.hasBlock(header3.Hash()))
 	require.True(t, cs.pendingBlocks.hasBlock(header2NotDescendant.Hash()))
 
-	require.Equal(t, block1.ToBlockData(), readyBlocks.pop(context.Background()))
-	require.Equal(t, block2.ToBlockData(), readyBlocks.pop(context.Background()))
-	require.Equal(t, block3.ToBlockData(), readyBlocks.pop(context.Background()))
+	blockData1, err := readyBlocks.pop(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, block1.ToBlockData(), blockData1)
+
+	blockData2, err := readyBlocks.pop(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, block2.ToBlockData(), blockData2)
+
+	blockData3, err := readyBlocks.pop(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, block3.ToBlockData(), blockData3)
 }
 
 func TestChainSync_determineSyncPeers(t *testing.T) {

--- a/dot/sync/errors.go
+++ b/dot/sync/errors.go
@@ -8,9 +8,6 @@ import (
 )
 
 var (
-	// ErrNilBlockData is returned when trying to process a BlockResponseMessage with nil BlockData
-	ErrNilBlockData = errors.New("got nil BlockData")
-
 	// ErrServiceStopped is returned when the service has been stopped
 	ErrServiceStopped = errors.New("service has been stopped")
 

--- a/dot/sync/tip_syncer_integration_test.go
+++ b/dot/sync/tip_syncer_integration_test.go
@@ -248,8 +248,9 @@ func TestTipSyncer_handleTick_case3(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []*worker(nil), w)
 	require.False(t, s.pendingBlocks.hasBlock(header.Hash()))
-	readyBlockData := s.readyBlocks.pop(context.Background())
+	readyBlockData, err := s.readyBlocks.pop(context.Background())
 	require.Equal(t, block.ToBlockData(), readyBlockData)
+	require.NoError(t, err)
 
 	// add pending block w/ full block, but block is not ready as parent is unknown
 	ctrl := gomock.NewController(t)
@@ -300,8 +301,9 @@ func TestTipSyncer_handleTick_case3(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []*worker(nil), w)
 	require.False(t, s.pendingBlocks.hasBlock(header.Hash()))
-	_ = s.readyBlocks.pop(context.Background()) // first pop will remove parent
-	readyBlockData = s.readyBlocks.pop(context.Background())
+	_, _ = s.readyBlocks.pop(context.Background()) // first pop will remove parent
+	readyBlockData, err = s.readyBlocks.pop(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, block.ToBlockData(), readyBlockData)
 }
 


### PR DESCRIPTION
## Changes

- `processBlockData`:
  - Split subblocks into functions:
    - `processBlockDataWithHeaderAndBody` function with test
    - `processBlockDataWithStateHeaderAndBody` function with test
  - takes block data `blockData` as value argument instead of pointer
  - Review error wrappings
  - Remove block data nil check
  - Rename receiver from `s` to `c` for `chainProcessor`
- Remove unneeded unit test cases for `processBlockData` (now covered in subfunctions associated tests)
- Push (possibly unneeded) justification length check up in caller of `handleJustification`.
- Return error on block import error
- Fix position of debug logs

Done whilst fixing tests in #2774 

:new: is kinda blocking me on #2912 (trying to fix the memmm)

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer/dot/sync
```

## Issues

## Primary Reviewer

@edwardmack 
