### PR TITLE
chore(trie): `GetChangedNodeHashes` returns both inserted and deleted node hashes

### DIFF
--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -85,12 +85,11 @@ func (s *StorageState) StoreTrie(ts *rtstorage.TrieState, header *types.Header) 
 	}
 
 	if header != nil {
-		insertedMerkleValues, err := ts.GetInsertedMerkleValues()
+		insertedMerkleValues, deletedMerkleValues, err := ts.GetChangedNodeHashes()
 		if err != nil {
 			return fmt.Errorf("failed to get state trie inserted keys: block %s %w", header.Hash(), err)
 		}
 
-		deletedMerkleValues := ts.GetDeletedMerkleValues()
 		err = s.pruner.StoreJournalRecord(deletedMerkleValues, insertedMerkleValues, header.Hash(), int64(header.Number))
 		if err != nil {
 			return err

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -271,18 +271,10 @@ func (s *TrieState) LoadCodeHash() (common.Hash, error) {
 	return common.Blake2bHash(code)
 }
 
-// GetInsertedMerkleValues returns the set of all node Merkle value inserted
-// into the state trie since the last block produced.
-func (s *TrieState) GetInsertedMerkleValues() (merkleValues map[string]struct{}, err error) {
+// GetChangedNodeHashes returns the two sets of hashes for all nodes
+// inserted and deleted in the state trie since the last block produced (trie snapshot).
+func (s *TrieState) GetChangedNodeHashes() (inserted, deleted map[string]struct{}, err error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-	return s.t.GetInsertedMerkleValues()
-}
-
-// GetDeletedMerkleValues returns the set of all node Merkle values deleted
-// from the state trie since the last block produced.
-func (s *TrieState) GetDeletedMerkleValues() (merkleValues map[string]struct{}) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.t.GetDeletedMerkleValues()
+	return s.t.GetChangedNodeHashes()
 }


### PR DESCRIPTION
## Changes

5 minutes work related to #2831 

## Tests

## Issues

## Primary Reviewer
