### PR TITLE
chore(state): review usages of `TrieState`

### DIFF
--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -31,14 +31,13 @@ func (s *Service) validateTransaction(head *types.Header, rt RuntimeInstance,
 
 	s.storageState.Unlock()
 
-	rt.SetContextStorage(temporaryState)
-
 	// validate each transaction
 	externalExt, err := s.buildExternalTransaction(rt, tx)
 	if err != nil {
 		return nil, fmt.Errorf("building external transaction: %w", err)
 	}
 
+	rt.SetContextStorage(temporaryState)
 	validity, err = rt.ValidateTransaction(externalExt)
 	if err != nil {
 		logger.Debugf("failed to validate transaction: %s", err)

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -43,6 +43,7 @@ func (s *Service) validateTransaction(head *types.Header, rt RuntimeInstance,
 		logger.Debugf("failed to validate transaction: %s", err)
 		return nil, err
 	}
+	rt.SetContextStorage(nil)
 
 	vtx := transaction.NewValidTransaction(tx, validity)
 

--- a/dot/core/messages.go
+++ b/dot/core/messages.go
@@ -22,7 +22,7 @@ func (s *Service) validateTransaction(head *types.Header, rt RuntimeInstance,
 	ts, err := s.storageState.TrieState(&head.StateRoot)
 	s.storageState.Unlock()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get trie state from storage for root %s: %w", head.StateRoot, err)
+		return nil, fmt.Errorf("getting trie state from storage: %w", err)
 	}
 
 	rt.SetContextStorage(ts)

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -179,6 +179,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 				}
 				runtimeInstance.EXPECT().Version().Return(version)
 				runtimeInstance.EXPECT().SetContextStorage(trieState.Snapshot())
+				runtimeInstance.EXPECT().SetContextStorage(nil)
 				validity := &transaction.Validity{Propagate: true}
 				externalExtrinsic := []byte{2, 1, 2, 3}
 				runtimeInstance.EXPECT().ValidateTransaction(externalExtrinsic).
@@ -240,6 +241,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 				}
 				runtimeInstance.EXPECT().Version().Return(version)
 				runtimeInstance.EXPECT().SetContextStorage(trieState.Snapshot())
+				runtimeInstance.EXPECT().SetContextStorage(nil)
 				validity := &transaction.Validity{}
 				externalExtrinsic := []byte{2, 1, 2, 3}
 				runtimeInstance.EXPECT().ValidateTransaction(externalExtrinsic).

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -78,7 +78,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 		errMessage            string
 		expectedMessage       *network.TransactionMessage
 	}{
-		"not synced": {
+		"not_synced": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(false)
@@ -87,7 +87,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 				}
 			},
 		},
-		"best block header error": {
+		"best_block_header_error": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -106,7 +106,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 			errMessage:      "getting best block header: test error",
 			expectedMessage: &network.TransactionMessage{},
 		},
-		"get runtime error": {
+		"get_runtime_error": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -127,7 +127,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 			errMessage:      "getting runtime from block state: test error",
 			expectedMessage: &network.TransactionMessage{},
 		},
-		"zero transaction": {
+		"zero_transaction": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -152,7 +152,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 			message:         &network.TransactionMessage{},
 			expectedMessage: &network.TransactionMessage{},
 		},
-		"valid transaction to propagate": {
+		"valid_transaction_to_propagate": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -214,7 +214,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 				Extrinsics: []types.Extrinsic{{1, 2, 3}},
 			},
 		},
-		"valid transaction to not propagate": {
+		"valid_transaction_to_not_propagate": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -273,7 +273,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 			},
 			expectedMessage: &network.TransactionMessage{},
 		},
-		"invalid transaction": {
+		"invalid_transaction": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -321,7 +321,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 			},
 			expectedMessage: &network.TransactionMessage{},
 		},
-		"unknown transaction": {
+		"unknown_transaction": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)
@@ -364,7 +364,7 @@ func Test_Service_HandleTransactionMessage(t *testing.T) {
 			},
 			expectedMessage: &network.TransactionMessage{},
 		},
-		"validate transaction other error": {
+		"validate_transaction_other_error": {
 			serviceBuilder: func(ctrl *gomock.Controller) *Service {
 				network := NewMockNetwork(ctrl)
 				network.EXPECT().IsSynced().Return(true)

--- a/dot/core/messages_test.go
+++ b/dot/core/messages_test.go
@@ -4,7 +4,6 @@
 package core
 
 import (
-	"bytes"
 	"errors"
 	"testing"
 
@@ -15,67 +14,14 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/transaction"
+	"github.com/ChainSafe/gossamer/lib/trie"
 
 	"github.com/golang/mock/gomock"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var errDummyErr = errors.New("dummy error for testing")
-
-type mockReportPeer struct {
-	change peerset.ReputationChange
-	id     peer.ID
-}
-
-type mockNetwork struct {
-	IsSynced   bool
-	ReportPeer *mockReportPeer
-}
-
-type mockBestHeader struct {
-	header *types.Header
-	err    error
-}
-
-type mockGetRuntime struct {
-	runtime RuntimeInstance
-	err     error
-}
-
-type mockBlockState struct {
-	bestHeader         *mockBestHeader
-	getRuntime         *mockGetRuntime
-	callsBestBlockHash bool
-}
-
-type mockStorageState struct {
-	input     *common.Hash
-	trieState *storage.TrieState
-	err       error
-}
-
-type mockTxnState struct {
-	input *transaction.ValidTransaction
-	hash  common.Hash
-}
-
-type mockSetContextStorage struct {
-	trieState *storage.TrieState
-}
-
-type mockValidateTxn struct {
-	input    types.Extrinsic
-	validity *transaction.Validity
-	err      error
-}
-
-type mockRuntime struct {
-	runtime           *MockRuntimeInstance
-	setContextStorage *mockSetContextStorage
-	validateTxn       *mockValidateTxn
-}
 
 func TestService_TransactionsCount(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -112,295 +58,360 @@ func TestService_TransactionsCount(t *testing.T) {
 	}
 }
 
-func TestServiceHandleTransactionMessage(t *testing.T) {
-	testEmptyHeader := types.NewEmptyHeader()
-	testExtrinsic := []types.Extrinsic{{1, 2, 3}}
+func Test_Service_HandleTransactionMessage(t *testing.T) {
+	t.Parallel()
 
-	ctrl := gomock.NewController(t)
-	runtimeMock := NewMockRuntimeInstance(ctrl)
-	runtimeMock2 := NewMockRuntimeInstance(ctrl)
-	runtimeMock3 := NewMockRuntimeInstance(ctrl)
+	errTest := errors.New("test error")
 
-	invalidTransaction := runtime.NewInvalidTransaction()
-	err := invalidTransaction.Set(runtime.Future{})
-	require.NoError(t, err)
-
-	type args struct {
-		peerID peer.ID
-		msg    *network.TransactionMessage
+	someHeader := &types.Header{
+		Number:    2,
+		StateRoot: common.Hash{2},
 	}
-	tests := []struct {
-		name             string
-		service          *Service
-		args             args
-		exp              bool
-		expErr           error
-		expErrMsg        string
-		ctrl             *gomock.Controller
-		mockNetwork      *mockNetwork
-		mockBlockState   *mockBlockState
-		mockStorageState *mockStorageState
-		mockTxnState     *mockTxnState
-		mockRuntime      *mockRuntime
+	someHeaderHash := someHeader.Hash()
+
+	testCases := map[string]struct {
+		serviceBuilder        func(ctrl *gomock.Controller) *Service
+		peerID                peer.ID
+		message               *network.TransactionMessage
+		propagateTransactions bool
+		errSentinel           error
+		errMessage            string
+		expectedMessage       *network.TransactionMessage
 	}{
-		{
-			name: "not_synced",
-			mockNetwork: &mockNetwork{
-				IsSynced: false,
-			},
-		},
-		{
-			name: "best_block_header_error",
-			mockNetwork: &mockNetwork{
-				IsSynced: true,
-			},
-			mockBlockState: &mockBlockState{
-				bestHeader: &mockBestHeader{
-					err: errDummyErr,
-				},
-			},
-			args: args{
-				msg: &network.TransactionMessage{Extrinsics: []types.Extrinsic{}},
-			},
-			expErr:    errDummyErr,
-			expErrMsg: errDummyErr.Error(),
-		},
-		{
-			name: "get_runtime_error",
-			mockNetwork: &mockNetwork{
-				IsSynced: true,
-			},
-			mockBlockState: &mockBlockState{
-				bestHeader: &mockBestHeader{
-					header: testEmptyHeader,
-				},
-				getRuntime: &mockGetRuntime{
-					err: errDummyErr,
-				},
-			},
-			args: args{
-				msg: &network.TransactionMessage{Extrinsics: []types.Extrinsic{}},
-			},
-			expErr:    errDummyErr,
-			expErrMsg: errDummyErr.Error(),
-		},
-		{
-			name: "happy_path_no_loop",
-			mockNetwork: &mockNetwork{
-				IsSynced: true,
-				ReportPeer: &mockReportPeer{
-					change: peerset.ReputationChange{
-						Value:  peerset.GoodTransactionValue,
-						Reason: peerset.GoodTransactionReason,
-					},
-				},
-			},
-			mockBlockState: &mockBlockState{
-				bestHeader: &mockBestHeader{
-					header: testEmptyHeader,
-				},
-				getRuntime: &mockGetRuntime{
-					runtime: runtimeMock,
-				},
-			},
-			args: args{
-				peerID: peer.ID("jimbo"),
-				msg:    &network.TransactionMessage{Extrinsics: []types.Extrinsic{}},
-			},
-		},
-		{
-			name: "trie_state_error",
-			mockNetwork: &mockNetwork{
-				IsSynced: true,
-			},
-			mockBlockState: &mockBlockState{
-				bestHeader: &mockBestHeader{
-					header: testEmptyHeader,
-				},
-				getRuntime: &mockGetRuntime{
-					runtime: runtimeMock,
-				},
-			},
-			mockStorageState: &mockStorageState{
-				input: &common.Hash{},
-				err:   errDummyErr,
-			},
-			args: args{
-				peerID: peer.ID("jimbo"),
-				msg: &network.TransactionMessage{
-					Extrinsics: []types.Extrinsic{{1, 2, 3}, {7, 8, 9, 0}, {0xa, 0xb}},
-				},
-			},
-			expErr: errDummyErr,
-			expErrMsg: "validating transaction from peerID D1KeRhQ: cannot get trie state from storage" +
-				" for root 0x0000000000000000000000000000000000000000000000000000000000000000: dummy error for testing",
-		},
-		{
-			name: "runtime.ErrInvalidTransaction",
-			mockNetwork: &mockNetwork{
-				IsSynced: true,
-				ReportPeer: &mockReportPeer{
-					change: peerset.ReputationChange{
-						Value:  peerset.BadTransactionValue,
-						Reason: peerset.BadTransactionReason,
-					},
-					id: peer.ID("jimbo"),
-				},
-			},
-			mockBlockState: &mockBlockState{
-				bestHeader: &mockBestHeader{
-					header: testEmptyHeader,
-				},
-				getRuntime: &mockGetRuntime{
-					runtime: runtimeMock2,
-				},
-				callsBestBlockHash: true,
-			},
-			mockStorageState: &mockStorageState{
-				input:     &common.Hash{},
-				trieState: &storage.TrieState{},
-			},
-			mockRuntime: &mockRuntime{
-				runtime:           runtimeMock2,
-				setContextStorage: &mockSetContextStorage{trieState: &storage.TrieState{}},
-				validateTxn: &mockValidateTxn{
-					input: types.Extrinsic(bytes.Join([][]byte{
-						{byte(types.TxnExternal)},
-						testExtrinsic[0],
-						testEmptyHeader.StateRoot.ToBytes(),
-					}, nil)),
-					err: invalidTransaction,
-				},
-			},
-			args: args{
-				peerID: peer.ID("jimbo"),
-				msg: &network.TransactionMessage{
-					Extrinsics: []types.Extrinsic{{1, 2, 3}},
-				},
-			},
-		},
-		{
-			name: "validTransaction",
-			mockNetwork: &mockNetwork{
-				IsSynced: true,
-				ReportPeer: &mockReportPeer{
-					change: peerset.ReputationChange{
-						Value:  peerset.GoodTransactionValue,
-						Reason: peerset.GoodTransactionReason,
-					},
-					id: peer.ID("jimbo"),
-				},
-			},
-			mockBlockState: &mockBlockState{
-				bestHeader: &mockBestHeader{
-					header: testEmptyHeader,
-				},
-				getRuntime: &mockGetRuntime{
-					runtime: runtimeMock3,
-				},
-				callsBestBlockHash: true,
-			},
-			mockStorageState: &mockStorageState{
-				input:     &common.Hash{},
-				trieState: &storage.TrieState{},
-			},
-			mockTxnState: &mockTxnState{
-				input: transaction.NewValidTransaction(
-					types.Extrinsic{1, 2, 3},
-					&transaction.Validity{
-						Propagate: true,
-					}),
-				hash: common.Hash{},
-			},
-			mockRuntime: &mockRuntime{
-				runtime:           runtimeMock3,
-				setContextStorage: &mockSetContextStorage{trieState: &storage.TrieState{}},
-				validateTxn: &mockValidateTxn{
-					input: types.Extrinsic(bytes.Join([][]byte{
-						{byte(types.TxnExternal)},
-						testExtrinsic[0],
-						testEmptyHeader.StateRoot.ToBytes(),
-					}, nil)),
-					validity: &transaction.Validity{Propagate: true},
-				},
-			},
-			args: args{
-				peerID: peer.ID("jimbo"),
-				msg: &network.TransactionMessage{
-					Extrinsics: []types.Extrinsic{{1, 2, 3}},
-				},
-			},
-			exp: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &Service{}
-			ctrl := gomock.NewController(t)
-			if tt.mockNetwork != nil {
-				mockNet := NewMockNetwork(ctrl)
-				mockNet.EXPECT().IsSynced().Return(tt.mockNetwork.IsSynced)
-				if tt.mockNetwork.ReportPeer != nil {
-					mockNet.EXPECT().ReportPeer(tt.mockNetwork.ReportPeer.change, tt.args.peerID)
+		"not synced": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(false)
+				return &Service{
+					net: network,
 				}
-				s.net = mockNet
-			}
-			if tt.mockBlockState != nil {
-				blockState := NewMockBlockState(ctrl)
-				blockState.EXPECT().BestBlockHeader().Return(
-					tt.mockBlockState.bestHeader.header,
-					tt.mockBlockState.bestHeader.err)
+			},
+		},
+		"best block header error": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
 
-				if tt.mockBlockState.getRuntime != nil {
-					blockState.EXPECT().GetRuntime(gomock.Any()).Return(
-						tt.mockBlockState.getRuntime.runtime,
-						tt.mockBlockState.getRuntime.err)
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(nil, errTest)
+
+				return &Service{
+					net:        network,
+					blockState: blockState,
 				}
-				if tt.mockBlockState.callsBestBlockHash {
-					blockState.EXPECT().BestBlockHash().Return(common.Hash{})
+			},
+			message:         &network.TransactionMessage{},
+			errSentinel:     errTest,
+			errMessage:      "getting best block header: test error",
+			expectedMessage: &network.TransactionMessage{},
+		},
+		"get runtime error": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(nil, errTest)
+
+				return &Service{
+					net:        network,
+					blockState: blockState,
 				}
-				s.blockState = blockState
-			}
-			if tt.mockStorageState != nil {
+			},
+			message:         &network.TransactionMessage{},
+			errSentinel:     errTest,
+			errMessage:      "getting runtime from block state: test error",
+			expectedMessage: &network.TransactionMessage{},
+		},
+		"zero transaction": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(nil, nil)
+
+				network.EXPECT().ReportPeer(peerset.ReputationChange{
+					Value:  peerset.GoodTransactionValue,
+					Reason: peerset.GoodTransactionReason,
+				}, peer.ID("a"))
+
+				return &Service{
+					net:        network,
+					blockState: blockState,
+				}
+			},
+			peerID:          peer.ID("a"),
+			message:         &network.TransactionMessage{},
+			expectedMessage: &network.TransactionMessage{},
+		},
+		"valid transaction to propagate": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(runtimeInstance, nil)
+
 				storageState := NewMockStorageState(ctrl)
 				storageState.EXPECT().Lock()
+				trieState := storage.NewTrieState(trie.NewEmptyTrie())
+				storageState.EXPECT().TrieState(&common.Hash{2}).
+					Return(trieState, nil)
 				storageState.EXPECT().Unlock()
-				storageState.EXPECT().TrieState(tt.mockStorageState.input).Return(
-					tt.mockStorageState.trieState,
-					tt.mockStorageState.err)
-				s.storageState = storageState
-			}
-			if tt.mockTxnState != nil {
-				txnState := NewMockTransactionState(ctrl)
-				txnState.EXPECT().AddToPool(tt.mockTxnState.input).Return(tt.mockTxnState.hash)
-				s.transactionState = txnState
-			}
-			if tt.mockRuntime != nil {
-				rt := tt.mockRuntime.runtime
-				rt.EXPECT().SetContextStorage(tt.mockRuntime.setContextStorage.trieState)
-				rt.EXPECT().ValidateTransaction(tt.mockRuntime.validateTxn.input).
-					Return(tt.mockRuntime.validateTxn.validity, tt.mockRuntime.validateTxn.err)
-				rt.EXPECT().Version().Return(runtime.Version{
-					SpecName:         []byte("polkadot"),
-					ImplName:         []byte("parity-polkadot"),
-					AuthoringVersion: authoringVersion,
-					SpecVersion:      specVersion,
-					ImplVersion:      implVersion,
+
+				version := runtime.Version{
 					APIItems: []runtime.APIItem{{
 						Name: common.MustBlake2b8([]byte("TaggedTransactionQueue")),
-						Ver:  3,
+						Ver:  2,
 					}},
-					TransactionVersion: transactionVersion,
-					StateVersion:       stateVersion,
-				})
-			}
+				}
+				runtimeInstance.EXPECT().Version().Return(version)
+				runtimeInstance.EXPECT().SetContextStorage(trieState.Snapshot())
+				validity := &transaction.Validity{Propagate: true}
+				externalExtrinsic := []byte{2, 1, 2, 3}
+				runtimeInstance.EXPECT().ValidateTransaction(externalExtrinsic).
+					Return(validity, nil)
 
-			res, err := s.HandleTransactionMessage(tt.args.peerID, tt.args.msg)
-			assert.ErrorIs(t, err, tt.expErr)
-			if tt.expErr != nil {
-				assert.EqualError(t, err, tt.expErrMsg)
+				transactionState := NewMockTransactionState(ctrl)
+				validTransaction := &transaction.ValidTransaction{
+					Extrinsic: types.Extrinsic{1, 2, 3},
+					Validity:  validity,
+				}
+				transactionState.EXPECT().AddToPool(validTransaction).
+					Return(common.Hash{3})
+
+				network.EXPECT().ReportPeer(peerset.ReputationChange{
+					Value:  peerset.GoodTransactionValue,
+					Reason: peerset.GoodTransactionReason,
+				}, peer.ID("a"))
+
+				return &Service{
+					net:              network,
+					blockState:       blockState,
+					storageState:     storageState,
+					transactionState: transactionState,
+				}
+			},
+			peerID: peer.ID("a"),
+			message: &network.TransactionMessage{
+				Extrinsics: []types.Extrinsic{{1, 2, 3}},
+			},
+			propagateTransactions: true,
+			expectedMessage: &network.TransactionMessage{
+				Extrinsics: []types.Extrinsic{{1, 2, 3}},
+			},
+		},
+		"valid transaction to not propagate": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(runtimeInstance, nil)
+
+				storageState := NewMockStorageState(ctrl)
+				storageState.EXPECT().Lock()
+				trieState := storage.NewTrieState(trie.NewEmptyTrie())
+				storageState.EXPECT().TrieState(&common.Hash{2}).
+					Return(trieState, nil)
+				storageState.EXPECT().Unlock()
+
+				version := runtime.Version{
+					APIItems: []runtime.APIItem{{
+						Name: common.MustBlake2b8([]byte("TaggedTransactionQueue")),
+						Ver:  2,
+					}},
+				}
+				runtimeInstance.EXPECT().Version().Return(version)
+				runtimeInstance.EXPECT().SetContextStorage(trieState.Snapshot())
+				validity := &transaction.Validity{}
+				externalExtrinsic := []byte{2, 1, 2, 3}
+				runtimeInstance.EXPECT().ValidateTransaction(externalExtrinsic).
+					Return(validity, nil)
+
+				transactionState := NewMockTransactionState(ctrl)
+				validTransaction := &transaction.ValidTransaction{
+					Extrinsic: types.Extrinsic{1, 2, 3},
+					Validity:  validity,
+				}
+				transactionState.EXPECT().AddToPool(validTransaction).
+					Return(common.Hash{3})
+
+				network.EXPECT().ReportPeer(peerset.ReputationChange{
+					Value:  peerset.GoodTransactionValue,
+					Reason: peerset.GoodTransactionReason,
+				}, peer.ID("a"))
+
+				return &Service{
+					net:              network,
+					blockState:       blockState,
+					storageState:     storageState,
+					transactionState: transactionState,
+				}
+			},
+			peerID: peer.ID("a"),
+			message: &network.TransactionMessage{
+				Extrinsics: []types.Extrinsic{{1, 2, 3}},
+			},
+			expectedMessage: &network.TransactionMessage{},
+		},
+		"invalid transaction": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(runtimeInstance, nil)
+
+				storageState := NewMockStorageState(ctrl)
+				storageState.EXPECT().Lock()
+				trieState := storage.NewTrieState(trie.NewEmptyTrie())
+				storageState.EXPECT().TrieState(&common.Hash{2}).
+					Return(trieState, nil)
+				storageState.EXPECT().Unlock()
+
+				version := runtime.Version{
+					APIItems: []runtime.APIItem{{
+						Name: common.MustBlake2b8([]byte("TaggedTransactionQueue")),
+						Ver:  2,
+					}},
+				}
+				runtimeInstance.EXPECT().Version().Return(version)
+				runtimeInstance.EXPECT().SetContextStorage(trieState.Snapshot())
+				externalExtrinsic := []byte{2, 1, 2, 3}
+				runtimeInstance.EXPECT().ValidateTransaction(externalExtrinsic).
+					Return(nil, runtime.InvalidTransaction{})
+
+				network.EXPECT().ReportPeer(peerset.ReputationChange{
+					Value:  peerset.BadTransactionValue,
+					Reason: peerset.BadTransactionReason,
+				}, peer.ID("a"))
+
+				return &Service{
+					net:          network,
+					blockState:   blockState,
+					storageState: storageState,
+				}
+			},
+			peerID: peer.ID("a"),
+			message: &network.TransactionMessage{
+				Extrinsics: []types.Extrinsic{{1, 2, 3}},
+			},
+			expectedMessage: &network.TransactionMessage{},
+		},
+		"unknown transaction": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(runtimeInstance, nil)
+
+				storageState := NewMockStorageState(ctrl)
+				storageState.EXPECT().Lock()
+				trieState := storage.NewTrieState(trie.NewEmptyTrie())
+				storageState.EXPECT().TrieState(&common.Hash{2}).
+					Return(trieState, nil)
+				storageState.EXPECT().Unlock()
+
+				version := runtime.Version{
+					APIItems: []runtime.APIItem{{
+						Name: common.MustBlake2b8([]byte("TaggedTransactionQueue")),
+						Ver:  2,
+					}},
+				}
+				runtimeInstance.EXPECT().Version().Return(version)
+				runtimeInstance.EXPECT().SetContextStorage(trieState.Snapshot())
+				externalExtrinsic := []byte{2, 1, 2, 3}
+				runtimeInstance.EXPECT().ValidateTransaction(externalExtrinsic).
+					Return(nil, runtime.UnknownTransaction{})
+
+				return &Service{
+					net:          network,
+					blockState:   blockState,
+					storageState: storageState,
+				}
+			},
+			peerID: peer.ID("a"),
+			message: &network.TransactionMessage{
+				Extrinsics: []types.Extrinsic{{1, 2, 3}},
+			},
+			expectedMessage: &network.TransactionMessage{},
+		},
+		"validate transaction other error": {
+			serviceBuilder: func(ctrl *gomock.Controller) *Service {
+				network := NewMockNetwork(ctrl)
+				network.EXPECT().IsSynced().Return(true)
+
+				blockState := NewMockBlockState(ctrl)
+				blockState.EXPECT().BestBlockHeader().
+					Return(someHeader, nil)
+				runtimeInstance := NewMockRuntimeInstance(ctrl)
+				blockState.EXPECT().GetRuntime(someHeaderHash).
+					Return(runtimeInstance, nil)
+
+				storageState := NewMockStorageState(ctrl)
+				storageState.EXPECT().Lock()
+				storageState.EXPECT().TrieState(&common.Hash{2}).
+					Return(nil, errTest)
+				storageState.EXPECT().Unlock()
+
+				return &Service{
+					net:          network,
+					blockState:   blockState,
+					storageState: storageState,
+				}
+			},
+			peerID: peer.ID("a"),
+			message: &network.TransactionMessage{
+				Extrinsics: []types.Extrinsic{{1, 2, 3}},
+			},
+			errSentinel: errTest,
+			errMessage: "validating transaction from peerID 2g: " +
+				"getting trie state from storage: test error",
+			expectedMessage: &network.TransactionMessage{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			service := testCase.serviceBuilder(ctrl)
+
+			propagateTransactions, err := service.HandleTransactionMessage(testCase.peerID, testCase.message)
+
+			assert.Equal(t, testCase.propagateTransactions, propagateTransactions)
+			assert.ErrorIs(t, err, testCase.errSentinel)
+			if testCase.errSentinel != nil {
+				assert.EqualError(t, err, testCase.errMessage)
 			}
-			assert.Equal(t, tt.exp, res)
 		})
 	}
 }

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -434,6 +434,7 @@ func (s *Service) maintainTransactionPool(block *types.Block, bestBlockHash comm
 		temporaryState := ts.Snapshot()
 		rt.SetContextStorage(temporaryState)
 		txnValidity, err := rt.ValidateTransaction(externalExt)
+		rt.SetContextStorage(nil)
 		if err != nil {
 			logger.Debugf("failed to validate transaction for extrinsic %s: %s", tx.Extrinsic, err)
 			s.transactionState.RemoveExtrinsic(tx.Extrinsic)
@@ -542,6 +543,8 @@ func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 	if err != nil {
 		return err
 	}
+	// TODO adding this fails polkadotjs tests
+	// rt.SetContextStorage(nil)
 
 	// add transaction to pool
 	vtx := transaction.NewValidTransaction(ext, transactionValidity)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -426,13 +426,13 @@ func (s *Service) maintainTransactionPool(block *types.Block, bestBlockHash comm
 			return fmt.Errorf("failed to get runtime to re-validate transactions in pool: %s", err)
 		}
 
-		// ValidateTransaction modifies the trie state so we use the temporary state.
-		rt.SetContextStorage(temporaryState)
 		externalExt, err := s.buildExternalTransaction(rt, tx.Extrinsic)
 		if err != nil {
 			return fmt.Errorf("building external transaction: %s", err)
 		}
 
+		// ValidateTransaction modifies the trie state so we use the temporary state.
+		rt.SetContextStorage(temporaryState)
 		txnValidity, err := rt.ValidateTransaction(externalExt)
 		if err != nil {
 			logger.Debugf("failed to validate transaction for extrinsic %s: %s", tx.Extrinsic, err)
@@ -529,16 +529,15 @@ func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 		return err
 	}
 
-	// ValidateTransaction modifies the trie state so we want to snapshot it
-	// so that the original trie state remains unaffected.
-	temporaryState := ts.Snapshot()
-	rt.SetContextStorage(temporaryState)
-
 	externalExt, err := s.buildExternalTransaction(rt, ext)
 	if err != nil {
 		return fmt.Errorf("building external transaction: %w", err)
 	}
 
+	// ValidateTransaction modifies the trie state so we want to snapshot it
+	// so that the original trie state remains unaffected.
+	temporaryState := ts.Snapshot()
+	rt.SetContextStorage(temporaryState)
 	transactionValidity, err := rt.ValidateTransaction(externalExt)
 	if err != nil {
 		return err

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -413,8 +413,7 @@ func (s *Service) maintainTransactionPool(block *types.Block, bestBlockHash comm
 
 	ts, err := s.storageState.TrieState(stateRoot)
 	if err != nil {
-		logger.Errorf(err.Error())
-		return err
+		return fmt.Errorf("getting trie state: %w", err)
 	}
 
 	// re-validate transactions in the pool and move them to the queue

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -543,8 +543,7 @@ func (s *Service) HandleSubmittedExtrinsic(ext types.Extrinsic) error {
 	if err != nil {
 		return err
 	}
-	// TODO adding this fails polkadotjs tests
-	// rt.SetContextStorage(nil)
+	rt.SetContextStorage(nil)
 
 	// add transaction to pool
 	vtx := transaction.NewValidTransaction(ext, transactionValidity)

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -415,7 +415,6 @@ func (s *Service) maintainTransactionPool(block *types.Block, bestBlockHash comm
 	if err != nil {
 		return fmt.Errorf("getting trie state: %w", err)
 	}
-	temporaryState := ts.Snapshot()
 
 	// re-validate transactions in the pool and move them to the queue
 	txs := s.transactionState.PendingInPool()
@@ -432,6 +431,7 @@ func (s *Service) maintainTransactionPool(block *types.Block, bestBlockHash comm
 		}
 
 		// ValidateTransaction modifies the trie state so we use the temporary state.
+		temporaryState := ts.Snapshot()
 		rt.SetContextStorage(temporaryState)
 		txnValidity, err := rt.ValidateTransaction(externalExt)
 		if err != nil {

--- a/dot/core/service.go
+++ b/dot/core/service.go
@@ -482,14 +482,22 @@ func (s *Service) DecodeSessionKeys(encodedSessionKeys []byte) ([]byte, error) {
 	return rt.DecodeSessionKeys(encodedSessionKeys)
 }
 
-// GetRuntimeVersion gets the current RuntimeVersion
-func (s *Service) GetRuntimeVersion(bhash *common.Hash) (
+// GetRuntimeVersion gets the current runtime version.
+func (s *Service) GetRuntimeVersion(blockHash *common.Hash) (
 	version runtime.Version, err error) {
-	rt, err := prepareRuntime(bhash, s.storageState, s.blockState)
-	if err != nil {
-		return version, fmt.Errorf("setting up runtime: %w", err)
+	var blockHashValue common.Hash
+	if blockHash != nil {
+		blockHashValue = *blockHash
+	} else {
+		blockHashValue = s.blockState.BestBlockHash()
 	}
-	return rt.Version(), nil
+
+	runtime, err := s.blockState.GetRuntime(blockHashValue)
+	if err != nil {
+		return version, fmt.Errorf("getting runtime: %w", err)
+	}
+
+	return runtime.Version(), nil
 }
 
 // HandleSubmittedExtrinsic is used to send a Transaction message containing a Extrinsic @ext

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -589,6 +589,7 @@ func Test_Service_maintainTransactionPool(t *testing.T) {
 		originalTrieState := rtstorage.NewTrieState(originalTrie)
 		snapshotTrieStateOnce := originalTrieState.Snapshot()
 		runtimeMock.EXPECT().SetContextStorage(snapshotTrieStateOnce)
+		runtimeMock.EXPECT().SetContextStorage(nil)
 
 		mockTxnState := NewMockTransactionState(ctrl)
 		mockTxnState.EXPECT().RemoveExtrinsic(types.Extrinsic{21}).Times(2)
@@ -658,6 +659,7 @@ func Test_Service_maintainTransactionPool(t *testing.T) {
 		originalTrieState := rtstorage.NewTrieState(originalTrie)
 		snapshotTrieStateOnce := originalTrieState.Snapshot()
 		runtimeMock.EXPECT().SetContextStorage(snapshotTrieStateOnce)
+		runtimeMock.EXPECT().SetContextStorage(nil)
 
 		mockTxnState := NewMockTransactionState(ctrl)
 		mockTxnState.EXPECT().RemoveExtrinsic(types.Extrinsic{21})

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -1111,7 +1111,7 @@ func TestServiceGetRuntimeVersion(t *testing.T) {
 		service := &Service{
 			blockState: mockBlockState,
 		}
-		const expectedErrMessage = "setting up runtime: getting runtime: dummy error for testing"
+		const expectedErrMessage = "getting runtime: dummy error for testing"
 		execTest(t, service, &common.Hash{1}, runtime.Version{}, errDummyErr, expectedErrMessage)
 	})
 
@@ -1293,60 +1293,29 @@ func TestServiceGetMetadata(t *testing.T) {
 		assert.Equal(t, exp, res)
 	}
 
-	t.Run("get state root error", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(nil, errDummyErr)
-		service := &Service{
-			storageState: mockStorageState,
-		}
-		const expectedErrMessage = "setting up runtime: getting state root from block hash: dummy error for testing"
-		execTest(t, service, &common.Hash{}, nil, errDummyErr, expectedErrMessage)
-	})
-
-	t.Run("trie state error", func(t *testing.T) {
-		t.Parallel()
-		ctrl := gomock.NewController(t)
-		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(nil).Return(nil, errDummyErr)
-		service := &Service{
-			storageState: mockStorageState,
-		}
-		const expectedErrMessage = "setting up runtime: getting trie state: dummy error for testing"
-		execTest(t, service, nil, nil, errDummyErr, expectedErrMessage)
-	})
-
 	t.Run("get runtime error", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
 		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(nil, errDummyErr)
 		service := &Service{
-			storageState: mockStorageState,
-			blockState:   mockBlockState,
+			blockState: mockBlockState,
 		}
-		const expectedErrMessage = "setting up runtime: getting runtime: dummy error for testing"
+		const expectedErrMessage = "getting runtime: dummy error for testing"
 		execTest(t, service, nil, nil, errDummyErr, expectedErrMessage)
 	})
 
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		mockStorageState := NewMockStorageState(ctrl)
-		mockStorageState.EXPECT().TrieState(nil).Return(&rtstorage.TrieState{}, nil)
 		runtimeMockOk := NewMockRuntimeInstance(ctrl)
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().BestBlockHash().Return(common.Hash{1})
 		mockBlockState.EXPECT().GetRuntime(common.Hash{1}).Return(runtimeMockOk, nil)
-		runtimeMockOk.EXPECT().SetContextStorage(&rtstorage.TrieState{})
 		runtimeMockOk.EXPECT().Metadata().Return([]byte{1, 2, 3}, nil)
 		service := &Service{
-			storageState: mockStorageState,
-			blockState:   mockBlockState,
+			blockState: mockBlockState,
 		}
 		const expectedErrMessage = "setting up runtime: getting state root from block hash: dummy error for testing"
 		execTest(t, service, nil, []byte{1, 2, 3}, nil, expectedErrMessage)

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -1277,7 +1277,8 @@ func TestServiceHandleSubmittedExtrinsic(t *testing.T) {
 		mockStorageState := NewMockStorageState(ctrl)
 		trieState := rtstorage.NewTrieState(trie.NewEmptyTrie())
 		mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(trieState, nil)
-		runtimeMock.EXPECT().SetContextStorage(trieState.Snapshot())
+		setCtxStorageCall := runtimeMock.EXPECT().SetContextStorage(trieState.Snapshot())
+		runtimeMock.EXPECT().SetContextStorage(nil).After(setCtxStorageCall)
 		mockStorageState.EXPECT().GetStateRootFromBlock(&common.Hash{}).Return(&common.Hash{}, nil)
 
 		mockTxnState := NewMockTransactionState(ctrl)

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -63,7 +63,10 @@ func TestStateModule_GetRuntimeVersion(t *testing.T) {
 	}{
 		{params: ""},
 		{params: hash.String()},
-		{params: randomHash.String(), errMsg: ErrKeyNotFound},
+		{
+			params: randomHash.String(),
+			errMsg: fmt.Sprintf("failed to get runtime instance: for block hash %s", randomHash),
+		},
 	}
 
 	for _, test := range testCases {

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -20,13 +19,6 @@ import (
 // storagePrefix storage key prefix.
 var storagePrefix = "storage"
 var codeKey = common.CodeKey
-
-// ErrTrieDoesNotExist is returned when attempting to interact with a trie that is not stored in the StorageState
-var ErrTrieDoesNotExist = errors.New("trie with given root does not exist")
-
-func errTrieDoesNotExist(hash common.Hash) error {
-	return fmt.Errorf("%w: %s", ErrTrieDoesNotExist, hash)
-}
 
 // StorageState is the struct that holds the trie, db and lock
 type StorageState struct {

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -119,7 +119,7 @@ func (s *StorageState) TrieState(root *common.Hash) (*rtstorage.TrieState, error
 		panic("trie does not have expected root")
 	}
 
-	return rtstorage.NewTrieState(t).Snapshot(), nil
+	return rtstorage.NewTrieState(t), nil
 }
 
 // LoadFromDB loads an encoded trie from the DB where the key is `root`

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -119,11 +119,7 @@ func (s *StorageState) TrieState(root *common.Hash) (*rtstorage.TrieState, error
 		panic("trie does not have expected root")
 	}
 
-	nextTrie := t.Snapshot()
-	next := rtstorage.NewTrieState(nextTrie)
-
-	logger.Tracef("returning trie with root %s to be modified", root)
-	return next, nil
+	return rtstorage.NewTrieState(t).Snapshot(), nil
 }
 
 // LoadFromDB loads an encoded trie from the DB where the key is `root`

--- a/dot/state/storage_notify.go
+++ b/dot/state/storage_notify.go
@@ -88,10 +88,6 @@ func (s *StorageState) notifyObserver(root common.Hash, o Observer) error {
 		return err
 	}
 
-	if t == nil {
-		return errTrieDoesNotExist(root)
-	}
-
 	subRes := &SubscriptionResult{
 		Hash: root,
 	}

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -24,6 +24,7 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
+	ts = ts.Snapshot() // TODO remove?
 
 	mockfilter := map[string][]byte{}
 	mockobs := NewMockObserver(ctrl)
@@ -64,6 +65,7 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 	ss := newTestStorageState(t)
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
+	ts = ts.Snapshot() // TODO remove?
 
 	num := 5
 
@@ -104,6 +106,7 @@ func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 	ss := newTestStorageState(t)
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
+	ts = ts.Snapshot() // TODO remove?
 
 	key1 := []byte("key1")
 	value1 := []byte("value1")

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -24,7 +24,7 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
-	ts = ts.Snapshot() // TODO remove?
+	ts = ts.Snapshot()
 
 	mockfilter := map[string][]byte{}
 	mockobs := NewMockObserver(ctrl)
@@ -65,7 +65,7 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 	ss := newTestStorageState(t)
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
-	ts = ts.Snapshot() // TODO remove?
+	ts = ts.Snapshot()
 
 	num := 5
 
@@ -106,7 +106,7 @@ func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 	ss := newTestStorageState(t)
 	ts, err := ss.TrieState(nil)
 	require.NoError(t, err)
-	ts = ts.Snapshot() // TODO remove?
+	ts = ts.Snapshot()
 
 	key1 := []byte("key1")
 	value1 := []byte("value1")

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -41,13 +41,9 @@ func TestStorage_StoreAndLoadTrie(t *testing.T) {
 	err = storage.StoreTrie(ts, nil)
 	require.NoError(t, err)
 
-	time.Sleep(time.Millisecond * 100)
-
 	trie, err := storage.LoadFromDB(root)
 	require.NoError(t, err)
-	ts2 := runtime.NewTrieState(trie)
-	new := ts2.Snapshot()
-	require.Equal(t, ts.Trie(), new)
+	require.Equal(t, ts.Trie(), trie.Snapshot())
 }
 
 func TestStorage_GetStorageByBlockHash(t *testing.T) {

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -43,7 +43,7 @@ func TestStorage_StoreAndLoadTrie(t *testing.T) {
 
 	trie, err := storage.LoadFromDB(root)
 	require.NoError(t, err)
-	require.Equal(t, ts.Trie(), trie.Snapshot())
+	require.Equal(t, ts.Trie(), trie)
 }
 
 func TestStorage_GetStorageByBlockHash(t *testing.T) {

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -240,6 +240,8 @@ func generateBlockWithRandomTrie(t *testing.T, serv *Service,
 	trieState, err := serv.Storage.TrieState(nil)
 	require.NoError(t, err)
 
+	trieState = trieState.Snapshot()
+
 	// Generate random data for trie state.
 	rand := time.Now().UnixNano()
 	key := []byte("testKey" + fmt.Sprint(rand))

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -274,7 +274,8 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 
 	rt.SetContextStorage(nil)
 
-	if err = s.blockImportHandler.HandleBlockImport(block, nextStorageState, announceImportedBlock); err != nil {
+	err = s.blockImportHandler.HandleBlockImport(block, nextStorageState, announceImportedBlock)
+	if err != nil {
 		return fmt.Errorf("handling block import: %w", err)
 	}
 

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -198,8 +198,6 @@ func (c *chainProcessor) processBlockDataWithStateHeaderAndBody(blockData types.
 
 	// Note we don't want to snapshot the state since we want to modify the underlying trie
 	// for the block header state root.
-	// TODO remove this:
-	state = state.Snapshot()
 
 	err = c.blockImportHandler.HandleBlockImport(block, state, announceImportedBlock)
 	if err != nil {

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -266,7 +266,7 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 	}
 
 	if err = s.blockImportHandler.HandleBlockImport(block, ts, announceImportedBlock); err != nil {
-		return err
+		return fmt.Errorf("handling block import: %w", err)
 	}
 
 	logger.Debugf("🔗 imported block number %d with hash %s", block.Header.Number, block.Header.Hash())

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -268,8 +268,11 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 
 	_, err = rt.ExecuteBlock(block)
 	if err != nil {
+		rt.SetContextStorage(nil)
 		return fmt.Errorf("failed to execute block %d: %w", block.Header.Number, err)
 	}
+
+	rt.SetContextStorage(nil)
 
 	if err = s.blockImportHandler.HandleBlockImport(block, nextStorageState, announceImportedBlock); err != nil {
 		return fmt.Errorf("handling block import: %w", err)

--- a/dot/sync/chain_processor.go
+++ b/dot/sync/chain_processor.go
@@ -252,10 +252,8 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 	if err != nil {
 		return err
 	}
-	// TODO put below
-	nextStorageState := ts.Snapshot()
 
-	root := nextStorageState.MustRoot()
+	root := ts.MustRoot()
 	if !bytes.Equal(parent.StateRoot[:], root[:]) {
 		panic("parent state root does not match snapshot state root")
 	}
@@ -265,6 +263,7 @@ func (s *chainProcessor) handleBlock(block *types.Block, announceImportedBlock b
 		return err
 	}
 
+	nextStorageState := ts.Snapshot()
 	rt.SetContextStorage(nextStorageState)
 
 	_, err = rt.ExecuteBlock(block)

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -91,6 +91,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(snapshottedTrie)
 				mockInstance.EXPECT().ExecuteBlock(&types.Block{Body: types.Body{}}).Return(nil, mockError)
+				mockInstance.EXPECT().SetContextStorage(nil)
 				mockBlockState.EXPECT().GetRuntime(testParentHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
@@ -117,6 +118,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(snapshottedTrie)
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
+				mockInstance.EXPECT().SetContextStorage(nil)
 				mockBlockState.EXPECT().GetRuntime(testParentHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
@@ -153,6 +155,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(snapshottedTrie)
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
+				mockInstance.EXPECT().SetContextStorage(nil)
 				mockBlockState.EXPECT().GetRuntime(mockHeaderHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
@@ -196,6 +199,7 @@ func Test_chainProcessor_handleBlock(t *testing.T) {
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(snapshottedTrie)
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
+				mockInstance.EXPECT().SetContextStorage(nil)
 				mockBlockState.EXPECT().GetRuntime(mockHeaderHash).Return(mockInstance, nil)
 				chainProcessor.blockState = mockBlockState
 				mockStorageState := NewMockStorageState(ctrl)
@@ -545,6 +549,7 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 				mockInstance := NewMockInstance(ctrl)
 				mockInstance.EXPECT().SetContextStorage(mockTrieState.Snapshot())
 				mockInstance.EXPECT().ExecuteBlock(mockBlock).Return(nil, nil)
+				mockInstance.EXPECT().SetContextStorage(nil)
 				mockBlockState := NewMockBlockState(ctrl)
 				mockBlockState.EXPECT().HasHeader(common.Hash{}).Return(false, nil)
 				mockBlockState.EXPECT().HasBlockBody(common.Hash{}).Return(false, nil)
@@ -883,6 +888,7 @@ func Test_chainProcessor_processBlockDataWithHeaderAndBody(t *testing.T) {
 					Body:   types.Body{{2}},
 				}
 				instance.EXPECT().ExecuteBlock(block).Return(nil, nil)
+				instance.EXPECT().SetContextStorage(nil)
 
 				blockImportHandler := NewMockBlockImportHandler(ctrl)
 				const announceImportedBlock = true

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -453,9 +453,8 @@ func Test_chainProcessor_processBlockData(t *testing.T) {
 				mockChainSync.EXPECT().syncState().Return(tip)
 
 				mockBlockImportHandler := NewMockBlockImportHandler(ctrl)
-				snapshottedTrieState := trieState.Snapshot()
 				mockBlockImportHandler.EXPECT().
-					HandleBlockImport(mockBlock, snapshottedTrieState, true).
+					HandleBlockImport(mockBlock, trieState, true).
 					Return(nil)
 
 				return chainProcessor{
@@ -727,9 +726,8 @@ func Test_chainProcessor_processBlockDataWithStateHeaderAndBody(t *testing.T) {
 					Return(trieState, nil)
 
 				blockImportHandler := NewMockBlockImportHandler(ctrl)
-				snapshottedTrieState := trieState.Snapshot()
 				const announceImportedBlock = true
-				blockImportHandler.EXPECT().HandleBlockImport(block, snapshottedTrieState, announceImportedBlock).
+				blockImportHandler.EXPECT().HandleBlockImport(block, trieState, announceImportedBlock).
 					Return(errTest)
 
 				return chainProcessor{
@@ -759,9 +757,8 @@ func Test_chainProcessor_processBlockDataWithStateHeaderAndBody(t *testing.T) {
 					Return(trieState, nil)
 
 				blockImportHandler := NewMockBlockImportHandler(ctrl)
-				snapshottedTrieState := trieState.Snapshot()
 				const announceImportedBlock = true
-				blockImportHandler.EXPECT().HandleBlockImport(block, snapshottedTrieState, announceImportedBlock).
+				blockImportHandler.EXPECT().HandleBlockImport(block, trieState, announceImportedBlock).
 					Return(nil)
 
 				return chainProcessor{

--- a/dot/sync/chain_processor_test.go
+++ b/dot/sync/chain_processor_test.go
@@ -1044,12 +1044,10 @@ func Test_chainProcessor_processReadyBlocks(t *testing.T) {
 			storageStateBuilder: func(ctrl *gomock.Controller, done chan struct{}) StorageState {
 				mockStorageState := NewMockStorageState(ctrl)
 				mockStorageState.EXPECT().Lock()
-				mockStorageState.EXPECT().Unlock()
-				mockStorageState.EXPECT().TrieState(&common.Hash{}).DoAndReturn(func(hash *common.Hash) (*storage.
-					TrieState, error) {
+				mockStorageState.EXPECT().Unlock().DoAndReturn(func() {
 					close(done)
-					return nil, mockError
 				})
+				mockStorageState.EXPECT().TrieState(&common.Hash{}).Return(nil, mockError)
 				return mockStorageState
 			},
 		},

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -512,6 +512,7 @@ func (b *Service) handleSlot(epoch, slotNum uint64,
 	rt.SetContextStorage(nextStorageState)
 
 	block, err := b.buildBlock(parent, currentSlot, rt, authorityIndex, preRuntimeDigest)
+	rt.SetContextStorage(nil)
 	if err != nil {
 		return err
 	}

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -508,7 +508,8 @@ func (b *Service) handleSlot(epoch, slotNum uint64,
 		return err
 	}
 
-	rt.SetContextStorage(ts)
+	nextStorageState := ts.Snapshot()
+	rt.SetContextStorage(nextStorageState)
 
 	block, err := b.buildBlock(parent, currentSlot, rt, authorityIndex, preRuntimeDigest)
 	if err != nil {
@@ -529,7 +530,8 @@ func (b *Service) handleSlot(epoch, slotNum uint64,
 		),
 	)
 
-	if err := b.blockImportHandler.HandleBlockProduced(block, ts); err != nil {
+	err = b.blockImportHandler.HandleBlockProduced(block, nextStorageState)
+	if err != nil {
 		logger.Warnf("failed to import built block: %s", err)
 		return err
 	}

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -509,11 +509,12 @@ func (bt *BlockTree) StoreRuntime(hash common.Hash, in Runtime) {
 	bt.runtimes.set(hash, in)
 }
 
-// GetBlockRuntime returns block runtime for corresponding block hash.
-func (bt *BlockTree) GetBlockRuntime(hash common.Hash) (Runtime, error) {
-	ins := bt.runtimes.get(hash)
-	if ins == nil {
-		return nil, ErrFailedToGetRuntime
+// GetBlockRuntime returns the runtime corresponding to the given block hash.
+func (bt *BlockTree) GetBlockRuntime(blockHash common.Hash) (
+	instance Runtime, err error) {
+	instance = bt.runtimes.get(blockHash)
+	if instance == nil {
+		return nil, fmt.Errorf("%w: for block hash %s", ErrFailedToGetRuntime, blockHash)
 	}
-	return ins, nil
+	return instance, nil
 }

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -37,11 +37,10 @@ func (s *TrieState) Trie() *trie.Trie {
 	return s.t
 }
 
-// Snapshot creates a new "version" of the trie. The trie before Snapshot is called
-// can no longer be modified, all further changes are on a new "version" of the trie.
-// It returns the new version of the trie.
-func (s *TrieState) Snapshot() *trie.Trie {
-	return s.t.Snapshot()
+// Snapshot creates a new "version" of the trie underlying the trie state.
+// See the trie Snapshot method for more information.
+func (s *TrieState) Snapshot() *TrieState {
+	return NewTrieState(s.t.Snapshot())
 }
 
 // BeginStorageTransaction begins a new nested storage transaction

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -280,7 +280,8 @@ func TestStateRPCAPI(t *testing.T) {
 			description: "Test invalid block hash state_getMetadata",
 			method:      "state_getMetadata",
 			params:      fmt.Sprintf(`["%s"]`, randomHash),
-			expected:    ErrKeyNotFound,
+			expected: "getting runtime: failed to get runtime instance: " +
+				"for block hash 0x580d77a9136035a0bc3c3cd86286172f7f81291164c5914266073a30466fba21",
 		},
 		{
 			description: "Test invalid block hash  state_getStorage",

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -268,7 +268,7 @@ func TestStateRPCAPI(t *testing.T) {
 			description: "Test invalid block hash state_getRuntimeVersion",
 			method:      "state_getRuntimeVersion",
 			params:      fmt.Sprintf(`["%s"]`, randomHash),
-			expected:    ErrKeyNotFound,
+			expected:    fmt.Sprintf("failed to get runtime instance: for block hash %s", randomHash),
 		},
 		{
 			description: "Test invalid block hash state_getPairs",


### PR DESCRIPTION
## Changes

- Split out snapshotting feature out of the `TrieState` method
- Add `TrieState` method `Snapshot` returning a snapshotted trie state
- `GetRuntimeMetadata` and `GetRuntimeVersion` do not need the trie
- Temporary modifiable trie snapshot for each pending transaction (instead of sharing the same trie)
- Move snapshotting operations closer to where they are needed
- Rework some related error wrappings and tests
- Remove impossible nil trie error check

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

@timwu20 
