### PR TITLE
chore(lib/keystore): `LoadKeyStore` more explicit

### DIFF
--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -259,9 +259,13 @@ func TestNewNodeIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	ks := keystore.NewGlobalKeystore()
-	err = keystore.LoadKeystore("alice", ks.Gran)
+	ed25519keyRing, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)
-	err = keystore.LoadKeystore("alice", ks.Babe)
+	err = keystore.LoadKeystore("alice", ks.Gran, ed25519keyRing)
+	require.NoError(t, err)
+	sr25519keyRing, err := keystore.NewSr25519Keyring()
+	require.NoError(t, err)
+	err = keystore.LoadKeystore("alice", ks.Babe, sr25519keyRing)
 	require.NoError(t, err)
 
 	cfg.Core.Roles = common.FullNodeRole
@@ -286,10 +290,15 @@ func TestNewNode_Authority(t *testing.T) {
 	require.NoError(t, err)
 
 	ks := keystore.NewGlobalKeystore()
-	err = keystore.LoadKeystore("alice", ks.Gran)
+	ed25519keyRing, err := keystore.NewEd25519Keyring()
+	require.NoError(t, err)
+	err = keystore.LoadKeystore("alice", ks.Gran, ed25519keyRing)
 	require.NoError(t, err)
 	require.Equal(t, 1, ks.Gran.Size())
-	err = keystore.LoadKeystore("alice", ks.Babe)
+
+	sr25519keyRing, err := keystore.NewSr25519Keyring()
+	require.NoError(t, err)
+	err = keystore.LoadKeystore("alice", ks.Babe, sr25519keyRing)
 	require.NoError(t, err)
 	require.Equal(t, 1, ks.Babe.Size())
 
@@ -317,9 +326,15 @@ func TestStartStopNode(t *testing.T) {
 	require.NoError(t, err)
 
 	ks := keystore.NewGlobalKeystore()
-	err = keystore.LoadKeystore("alice", ks.Gran)
+
+	ed25519keyRing, err := keystore.NewEd25519Keyring()
 	require.NoError(t, err)
-	err = keystore.LoadKeystore("alice", ks.Babe)
+	err = keystore.LoadKeystore("alice", ks.Gran, ed25519keyRing)
+	require.NoError(t, err)
+
+	sr25519keyRing, err := keystore.NewSr25519Keyring()
+	require.NoError(t, err)
+	err = keystore.LoadKeystore("alice", ks.Babe, sr25519keyRing)
 	require.NoError(t, err)
 
 	cfg.Core.Roles = common.FullNodeRole

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -5,6 +5,7 @@ package dot
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -158,16 +159,28 @@ func TestNodeInitialized(t *testing.T) {
 	}
 }
 
-func initKeystore(t *testing.T, cfg *Config) (*keystore.GlobalKeystore, error) {
+func initKeystore(t *testing.T, cfg *Config) (
+	globalKeyStore *keystore.GlobalKeystore, err error) {
 	ks := keystore.NewGlobalKeystore()
+
+	sr25519KeyRing, err := keystore.NewSr25519Keyring()
+	if err != nil {
+		return nil, fmt.Errorf("creating sr25519 keyring: %w", err)
+	}
+
 	// load built-in test keys if specified by `cfg.Account.Key`
-	err := keystore.LoadKeystore(cfg.Account.Key, ks.Acco)
+	err = keystore.LoadKeystore(cfg.Account.Key, ks.Acco, sr25519KeyRing)
 	require.NoError(t, err)
 
-	err = keystore.LoadKeystore(cfg.Account.Key, ks.Babe)
+	err = keystore.LoadKeystore(cfg.Account.Key, ks.Babe, sr25519KeyRing)
 	require.NoError(t, err)
 
-	err = keystore.LoadKeystore(cfg.Account.Key, ks.Gran)
+	ed25519KeyRing, err := keystore.NewEd25519Keyring()
+	if err != nil {
+		return nil, fmt.Errorf("creating ed25519 keyring: %w", err)
+	}
+
+	err = keystore.LoadKeystore(cfg.Account.Key, ks.Gran, ed25519KeyRing)
 	require.NoError(t, err)
 
 	// if authority node, should have at least 1 key in keystore

--- a/lib/keystore/helpers.go
+++ b/lib/keystore/helpers.go
@@ -111,62 +111,46 @@ func GenerateKeypair(keytype string, kp PublicPrivater, basepath string, passwor
 	return fp, nil
 }
 
+// KeyRing is the key ring with multiple named keypairs.
+type KeyRing interface {
+	Alice() KeyPair
+	Bob() KeyPair
+	Charlie() KeyPair
+	Dave() KeyPair
+	Eve() KeyPair
+	Ferdie() KeyPair
+	George() KeyPair
+	Heather() KeyPair
+	Ian() KeyPair
+}
+
 // LoadKeystore loads a new keystore and inserts the test key into the keystore
-func LoadKeystore(key string, ks TyperInserter) (err error) {
-	if key != "" {
-		var kr interface {
-			Alice() KeyPair
-			Bob() KeyPair
-			Charlie() KeyPair
-			Dave() KeyPair
-			Eve() KeyPair
-			Ferdie() KeyPair
-			George() KeyPair
-			Heather() KeyPair
-			Ian() KeyPair
-		}
-
-		switch ks.Type() {
-		case crypto.Ed25519Type:
-			kr, err = NewEd25519Keyring()
-			if err != nil {
-				return fmt.Errorf("failed to create keyring: %s", err)
-			}
-		default:
-			kr, err = NewSr25519Keyring()
-			if err != nil {
-				return fmt.Errorf("failed to create keyring: %s", err)
-			}
-		}
-
-		switch strings.ToLower(key) {
-		// Insert can error only if kestore type do not match with key
-		// type do not match. Since we have created keyring based on ks.Type(),
-		// Insert would never error here. Thus, ignoring those errors.
-		case "alice":
-			_ = ks.Insert(kr.Alice())
-		case "bob":
-			_ = ks.Insert(kr.Bob())
-		case "charlie":
-			_ = ks.Insert(kr.Charlie())
-		case "dave":
-			_ = ks.Insert(kr.Dave())
-		case "eve":
-			_ = ks.Insert(kr.Eve())
-		case "ferdie":
-			_ = ks.Insert(kr.Ferdie())
-		case "george":
-			_ = ks.Insert(kr.George())
-		case "heather":
-			_ = ks.Insert(kr.Heather())
-		case "ian":
-			_ = ks.Insert(kr.Ian())
-		default:
-			return fmt.Errorf("invalid test key provided")
-		}
+func LoadKeystore(key string, keyStore TyperInserter, keyRing KeyRing) (err error) {
+	switch strings.ToLower(key) {
+	// Insert can error only if kestore type do not match with key
+	// type do not match. Since we have created keyring based on ks.Type(),
+	// Insert would never error here. Thus, ignoring those errors.
+	case "alice":
+		return keyStore.Insert(keyRing.Alice())
+	case "bob":
+		return keyStore.Insert(keyRing.Bob())
+	case "charlie":
+		return keyStore.Insert(keyRing.Charlie())
+	case "dave":
+		return keyStore.Insert(keyRing.Dave())
+	case "eve":
+		return keyStore.Insert(keyRing.Eve())
+	case "ferdie":
+		return keyStore.Insert(keyRing.Ferdie())
+	case "george":
+		return keyStore.Insert(keyRing.George())
+	case "heather":
+		return keyStore.Insert(keyRing.Heather())
+	case "ian":
+		return keyStore.Insert(keyRing.Ian())
+	default:
+		return fmt.Errorf("invalid test key provided")
 	}
-
-	return nil
 }
 
 // ImportKeypair imports a key specified by its filename into a subdirectory

--- a/lib/keystore/helpers_test.go
+++ b/lib/keystore/helpers_test.go
@@ -23,12 +23,19 @@ import (
 
 func TestLoadKeystore(t *testing.T) {
 	ks := NewBasicKeystore("test", crypto.Sr25519Type)
-	err := LoadKeystore("alice", ks)
+
+	sr25519KeyRing, err := NewSr25519Keyring()
+	require.NoError(t, err)
+
+	err = LoadKeystore("alice", ks, sr25519KeyRing)
 	require.NoError(t, err)
 	require.Equal(t, 1, ks.Size())
 
+	ed25519KeyRing, err := NewEd25519Keyring()
+	require.NoError(t, err)
+
 	ks = NewBasicKeystore("test", crypto.Ed25519Type)
-	err = LoadKeystore("bob", ks)
+	err = LoadKeystore("bob", ks, ed25519KeyRing)
 	require.NoError(t, err)
 	require.Equal(t, 1, ks.Size())
 }


### PR DESCRIPTION
## Changes

From Eclesio's suggested changes in #2867 

Change `lib/keystore`'s `LoadKeystore` to be more 'explicit', injecting the keyring as an argument, and moving the empty account key check up in the call stack.

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues


## Primary Reviewer

@EclesioMeloJunior 
