### PR TITLE
remove `digest type not supported` error

### DIFF
--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -110,7 +110,6 @@ func (h *Handler) toConsensusDigests(scaleVaryingTypes []scale.VaryingDataType) 
 		}
 		digest, ok := digestValue.(types.ConsensusDigest)
 		if !ok {
-			h.logger.Errorf("digest type not supported: %T", digestValue)
 			continue
 		}
 


### PR DESCRIPTION
This is not an error. We are iterating over all digests and picking consensus digests. It is completely fine to see other types of digests.

## Changes

<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20 