### PR TITLE
chore(lib/trie): `LoadFromMap` as function for transactional trie mutation

### DIFF
--- a/dot/import.go
+++ b/dot/import.go
@@ -62,13 +62,12 @@ func newTrieFromPairs(filename string) (*trie.Trie, error) {
 		entries[pairArr[0].(string)] = pairArr[1].(string)
 	}
 
-	tr := trie.NewEmptyTrie()
-	err = tr.LoadFromMap(entries)
+	tr, err := trie.LoadFromMap(entries)
 	if err != nil {
 		return nil, err
 	}
 
-	return tr, nil
+	return &tr, nil
 }
 
 func newHeaderFromFile(filename string) (*types.Header, error) {

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -186,8 +186,7 @@ func TestInitNode_LoadStorageRoot(t *testing.T) {
 	node, err := NewNode(cfg, ks)
 	require.NoError(t, err)
 
-	expected := &trie.Trie{}
-	err = expected.LoadFromMap(gen.GenesisFields().Raw["top"])
+	expected, err := trie.LoadFromMap(gen.GenesisFields().Raw["top"])
 	require.NoError(t, err)
 
 	expectedRoot, err := expected.Hash()

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -1083,8 +1083,7 @@ func newTrieFromPairs(t *testing.T, filename string) *trie.Trie {
 		entries[pairArr[0].(string)] = pairArr[1].(string)
 	}
 
-	tr := trie.NewEmptyTrie()
-	err = tr.LoadFromMap(entries)
+	tr, err := trie.LoadFromMap(entries)
 	require.NoError(t, err)
-	return tr
+	return &tr
 }

--- a/lib/runtime/wasmer/genesis.go
+++ b/lib/runtime/wasmer/genesis.go
@@ -26,7 +26,7 @@ func NewTrieFromGenesis(gen genesis.Genesis) (tr trie.Trie, err error) {
 			ErrGenesisTopNotFound, gen.Name)
 	}
 
-	err = tr.LoadFromMap(keyValues)
+	tr, err = trie.LoadFromMap(keyValues)
 	if err != nil {
 		return tr, fmt.Errorf("loading genesis top key values into trie: %w", err)
 	}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -511,25 +511,26 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte) (
 	return newParentBranch, mutated, nodesCreated
 }
 
-// LoadFromMap loads the given data mapping of key to value into the trie.
+// LoadFromMap loads the given data mapping of key to value into a new empty trie.
 // The keys are in hexadecimal little Endian encoding and the values
 // are hexadecimal encoded.
-func (t *Trie) LoadFromMap(data map[string]string) (err error) {
+func LoadFromMap(data map[string]string) (trie Trie, err error) {
+	trie = *NewEmptyTrie()
 	for key, value := range data {
 		keyLEBytes, err := common.HexToBytes(key)
 		if err != nil {
-			return fmt.Errorf("cannot convert key hex to bytes: %w", err)
+			return Trie{}, fmt.Errorf("cannot convert key hex to bytes: %w", err)
 		}
 
 		valueBytes, err := common.HexToBytes(value)
 		if err != nil {
-			return fmt.Errorf("cannot convert value hex to bytes: %w", err)
+			return Trie{}, fmt.Errorf("cannot convert value hex to bytes: %w", err)
 		}
 
-		t.Put(keyLEBytes, valueBytes)
+		trie.Put(keyLEBytes, valueBytes)
 	}
 
-	return nil
+	return trie, nil
 }
 
 // GetKeysWithPrefix returns all keys in little Endian

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -1568,19 +1568,27 @@ func Test_Trie_insertInBranch(t *testing.T) {
 	}
 }
 
-func Test_Trie_LoadFromMap(t *testing.T) {
+func Test_LoadFromMap(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		trie         Trie
 		data         map[string]string
 		expectedTrie Trie
 		errWrapped   error
 		errMessage   string
 	}{
-		"nil data": {},
+		"nil data": {
+			expectedTrie: Trie{
+				childTries:          map[common.Hash]*Trie{},
+				deletedMerkleValues: map[string]struct{}{},
+			},
+		},
 		"empty data": {
 			data: map[string]string{},
+			expectedTrie: Trie{
+				childTries:          map[common.Hash]*Trie{},
+				deletedMerkleValues: map[string]struct{}{},
+			},
 		},
 		"bad key": {
 			data: map[string]string{
@@ -1622,56 +1630,8 @@ func Test_Trie_LoadFromMap(t *testing.T) {
 						},
 					}),
 				},
-			},
-		},
-		"override trie": {
-			trie: Trie{
-				root: &Node{
-					Key:         []byte{00, 01},
-					SubValue:    []byte{106},
-					Dirty:       true,
-					Descendants: 2,
-					Children: padRightChildren([]*Node{
-						{
-							SubValue: []byte{9},
-						},
-						nil,
-						{
-							Key:      []byte{0},
-							SubValue: []byte{107},
-							Dirty:    true,
-						},
-					}),
-				},
-			},
-			data: map[string]string{
-				"0x01":   "0x06",
-				"0x0120": "0x07",
-				"0x0130": "0x08",
-			},
-			expectedTrie: Trie{
-				root: &Node{
-					Key:         []byte{00, 01},
-					SubValue:    []byte{6},
-					Dirty:       true,
-					Descendants: 3,
-					Children: padRightChildren([]*Node{
-						{
-							SubValue: []byte{9},
-						},
-						nil,
-						{
-							Key:      []byte{0},
-							SubValue: []byte{7},
-							Dirty:    true,
-						},
-						{
-							Key:      []byte{0},
-							SubValue: []byte{8},
-							Dirty:    true,
-						},
-					}),
-				},
+				childTries:          map[common.Hash]*Trie{},
+				deletedMerkleValues: map[string]struct{}{},
 			},
 		},
 	}
@@ -1681,14 +1641,14 @@ func Test_Trie_LoadFromMap(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			err := testCase.trie.LoadFromMap(testCase.data)
+			trie, err := LoadFromMap(testCase.data)
 
 			assert.ErrorIs(t, err, testCase.errWrapped)
 			if testCase.errWrapped != nil {
 				assert.EqualError(t, err, testCase.errMessage)
 			}
 
-			assert.Equal(t, testCase.expectedTrie, testCase.trie)
+			assert.Equal(t, testCase.expectedTrie, trie)
 		})
 	}
 }


### PR DESCRIPTION
## Changes

- Trie mutation should be transactional/atomic as a method, in case an error occurs
- Changed from method to function to avoid leaving a trie in a bad state
- Function returns a new empty trie with all the key and value pairs given

This will become important for lazy loading where a disk write operation could fail for real.

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/trie/...
```

## Issues

Related to #2838 

## Primary Reviewer

@jimjbrettj 