### PR TITLE
fix(trie): do not get/create buffer for nil child

### DIFF
--- a/internal/trie/node/branch_encode.go
+++ b/internal/trie/node/branch_encode.go
@@ -90,9 +90,10 @@ func encodeChildrenOpportunisticParallel(children []*Node, buffer io.Writer) (er
 				break
 			}
 
+			delete(indexToBuffer, currentIndex)
+
 			nilChildNode := resultBuffer == nil
 			if nilChildNode {
-				delete(indexToBuffer, currentIndex)
 				currentIndex++
 				continue
 			}
@@ -108,7 +109,6 @@ func encodeChildrenOpportunisticParallel(children []*Node, buffer io.Writer) (er
 				}
 			}
 
-			delete(indexToBuffer, currentIndex)
 			currentIndex++
 		}
 	}

--- a/internal/trie/node/branch_encode_test.go
+++ b/internal/trie/node/branch_encode_test.go
@@ -283,7 +283,6 @@ func Test_encodeChild(t *testing.T) {
 		wrappedErr error
 		errMessage string
 	}{
-		"nil node": {},
 		"empty branch child": {
 			child: &Node{
 				Children: make([]*Node, ChildrenCapacity),


### PR DESCRIPTION
## Changes

Do not get a buffer from the sync pool for each `nil` child of a branch

:question: why? Because this might request the creation of many buffers (allocated as 1.9MB - changing this in #2929) which are not needed, and GC of sync.Pool takes potentially longer than non-pool local buffers.

:question: :question: this would likely reduce memory usage, but #2929 is likely more of a nail in the coffin. Although for clarity and small performance gains, I think it's better we still merge this.

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/trie/... github.com/ChainSafe/gossamer/internal/trie/...
```

## Issues

#1936 

## Primary Reviewer

@timwu20