### PR TITLE
chore(lib/trie): database.go small simplifications

### DIFF
--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -78,8 +78,10 @@ func (s *StorageState) StoreTrie(ts *rtstorage.TrieState, header *types.Header) 
 
 	s.tries.softSet(root, ts.Trie())
 
-	if _, ok := s.pruner.(*pruner.FullNode); header == nil && ok {
-		return fmt.Errorf("block cannot be empty for Full node pruner")
+	if header == nil {
+		if _, ok := s.pruner.(*pruner.FullNode); ok {
+			panic("block header cannot be empty for Full node pruner")
+		}
 	}
 
 	if header != nil {

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -205,23 +205,6 @@ func (t *Trie) PopulateNodeHashes(n *Node, hashesSet map[common.Hash]struct{}) {
 	}
 }
 
-// DeleteFromDB deletes a value from the trie at the key given.
-// It writes the updated nodes from the changed node up to the root node
-// to the database in a batch operation.
-func (t *Trie) DeleteFromDB(db chaindb.Database, key []byte) error {
-	t.Delete(key)
-	return t.WriteDirty(db)
-}
-
-// ClearPrefixFromDB deletes all nodes with keys starting the given prefix
-// from the trie. It writes the updated nodes from the changed node up to
-// the root node to the database in a batch operation.
-// in a batch operation.
-func (t *Trie) ClearPrefixFromDB(db chaindb.Database, prefix []byte) error {
-	t.ClearPrefix(prefix)
-	return t.WriteDirty(db)
-}
-
 // GetFromDB retrieves a value at the given key from the trie using the database.
 // It recursively descends into the trie using the database starting
 // from the root node until it reaches the node with the given key.

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -205,14 +205,6 @@ func (t *Trie) PopulateNodeHashes(n *Node, hashesSet map[common.Hash]struct{}) {
 	}
 }
 
-// PutInDB inserts a value in the trie at the key given.
-// It writes the updated nodes from the changed node up to the root node
-// to the database in a batch operation.
-func (t *Trie) PutInDB(db chaindb.Database, key, value []byte) error {
-	t.Put(key, value)
-	return t.WriteDirty(db)
-}
-
 // DeleteFromDB deletes a value from the trie at the key given.
 // It writes the updated nodes from the changed node up to the root node
 // to the database in a batch operation.

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -105,7 +105,8 @@ func Test_Trie_WriteDirty_Delete(t *testing.T) {
 
 	deletedKeys := make(map[string]struct{}, len(keysToDelete))
 	for _, keyToDelete := range keysToDelete {
-		err = trie.DeleteFromDB(db, keyToDelete)
+		trie.Delete(keyToDelete)
+		err = trie.WriteDirty(db)
 		require.NoError(t, err)
 
 		deletedKeys[string(keyToDelete)] = struct{}{}
@@ -144,7 +145,8 @@ func Test_Trie_WriteDirty_ClearPrefix(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, keyToClearPrefix := range keysToClearPrefix {
-		err = trie.ClearPrefixFromDB(db, keyToClearPrefix)
+		trie.ClearPrefix(keyToClearPrefix)
+		err = trie.WriteDirty(db)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
## Changes

- lib/trie: remove unused trie method `PutInDB`
- lib/trie: remove test-only trie methods `DeleteFromDB` and `ClearPrefixFromDB` and move them inline in trie tests
- dot/state: do not do type assertion on pruner every time


## Tests

## Issues


## Primary Reviewer

@EclesioMeloJunior 