### PR TITLE
chore(lib/trie): remove `Store` method

### DIFF
--- a/dot/state/base_test.go
+++ b/dot/state/base_test.go
@@ -26,7 +26,7 @@ func TestTrie_StoreAndLoadFromDB(t *testing.T) {
 		tt.Put(key, value)
 	}
 
-	err := tt.Store(db)
+	err := tt.WriteDirty(db)
 	require.NoError(t, err)
 
 	encroot, err := tt.Hash()

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -42,7 +42,7 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to clear database: %s", err)
 	}
 
-	if err = t.Store(chaindb.NewTable(db, storagePrefix)); err != nil {
+	if err = t.WriteDirty(chaindb.NewTable(db, storagePrefix)); err != nil {
 		return fmt.Errorf("failed to write genesis trie to database: %w", err)
 	}
 
@@ -137,7 +137,7 @@ func loadGrandpaAuthorities(t *trie.Trie) ([]types.GrandpaVoter, error) {
 // storeInitialValues writes initial genesis values to the state database
 func (s *Service) storeInitialValues(data *genesis.Data, t *trie.Trie) error {
 	// write genesis trie to database
-	if err := t.Store(chaindb.NewTable(s.db, storagePrefix)); err != nil {
+	if err := t.WriteDirty(chaindb.NewTable(s.db, storagePrefix)); err != nil {
 		return fmt.Errorf("failed to write trie to database: %s", err)
 	}
 

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -316,7 +316,7 @@ func (s *Service) Import(header *types.Header, t *trie.Trie, firstSlot uint64) e
 	logger.Info("importing storage trie from base path " +
 		s.dbPath + " with root " + root.String() + "...")
 
-	if err := t.Store(storage.db); err != nil {
+	if err := t.WriteDirty(storage.db); err != nil {
 		return err
 	}
 

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1789,7 +1789,7 @@ func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	tr.Put([]byte("otherwise"), []byte("randomstuff"))
 	tr.Put([]byte("cat"), []byte("another animal"))
 
-	err = tr.Store(memdb)
+	err = tr.WriteDirty(memdb)
 	require.NoError(t, err)
 
 	hash, err := tr.Hash()

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -29,7 +29,7 @@ func Test_Trie_Store_Load(t *testing.T) {
 	rootHash := trie.MustHash()
 
 	db := newTestDB(t)
-	err := trie.Store(db)
+	err := trie.WriteDirty(db)
 	require.NoError(t, err)
 
 	trieFromDB := NewEmptyTrie()
@@ -64,7 +64,7 @@ func Test_Trie_WriteDirty_Put(t *testing.T) {
 		assert.Equalf(t, value, valueFromDB, "for key=%x", key)
 	}
 
-	err := trie.Store(db)
+	err := trie.WriteDirty(db)
 	require.NoError(t, err)
 
 	// Pick an existing key and replace its value
@@ -100,7 +100,7 @@ func Test_Trie_WriteDirty_Delete(t *testing.T) {
 	keysToDelete := pickKeys(keyValues, generator, size/50)
 
 	db := newTestDB(t)
-	err := trie.Store(db)
+	err := trie.WriteDirty(db)
 	require.NoError(t, err)
 
 	deletedKeys := make(map[string]struct{}, len(keysToDelete))
@@ -141,7 +141,7 @@ func Test_Trie_WriteDirty_ClearPrefix(t *testing.T) {
 	keysToClearPrefix := pickKeys(keyValues, generator, size/50)
 
 	db := newTestDB(t)
-	err := trie.Store(db)
+	err := trie.WriteDirty(db)
 	require.NoError(t, err)
 
 	for _, keyToClearPrefix := range keysToClearPrefix {
@@ -261,7 +261,7 @@ func Test_GetFromDB(t *testing.T) {
 	trie, keyValues := makeSeededTrie(t, size)
 
 	db := newTestDB(t)
-	err := trie.Store(db)
+	err := trie.WriteDirty(db)
 	require.NoError(t, err)
 
 	root := trie.MustHash()
@@ -298,7 +298,7 @@ func Test_Trie_PutChild_Store_Load(t *testing.T) {
 		err := trie.PutChild(keyToChildTrie, childTrie)
 		require.NoError(t, err)
 
-		err = trie.Store(db)
+		err = trie.WriteDirty(db)
 		require.NoError(t, err)
 
 		trieFromDB := NewEmptyTrie()

--- a/lib/trie/proof/proof_test.go
+++ b/lib/trie/proof/proof_test.go
@@ -37,7 +37,7 @@ func Test_Generate_Verify(t *testing.T) {
 		InMemory: true,
 	})
 	require.NoError(t, err)
-	err = trie.Store(database)
+	err = trie.WriteDirty(database)
 	require.NoError(t, err)
 
 	for i, key := range keys {

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -304,7 +304,7 @@ func TestTrieDiff(t *testing.T) {
 	}
 
 	newTrie := trie.Snapshot()
-	err = trie.Store(storageDB)
+	err = trie.WriteDirty(storageDB)
 	require.NoError(t, err)
 
 	tests = []keyValues{


### PR DESCRIPTION
## Changes

- `WriteDirty` is just the clever version of `Store`, where we write only nodes that got changed in-memory from the version we have in the database.
- This also ensures all the nodes are set as dirty correctly

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/...
```

## Issues

Trying to fix up strange root hash mismatch panic found in #2919 

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
