### PR TITLE
fix(lib/trie): deep copy subvalue byte slices to allow GC

### DIFF
--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -342,13 +342,7 @@ func (t *Trie) Put(keyLE, value []byte) {
 		t.handleTrackedDeltas(success, pendingDeletedMerkleValues)
 	}()
 
-	var subValue []byte
-	if value != nil {
-		subValue = make([]byte, len(value))
-		copy(subValue, value)
-	}
-
-	t.insertKeyLE(keyLE, subValue, pendingDeletedMerkleValues)
+	t.insertKeyLE(keyLE, copyBytes(value), pendingDeletedMerkleValues)
 }
 
 func (t *Trie) insertKeyLE(keyLE, value []byte, deletedMerkleValues map[string]struct{}) {
@@ -681,12 +675,7 @@ func makeChildPrefix(branchPrefix, branchKey []byte,
 func (t *Trie) Get(keyLE []byte) (value []byte) {
 	keyNibbles := codec.KeyLEToNibbles(keyLE)
 	subValue := retrieve(t.root, keyNibbles)
-	if subValue == nil {
-		return nil
-	}
-	value = make([]byte, len(subValue))
-	copy(value, subValue)
-	return value
+	return copyBytes(subValue)
 }
 
 func retrieve(parent *Node, key []byte) (value []byte) {
@@ -1189,6 +1178,16 @@ func lenCommonPrefix(a, b []byte) (length int) {
 	}
 
 	return length
+}
+
+func copyBytes(original []byte) (deepCopy []byte) {
+	if original == nil {
+		return nil
+	}
+
+	deepCopy = make([]byte, len(original))
+	copy(deepCopy, original)
+	return deepCopy
 }
 
 func concatenateSlices(sliceOne, sliceTwo []byte, otherSlices ...[]byte) (concatenated []byte) {

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -223,7 +223,7 @@ func entries(parent *Node, prefix []byte, kv map[string][]byte) map[string][]byt
 		parentKey := parent.Key
 		fullKeyNibbles := concatenateSlices(prefix, parentKey)
 		keyLE := string(codec.NibblesToKeyLE(fullKeyNibbles))
-		kv[keyLE] = parent.SubValue
+		kv[keyLE] = copyBytes(parent.SubValue)
 		return kv
 	}
 
@@ -231,7 +231,7 @@ func entries(parent *Node, prefix []byte, kv map[string][]byte) map[string][]byt
 	if branch.SubValue != nil {
 		fullKeyNibbles := concatenateSlices(prefix, branch.Key)
 		keyLE := string(codec.NibblesToKeyLE(fullKeyNibbles))
-		kv[keyLE] = branch.SubValue
+		kv[keyLE] = copyBytes(branch.SubValue)
 	}
 
 	for i, child := range branch.Children {

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -341,7 +341,14 @@ func (t *Trie) Put(keyLE, value []byte) {
 		const success = true
 		t.handleTrackedDeltas(success, pendingDeletedMerkleValues)
 	}()
-	t.insertKeyLE(keyLE, value, pendingDeletedMerkleValues)
+
+	var subValue []byte
+	if value != nil {
+		subValue = make([]byte, len(value))
+		copy(subValue, value)
+	}
+
+	t.insertKeyLE(keyLE, subValue, pendingDeletedMerkleValues)
 }
 
 func (t *Trie) insertKeyLE(keyLE, value []byte, deletedMerkleValues map[string]struct{}) {

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -673,7 +673,13 @@ func makeChildPrefix(branchPrefix, branchKey []byte,
 // Note the key argument is given in little Endian format.
 func (t *Trie) Get(keyLE []byte) (value []byte) {
 	keyNibbles := codec.KeyLEToNibbles(keyLE)
-	return retrieve(t.root, keyNibbles)
+	subValue := retrieve(t.root, keyNibbles)
+	if subValue == nil {
+		return nil
+	}
+	value = make([]byte, len(subValue))
+	copy(value, subValue)
+	return value
 }
 
 func retrieve(parent *Node, key []byte) (value []byte) {

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -3824,6 +3824,43 @@ func Test_lenCommonPrefix(t *testing.T) {
 	}
 }
 
+func Test_copyBytes(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		original []byte
+		deepCopy []byte
+	}{
+		"nil": {},
+		"empty slice": {
+			original: []byte{},
+			deepCopy: []byte{},
+		},
+		"non empty slice": {
+			original: []byte{1},
+			deepCopy: []byte{1},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			deepCopy := copyBytes(testCase.original)
+
+			require.Equal(t, testCase.deepCopy, deepCopy)
+
+			if len(testCase.original) == 0 {
+				deepCopy = append(deepCopy, 1)
+			} else {
+				deepCopy[0]++
+			}
+			assert.NotEqual(t, testCase.original, deepCopy)
+		})
+	}
+}
+
 func Test_concatenateSlices(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

Some subvalues passed to or returned from trie methods are sometimes held in external data structures from the callers, preventing the GC from removing them when the root node is removed.

This simply deep copies subvalues instead of returning/passing them directly to in memory trie nodes.

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

#1936 

## Primary Reviewer

@timwu20