### PR TITLE
enhancement(pkg/scale): remove sorting logic from encodeMap method

### DIFF
--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/big"
 	"reflect"
-	"sort"
 )
 
 // Encoder scale encodes to a given io.Writer.
@@ -233,21 +232,14 @@ func (es *encodeState) encodeMap(in interface{}) (err error) {
 		return fmt.Errorf("encoding length: %w", err)
 	}
 
-	mapKeys := v.MapKeys()
-
-	sort.Slice(mapKeys, func(i, j int) bool {
-		keyByteOfI, _ := Marshal(mapKeys[i].Interface())
-		keyByteOfJ, _ := Marshal(mapKeys[j].Interface())
-		return bytes.Compare(keyByteOfI, keyByteOfJ) < 0
-	})
-
-	for _, key := range mapKeys {
+	for keyValue := v.MapRange(); keyValue.Next(); {
+		key := keyValue.Key()
 		err = es.marshal(key.Interface())
 		if err != nil {
 			return fmt.Errorf("encoding map key: %w", err)
 		}
 
-		mapValue := v.MapIndex(key)
+		mapValue := keyValue.Value()
 		if !mapValue.CanInterface() {
 			continue
 		}

--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -232,14 +232,15 @@ func (es *encodeState) encodeMap(in interface{}) (err error) {
 		return fmt.Errorf("encoding length: %w", err)
 	}
 
-	for keyValue := v.MapRange(); keyValue.Next(); {
-		key := keyValue.Key()
+	iterator := v.MapRange()
+	for iterator.Next() {
+		key := iterator.Key()
 		err = es.marshal(key.Interface())
 		if err != nil {
 			return fmt.Errorf("encoding map key: %w", err)
 		}
 
-		mapValue := keyValue.Value()
+		mapValue := iterator.Value()
 		if !mapValue.CanInterface() {
 			continue
 		}

--- a/pkg/scale/encode_test.go
+++ b/pkg/scale/encode_test.go
@@ -909,28 +909,9 @@ var (
 		},
 	}
 
-	mapTests = tests{
-		{
-			name: "testMap1",
-			in:   map[int8][]byte{2: []byte("some string")},
-			want: []byte{4, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103},
-		},
-		{
-			name: "testMap2",
-			in: map[int8][]byte{
-				2:  []byte("some string"),
-				16: []byte("lorem ipsum"),
-			},
-			want: []byte{
-				8, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103, 16, 44, 108, 111, 114, 101, 109, 32,
-				105, 112, 115, 117, 109,
-			},
-		},
-	}
-
 	allTests = newTests(
 		fixedWidthIntegerTests, variableWidthIntegerTests, stringTests,
-		boolTests, structTests, sliceTests, arrayTests, mapTests,
+		boolTests, structTests, sliceTests, arrayTests,
 		varyingDataTypeTests,
 	)
 )
@@ -1116,6 +1097,32 @@ func Test_encodeState_encodeArray(t *testing.T) {
 }
 
 func Test_encodeState_encodeMap(t *testing.T) {
+	mapTests := []struct {
+		name    string
+		in      interface{}
+		wantErr bool
+		want    [][]byte
+	}{
+		{
+			name: "testMap1",
+			in:   map[int8][]byte{2: []byte("some string")},
+			want: [][]byte{{4, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103}},
+		},
+		{
+			name: "testMap2",
+			in: map[int8][]byte{
+				2:  []byte("some string"),
+				16: []byte("lorem ipsum"),
+			},
+			want: [][]byte{
+				{8, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103, 16, 44, 108, 111, 114, 101, 109, 32,
+					105, 112, 115, 117, 109},
+				{8, 16, 44, 108, 111, 114, 101, 109, 32, 105, 112, 115, 117, 109, 2, 44, 115, 111, 109, 101, 32, 115,
+					116, 114, 105, 110, 103},
+			},
+		},
+	}
+
 	for _, tt := range mapTests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
@@ -1127,8 +1134,16 @@ func Test_encodeState_encodeMap(t *testing.T) {
 			if err := es.marshal(tt.in); (err != nil) != tt.wantErr {
 				t.Errorf("encodeState.encodeMap() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(buffer.Bytes(), tt.want) {
-				t.Errorf("encodeState.encodeMap() = %v, want %v", buffer.Bytes(), tt.want)
+
+			gotExpectedEncode := false
+			for _, expectedValue := range tt.want {
+				if reflect.DeepEqual(buffer.Bytes(), expectedValue) {
+					gotExpectedEncode = true
+					break
+				}
+			}
+			if !gotExpectedEncode {
+				t.Errorf("encodeState.encodeMap() = %v, want %v", buffer.Bytes(), tt.want[0])
 			}
 		})
 	}

--- a/pkg/scale/encode_test.go
+++ b/pkg/scale/encode_test.go
@@ -1098,15 +1098,15 @@ func Test_encodeState_encodeArray(t *testing.T) {
 
 func Test_encodeState_encodeMap(t *testing.T) {
 	mapTests := []struct {
-		name    string
-		in      interface{}
-		wantErr bool
-		want    [][]byte
+		name      string
+		in        interface{}
+		wantErr   bool
+		wantOneOf [][]byte
 	}{
 		{
-			name: "testMap1",
-			in:   map[int8][]byte{2: []byte("some string")},
-			want: [][]byte{{4, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103}},
+			name:      "testMap1",
+			in:        map[int8][]byte{2: []byte("some string")},
+			wantOneOf: [][]byte{{4, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103}},
 		},
 		{
 			name: "testMap2",
@@ -1114,7 +1114,7 @@ func Test_encodeState_encodeMap(t *testing.T) {
 				2:  []byte("some string"),
 				16: []byte("lorem ipsum"),
 			},
-			want: [][]byte{
+			wantOneOf: [][]byte{
 				{8, 2, 44, 115, 111, 109, 101, 32, 115, 116, 114, 105, 110, 103, 16, 44, 108, 111, 114, 101, 109, 32,
 					105, 112, 115, 117, 109},
 				{8, 16, 44, 108, 111, 114, 101, 109, 32, 105, 112, 115, 117, 109, 2, 44, 115, 111, 109, 101, 32, 115,
@@ -1134,17 +1134,7 @@ func Test_encodeState_encodeMap(t *testing.T) {
 			if err := es.marshal(tt.in); (err != nil) != tt.wantErr {
 				t.Errorf("encodeState.encodeMap() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
-			gotExpectedEncode := false
-			for _, expectedValue := range tt.want {
-				if reflect.DeepEqual(buffer.Bytes(), expectedValue) {
-					gotExpectedEncode = true
-					break
-				}
-			}
-			if !gotExpectedEncode {
-				t.Errorf("encodeState.encodeMap() = %v, want %v", buffer.Bytes(), tt.want[0])
-			}
+			assert.Contains(t, tt.wantOneOf, buffer.Bytes())
 		})
 	}
 }


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Removed sorting logic for map keys in encodeMap method as @timwu20 suggested over [here](https://github.com/ChainSafe/gossamer/pull/2894#discussion_r1005921855) in PR #2894 .


## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
