### PR TITLE
chore(lib/trie): `deleteNodesLimit` takes no `prefix`

### DIFF
--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -688,8 +688,7 @@ func (t *Trie) clearPrefixLimitBranch(branch *Node, prefix []byte, limit uint32)
 	newParent = branch
 
 	if bytes.HasPrefix(branch.Key, prefix) {
-		nilPrefix := ([]byte)(nil)
-		newParent, valuesDeleted, nodesRemoved = t.deleteNodesLimit(branch, nilPrefix, limit)
+		newParent, valuesDeleted, nodesRemoved = t.deleteNodesLimit(branch, limit)
 		allDeleted = newParent == nil
 		return newParent, valuesDeleted, nodesRemoved, allDeleted
 	}
@@ -743,8 +742,7 @@ func (t *Trie) clearPrefixLimitChild(branch *Node, prefix []byte, limit uint32) 
 		return newParent, valuesDeleted, nodesRemoved, allDeleted
 	}
 
-	nilPrefix := ([]byte)(nil)
-	child, valuesDeleted, nodesRemoved = t.deleteNodesLimit(child, nilPrefix, limit)
+	child, valuesDeleted, nodesRemoved = t.deleteNodesLimit(child, limit)
 	if valuesDeleted == 0 {
 		allDeleted = branch.Children[childIndex] == nil
 		return branch, valuesDeleted, nodesRemoved, allDeleted
@@ -764,7 +762,7 @@ func (t *Trie) clearPrefixLimitChild(branch *Node, prefix []byte, limit uint32) 
 	return newParent, valuesDeleted, nodesRemoved, allDeleted
 }
 
-func (t *Trie) deleteNodesLimit(parent *Node, prefix []byte, limit uint32) (
+func (t *Trie) deleteNodesLimit(parent *Node, limit uint32) (
 	newParent *Node, valuesDeleted, nodesRemoved uint32) {
 	if limit == 0 {
 		valuesDeleted, nodesRemoved = 0, 0
@@ -783,8 +781,6 @@ func (t *Trie) deleteNodesLimit(parent *Node, prefix []byte, limit uint32) (
 
 	branch := parent
 
-	fullKey := concatenateSlices(prefix, branch.Key)
-
 	nilChildren := node.ChildrenCapacity - branch.NumChildren()
 
 	var newDeleted, newNodesRemoved uint32
@@ -796,7 +792,7 @@ func (t *Trie) deleteNodesLimit(parent *Node, prefix []byte, limit uint32) (
 
 		copySettings := node.DefaultCopySettings
 		branch = t.prepBranchForMutation(branch, copySettings)
-		branch.Children[i], newDeleted, newNodesRemoved = t.deleteNodesLimit(child, fullKey, limit)
+		branch.Children[i], newDeleted, newNodesRemoved = t.deleteNodesLimit(child, limit)
 		if branch.Children[i] == nil {
 			nilChildren++
 		}
@@ -807,7 +803,7 @@ func (t *Trie) deleteNodesLimit(parent *Node, prefix []byte, limit uint32) (
 
 		branch.SetDirty()
 
-		newParent, branchChildMerged = handleDeletion(branch, fullKey)
+		newParent, branchChildMerged = handleDeletion(branch, branch.Key)
 		if branchChildMerged {
 			nodesRemoved++
 		}

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -2671,7 +2671,6 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 	testCases := map[string]struct {
 		trie          Trie
 		parent        *Node
-		prefix        []byte
 		limit         uint32
 		newNode       *Node
 		valuesDeleted uint32
@@ -2806,8 +2805,7 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 					{Key: []byte{3}, SubValue: []byte{1}},
 				}),
 			},
-			prefix: []byte{1, 2},
-			limit:  2,
+			limit: 2,
 			newNode: &Node{
 				Key:        []byte{3, 5, 3},
 				SubValue:   []byte{1},
@@ -2828,7 +2826,7 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 			expectedTrie := *trie.DeepCopy()
 
 			newNode, valuesDeleted, nodesRemoved :=
-				trie.deleteNodesLimit(testCase.parent, testCase.prefix, testCase.limit)
+				trie.deleteNodesLimit(testCase.parent, testCase.limit)
 
 			assert.Equal(t, testCase.newNode, newNode)
 			assert.Equal(t, testCase.valuesDeleted, valuesDeleted)


### PR DESCRIPTION
## Changes

Why:

- Prefix is always inject as `nil`
- Working of `deleteNodesLimit` given a `prefix` was wrong

Also because I'm reviewing trie node snapshotting and found this which was troublesome in another branch. I prefer to keep it simpler and remove the prefix functionality than fixing it since there is no use for it.

## Tests

```sh
go test ./internal/trie/... ./lib/trie/...
```

## Issues

## Primary Reviewer

@EclesioMeloJunior 