### PR TITLE
feat(wasmer): Add `SetTestVersion` method to `Config` struct

### DIFF
--- a/lib/runtime/wasmer/config.go
+++ b/lib/runtime/wasmer/config.go
@@ -4,6 +4,8 @@
 package wasmer
 
 import (
+	"testing"
+
 	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/keystore"
@@ -22,4 +24,15 @@ type Config struct {
 	Transaction runtime.TransactionState
 	CodeHash    common.Hash
 	testVersion *runtime.Version
+}
+
+// SetTestVersion sets the test version for the runtime.
+// WARNING: This should only be used for testing purposes.
+// The *testing.T argument is only required to enforce this function
+// to be used in tests only.
+func (c *Config) SetTestVersion(t *testing.T, version runtime.Version) {
+	if t == nil {
+		panic("*testing.T argument cannot be nil. Please don't use this function outside of Go tests.")
+	}
+	c.testVersion = &version
 }

--- a/lib/runtime/wasmer/config_test.go
+++ b/lib/runtime/wasmer/config_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package wasmer
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Config_SetTestVersion(t *testing.T) {
+	t.Run("panics with nil *testing.T", func(t *testing.T) {
+		var c Config
+		assert.PanicsWithValue(t,
+			"*testing.T argument cannot be nil. Please don't use this function outside of Go tests.",
+			func() {
+				c.SetTestVersion(nil, runtime.Version{})
+			})
+	})
+
+	t.Run("set test version", func(t *testing.T) {
+		var c Config
+		testVersion := runtime.Version{
+			StateVersion: 1,
+		}
+
+		c.SetTestVersion(t, testVersion)
+
+		require.NotNil(t, c.testVersion)
+		assert.Equal(t, testVersion, *c.testVersion)
+	})
+}


### PR DESCRIPTION
## Changes

> It seems the latest update to the testsuite breaks support for runtimes without Core_version and the [workaround](https://github.com/ChainSafe/gossamer/blob/78a1dbd88907d91662dffbfa35c5c00afdb26cb4/lib/runtime/wasmer/test_helpers.go#L55) is only available to your testsuite. Is there any way we could access to this or to only cache the version the first time it is requested?

Adds an exported method for external test suites to fiddle with the test version

## Tests

## Issues

Fixes #2816 

## Primary Reviewer

@timwu20
