### PR TITLE
fix(lib/trie): record deleted Merkle values fixed

### DIFF
--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -244,7 +244,8 @@ func generateBlockWithRandomTrie(t *testing.T, serv *Service,
 	rand := time.Now().UnixNano()
 	key := []byte("testKey" + fmt.Sprint(rand))
 	value := []byte("testValue" + fmt.Sprint(rand))
-	trieState.Put(key, value)
+	err = trieState.Put(key, value)
+	require.NoError(t, err)
 
 	trieStateRoot, err := trieState.Root()
 	require.NoError(t, err)

--- a/lib/runtime/interfaces.go
+++ b/lib/runtime/interfaces.go
@@ -11,22 +11,24 @@ import (
 
 // Storage runtime interface.
 type Storage interface {
-	Put(key []byte, value []byte)
+	Put(key []byte, value []byte) (err error)
 	Get(key []byte) []byte
 	Root() (common.Hash, error)
 	SetChild(keyToChild []byte, child *trie.Trie) error
 	SetChildStorage(keyToChild, key, value []byte) error
 	GetChildStorage(keyToChild, key []byte) ([]byte, error)
-	Delete(key []byte)
-	DeleteChild(keyToChild []byte)
-	DeleteChildLimit(keyToChild []byte, limit *[]byte) (uint32, bool, error)
+	Delete(key []byte) (err error)
+	DeleteChild(keyToChild []byte) (err error)
+	DeleteChildLimit(keyToChild []byte, limit *[]byte) (
+		deleted uint32, allDeleted bool, err error)
 	ClearChildStorage(keyToChild, key []byte) error
 	NextKey([]byte) []byte
 	ClearPrefixInChild(keyToChild, prefix []byte) error
 	GetChildNextKey(keyToChild, key []byte) ([]byte, error)
 	GetChild(keyToChild []byte) (*trie.Trie, error)
-	ClearPrefix(prefix []byte)
-	ClearPrefixLimit(prefix []byte, limit uint32) (uint32, bool)
+	ClearPrefix(prefix []byte) (err error)
+	ClearPrefixLimit(prefix []byte, limit uint32) (
+		deleted uint32, allDeleted bool, err error)
 	BeginStorageTransaction()
 	CommitStorageTransaction()
 	RollbackStorageTransaction()

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -108,7 +108,7 @@ func (s *TrieState) Delete(key []byte) (err error) {
 	defer s.lock.Unlock()
 	err = s.t.Delete(key)
 	if err != nil {
-		return err
+		return fmt.Errorf("deleting from trie: %w", err)
 	}
 
 	return nil

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -210,6 +210,7 @@ func (s *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (
 		// If one deletion fails, the child trie and its parent trie are then in
 		// a bad intermediary state. Take also care of the caching of deleted Merkle
 		// values within the tries, which is used for online pruning.
+		// See https://github.com/ChainSafe/gossamer/issues/3032
 		err = tr.Delete([]byte(k))
 		if err != nil {
 			return deleted, allDeleted, fmt.Errorf("deleting from child trie located at key 0x%x: %w", key, err)

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -5,6 +5,7 @@ package storage
 
 import (
 	"encoding/binary"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -67,11 +68,11 @@ func (s *TrieState) RollbackStorageTransaction() {
 	s.oldTrie = nil
 }
 
-// Put puts thread safely a value at the specified key in the trie.
-func (s *TrieState) Put(key, value []byte) {
+// Put puts a key-value pair in the trie
+func (s *TrieState) Put(key, value []byte) (err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.t.Put(key, value)
+	return s.t.Put(key, value)
 }
 
 // Get gets a value from the trie
@@ -97,15 +98,20 @@ func (s *TrieState) Has(key []byte) bool {
 }
 
 // Delete deletes a key from the trie
-func (s *TrieState) Delete(key []byte) {
+func (s *TrieState) Delete(key []byte) (err error) {
 	val := s.t.Get(key)
 	if val == nil {
-		return
+		return nil
 	}
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.t.Delete(key)
+	err = s.t.Delete(key)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NextKey returns the next key in the trie in lexicographical order. If it does not exist, it returns nil.
@@ -116,19 +122,19 @@ func (s *TrieState) NextKey(key []byte) []byte {
 }
 
 // ClearPrefix deletes all key-value pairs from the trie where the key starts with the given prefix
-func (s *TrieState) ClearPrefix(prefix []byte) {
+func (s *TrieState) ClearPrefix(prefix []byte) (err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.t.ClearPrefix(prefix)
+	return s.t.ClearPrefix(prefix)
 }
 
 // ClearPrefixLimit deletes key-value pairs from the trie where the key starts with the given prefix till limit reached
-func (s *TrieState) ClearPrefixLimit(prefix []byte, limit uint32) (uint32, bool) {
+func (s *TrieState) ClearPrefixLimit(prefix []byte, limit uint32) (
+	deleted uint32, allDeleted bool, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	num, del := s.t.ClearPrefixLimit(prefix, limit)
-	return num, del
+	return s.t.ClearPrefixLimit(prefix, limit)
 }
 
 // TrieEntries returns every key-value pair in the trie
@@ -167,24 +173,29 @@ func (s *TrieState) GetChildStorage(keyToChild, key []byte) ([]byte, error) {
 }
 
 // DeleteChild deletes a child trie from the main trie
-func (s *TrieState) DeleteChild(key []byte) {
+func (s *TrieState) DeleteChild(key []byte) (err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.t.DeleteChild(key)
+	return s.t.DeleteChild(key)
 }
 
-// DeleteChildLimit deletes up to limit of database entries by lexicographic order, return number
-//  deleted, true if all delete otherwise false
-func (s *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (uint32, bool, error) {
+// DeleteChildLimit deletes up to limit of database entries by lexicographic order.
+func (s *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (
+	deleted uint32, allDeleted bool, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	tr, err := s.t.GetChild(key)
 	if err != nil {
 		return 0, false, err
 	}
+
 	qtyEntries := uint32(len(tr.Entries()))
 	if limit == nil {
-		s.t.DeleteChild(key)
+		err = s.t.DeleteChild(key)
+		if err != nil {
+			return 0, false, err
+		}
+
 		return qtyEntries, true, nil
 	}
 	limitUint := binary.LittleEndian.Uint32(*limit)
@@ -194,20 +205,24 @@ func (s *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (uint32, bool, e
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	deleted := uint32(0)
 	for _, k := range keys {
-		tr.Delete([]byte(k))
+		// TODO have a transactional/atomic way to delete multiple keys in trie.
+		// If one deletion fails, the child trie and its parent trie are then in
+		// a bad intermediary state. Take also care of the caching of deleted Merkle
+		// values within the tries, which is used for online pruning.
+		err = tr.Delete([]byte(k))
+		if err != nil {
+			return deleted, allDeleted, fmt.Errorf("deleting from child trie at key 0x%x: %w", key, err)
+		}
+
 		deleted++
 		if deleted == limitUint {
 			break
 		}
 	}
 
-	if deleted == qtyEntries {
-		return deleted, true, nil
-	}
-
-	return deleted, false, nil
+	allDeleted = deleted == qtyEntries
+	return deleted, allDeleted, nil
 }
 
 // ClearChildStorage removes the child storage entry from the trie
@@ -230,7 +245,11 @@ func (s *TrieState) ClearPrefixInChild(keyToChild, prefix []byte) error {
 		return nil
 	}
 
-	child.ClearPrefix(prefix)
+	err = child.ClearPrefix(prefix)
+	if err != nil {
+		return fmt.Errorf("clearing prefix in child trie at key 0x%x: %w", keyToChild, err)
+	}
+
 	return nil
 }
 

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -193,7 +193,7 @@ func (s *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (
 	if limit == nil {
 		err = s.t.DeleteChild(key)
 		if err != nil {
-			return 0, false, err
+			return 0, false, fmt.Errorf("deleting child trie: %w", err)
 		}
 
 		return qtyEntries, true, nil
@@ -212,7 +212,7 @@ func (s *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (
 		// values within the tries, which is used for online pruning.
 		err = tr.Delete([]byte(k))
 		if err != nil {
-			return deleted, allDeleted, fmt.Errorf("deleting from child trie at key 0x%x: %w", key, err)
+			return deleted, allDeleted, fmt.Errorf("deleting from child trie located at key 0x%x: %w", key, err)
 		}
 
 		deleted++
@@ -247,7 +247,7 @@ func (s *TrieState) ClearPrefixInChild(keyToChild, prefix []byte) error {
 
 	err = child.ClearPrefix(prefix)
 	if err != nil {
-		return fmt.Errorf("clearing prefix in child trie at key 0x%x: %w", keyToChild, err)
+		return fmt.Errorf("clearing prefix in child trie located at key 0x%x: %w", keyToChild, err)
 	}
 
 	return nil

--- a/lib/runtime/wasmer/helpers.go
+++ b/lib/runtime/wasmer/helpers.go
@@ -208,7 +208,7 @@ func toWasmMemoryFixedSizeOptional(context wasmer.InstanceContext, data []byte) 
 	return toWasmMemory(context, encodedOptionalFixedSize)
 }
 
-func storageAppend(storage GetSetter, key, valueToAppend []byte) error {
+func storageAppend(storage GetSetter, key, valueToAppend []byte) (err error) {
 	// this function assumes the item in storage is a SCALE encoded array of items
 	// the valueToAppend is a new item, so it appends the item and increases the length prefix by 1
 	currentValue := storage.Get(key)
@@ -259,7 +259,16 @@ func storageAppend(storage GetSetter, key, valueToAppend []byte) error {
 		}
 	}
 
-	logger.Debugf("resulting value: 0x%x", value)
-	storage.Put(key, value)
+	err = storage.Put(key, value)
+	if err != nil {
+		return fmt.Errorf("putting key and value in storage: %w", err)
+	}
+
 	return nil
+}
+
+func panicOnError(err error) {
+	if err != nil {
+		panic(err)
+	}
 }

--- a/lib/runtime/wasmer/helpers_test.go
+++ b/lib/runtime/wasmer/helpers_test.go
@@ -5,6 +5,7 @@ package wasmer
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,4 +66,14 @@ func Test_pointerSize(t *testing.T) {
 			assert.Equal(t, testCase.size, size)
 		})
 	}
+}
+
+func Test_panicOnError(t *testing.T) {
+	t.Parallel()
+
+	err := (error)(nil)
+	assert.NotPanics(t, func() { panicOnError(err) })
+
+	err = errors.New("test error")
+	assert.PanicsWithValue(t, err, func() { panicOnError(err) })
 }

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -817,7 +817,12 @@ func ext_trie_blake2_256_root_version_1(context unsafe.Pointer, dataSpan C.int64
 	}
 
 	for _, kv := range kvs {
-		t.Put(kv.Key, kv.Value)
+		err := t.Put(kv.Key, kv.Value)
+		if err != nil {
+			logger.Errorf("failed putting key 0x%x and value 0x%x into trie: %s",
+				kv.Key, kv.Value, err)
+			return 0
+		}
 	}
 
 	// allocate memory for value and copy value to memory
@@ -865,7 +870,12 @@ func ext_trie_blake2_256_ordered_root_version_1(context unsafe.Pointer, dataSpan
 			"put key=0x%x and value=0x%x",
 			key, value)
 
-		t.Put(key, value)
+		err = t.Put(key, value)
+		if err != nil {
+			logger.Errorf("failed putting key 0x%x and value 0x%x into trie: %s",
+				key, value, err)
+			return 0
+		}
 	}
 
 	// allocate memory for value and copy value to memory
@@ -1180,7 +1190,8 @@ func ext_default_child_storage_storage_kill_version_1(context unsafe.Pointer, ch
 	storage := ctx.Storage
 
 	childStorageKey := asMemorySlice(instanceContext, childStorageKeySpan)
-	storage.DeleteChild(childStorageKey)
+	err := storage.DeleteChild(childStorageKey)
+	panicOnError(err)
 }
 
 //export ext_default_child_storage_storage_kill_version_2
@@ -1843,7 +1854,8 @@ func ext_storage_clear_version_1(context unsafe.Pointer, keySpan C.int64_t) {
 	key := asMemorySlice(instanceContext, keySpan)
 
 	logger.Debugf("key: 0x%x", key)
-	storage.Delete(key)
+	err := storage.Delete(key)
+	panicOnError(err)
 }
 
 //export ext_storage_clear_prefix_version_1
@@ -1856,7 +1868,8 @@ func ext_storage_clear_prefix_version_1(context unsafe.Pointer, prefixSpan C.int
 	prefix := asMemorySlice(instanceContext, prefixSpan)
 	logger.Debugf("prefix: 0x%x", prefix)
 
-	storage.ClearPrefix(prefix)
+	err := storage.ClearPrefix(prefix)
+	panicOnError(err)
 }
 
 //export ext_storage_clear_prefix_version_2
@@ -1885,7 +1898,13 @@ func ext_storage_clear_prefix_version_2(context unsafe.Pointer, prefixSpan, lim 
 	}
 
 	limitUint := binary.LittleEndian.Uint32(limit)
-	numRemoved, all := storage.ClearPrefixLimit(prefix, limitUint)
+	numRemoved, all, err := storage.ClearPrefixLimit(prefix, limitUint)
+	if err != nil {
+		logger.Errorf("failed to clear prefix limit: %s", err)
+		ret, _ := toWasmMemory(instanceContext, nil)
+		return C.int64_t(ret)
+	}
+
 	encBytes, err := toKillStorageResultEnum(all, numRemoved)
 	if err != nil {
 		logger.Errorf("failed to allocate memory: %s", err)
@@ -2044,7 +2063,8 @@ func ext_storage_set_version_1(context unsafe.Pointer, keySpan, valueSpan C.int6
 	logger.Debugf(
 		"key 0x%x has value 0x%x",
 		key, value)
-	storage.Put(key, cp)
+	err := storage.Put(key, cp)
+	panicOnError(err)
 }
 
 //export ext_storage_start_transaction_version_1

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1901,8 +1901,7 @@ func ext_storage_clear_prefix_version_2(context unsafe.Pointer, prefixSpan, lim 
 	numRemoved, all, err := storage.ClearPrefixLimit(prefix, limitUint)
 	if err != nil {
 		logger.Errorf("failed to clear prefix limit: %s", err)
-		ret, _ := toWasmMemory(instanceContext, nil)
-		return C.int64_t(ret)
+		return mustToWasmMemoryNil(instanceContext)
 	}
 
 	encBytes, err := toKillStorageResultEnum(all, numRemoved)

--- a/lib/runtime/wasmer/interfaces.go
+++ b/lib/runtime/wasmer/interfaces.go
@@ -17,16 +17,17 @@ type Storage interface {
 	SetChild(keyToChild []byte, child *trie.Trie) error
 	SetChildStorage(keyToChild, key, value []byte) error
 	GetChildStorage(keyToChild, key []byte) ([]byte, error)
-	Delete(key []byte)
-	DeleteChild(keyToChild []byte)
+	Delete(key []byte) (err error)
+	DeleteChild(keyToChild []byte) (err error)
 	DeleteChildLimit(keyToChild []byte, limit *[]byte) (uint32, bool, error)
 	ClearChildStorage(keyToChild, key []byte) error
 	NextKey([]byte) []byte
 	ClearPrefixInChild(keyToChild, prefix []byte) error
 	GetChildNextKey(keyToChild, key []byte) ([]byte, error)
 	GetChild(keyToChild []byte) (*trie.Trie, error)
-	ClearPrefix(prefix []byte)
-	ClearPrefixLimit(prefix []byte, limit uint32) (uint32, bool)
+	ClearPrefix(prefix []byte) (err error)
+	ClearPrefixLimit(prefix []byte, limit uint32) (
+		deleted uint32, allDeleted bool, err error)
 	BeginStorageTransaction()
 	CommitStorageTransaction()
 	RollbackStorageTransaction()
@@ -46,7 +47,7 @@ type Getter interface {
 
 // Putter puts a value for a key.
 type Putter interface {
-	Put(key []byte, value []byte)
+	Put(key []byte, value []byte) (err error)
 }
 
 // BasicNetwork interface for functions used by runtime network state function

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -30,7 +30,7 @@ func (t *Trie) SetChild(keyToChild []byte, child *Trie) error {
 
 	err = t.Put(key, childHash.ToBytes())
 	if err != nil {
-		return fmt.Errorf("putting child trie root hash %s in main trie: %w", childHash, err)
+		return fmt.Errorf("putting child trie root hash %s in trie: %w", childHash, err)
 	}
 
 	t.childTries[childHash] = child
@@ -65,7 +65,7 @@ func (t *Trie) PutIntoChild(keyToChild, key, value []byte) error {
 
 	err = child.Put(key, value)
 	if err != nil {
-		return fmt.Errorf("putting into child trie at key 0x%x: %w", keyToChild, err)
+		return fmt.Errorf("putting into child trie located at key 0x%x: %w", keyToChild, err)
 	}
 
 	childHash, err := child.Hash()
@@ -103,7 +103,7 @@ func (t *Trie) DeleteChild(keyToChild []byte) (err error) {
 
 	err = t.Delete(key)
 	if err != nil {
-		return fmt.Errorf("deleting child trie at key 0x%x: %w", key, err)
+		return fmt.Errorf("deleting child trie located at key 0x%x: %w", keyToChild, err)
 	}
 	return nil
 }
@@ -120,7 +120,7 @@ func (t *Trie) ClearFromChild(keyToChild, key []byte) error {
 
 	err = child.Delete(key)
 	if err != nil {
-		return fmt.Errorf("deleting from child trie at key 0x%x: %w", keyToChild, err)
+		return fmt.Errorf("deleting from child trie located at key 0x%x: %w", keyToChild, err)
 	}
 
 	return nil

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -28,7 +28,11 @@ func (t *Trie) SetChild(keyToChild []byte, child *Trie) error {
 	copy(key, ChildStorageKeyPrefix)
 	copy(key[len(ChildStorageKeyPrefix):], keyToChild)
 
-	t.Put(key, childHash.ToBytes())
+	err = t.Put(key, childHash.ToBytes())
+	if err != nil {
+		return fmt.Errorf("putting child trie root hash %s in main trie: %w", childHash, err)
+	}
+
 	t.childTries[childHash] = child
 	return nil
 }
@@ -59,7 +63,11 @@ func (t *Trie) PutIntoChild(keyToChild, key, value []byte) error {
 		return err
 	}
 
-	child.Put(key, value)
+	err = child.Put(key, value)
+	if err != nil {
+		return fmt.Errorf("putting into child trie at key 0x%x: %w", keyToChild, err)
+	}
+
 	childHash, err := child.Hash()
 	if err != nil {
 		return err
@@ -88,12 +96,16 @@ func (t *Trie) GetFromChild(keyToChild, key []byte) ([]byte, error) {
 }
 
 // DeleteChild deletes the child storage trie
-func (t *Trie) DeleteChild(keyToChild []byte) {
+func (t *Trie) DeleteChild(keyToChild []byte) (err error) {
 	key := make([]byte, len(ChildStorageKeyPrefix)+len(keyToChild))
 	copy(key, ChildStorageKeyPrefix)
 	copy(key[len(ChildStorageKeyPrefix):], keyToChild)
 
-	t.Delete(key)
+	err = t.Delete(key)
+	if err != nil {
+		return fmt.Errorf("deleting child trie at key 0x%x: %w", key, err)
+	}
+	return nil
 }
 
 // ClearFromChild removes the child storage entry
@@ -105,6 +117,11 @@ func (t *Trie) ClearFromChild(keyToChild, key []byte) error {
 	if child == nil {
 		return fmt.Errorf("%w at key 0x%x%x", ErrChildTrieDoesNotExist, ChildStorageKeyPrefix, keyToChild)
 	}
-	child.Delete(key)
+
+	err = child.Delete(key)
+	if err != nil {
+		return fmt.Errorf("deleting from child trie at key 0x%x: %w", keyToChild, err)
+	}
+
 	return nil
 }

--- a/lib/trie/helpers_test.go
+++ b/lib/trie/helpers_test.go
@@ -118,3 +118,20 @@ func padRightChildren(slice []*Node) (paddedSlice []*Node) {
 	copy(paddedSlice, slice)
 	return paddedSlice
 }
+
+func checkMerkleValuesAreSet(t *testing.T, n *Node) {
+	t.Helper()
+
+	if n == nil {
+		return
+	}
+
+	require.NotEmpty(t, n.MerkleValue)
+	if n.Kind() == node.Leaf {
+		return
+	}
+
+	for _, child := range n.Children {
+		checkMerkleValuesAreSet(t, child)
+	}
+}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1165,7 +1165,7 @@ func (t *Trie) Delete(keyLE []byte) (err error) {
 	key := codec.KeyLEToNibbles(keyLE)
 	root, _, _, err := t.deleteAtNode(t.root, key, pendingDeletedMerkleValues)
 	if err != nil {
-		return err
+		return fmt.Errorf("deleting key %x: %w", keyLE, err)
 	}
 	t.root = root
 	return nil

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -81,50 +81,79 @@ func (t *Trie) handleTrackedDeltas(success bool, pendingDeletedMerkleValues map[
 
 func (t *Trie) prepLeafForMutation(currentLeaf *Node,
 	copySettings node.CopySettings,
-	pendingDeletedMerkleValues map[string]struct{}) (newLeaf *Node) {
+	pendingDeletedMerkleValues map[string]struct{}) (
+	newLeaf *Node, err error) {
 	if currentLeaf.Generation == t.generation {
 		// no need to deep copy and update generation
 		// of current leaf.
 		newLeaf = currentLeaf
 	} else {
-		newLeaf = updateGeneration(currentLeaf, t.generation, pendingDeletedMerkleValues, copySettings)
+		newLeaf, err = t.updateGeneration(currentLeaf, pendingDeletedMerkleValues, copySettings)
+		if err != nil {
+			return nil, fmt.Errorf("updating generation: %w", err)
+		}
 	}
 	newLeaf.SetDirty()
-	return newLeaf
+	return newLeaf, nil
 }
 
 func (t *Trie) prepBranchForMutation(currentBranch *Node,
 	copySettings node.CopySettings,
-	pendingDeletedMerkleValues map[string]struct{}) (newBranch *Node) {
+	pendingDeletedMerkleValues map[string]struct{}) (
+	newBranch *Node, err error) {
 	if currentBranch.Generation == t.generation {
 		// no need to deep copy and update generation
 		// of current branch.
 		newBranch = currentBranch
 	} else {
-		newBranch = updateGeneration(currentBranch, t.generation, pendingDeletedMerkleValues, copySettings)
+		newBranch, err = t.updateGeneration(currentBranch, pendingDeletedMerkleValues, copySettings)
+		if err != nil {
+			return nil, fmt.Errorf("updating generation: %w", err)
+		}
 	}
 	newBranch.SetDirty()
-	return newBranch
+	return newBranch, nil
 }
 
 // updateGeneration is called when the currentNode is from
 // an older trie generation (snapshot) so we deep copy the
 // node and update the generation on the newer copy.
-func updateGeneration(currentNode *Node, trieGeneration uint64,
-	deletedMerkleValues map[string]struct{}, copySettings node.CopySettings) (
-	newNode *Node) {
-	newNode = currentNode.Copy(copySettings)
-	newNode.Generation = trieGeneration
-
-	// The hash of the node from a previous snapshotted trie
-	// is usually already computed.
-	deletedMerkleValue := currentNode.MerkleValue
-	if len(deletedMerkleValue) > 0 {
-		deletedMerkleValueString := string(deletedMerkleValue)
-		deletedMerkleValues[deletedMerkleValueString] = struct{}{}
+func (t *Trie) updateGeneration(currentNode *Node,
+	pendingDeletedMerkleValues map[string]struct{},
+	copySettings node.CopySettings) (newNode *Node, err error) {
+	isRoot := currentNode == t.root
+	err = registerDeletedMerkleValue(currentNode, isRoot, pendingDeletedMerkleValues)
+	if err != nil {
+		return nil, fmt.Errorf("registering deleted merkle value: %w", err)
 	}
 
-	return newNode
+	newNode = currentNode.Copy(copySettings)
+	newNode.Generation = t.generation
+
+	return newNode, nil
+}
+
+func registerDeletedMerkleValue(node *Node, isRoot bool,
+	pendingDeletedMerkleValues map[string]struct{}) (err error) {
+	err = ensureMerkleValueIsCalculated(node, isRoot)
+	if err != nil {
+		return fmt.Errorf("ensuring Merkle value is calculated: %w", err)
+	}
+
+	if len(node.MerkleValue) < 32 {
+		// Merkle values which are less than 32 bytes are inlined
+		// in the parent branch and are not stored on disk, so there
+		// is no need to track their deletion for the online pruning.
+		return nil
+	}
+
+	if !node.Dirty {
+		// Only register deleted nodes that were not previously modified
+		// since the last trie snapshot.
+		pendingDeletedMerkleValues[string(node.MerkleValue)] = struct{}{}
+	}
+
+	return nil
 }
 
 // DeepCopy deep copies the trie and returns
@@ -322,30 +351,36 @@ func findNextKeyChild(children []*Node, startIndex byte,
 
 // Put inserts a value into the trie at the
 // key specified in little Endian format.
-func (t *Trie) Put(keyLE, value []byte) {
+func (t *Trie) Put(keyLE, value []byte) (err error) {
 	pendingDeletedMerkleValues := make(map[string]struct{})
 	defer func() {
 		const success = true
 		t.handleTrackedDeltas(success, pendingDeletedMerkleValues)
 	}()
-	t.insertKeyLE(keyLE, value, pendingDeletedMerkleValues)
+	return t.insertKeyLE(keyLE, value, pendingDeletedMerkleValues)
 }
 
-func (t *Trie) insertKeyLE(keyLE, value []byte, deletedMerkleValues map[string]struct{}) {
+func (t *Trie) insertKeyLE(keyLE, value []byte,
+	deletedMerkleValues map[string]struct{}) (err error) {
 	nibblesKey := codec.KeyLEToNibbles(keyLE)
 	if value == nil {
 		// Force nil value to be inserted to []byte{} since `nil` means there
 		// is no value.
 		value = []byte{}
 	}
-	t.root, _, _ = t.insert(t.root, nibblesKey, value, deletedMerkleValues)
+	root, _, _, err := t.insert(t.root, nibblesKey, value, deletedMerkleValues)
+	if err != nil {
+		return err
+	}
+	t.root = root
+	return nil
 }
 
 // insert inserts a value in the trie at the key specified.
 // It may create one or more new nodes or update an existing node.
 func (t *Trie) insert(parent *Node, key, value []byte,
 	deletedMerkleValues map[string]struct{}) (newParent *Node,
-	mutated bool, nodesCreated uint32) {
+	mutated bool, nodesCreated uint32, err error) {
 	if parent == nil {
 		mutated = true
 		nodesCreated = 1
@@ -354,33 +389,51 @@ func (t *Trie) insert(parent *Node, key, value []byte,
 			StorageValue: value,
 			Generation:   t.generation,
 			Dirty:        true,
-		}, mutated, nodesCreated
+		}, mutated, nodesCreated, nil
 	}
 
 	// TODO ensure all values have dirty set to true
 
 	if parent.Kind() == node.Branch {
-		return t.insertInBranch(parent, key, value, deletedMerkleValues)
+		newParent, mutated, nodesCreated, err = t.insertInBranch(
+			parent, key, value, deletedMerkleValues)
+		if err != nil {
+			// `insertInBranch` may call `insert` so do not wrap the
+			// error since this may be a deep recursive call.
+			return nil, false, 0, err
+		}
+		return newParent, mutated, nodesCreated, nil
 	}
-	return t.insertInLeaf(parent, key, value, deletedMerkleValues)
+
+	newParent, mutated, nodesCreated, err = t.insertInLeaf(
+		parent, key, value, deletedMerkleValues)
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("inserting in leaf: %w", err)
+	}
+
+	return newParent, mutated, nodesCreated, nil
 }
 
 func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, mutated bool, nodesCreated uint32) {
+	newParent *Node, mutated bool, nodesCreated uint32, err error) {
 	if bytes.Equal(parentLeaf.PartialKey, key) {
 		nodesCreated = 0
 		if parentLeaf.StorageValueEqual(value) {
 			mutated = false
-			return parentLeaf, mutated, nodesCreated
+			return parentLeaf, mutated, nodesCreated, nil
 		}
 
 		copySettings := node.DefaultCopySettings
 		copySettings.CopyStorageValue = false
-		parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
+		parentLeaf, err = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("preparing leaf for mutation: %w", err)
+		}
+
 		parentLeaf.StorageValue = value
 		mutated = true
-		return parentLeaf, mutated, nodesCreated
+		return parentLeaf, mutated, nodesCreated, nil
 	}
 
 	commonPrefixLength := lenCommonPrefix(key, parentLeaf.PartialKey)
@@ -405,7 +458,10 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 			childIndex := parentLeafKey[commonPrefixLength]
 			newParentLeafKey := parentLeaf.PartialKey[commonPrefixLength+1:]
 			if !bytes.Equal(parentLeaf.PartialKey, newParentLeafKey) {
-				parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
+				parentLeaf, err = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
+				if err != nil {
+					return nil, false, 0, fmt.Errorf("preparing leaf for mutation: %w", err)
+				}
 				parentLeaf.PartialKey = newParentLeafKey
 			}
 			newBranchParent.Children[childIndex] = parentLeaf
@@ -413,7 +469,7 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 			nodesCreated++
 		}
 
-		return newBranchParent, mutated, nodesCreated
+		return newBranchParent, mutated, nodesCreated, nil
 	}
 
 	if len(parentLeaf.PartialKey) == commonPrefixLength {
@@ -425,7 +481,10 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 		childIndex := parentLeafKey[commonPrefixLength]
 		newParentLeafKey := parentLeaf.PartialKey[commonPrefixLength+1:]
 		if !bytes.Equal(parentLeaf.PartialKey, newParentLeafKey) {
-			parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
+			parentLeaf, err = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
+			if err != nil {
+				return nil, false, 0, fmt.Errorf("preparing leaf for mutation: %w", err)
+			}
 			parentLeaf.PartialKey = newParentLeafKey
 		}
 		newBranchParent.Children[childIndex] = parentLeaf
@@ -442,23 +501,26 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 	newBranchParent.Descendants++
 	nodesCreated++
 
-	return newBranchParent, mutated, nodesCreated
+	return newBranchParent, mutated, nodesCreated, nil
 }
 
 func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, mutated bool, nodesCreated uint32) {
+	newParent *Node, mutated bool, nodesCreated uint32, err error) {
 	copySettings := node.DefaultCopySettings
 
 	if bytes.Equal(key, parentBranch.PartialKey) {
 		if parentBranch.StorageValueEqual(value) {
 			mutated = false
-			return parentBranch, mutated, 0
+			return parentBranch, mutated, 0, nil
 		}
-		parentBranch = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+		parentBranch, err = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+		}
 		parentBranch.StorageValue = value
 		mutated = true
-		return parentBranch, mutated, 0
+		return parentBranch, mutated, 0, nil
 	}
 
 	if bytes.HasPrefix(key, parentBranch.PartialKey) {
@@ -476,22 +538,32 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 				Dirty:        true,
 			}
 			nodesCreated = 1
-			parentBranch = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+			parentBranch, err = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+			if err != nil {
+				return nil, false, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+			}
 			parentBranch.Children[childIndex] = child
 			parentBranch.Descendants += nodesCreated
 			mutated = true
-			return parentBranch, mutated, nodesCreated
+			return parentBranch, mutated, nodesCreated, nil
 		}
 
-		child, mutated, nodesCreated = t.insert(child, remainingKey, value, deletedMerkleValues)
-		if !mutated {
-			return parentBranch, mutated, 0
+		child, mutated, nodesCreated, err = t.insert(child, remainingKey, value, deletedMerkleValues)
+		if err != nil {
+			// do not wrap error since `insert` may call `insertInBranch` recursively
+			return nil, false, 0, err
+		} else if !mutated {
+			return parentBranch, mutated, 0, nil
 		}
 
-		parentBranch = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+		parentBranch, err = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+		}
+
 		parentBranch.Children[childIndex] = child
 		parentBranch.Descendants += nodesCreated
-		return parentBranch, mutated, nodesCreated
+		return parentBranch, mutated, nodesCreated, nil
 	}
 
 	// we need to branch out at the point where the keys diverge
@@ -510,7 +582,11 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 	remainingOldParentKey := parentBranch.PartialKey[commonPrefixLength+1:]
 
 	// Note: parentBranch.Key != remainingOldParentKey
-	parentBranch = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+	parentBranch, err = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+	}
+
 	parentBranch.PartialKey = remainingOldParentKey
 	newParentBranch.Children[oldParentIndex] = parentBranch
 	newParentBranch.Descendants += 1 + parentBranch.Descendants
@@ -521,13 +597,18 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 		childIndex := key[commonPrefixLength]
 		remainingKey := key[commonPrefixLength+1:]
 		var additionalNodesCreated uint32
-		newParentBranch.Children[childIndex], _, additionalNodesCreated = t.insert(
+		newParentBranch.Children[childIndex], _, additionalNodesCreated, err = t.insert(
 			nil, remainingKey, value, deletedMerkleValues)
+		if err != nil {
+			// do not wrap error since `insert` may call `insertInBranch` recursively
+			return nil, false, 0, err
+		}
+
 		nodesCreated += additionalNodesCreated
 		newParentBranch.Descendants += additionalNodesCreated
 	}
 
-	return newParentBranch, mutated, nodesCreated
+	return newParentBranch, mutated, nodesCreated, nil
 }
 
 // LoadFromMap loads the given data mapping of key to value into a new empty trie.
@@ -552,7 +633,10 @@ func LoadFromMap(data map[string]string) (trie Trie, err error) {
 			return Trie{}, fmt.Errorf("cannot convert value hex to bytes: %w", err)
 		}
 
-		trie.insertKeyLE(keyLEBytes, valueBytes, pendingDeletedMerkleValues)
+		err = trie.insertKeyLE(keyLEBytes, valueBytes, pendingDeletedMerkleValues)
+		if err != nil {
+			return Trie{}, fmt.Errorf("inserting key value pair in trie: %w", err)
+		}
 	}
 
 	return trie, nil
@@ -706,7 +790,8 @@ func retrieveFromBranch(branch *Node, key []byte) (value []byte) {
 // Endian format for up to `limit` keys. It returns the number of deleted
 // keys and a boolean indicating if all keys with the prefix were deleted
 // within the limit.
-func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (deleted uint32, allDeleted bool) {
+func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (
+	deleted uint32, allDeleted bool, err error) {
 	pendingDeletedMerkleValues := make(map[string]struct{})
 	defer func() {
 		const success = true
@@ -714,15 +799,21 @@ func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (deleted uint32, 
 	}()
 
 	if limit == 0 {
-		return 0, false
+		return 0, false, nil
 	}
 
 	prefix := codec.KeyLEToNibbles(prefixLE)
 	prefix = bytes.TrimSuffix(prefix, []byte{0})
 
-	t.root, deleted, _, allDeleted = t.clearPrefixLimitAtNode(
+	t.root, deleted, _, allDeleted, err = t.clearPrefixLimitAtNode(
 		t.root, prefix, limit, pendingDeletedMerkleValues)
-	return deleted, allDeleted
+	if err != nil {
+		// Note: no need to wrap the error really since the private function has
+		// the same name as the exported function `ClearPrefixLimit`.
+		return 0, false, err
+	}
+
+	return deleted, allDeleted, nil
 }
 
 // clearPrefixLimitAtNode deletes the keys having the prefix until the value deletion limit is reached.
@@ -730,9 +821,9 @@ func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (deleted uint32, 
 // allDeleted boolean indicating if there is no key left with the prefix.
 func (t *Trie) clearPrefixLimitAtNode(parent *Node, prefix []byte,
 	limit uint32, deletedMerkleValues map[string]struct{}) (
-	newParent *Node, valuesDeleted, nodesRemoved uint32, allDeleted bool) {
+	newParent *Node, valuesDeleted, nodesRemoved uint32, allDeleted bool, err error) {
 	if parent == nil {
-		return nil, 0, 0, true
+		return nil, 0, 0, true, nil
 	}
 
 	if parent.Kind() == node.Leaf {
@@ -740,25 +831,37 @@ func (t *Trie) clearPrefixLimitAtNode(parent *Node, prefix []byte,
 		// TODO check this is the same behaviour as in substrate
 		const allDeleted = true
 		if bytes.HasPrefix(parent.PartialKey, prefix) {
+			isRoot := parent == t.root
+			err = registerDeletedMerkleValue(parent, isRoot, deletedMerkleValues)
+			if err != nil {
+				return nil, 0, 0, false,
+					fmt.Errorf("registering deleted Merkle value: %w", err)
+			}
+
 			valuesDeleted, nodesRemoved = 1, 1
-			return nil, valuesDeleted, nodesRemoved, allDeleted
+			return nil, valuesDeleted, nodesRemoved, allDeleted, nil
 		}
-		return parent, 0, 0, allDeleted
+		return parent, 0, 0, allDeleted, nil
 	}
 
+	// Note: `clearPrefixLimitBranch` may call `clearPrefixLimitAtNode` so do not wrap
+	// the error since that could be a deep recursive call.
 	return t.clearPrefixLimitBranch(parent, prefix, limit, deletedMerkleValues)
 }
 
 func (t *Trie) clearPrefixLimitBranch(branch *Node, prefix []byte, limit uint32,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, valuesDeleted, nodesRemoved uint32, allDeleted bool) {
+	newParent *Node, valuesDeleted, nodesRemoved uint32, allDeleted bool, err error) {
 	newParent = branch
 
 	if bytes.HasPrefix(branch.PartialKey, prefix) {
-		newParent, valuesDeleted, nodesRemoved = t.deleteNodesLimit(
+		newParent, valuesDeleted, nodesRemoved, err = t.deleteNodesLimit(
 			branch, limit, deletedMerkleValues)
+		if err != nil {
+			return nil, 0, 0, false, fmt.Errorf("deleting nodes: %w", err)
+		}
 		allDeleted = newParent == nil
-		return newParent, valuesDeleted, nodesRemoved, allDeleted
+		return newParent, valuesDeleted, nodesRemoved, allDeleted, nil
 	}
 
 	if len(prefix) == len(branch.PartialKey)+1 &&
@@ -772,34 +875,44 @@ func (t *Trie) clearPrefixLimitBranch(branch *Node, prefix []byte, limit uint32,
 	if noPrefixForNode {
 		valuesDeleted, nodesRemoved = 0, 0
 		allDeleted = true
-		return newParent, valuesDeleted, nodesRemoved, allDeleted
+		return newParent, valuesDeleted, nodesRemoved, allDeleted, nil
 	}
 
 	childIndex := prefix[len(branch.PartialKey)]
 	childPrefix := prefix[len(branch.PartialKey)+1:]
 	child := branch.Children[childIndex]
 
-	child, valuesDeleted, nodesRemoved, allDeleted = t.clearPrefixLimitAtNode(
+	child, valuesDeleted, nodesRemoved, allDeleted, err = t.clearPrefixLimitAtNode(
 		child, childPrefix, limit, deletedMerkleValues)
-	if valuesDeleted == 0 {
-		return branch, valuesDeleted, nodesRemoved, allDeleted
+	if err != nil {
+		return nil, 0, 0, false, fmt.Errorf("clearing prefix limit at node: %w", err)
+	} else if valuesDeleted == 0 {
+		return branch, valuesDeleted, nodesRemoved, allDeleted, nil
 	}
 
 	copySettings := node.DefaultCopySettings
-	branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, 0, false, fmt.Errorf("preparing branch for mutation: %w", err)
+	}
+
 	branch.Children[childIndex] = child
 	branch.Descendants -= nodesRemoved
-	newParent, branchChildMerged := handleDeletion(branch, prefix)
+	newParent, branchChildMerged, err := handleDeletion(branch, prefix, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, 0, false, fmt.Errorf("handling deletion: %w", err)
+	}
+
 	if branchChildMerged {
 		nodesRemoved++
 	}
 
-	return newParent, valuesDeleted, nodesRemoved, allDeleted
+	return newParent, valuesDeleted, nodesRemoved, allDeleted, nil
 }
 
 func (t *Trie) clearPrefixLimitChild(branch *Node, prefix []byte, limit uint32,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, valuesDeleted, nodesRemoved uint32, allDeleted bool) {
+	newParent *Node, valuesDeleted, nodesRemoved uint32, allDeleted bool, err error) {
 	newParent = branch
 
 	childIndex := prefix[len(branch.PartialKey)]
@@ -809,51 +922,80 @@ func (t *Trie) clearPrefixLimitChild(branch *Node, prefix []byte, limit uint32,
 		const valuesDeleted, nodesRemoved = 0, 0
 		// TODO ensure this is the same behaviour as in substrate
 		allDeleted = true
-		return newParent, valuesDeleted, nodesRemoved, allDeleted
+		return newParent, valuesDeleted, nodesRemoved, allDeleted, nil
 	}
 
-	child, valuesDeleted, nodesRemoved = t.deleteNodesLimit(
+	child, valuesDeleted, nodesRemoved, err = t.deleteNodesLimit(
 		child, limit, deletedMerkleValues)
+	if err != nil {
+		// Note: do not wrap error since this is recursive.
+		return nil, 0, 0, false, err
+	}
+
 	if valuesDeleted == 0 {
 		allDeleted = branch.Children[childIndex] == nil
-		return branch, valuesDeleted, nodesRemoved, allDeleted
+		return branch, valuesDeleted, nodesRemoved, allDeleted, nil
 	}
 
 	copySettings := node.DefaultCopySettings
-	branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, 0, false, fmt.Errorf("preparing branch for mutation: %w", err)
+	}
+
 	branch.Children[childIndex] = child
 	branch.Descendants -= nodesRemoved
 
-	newParent, branchChildMerged := handleDeletion(branch, prefix)
+	newParent, branchChildMerged, err := handleDeletion(branch, prefix, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, 0, false, fmt.Errorf("handling deletion: %w", err)
+	}
+
 	if branchChildMerged {
 		nodesRemoved++
 	}
 
 	allDeleted = branch.Children[childIndex] == nil
-	return newParent, valuesDeleted, nodesRemoved, allDeleted
+	return newParent, valuesDeleted, nodesRemoved, allDeleted, nil
 }
 
 func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, valuesDeleted, nodesRemoved uint32) {
+	newParent *Node, valuesDeleted, nodesRemoved uint32, err error) {
 	if limit == 0 {
 		valuesDeleted, nodesRemoved = 0, 0
-		return parent, valuesDeleted, nodesRemoved
+		return parent, valuesDeleted, nodesRemoved, nil
 	}
 
 	if parent == nil {
 		valuesDeleted, nodesRemoved = 0, 0
-		return nil, valuesDeleted, nodesRemoved
+		return nil, valuesDeleted, nodesRemoved, nil
 	}
 
 	if parent.Kind() == node.Leaf {
+		isRoot := parent == t.root
+		err = registerDeletedMerkleValue(parent, isRoot, deletedMerkleValues)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("registering deleted merkle value: %w", err)
+		}
 		valuesDeleted, nodesRemoved = 1, 1
-		return nil, valuesDeleted, nodesRemoved
+		return nil, valuesDeleted, nodesRemoved, nil
 	}
 
 	branch := parent
 
 	nilChildren := node.ChildrenCapacity - branch.NumChildren()
+	if nilChildren == node.ChildrenCapacity {
+		panic("got branch with all nil children")
+	}
+
+	// Note: there is at least one non-nil child and the limit isn't zero,
+	// therefore it is safe to prepare the branch for mutation.
+	copySettings := node.DefaultCopySettings
+	branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+	}
 
 	var newDeleted, newNodesRemoved uint32
 	var branchChildMerged bool
@@ -862,14 +1004,13 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 			continue
 		}
 
-		copySettings := node.DefaultCopySettings
-		branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
-
-		branch.Children[i], newDeleted, newNodesRemoved = t.deleteNodesLimit(
+		branch.Children[i], newDeleted, newNodesRemoved, err = t.deleteNodesLimit(
 			child, limit, deletedMerkleValues)
-		// Note: newDeleted can never be zero here since the limit isn't zero
-		// and the child is not nil. Therefore it is safe to prepare the branch
-		// for mutation right before this call.
+		if err != nil {
+			// `deleteNodesLimit` is recursive, so do not wrap error.
+			return nil, 0, 0, err
+		}
+
 		if branch.Children[i] == nil {
 			nilChildren++
 		}
@@ -878,18 +1019,22 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 		nodesRemoved += newNodesRemoved
 		branch.Descendants -= newNodesRemoved
 
-		newParent, branchChildMerged = handleDeletion(branch, branch.PartialKey)
+		newParent, branchChildMerged, err = handleDeletion(branch, branch.PartialKey, deletedMerkleValues)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("handling deletion: %w", err)
+		}
+
 		if branchChildMerged {
 			nodesRemoved++
 		}
 
 		if nilChildren == node.ChildrenCapacity &&
 			branch.StorageValue == nil {
-			return nil, valuesDeleted, nodesRemoved
+			return nil, valuesDeleted, nodesRemoved, nil
 		}
 
 		if limit == 0 {
-			return newParent, valuesDeleted, nodesRemoved
+			return newParent, valuesDeleted, nodesRemoved, nil
 		}
 	}
 
@@ -898,12 +1043,12 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 		valuesDeleted++
 	}
 
-	return nil, valuesDeleted, nodesRemoved
+	return nil, valuesDeleted, nodesRemoved, nil
 }
 
 // ClearPrefix deletes all nodes in the trie for which the key contains the
 // prefix given in little Endian format.
-func (t *Trie) ClearPrefix(prefixLE []byte) {
+func (t *Trie) ClearPrefix(prefixLE []byte) (err error) {
 	pendingDeletedMerkleValues := make(map[string]struct{})
 	defer func() {
 		const success = true
@@ -911,6 +1056,13 @@ func (t *Trie) ClearPrefix(prefixLE []byte) {
 	}()
 
 	if len(prefixLE) == 0 {
+		const isRoot = true
+		err = ensureMerkleValueIsCalculated(t.root, isRoot)
+		if err != nil {
+			return fmt.Errorf("ensuring Merkle values are calculated: %w", err)
+		}
+
+		PopulateNodeHashes(t.root, pendingDeletedMerkleValues)
 		t.root = nil
 		return
 	}
@@ -918,25 +1070,39 @@ func (t *Trie) ClearPrefix(prefixLE []byte) {
 	prefix := codec.KeyLEToNibbles(prefixLE)
 	prefix = bytes.TrimSuffix(prefix, []byte{0})
 
-	t.root, _ = t.clearPrefixAtNode(t.root, prefix, pendingDeletedMerkleValues)
+	root, _, err := t.clearPrefixAtNode(t.root, prefix, pendingDeletedMerkleValues)
+	if err != nil {
+		return fmt.Errorf("clearing prefix at root node: %w", err)
+	}
+	t.root = root
+
+	return nil
 }
 
 func (t *Trie) clearPrefixAtNode(parent *Node, prefix []byte,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, nodesRemoved uint32) {
+	newParent *Node, nodesRemoved uint32, err error) {
 	if parent == nil {
 		const nodesRemoved = 0
-		return nil, nodesRemoved
+		return nil, nodesRemoved, nil
 	}
 
 	if bytes.HasPrefix(parent.PartialKey, prefix) {
+		isRoot := parent == t.root
+		err = ensureMerkleValueIsCalculated(parent, isRoot)
+		if err != nil {
+			nodesRemoved = 0
+			return parent, nodesRemoved, fmt.Errorf("ensuring Merkle values are calculated: %w", err)
+		}
+
+		PopulateNodeHashes(parent, deletedMerkleValues)
 		nodesRemoved = 1 + parent.Descendants
-		return nil, nodesRemoved
+		return nil, nodesRemoved, nil
 	}
 
 	if parent.Kind() == node.Leaf {
 		const nodesRemoved = 0
-		return parent, nodesRemoved
+		return parent, nodesRemoved, nil
 	}
 
 	branch := parent
@@ -948,54 +1114,80 @@ func (t *Trie) clearPrefixAtNode(parent *Node, prefix []byte,
 
 		if child == nil {
 			const nodesRemoved = 0
-			return parent, nodesRemoved
+			return parent, nodesRemoved, nil
 		}
 
 		nodesRemoved = 1 + child.Descendants
 		copySettings := node.DefaultCopySettings
-		branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+		branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+		if err != nil {
+			return nil, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+		}
+
+		const isRoot = false // child so it cannot be the root
+		err = registerDeletedMerkleValue(child, isRoot, deletedMerkleValues)
+		if err != nil {
+			return nil, 0, fmt.Errorf("registering deleted merkle value for child: %w", err)
+		}
+
 		branch.Children[childIndex] = nil
 		branch.Descendants -= nodesRemoved
 		var branchChildMerged bool
-		newParent, branchChildMerged = handleDeletion(branch, prefix)
+		newParent, branchChildMerged, err = handleDeletion(branch, prefix, deletedMerkleValues)
+		if err != nil {
+			return nil, 0, fmt.Errorf("handling deletion: %w", err)
+		}
+
 		if branchChildMerged {
 			nodesRemoved++
 		}
-		return newParent, nodesRemoved
+		return newParent, nodesRemoved, nil
 	}
 
 	noPrefixForNode := len(prefix) <= len(branch.PartialKey) ||
 		lenCommonPrefix(branch.PartialKey, prefix) < len(branch.PartialKey)
 	if noPrefixForNode {
 		const nodesRemoved = 0
-		return parent, nodesRemoved
+		return parent, nodesRemoved, nil
 	}
 
 	childIndex := prefix[len(branch.PartialKey)]
 	childPrefix := prefix[len(branch.PartialKey)+1:]
 	child := branch.Children[childIndex]
 
-	child, nodesRemoved = t.clearPrefixAtNode(child, childPrefix, deletedMerkleValues)
-	if nodesRemoved == 0 {
-		return parent, nodesRemoved
+	child, nodesRemoved, err = t.clearPrefixAtNode(child, childPrefix, deletedMerkleValues)
+	if err != nil {
+		nodesRemoved = 0
+		// Note: do not wrap error since this is recursive
+		return parent, nodesRemoved, err
+	} else if nodesRemoved == 0 {
+		return parent, nodesRemoved, nil
 	}
 
 	copySettings := node.DefaultCopySettings
-	branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+	}
+
 	branch.Descendants -= nodesRemoved
 	branch.Children[childIndex] = child
-	newParent, branchChildMerged := handleDeletion(branch, prefix)
+	newParent, branchChildMerged, err := handleDeletion(branch, prefix, deletedMerkleValues)
+	if err != nil {
+		return nil, 0, fmt.Errorf("handling deletion: %w", err)
+	}
+
 	if branchChildMerged {
 		nodesRemoved++
 	}
 
-	return newParent, nodesRemoved
+	return newParent, nodesRemoved, nil
 }
 
 // Delete removes the node of the trie with the key
 // matching the key given in little Endian format.
 // If no node is found at this key, nothing is deleted.
-func (t *Trie) Delete(keyLE []byte) {
+func (t *Trie) Delete(keyLE []byte) (err error) {
 	pendingDeletedMerkleValues := make(map[string]struct{})
 	defer func() {
 		const success = true
@@ -1003,80 +1195,129 @@ func (t *Trie) Delete(keyLE []byte) {
 	}()
 
 	key := codec.KeyLEToNibbles(keyLE)
-	t.root, _, _ = t.deleteAtNode(t.root, key, pendingDeletedMerkleValues)
+	root, _, _, err := t.deleteAtNode(t.root, key, pendingDeletedMerkleValues)
+	if err != nil {
+		return err
+	}
+	t.root = root
+	return nil
 }
 
 func (t *Trie) deleteAtNode(parent *Node, key []byte,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, deleted bool, nodesRemoved uint32) {
+	newParent *Node, deleted bool, nodesRemoved uint32, err error) {
 	if parent == nil {
 		const nodesRemoved = 0
-		return nil, false, nodesRemoved
+		return nil, false, nodesRemoved, nil
 	}
 
 	if parent.Kind() == node.Leaf {
-		if deleteLeaf(parent, key) == nil {
+		newParent, err = t.deleteLeaf(parent, key, deletedMerkleValues)
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("deleting leaf: %w", err)
+		}
+
+		if newParent == nil {
 			const nodesRemoved = 1
-			return nil, true, nodesRemoved
+			return nil, true, nodesRemoved, nil
 		}
 		const nodesRemoved = 0
-		return parent, false, nodesRemoved
+		return parent, false, nodesRemoved, nil
 	}
-	return t.deleteBranch(parent, key, deletedMerkleValues)
+
+	newParent, deleted, nodesRemoved, err = t.deleteBranch(parent, key, deletedMerkleValues)
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("deleting branch: %w", err)
+	}
+
+	return newParent, deleted, nodesRemoved, nil
 }
 
-func deleteLeaf(parent *Node, key []byte) (newParent *Node) {
-	if len(key) == 0 || bytes.Equal(key, parent.PartialKey) {
-		return nil
+func (t *Trie) deleteLeaf(parent *Node, key []byte,
+	deletedMerkleValues map[string]struct{}) (
+	newParent *Node, err error) {
+	if len(key) > 0 && !bytes.Equal(key, parent.PartialKey) {
+		return parent, nil
 	}
-	return parent
+
+	newParent = nil
+
+	isRoot := parent == t.root
+	err = registerDeletedMerkleValue(parent, isRoot, deletedMerkleValues)
+	if err != nil {
+		return nil, fmt.Errorf("registering deleted merkle value: %w", err)
+	}
+
+	return newParent, nil
 }
 
 func (t *Trie) deleteBranch(branch *Node, key []byte,
 	deletedMerkleValues map[string]struct{}) (
-	newParent *Node, deleted bool, nodesRemoved uint32) {
+	newParent *Node, deleted bool, nodesRemoved uint32, err error) {
 	if len(key) == 0 || bytes.Equal(branch.PartialKey, key) {
 		copySettings := node.DefaultCopySettings
 		copySettings.CopyStorageValue = false
-		branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+		branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+		}
+
 		// we need to set to nil if the branch has the same generation
 		// as the current trie.
 		branch.StorageValue = nil
 		deleted = true
 		var branchChildMerged bool
-		newParent, branchChildMerged = handleDeletion(branch, key)
+		newParent, branchChildMerged, err = handleDeletion(branch, key, deletedMerkleValues)
+		if err != nil {
+			return nil, false, 0, fmt.Errorf("handling deletion: %w", err)
+		}
+
 		if branchChildMerged {
 			nodesRemoved = 1
 		}
-		return newParent, deleted, nodesRemoved
+		return newParent, deleted, nodesRemoved, nil
 	}
 
 	commonPrefixLength := lenCommonPrefix(branch.PartialKey, key)
 	keyDoesNotExist := commonPrefixLength == len(key)
 	if keyDoesNotExist {
-		return branch, false, 0
+		return branch, false, 0, nil
 	}
 	childIndex := key[commonPrefixLength]
 	childKey := key[commonPrefixLength+1:]
 	child := branch.Children[childIndex]
 
-	newChild, deleted, nodesRemoved := t.deleteAtNode(child, childKey, deletedMerkleValues)
+	newChild, deleted, nodesRemoved, err := t.deleteAtNode(child, childKey, deletedMerkleValues)
+	if err != nil {
+		// deleteAtNode may call deleteBranch so don't wrap the error
+		// since this may be a recursive call.
+		return nil, false, 0, err
+	}
+
 	if !deleted {
 		const nodesRemoved = 0
-		return branch, false, nodesRemoved
+		return branch, false, nodesRemoved, nil
 	}
 
 	copySettings := node.DefaultCopySettings
-	branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	branch, err = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("preparing branch for mutation: %w", err)
+	}
+
 	branch.Descendants -= nodesRemoved
 	branch.Children[childIndex] = newChild
 
-	newParent, branchChildMerged := handleDeletion(branch, key)
+	newParent, branchChildMerged, err := handleDeletion(branch, key, deletedMerkleValues)
+	if err != nil {
+		return nil, false, 0, fmt.Errorf("handling deletion: %w", err)
+	}
+
 	if branchChildMerged {
 		nodesRemoved++
 	}
 
-	return newParent, true, nodesRemoved
+	return newParent, true, nodesRemoved, nil
 }
 
 // handleDeletion is called when a value is deleted from a branch to handle
@@ -1085,7 +1326,9 @@ func (t *Trie) deleteBranch(branch *Node, key []byte,
 // In this first case, branchChildMerged is returned as true to keep track of the removal
 // of one node in callers.
 // If the branch has a value and no child, it will be changed into a leaf.
-func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged bool) {
+func handleDeletion(branch *Node, key []byte,
+	deletedMerkleValues map[string]struct{}) (
+	newNode *Node, branchChildMerged bool, err error) {
 	childrenCount := 0
 	firstChildIndex := -1
 	for i, child := range branch.Children {
@@ -1101,8 +1344,11 @@ func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged 
 	switch {
 	default:
 		const branchChildMerged = false
-		return branch, branchChildMerged
+		return branch, branchChildMerged, nil
 	case childrenCount == 0 && branch.StorageValue != nil:
+		// The branch passed to handleDeletion is always a modified branch
+		// so the original branch Merkle value is already tracked in the deleted
+		// Merkle values map.
 		const branchChildMerged = false
 		commonPrefixLength := lenCommonPrefix(branch.PartialKey, key)
 		return &Node{
@@ -1110,11 +1356,19 @@ func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged 
 			StorageValue: branch.StorageValue,
 			Dirty:        true,
 			Generation:   branch.Generation,
-		}, branchChildMerged
+		}, branchChildMerged, nil
 	case childrenCount == 1 && branch.StorageValue == nil:
+		// The branch passed to handleDeletion is always a modified branch
+		// so the original branch Merkle value is already tracked in the deleted
+		// Merkle values map.
 		const branchChildMerged = true
 		childIndex := firstChildIndex
 		child := branch.Children[firstChildIndex]
+		const isRoot = false // child so it cannot be the root node
+		err = registerDeletedMerkleValue(child, isRoot, deletedMerkleValues)
+		if err != nil {
+			return nil, false, fmt.Errorf("registering deleted merkle value: %w", err)
+		}
 
 		if child.Kind() == node.Leaf {
 			newLeafKey := concatenateSlices(branch.PartialKey, intToByteSlice(childIndex), child.PartialKey)
@@ -1123,7 +1377,7 @@ func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged 
 				StorageValue: child.StorageValue,
 				Dirty:        true,
 				Generation:   branch.Generation,
-			}, branchChildMerged
+			}, branchChildMerged, nil
 		}
 
 		childBranch := child
@@ -1147,8 +1401,32 @@ func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged 
 			}
 		}
 
-		return newBranch, branchChildMerged
+		return newBranch, branchChildMerged, nil
 	}
+}
+
+// ensureMerkleValueIsCalculated is used before calling PopulateMerkleValues
+// to ensure the parent node and all its descendant nodes have their Merkle
+// value computed and ready to be used. This has a close to zero performance
+// impact if the parent node Merkle value is already computed.
+func ensureMerkleValueIsCalculated(parent *Node, isRoot bool) (err error) {
+	if parent == nil {
+		return nil
+	}
+
+	if isRoot {
+		_, err = parent.CalculateRootMerkleValue()
+		if err != nil {
+			return fmt.Errorf("calculating Merkle value of root node: %w", err)
+		}
+	} else {
+		_, err = parent.CalculateMerkleValue()
+		if err != nil {
+			return fmt.Errorf("calculating Merkle value of node: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // lenCommonPrefix returns the length of the

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1065,7 +1065,7 @@ func (t *Trie) ClearPrefix(prefixLE []byte) (err error) {
 
 		PopulateNodeHashes(t.root, pendingDeletedMerkleValues)
 		t.root = nil
-		return
+		return nil
 	}
 
 	prefix := codec.KeyLEToNibbles(prefixLE)

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -777,8 +777,6 @@ func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (
 	root, deleted, _, allDeleted, err := t.clearPrefixLimitAtNode(
 		t.root, prefix, limit, pendingDeletedMerkleValues)
 	if err != nil {
-		// Note: no need to wrap the error really since the private function has
-		// the same name as the exported function `ClearPrefixLimit`.
 		return 0, false, err
 	}
 	t.root = root

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -90,8 +90,7 @@ func (t *Trie) prepForMutation(currentNode *Node,
 		// update the node generation.
 		newNode = currentNode
 	} else {
-		isRoot := currentNode == t.root
-		err = registerDeletedMerkleValue(currentNode, isRoot,
+		err = t.registerDeletedMerkleValue(currentNode,
 			pendingDeletedMerkleValues)
 		if err != nil {
 			return nil, fmt.Errorf("registering deleted node: %w", err)
@@ -103,8 +102,9 @@ func (t *Trie) prepForMutation(currentNode *Node,
 	return newNode, nil
 }
 
-func registerDeletedMerkleValue(node *Node, isRoot bool,
+func (t *Trie) registerDeletedMerkleValue(node *Node,
 	pendingDeletedMerkleValues map[string]struct{}) (err error) {
+	isRoot := node == t.root
 	err = ensureMerkleValueIsCalculated(node, isRoot)
 	if err != nil {
 		return fmt.Errorf("ensuring Merkle value is calculated: %w", err)
@@ -802,8 +802,7 @@ func (t *Trie) clearPrefixLimitAtNode(parent *Node, prefix []byte,
 		// TODO check this is the same behaviour as in substrate
 		const allDeleted = true
 		if bytes.HasPrefix(parent.PartialKey, prefix) {
-			isRoot := parent == t.root
-			err = registerDeletedMerkleValue(parent, isRoot, deletedMerkleValues)
+			err = t.registerDeletedMerkleValue(parent, deletedMerkleValues)
 			if err != nil {
 				return nil, 0, 0, false,
 					fmt.Errorf("registering deleted Merkle value: %w", err)
@@ -869,7 +868,7 @@ func (t *Trie) clearPrefixLimitBranch(branch *Node, prefix []byte, limit uint32,
 
 	branch.Children[childIndex] = child
 	branch.Descendants -= nodesRemoved
-	newParent, branchChildMerged, err := handleDeletion(branch, prefix, deletedMerkleValues)
+	newParent, branchChildMerged, err := t.handleDeletion(branch, prefix, deletedMerkleValues)
 	if err != nil {
 		return nil, 0, 0, false, fmt.Errorf("handling deletion: %w", err)
 	}
@@ -917,7 +916,7 @@ func (t *Trie) clearPrefixLimitChild(branch *Node, prefix []byte, limit uint32,
 	branch.Children[childIndex] = child
 	branch.Descendants -= nodesRemoved
 
-	newParent, branchChildMerged, err := handleDeletion(branch, prefix, deletedMerkleValues)
+	newParent, branchChildMerged, err := t.handleDeletion(branch, prefix, deletedMerkleValues)
 	if err != nil {
 		return nil, 0, 0, false, fmt.Errorf("handling deletion: %w", err)
 	}
@@ -944,8 +943,7 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 	}
 
 	if parent.Kind() == node.Leaf {
-		isRoot := parent == t.root
-		err = registerDeletedMerkleValue(parent, isRoot, deletedMerkleValues)
+		err = t.registerDeletedMerkleValue(parent, deletedMerkleValues)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("registering deleted merkle value: %w", err)
 		}
@@ -990,7 +988,7 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 		nodesRemoved += newNodesRemoved
 		branch.Descendants -= newNodesRemoved
 
-		newParent, branchChildMerged, err = handleDeletion(branch, branch.PartialKey, deletedMerkleValues)
+		newParent, branchChildMerged, err = t.handleDeletion(branch, branch.PartialKey, deletedMerkleValues)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("handling deletion: %w", err)
 		}
@@ -1095,8 +1093,7 @@ func (t *Trie) clearPrefixAtNode(parent *Node, prefix []byte,
 			return nil, 0, fmt.Errorf("preparing branch for mutation: %w", err)
 		}
 
-		const isRoot = false // child so it cannot be the root
-		err = registerDeletedMerkleValue(child, isRoot, deletedMerkleValues)
+		err = t.registerDeletedMerkleValue(child, deletedMerkleValues)
 		if err != nil {
 			return nil, 0, fmt.Errorf("registering deleted merkle value for child: %w", err)
 		}
@@ -1104,7 +1101,7 @@ func (t *Trie) clearPrefixAtNode(parent *Node, prefix []byte,
 		branch.Children[childIndex] = nil
 		branch.Descendants -= nodesRemoved
 		var branchChildMerged bool
-		newParent, branchChildMerged, err = handleDeletion(branch, prefix, deletedMerkleValues)
+		newParent, branchChildMerged, err = t.handleDeletion(branch, prefix, deletedMerkleValues)
 		if err != nil {
 			return nil, 0, fmt.Errorf("handling deletion: %w", err)
 		}
@@ -1143,7 +1140,7 @@ func (t *Trie) clearPrefixAtNode(parent *Node, prefix []byte,
 
 	branch.Descendants -= nodesRemoved
 	branch.Children[childIndex] = child
-	newParent, branchChildMerged, err := handleDeletion(branch, prefix, deletedMerkleValues)
+	newParent, branchChildMerged, err := t.handleDeletion(branch, prefix, deletedMerkleValues)
 	if err != nil {
 		return nil, 0, fmt.Errorf("handling deletion: %w", err)
 	}
@@ -1213,8 +1210,7 @@ func (t *Trie) deleteLeaf(parent *Node, key []byte,
 
 	newParent = nil
 
-	isRoot := parent == t.root
-	err = registerDeletedMerkleValue(parent, isRoot, deletedMerkleValues)
+	err = t.registerDeletedMerkleValue(parent, deletedMerkleValues)
 	if err != nil {
 		return nil, fmt.Errorf("registering deleted merkle value: %w", err)
 	}
@@ -1238,7 +1234,7 @@ func (t *Trie) deleteBranch(branch *Node, key []byte,
 		branch.StorageValue = nil
 		deleted = true
 		var branchChildMerged bool
-		newParent, branchChildMerged, err = handleDeletion(branch, key, deletedMerkleValues)
+		newParent, branchChildMerged, err = t.handleDeletion(branch, key, deletedMerkleValues)
 		if err != nil {
 			return nil, false, 0, fmt.Errorf("handling deletion: %w", err)
 		}
@@ -1279,7 +1275,7 @@ func (t *Trie) deleteBranch(branch *Node, key []byte,
 	branch.Descendants -= nodesRemoved
 	branch.Children[childIndex] = newChild
 
-	newParent, branchChildMerged, err := handleDeletion(branch, key, deletedMerkleValues)
+	newParent, branchChildMerged, err := t.handleDeletion(branch, key, deletedMerkleValues)
 	if err != nil {
 		return nil, false, 0, fmt.Errorf("handling deletion: %w", err)
 	}
@@ -1297,7 +1293,7 @@ func (t *Trie) deleteBranch(branch *Node, key []byte,
 // In this first case, branchChildMerged is returned as true to keep track of the removal
 // of one node in callers.
 // If the branch has a value and no child, it will be changed into a leaf.
-func handleDeletion(branch *Node, key []byte,
+func (t *Trie) handleDeletion(branch *Node, key []byte,
 	deletedMerkleValues map[string]struct{}) (
 	newNode *Node, branchChildMerged bool, err error) {
 	childrenCount := 0
@@ -1335,8 +1331,7 @@ func handleDeletion(branch *Node, key []byte,
 		const branchChildMerged = true
 		childIndex := firstChildIndex
 		child := branch.Children[firstChildIndex]
-		const isRoot = false // child so it cannot be the root node
-		err = registerDeletedMerkleValue(child, isRoot, deletedMerkleValues)
+		err = t.registerDeletedMerkleValue(child, deletedMerkleValues)
 		if err != nil {
 			return nil, false, fmt.Errorf("registering deleted merkle value: %w", err)
 		}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -805,13 +805,14 @@ func (t *Trie) ClearPrefixLimit(prefixLE []byte, limit uint32) (
 	prefix := codec.KeyLEToNibbles(prefixLE)
 	prefix = bytes.TrimSuffix(prefix, []byte{0})
 
-	t.root, deleted, _, allDeleted, err = t.clearPrefixLimitAtNode(
+	root, deleted, _, allDeleted, err := t.clearPrefixLimitAtNode(
 		t.root, prefix, limit, pendingDeletedMerkleValues)
 	if err != nil {
 		// Note: no need to wrap the error really since the private function has
 		// the same name as the exported function `ClearPrefixLimit`.
 		return 0, false, err
 	}
+	t.root = root
 
 	return deleted, allDeleted, nil
 }

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -361,8 +361,6 @@ func (t *Trie) insert(parent *Node, key, value []byte,
 		}, mutated, nodesCreated, nil
 	}
 
-	// TODO ensure all values have dirty set to true
-
 	if parent.Kind() == node.Branch {
 		newParent, mutated, nodesCreated, err = t.insertInBranch(
 			parent, key, value, deletedMerkleValues)
@@ -888,6 +886,7 @@ func (t *Trie) clearPrefixLimitChild(branch *Node, prefix []byte, limit uint32,
 	if child == nil {
 		const valuesDeleted, nodesRemoved = 0, 0
 		// TODO ensure this is the same behaviour as in substrate
+		// See https://github.com/ChainSafe/gossamer/issues/3033
 		allDeleted = true
 		return newParent, valuesDeleted, nodesRemoved, allDeleted, nil
 	}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -70,7 +70,9 @@ func (t *Trie) Snapshot() (newTrie *Trie) {
 // handleTrackedDeltas sets the pending deleted Merkle values in
 // the trie deleted merkle values set if and only if success is true.
 func (t *Trie) handleTrackedDeltas(success bool, pendingDeletedMerkleValues map[string]struct{}) {
-	if !success {
+	if !success || t.generation == 0 {
+		// Do not persist tracked deleted node hashes if the operation failed or
+		// if the trie generation is zero (first block, no trie snapshot done yet).
 		return
 	}
 

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -104,8 +104,7 @@ func (t *Trie) prepForMutation(currentNode *Node,
 
 func (t *Trie) registerDeletedMerkleValue(node *Node,
 	pendingDeletedMerkleValues map[string]struct{}) (err error) {
-	isRoot := node == t.root
-	err = ensureMerkleValueIsCalculated(node, isRoot)
+	err = t.ensureMerkleValueIsCalculated(node)
 	if err != nil {
 		return fmt.Errorf("ensuring Merkle value is calculated: %w", err)
 	}
@@ -1025,8 +1024,7 @@ func (t *Trie) ClearPrefix(prefixLE []byte) (err error) {
 	}()
 
 	if len(prefixLE) == 0 {
-		const isRoot = true
-		err = ensureMerkleValueIsCalculated(t.root, isRoot)
+		err = t.ensureMerkleValueIsCalculated(t.root)
 		if err != nil {
 			return fmt.Errorf("ensuring Merkle values are calculated: %w", err)
 		}
@@ -1057,8 +1055,7 @@ func (t *Trie) clearPrefixAtNode(parent *Node, prefix []byte,
 	}
 
 	if bytes.HasPrefix(parent.PartialKey, prefix) {
-		isRoot := parent == t.root
-		err = ensureMerkleValueIsCalculated(parent, isRoot)
+		err = t.ensureMerkleValueIsCalculated(parent)
 		if err != nil {
 			nodesRemoved = 0
 			return parent, nodesRemoved, fmt.Errorf("ensuring Merkle values are calculated: %w", err)
@@ -1375,12 +1372,12 @@ func (t *Trie) handleDeletion(branch *Node, key []byte,
 // to ensure the parent node and all its descendant nodes have their Merkle
 // value computed and ready to be used. This has a close to zero performance
 // impact if the parent node Merkle value is already computed.
-func ensureMerkleValueIsCalculated(parent *Node, isRoot bool) (err error) {
+func (t *Trie) ensureMerkleValueIsCalculated(parent *Node) (err error) {
 	if parent == nil {
 		return nil
 	}
 
-	if isRoot {
+	if parent == t.root {
 		_, err = parent.CalculateRootMerkleValue()
 		if err != nil {
 			return fmt.Errorf("calculating Merkle value of root node: %w", err)

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1314,8 +1314,8 @@ func (t *Trie) handleDeletion(branch *Node, key []byte,
 		return branch, branchChildMerged, nil
 	case childrenCount == 0 && branch.StorageValue != nil:
 		// The branch passed to handleDeletion is always a modified branch
-		// so the original branch Merkle value is already tracked in the deleted
-		// Merkle values map.
+		// so the original branch node hash is already tracked in the
+		// pending deltas.
 		const branchChildMerged = false
 		commonPrefixLength := lenCommonPrefix(branch.PartialKey, key)
 		return &Node{
@@ -1326,8 +1326,8 @@ func (t *Trie) handleDeletion(branch *Node, key []byte,
 		}, branchChildMerged, nil
 	case childrenCount == 1 && branch.StorageValue == nil:
 		// The branch passed to handleDeletion is always a modified branch
-		// so the original branch Merkle value is already tracked in the deleted
-		// Merkle values map.
+		// so the original branch node hash is already tracked in the
+		// pending deltas.
 		const branchChildMerged = true
 		childIndex := firstChildIndex
 		child := branch.Children[firstChildIndex]

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -113,12 +113,30 @@ func Test_Trie_handleTrackedDeltas(t *testing.T) {
 		pendingDeletedMerkleValues map[string]struct{}
 		expectedTrie               Trie
 	}{
-		"no success": {
+		"no success and generation 1": {
+			trie: Trie{
+				generation: 1,
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+				},
+			},
+			pendingDeletedMerkleValues: map[string]struct{}{
+				"b": {},
+			},
+			expectedTrie: Trie{
+				generation: 1,
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+				},
+			},
+		},
+		"success and generation 0": {
 			trie: Trie{
 				deletedMerkleValues: map[string]struct{}{
 					"a": {},
 				},
 			},
+			success: true,
 			pendingDeletedMerkleValues: map[string]struct{}{
 				"b": {},
 			},
@@ -128,8 +146,9 @@ func Test_Trie_handleTrackedDeltas(t *testing.T) {
 				},
 			},
 		},
-		"success": {
+		"success and generation 1": {
 			trie: Trie{
+				generation: 1,
 				deletedMerkleValues: map[string]struct{}{
 					"a": {},
 				},
@@ -140,6 +159,7 @@ func Test_Trie_handleTrackedDeltas(t *testing.T) {
 				"b": {},
 			},
 			expectedTrie: Trie{
+				generation: 1,
 				deletedMerkleValues: map[string]struct{}{
 					"a": {},
 					"b": {},
@@ -2988,9 +3008,11 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 		"nil prefix": {
 			trie: Trie{
 				root:                &Node{StorageValue: []byte{1}},
+				generation:          1,
 				deletedMerkleValues: map[string]struct{}{},
 			},
 			expectedTrie: Trie{
+				generation: 1,
 				deletedMerkleValues: map[string]struct{}{
 					"\xf9jt\x15\"\xbc\xc1O\n\xea/p`DR$\x1dY\xb5\xf2ݫ\x9aiH\xfd\xb3\xfe\xf5\xf9\x86C": {},
 				},
@@ -2999,10 +3021,12 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 		"empty prefix": {
 			trie: Trie{
 				root:                &Node{StorageValue: []byte{1}},
+				generation:          1,
 				deletedMerkleValues: map[string]struct{}{},
 			},
 			prefix: []byte{},
 			expectedTrie: Trie{
+				generation: 1,
 				deletedMerkleValues: map[string]struct{}{
 					"\xf9jt\x15\"\xbc\xc1O\n\xea/p`DR$\x1dY\xb5\xf2ݫ\x9aiH\xfd\xb3\xfe\xf5\xf9\x86C": {},
 				},
@@ -3013,6 +3037,7 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 		},
 		"clear prefix": {
 			trie: Trie{
+				generation: 1,
 				root: &Node{
 					PartialKey:  []byte{1, 2},
 					Descendants: 3,
@@ -3033,13 +3058,19 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 						},
 					}),
 				},
+				deletedMerkleValues: map[string]struct{}{},
 			},
 			prefix: []byte{0x12, 0x16},
 			expectedTrie: Trie{
+				generation: 1,
 				root: &Node{
 					PartialKey:   []byte{1, 2, 0, 5},
 					StorageValue: []byte{1},
+					Generation:   1,
 					Dirty:        true,
+				},
+				deletedMerkleValues: map[string]struct{}{
+					"_\xe1\b\xc8=\b2\x93S֑\x8e\x01\x04\xda̝!\x87\xfd\x9d\xaf\xa5\x82\xd1\xc52\xe5\xfe{.P": {},
 				},
 			},
 		},
@@ -3407,9 +3438,11 @@ func Test_Trie_Delete(t *testing.T) {
 		"nil key": {
 			trie: Trie{
 				root:                &Node{StorageValue: []byte{1}},
+				generation:          1,
 				deletedMerkleValues: map[string]struct{}{},
 			},
 			expectedTrie: Trie{
+				generation: 1,
 				deletedMerkleValues: map[string]struct{}{
 					"\xf9jt\x15\"\xbc\xc1O\n\xea/p`DR$\x1dY\xb5\xf2ݫ\x9aiH\xfd\xb3\xfe\xf5\xf9\x86C": {},
 				},
@@ -3418,9 +3451,11 @@ func Test_Trie_Delete(t *testing.T) {
 		"empty key": {
 			trie: Trie{
 				root:                &Node{StorageValue: []byte{1}},
+				generation:          1,
 				deletedMerkleValues: map[string]struct{}{},
 			},
 			expectedTrie: Trie{
+				generation: 1,
 				deletedMerkleValues: map[string]struct{}{
 					"\xf9jt\x15\"\xbc\xc1O\n\xea/p`DR$\x1dY\xb5\xf2ݫ\x9aiH\xfd\xb3\xfe\xf5\xf9\x86C": {},
 				},

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -104,6 +104,63 @@ func Test_Trie_Snapshot(t *testing.T) {
 	assert.Equal(t, expectedTrie.childTries, newTrie.childTries)
 }
 
+func Test_Trie_handleTrackedDeltas(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		trie                       Trie
+		success                    bool
+		pendingDeletedMerkleValues map[string]struct{}
+		expectedTrie               Trie
+	}{
+		"no success": {
+			trie: Trie{
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+				},
+			},
+			pendingDeletedMerkleValues: map[string]struct{}{
+				"b": {},
+			},
+			expectedTrie: Trie{
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+				},
+			},
+		},
+		"success": {
+			trie: Trie{
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+				},
+			},
+			success: true,
+			pendingDeletedMerkleValues: map[string]struct{}{
+				"a": {},
+				"b": {},
+			},
+			expectedTrie: Trie{
+				deletedMerkleValues: map[string]struct{}{
+					"a": {},
+					"b": {},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			trie := testCase.trie
+			trie.handleTrackedDeltas(testCase.success, testCase.pendingDeletedMerkleValues)
+
+			assert.Equal(t, testCase.expectedTrie, trie)
+		})
+	}
+}
+
 func Test_Trie_updateGeneration(t *testing.T) {
 	t.Parallel()
 

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -161,25 +161,40 @@ func Test_Trie_handleTrackedDeltas(t *testing.T) {
 	}
 }
 
-func Test_Trie_updateGeneration(t *testing.T) {
+func Test_Trie_prepForMutation(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
 		trie                               Trie
-		node                               *Node
-		pendingDeletedMerkleValues         map[string]struct{}
+		currentNode                        *Node
 		copySettings                       node.CopySettings
+		pendingDeletedMerkleValues         map[string]struct{}
 		newNode                            *Node
+		copied                             bool
 		errSentinel                        error
 		errMessage                         string
-		copied                             bool
 		expectedPendingDeletedMerkleValues map[string]struct{}
 	}{
+		"no update": {
+			trie: Trie{
+				generation: 1,
+			},
+			currentNode: &Node{
+				Generation: 1,
+				PartialKey: []byte{1},
+			},
+			copySettings: node.DefaultCopySettings,
+			newNode: &Node{
+				Generation: 1,
+				PartialKey: []byte{1},
+				Dirty:      true,
+			},
+		},
 		"update without registering deleted merkle value": {
 			trie: Trie{
 				generation: 2,
 			},
-			node: &Node{
+			currentNode: &Node{
 				Generation: 1,
 				PartialKey: []byte{1},
 			},
@@ -187,6 +202,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 			newNode: &Node{
 				Generation: 2,
 				PartialKey: []byte{1},
+				Dirty:      true,
 			},
 			copied: true,
 		},
@@ -195,7 +211,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				generation: 2,
 			},
 			pendingDeletedMerkleValues: map[string]struct{}{},
-			node: &Node{
+			currentNode: &Node{
 				Generation: 1,
 				PartialKey: []byte{1},
 				StorageValue: []byte{
@@ -213,6 +229,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 					9, 10, 11, 12, 13, 14, 15, 16,
 					17, 18, 19, 20, 21, 22, 23, 24,
 					25, 26, 27, 28, 29, 30, 31, 32},
+				Dirty: true,
 			},
 			copied: true,
 			expectedPendingDeletedMerkleValues: map[string]struct{}{
@@ -226,18 +243,19 @@ func Test_Trie_updateGeneration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
+			trie := testCase.trie
 			expectedTrie := *testCase.trie.DeepCopy()
 
-			newNode, err := testCase.trie.updateGeneration(
-				testCase.node, testCase.pendingDeletedMerkleValues, testCase.copySettings)
+			newNode, err := trie.prepForMutation(testCase.currentNode, testCase.copySettings,
+				testCase.pendingDeletedMerkleValues)
 
-			assert.ErrorIs(t, err, testCase.errSentinel)
+			require.ErrorIs(t, err, testCase.errSentinel)
 			if testCase.errSentinel != nil {
 				assert.EqualError(t, err, testCase.errMessage)
 			}
 			assert.Equal(t, testCase.newNode, newNode)
-			assert.Equal(t, expectedTrie, testCase.trie)
 			assert.Equal(t, testCase.expectedPendingDeletedMerkleValues, testCase.pendingDeletedMerkleValues)
+			assert.Equal(t, expectedTrie, trie)
 
 			// Check for deep copy
 			if newNode != nil && testCase.copied {
@@ -246,7 +264,7 @@ func Test_Trie_updateGeneration(t *testing.T) {
 				} else {
 					newNode.SetDirty()
 				}
-				assert.NotEqual(t, testCase.node, newNode)
+				assert.NotEqual(t, testCase.newNode, newNode)
 			}
 		})
 	}

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1153,14 +1153,15 @@ func Test_Trie_insert(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie                Trie
-		parent              *Node
-		key                 []byte
-		value               []byte
-		deletedMerkleValues map[string]struct{}
-		newNode             *Node
-		mutated             bool
-		nodesCreated        uint32
+		trie                        Trie
+		parent                      *Node
+		key                         []byte
+		value                       []byte
+		deletedMerkleValues         map[string]struct{}
+		newNode                     *Node
+		mutated                     bool
+		nodesCreated                uint32
+		expectedDeletedMerkleValues map[string]struct{}
 	}{
 		"nil parent": {
 			trie: Trie{
@@ -1376,6 +1377,7 @@ func Test_Trie_insert(t *testing.T) {
 			assert.Equal(t, testCase.mutated, mutated)
 			assert.Equal(t, testCase.nodesCreated, nodesCreated)
 			assert.Equal(t, expectedTrie, trie)
+			assert.Equal(t, testCase.expectedDeletedMerkleValues, testCase.deletedMerkleValues)
 		})
 	}
 }
@@ -2280,17 +2282,18 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie                Trie
-		parent              *Node
-		prefix              []byte
-		limit               uint32
-		deletedMerkleValues map[string]struct{}
-		newParent           *Node
-		valuesDeleted       uint32
-		nodesRemoved        uint32
-		allDeleted          bool
-		errSentinel         error
-		errMessage          string
+		trie                        Trie
+		parent                      *Node
+		prefix                      []byte
+		limit                       uint32
+		deletedMerkleValues         map[string]struct{}
+		newParent                   *Node
+		valuesDeleted               uint32
+		nodesRemoved                uint32
+		allDeleted                  bool
+		errSentinel                 error
+		errMessage                  string
+		expectedDeletedMerkleValues map[string]struct{}
 	}{
 		"limit is zero": {
 			allDeleted: true,
@@ -2826,6 +2829,7 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 			assert.Equal(t, testCase.nodesRemoved, nodesRemoved)
 			assert.Equal(t, testCase.allDeleted, allDeleted)
 			assert.Equal(t, expectedTrie, trie)
+			assert.Equal(t, testCase.expectedDeletedMerkleValues, testCase.deletedMerkleValues)
 		})
 	}
 }
@@ -2834,15 +2838,16 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie                Trie
-		parent              *Node
-		limit               uint32
-		deletedMerkleValues map[string]struct{}
-		newNode             *Node
-		valuesDeleted       uint32
-		nodesRemoved        uint32
-		errSentinel         error
-		errMessage          string
+		trie                        Trie
+		parent                      *Node
+		limit                       uint32
+		deletedMerkleValues         map[string]struct{}
+		newNode                     *Node
+		valuesDeleted               uint32
+		nodesRemoved                uint32
+		errSentinel                 error
+		errMessage                  string
+		expectedDeletedMerkleValues map[string]struct{}
 	}{
 		"zero limit": {
 			trie: Trie{
@@ -3009,6 +3014,7 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 			assert.Equal(t, testCase.valuesDeleted, valuesDeleted)
 			assert.Equal(t, testCase.nodesRemoved, nodesRemoved)
 			assert.Equal(t, expectedTrie, trie)
+			assert.Equal(t, testCase.expectedDeletedMerkleValues, testCase.deletedMerkleValues)
 		})
 	}
 }
@@ -3116,13 +3122,14 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie                Trie
-		parent              *Node
-		prefix              []byte
-		deletedMerkleValues map[string]struct{}
-		newParent           *Node
-		nodesRemoved        uint32
-		expectedTrie        Trie
+		trie                        Trie
+		parent                      *Node
+		prefix                      []byte
+		deletedMerkleValues         map[string]struct{}
+		newParent                   *Node
+		nodesRemoved                uint32
+		expectedTrie                Trie
+		expectedDeletedMerkleValues map[string]struct{}
 	}{
 		"delete one of two children of branch": {
 			trie: Trie{
@@ -3439,6 +3446,7 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 			assert.Equal(t, testCase.newParent, newParent)
 			assert.Equal(t, testCase.nodesRemoved, nodesRemoved)
 			assert.Equal(t, testCase.expectedTrie, trie)
+			assert.Equal(t, testCase.expectedDeletedMerkleValues, testCase.deletedMerkleValues)
 		})
 	}
 }
@@ -3559,16 +3567,17 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie                Trie
-		parent              *Node
-		key                 []byte
-		deletedMerkleValues map[string]struct{}
-		newParent           *Node
-		updated             bool
-		nodesRemoved        uint32
-		errSentinel         error
-		errMessage          string
-		expectedTrie        Trie
+		trie                        Trie
+		parent                      *Node
+		key                         []byte
+		deletedMerkleValues         map[string]struct{}
+		newParent                   *Node
+		updated                     bool
+		nodesRemoved                uint32
+		errSentinel                 error
+		errMessage                  string
+		expectedTrie                Trie
+		expectedDeletedMerkleValues map[string]struct{}
 	}{
 		"nil parent": {
 			key: []byte{1},
@@ -3908,6 +3917,7 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 			assert.Equal(t, testCase.nodesRemoved, nodesRemoved)
 			assert.Equal(t, testCase.expectedTrie, testCase.trie)
 			assert.Equal(t, expectedKey, testCase.key)
+			assert.Equal(t, testCase.expectedDeletedMerkleValues, testCase.deletedMerkleValues)
 		})
 	}
 }


### PR DESCRIPTION
## Changes

- Record Merkle values deleted only if they are NOT 'dirty' (the same as in the last trie snapshot)
- Record Merkle values deleted when one or more nodes are deleted from the trie
- Do NOT record Merkle values of inlined nodes in the deleted set of Merkle values
- Lazy calculate Merkle values if they are missing (especially for delete operations)
- Update tests to have full trie.go coverage again (except hashing error due to the buffer sync pools at global scope)
- Fix preparing branch for mutation only once before for loop (instead of N times)
- Check errors from merkle value computation (useful for lazy loading to handle database errors)

Eventually add more test cases to test for correct registration of deleted Merkle values, but meh might not be that useful with incoming lazy loading changes

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/trie/...
```

## Issues

Blocking ~#2854 and~ #2838 

## Primary Reviewer

@timwu20