### PR TITLE
fix(trie): `PopulateMerkleValues` behavior

### DIFF
--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -121,7 +121,10 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 			return err
 		}
 
-		tr.PopulateMerkleValues(tr.RootNode(), merkleValues)
+		err = tr.PopulateMerkleValues(tr.RootNode(), merkleValues)
+		if err != nil {
+			return fmt.Errorf("populating Merkle values from trie: %w", err)
+		}
 
 		// get parent header of current block
 		header, err = p.blockState.GetHeader(header.ParentHash)

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -121,10 +121,7 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 			return err
 		}
 
-		err = tr.PopulateMerkleValues(tr.RootNode(), merkleValues)
-		if err != nil {
-			return fmt.Errorf("populating Merkle values from trie: %w", err)
-		}
+		trie.PopulateMerkleValues(tr.RootNode(), merkleValues)
 
 		// get parent header of current block
 		header, err = p.blockState.GetHeader(header.ParentHash)

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -121,7 +121,7 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 			return err
 		}
 
-		trie.PopulateMerkleValues(tr.RootNode(), merkleValues)
+		trie.PopulateNodeHashes(tr.RootNode(), merkleValues)
 
 		// get parent header of current block
 		header, err = p.blockState.GetHeader(header.ParentHash)

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -186,7 +186,7 @@ func (t *Trie) loadNode(db Database, n *Node) error {
 }
 
 // PopulateMerkleValues writes the Merkle values of the node given and of
-// all its descendant nodes as keys to the map merkleValues.
+// all its descendant nodes as keys to the merkleValues map.
 // It is assumed the node and its descendant nodes have their Merkle value already
 // computed.
 func PopulateMerkleValues(n *Node, merkleValues map[string]struct{}) {

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -196,6 +196,8 @@ func PopulateNodeHashes(n *Node, nodeHashes map[string]struct{}) {
 
 	switch {
 	case len(n.MerkleValue) == 0:
+		// TODO remove once lazy loading of nodes is implemented
+		// https://github.com/ChainSafe/gossamer/issues/2838
 		panic(fmt.Sprintf("node with key 0x%x has no Merkle value computed", n.Key))
 	case len(n.MerkleValue) < 32:
 		// Inlined node where its Merkle value is its

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -158,57 +158,77 @@ func Test_Trie_WriteDirty_ClearPrefix(t *testing.T) {
 	assert.Equal(t, trie.String(), trieFromDB.String())
 }
 
-func Test_PopulateMerkleValues(t *testing.T) {
+func Test_PopulateNodeHashes(t *testing.T) {
 	t.Parallel()
 
+	const (
+		merkleValue32Zeroes = "00000000000000000000000000000000"
+		merkleValue32Ones   = "11111111111111111111111111111111"
+		merkleValue32Twos   = "22222222222222222222222222222222"
+		merkleValue32Threes = "33333333333333333333333333333333"
+	)
+
 	testCases := map[string]struct {
-		node         *Node
-		merkleValues map[string]struct{}
-		panicValue   interface{}
+		node       *Node
+		nodeHashes map[string]struct{}
+		panicValue interface{}
 	}{
 		"nil node": {
-			merkleValues: map[string]struct{}{},
+			nodeHashes: map[string]struct{}{},
+		},
+		"inlined leaf node": {
+			node:       &Node{MerkleValue: []byte("a")},
+			nodeHashes: map[string]struct{}{},
 		},
 		"leaf node": {
-			node: &Node{MerkleValue: []byte("a")},
-			merkleValues: map[string]struct{}{
-				"a": {},
+			node: &Node{MerkleValue: []byte(merkleValue32Zeroes)},
+			nodeHashes: map[string]struct{}{
+				merkleValue32Zeroes: {},
 			},
 		},
 		"leaf node without Merkle value": {
 			node:       &Node{Key: []byte{1}, SubValue: []byte{2}},
 			panicValue: "node with key 0x01 has no Merkle value computed",
 		},
-		"branch node": {
+		"inlined branch node": {
 			node: &Node{
 				MerkleValue: []byte("a"),
 				Children: padRightChildren([]*Node{
 					{MerkleValue: []byte("b")},
 				}),
 			},
-			merkleValues: map[string]struct{}{
-				"a": {},
-				"b": {},
+			nodeHashes: map[string]struct{}{},
+		},
+		"branch node": {
+			node: &Node{
+				MerkleValue: []byte(merkleValue32Zeroes),
+				Children: padRightChildren([]*Node{
+					{MerkleValue: []byte(merkleValue32Ones)},
+				}),
+			},
+			nodeHashes: map[string]struct{}{
+				merkleValue32Zeroes: {},
+				merkleValue32Ones:   {},
 			},
 		},
 		"nested branch node": {
 			node: &Node{
-				MerkleValue: []byte("a"),
+				MerkleValue: []byte(merkleValue32Zeroes),
 				Children: padRightChildren([]*Node{
-					{MerkleValue: []byte("b")},
+					{MerkleValue: []byte(merkleValue32Ones)},
 					{
-						MerkleValue: []byte("c"),
+						MerkleValue: []byte(merkleValue32Twos),
 						Children: padRightChildren([]*Node{
-							{MerkleValue: []byte("d")},
+							{MerkleValue: []byte(merkleValue32Threes)},
 						}),
 					},
 				}),
 			},
-			merkleValues: map[string]struct{}{
-				"a": {},
-				"b": {},
-				"c": {},
-				"d": {},
+			nodeHashes: map[string]struct{}{
+				merkleValue32Zeroes: {},
+				merkleValue32Ones:   {},
+				merkleValue32Twos:   {},
+				merkleValue32Threes: {},
 			},
 		},
 	}
@@ -218,18 +238,18 @@ func Test_PopulateMerkleValues(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			merkleValues := make(map[string]struct{})
+			nodeHashes := make(map[string]struct{})
 
 			if testCase.panicValue != nil {
 				assert.PanicsWithValue(t, testCase.panicValue, func() {
-					PopulateMerkleValues(testCase.node, merkleValues)
+					PopulateNodeHashes(testCase.node, nodeHashes)
 				})
 				return
 			}
 
-			PopulateMerkleValues(testCase.node, merkleValues)
+			PopulateNodeHashes(testCase.node, nodeHashes)
 
-			assert.Equal(t, testCase.merkleValues, merkleValues)
+			assert.Equal(t, testCase.nodeHashes, nodeHashes)
 		})
 	}
 }

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -161,44 +161,25 @@ func Test_Trie_WriteDirty_ClearPrefix(t *testing.T) {
 func Test_PopulateMerkleValues(t *testing.T) {
 	t.Parallel()
 
-	someNode := &Node{Key: []byte{1}, SubValue: []byte{2}}
-
 	testCases := map[string]struct {
-		trie         *Trie
 		node         *Node
 		merkleValues map[string]struct{}
-		errSentinel  error
-		errMessage   string
+		panicValue   interface{}
 	}{
 		"nil node": {
-			trie:         &Trie{},
 			merkleValues: map[string]struct{}{},
 		},
 		"leaf node": {
-			trie: &Trie{},
 			node: &Node{MerkleValue: []byte("a")},
 			merkleValues: map[string]struct{}{
 				"a": {},
 			},
 		},
 		"leaf node without Merkle value": {
-			trie: &Trie{},
-			node: &Node{Key: []byte{1}, SubValue: []byte{2}},
-			merkleValues: map[string]struct{}{
-				"A\x01\x04\x02": {},
-			},
-		},
-		"root leaf node without Merkle value": {
-			trie: &Trie{
-				root: someNode,
-			},
-			node: someNode,
-			merkleValues: map[string]struct{}{
-				"`Qm\v\xb6\xe1\xbb\xfb\x12\x93\xf1\xb2v\xea\x95\x05\xe9\xf4\xa4\xe7ُb\r\x05\x11^\v\x85'J\xe1": {},
-			},
+			node:       &Node{Key: []byte{1}, SubValue: []byte{2}},
+			panicValue: "node with key 0x01 has no Merkle value computed",
 		},
 		"branch node": {
-			trie: &Trie{},
 			node: &Node{
 				MerkleValue: []byte("a"),
 				Children: padRightChildren([]*Node{
@@ -211,7 +192,6 @@ func Test_PopulateMerkleValues(t *testing.T) {
 			},
 		},
 		"nested branch node": {
-			trie: &Trie{},
 			node: &Node{
 				MerkleValue: []byte("a"),
 				Children: padRightChildren([]*Node{
@@ -240,12 +220,15 @@ func Test_PopulateMerkleValues(t *testing.T) {
 
 			merkleValues := make(map[string]struct{})
 
-			err := testCase.trie.PopulateMerkleValues(testCase.node, merkleValues)
-
-			assert.ErrorIs(t, err, testCase.errSentinel)
-			if testCase.errSentinel != nil {
-				assert.EqualError(t, err, testCase.errMessage)
+			if testCase.panicValue != nil {
+				assert.PanicsWithValue(t, testCase.panicValue, func() {
+					PopulateMerkleValues(testCase.node, merkleValues)
+				})
+				return
 			}
+
+			PopulateMerkleValues(testCase.node, merkleValues)
+
 			assert.Equal(t, testCase.merkleValues, merkleValues)
 		})
 	}


### PR DESCRIPTION
## Changes

- Include Merkle value of the parent node passed as argument
- Update comment all nodes are expected to have their Merkle value computed
- Enforce all nodes to have their Merkle value computed with a `panic` (this will be thrown out with lazy loading)
- Add unit test

For now this only affects the offline pruning, but this function is to be used in another PR to fix the tracking of deleted Merkle values and add cached tracking of inserted Merkle values

## Tests

```sh
go test github.com/ChainSafe/gossamer/lib/trie/...
```

## Issues

Related to #2854 

## Primary Reviewer

@kishansagathiya 