### PR TITLE
fix(trie): remove encoding buffers pool

### DIFF
--- a/internal/trie/node/hash.go
+++ b/internal/trie/node/hash.go
@@ -145,21 +145,13 @@ func (n *Node) encodeIfNeeded() (encoding []byte, err error) {
 		return n.Encoding, nil // no need to copy
 	}
 
-	buffer := pools.EncodingBuffers.Get().(*bytes.Buffer)
-	buffer.Reset()
-	defer pools.EncodingBuffers.Put(buffer)
-
+	buffer := bytes.NewBuffer(nil)
 	err = n.Encode(buffer)
 	if err != nil {
 		return nil, fmt.Errorf("encoding: %w", err)
 	}
 
-	bufferBytes := buffer.Bytes()
-
-	// TODO remove this copying since it defeats the purpose of `buffer`
-	// and the sync.Pool.
-	n.Encoding = make([]byte, len(bufferBytes))
-	copy(n.Encoding, bufferBytes)
+	n.Encoding = buffer.Bytes()
 
 	return n.Encoding, nil // no need to copy
 }

--- a/internal/trie/pools/pools.go
+++ b/internal/trie/pools/pools.go
@@ -19,15 +19,6 @@ var DigestBuffers = &sync.Pool{
 	},
 }
 
-// EncodingBuffers is a sync pool of buffers of capacity 1.9MB.
-var EncodingBuffers = &sync.Pool{
-	New: func() interface{} {
-		const initialBufferCapacity = 1900000 // 1.9MB, from checking capacities at runtime
-		b := make([]byte, 0, initialBufferCapacity)
-		return bytes.NewBuffer(b)
-	},
-}
-
 // Hashers is a sync pool of blake2b 256 hashers.
 var Hashers = &sync.Pool{
 	New: func() interface{} {

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ChainSafe/gossamer/internal/trie/codec"
 	"github.com/ChainSafe/gossamer/internal/trie/node"
-	"github.com/ChainSafe/gossamer/internal/trie/pools"
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
@@ -196,10 +195,7 @@ func (t *Trie) MustHash() common.Hash {
 
 // Hash returns the hashed root of the trie.
 func (t *Trie) Hash() (rootHash common.Hash, err error) {
-	buffer := pools.EncodingBuffers.Get().(*bytes.Buffer)
-	buffer.Reset()
-	defer pools.EncodingBuffers.Put(buffer)
-
+	buffer := bytes.NewBuffer(nil)
 	err = encodeRoot(t.root, buffer)
 	if err != nil {
 		return [32]byte{}, err


### PR DESCRIPTION
## Changes

Removes the encoding sync pool of buffers and use simple inlined GC'ed buffers instead.

Until now encoding of nodes was using a `sync.Pool` of memory buffers.

The first obvious problem was that (shame on my past self) each buffer would take 1.9MB to have enough room for the larger encoding seen in production. That means that if encoding is fast CPU wise, a lot of 1.9MB buffers would be created and held by the pool for a period at least longer than a GC cycle. Even if these are re-used, this might still represent a lot of memory, which could be the reason of the 35% memory usage due to `encodeIfNeeded` from heap profiles.

The first solution which came to my mind was to reduce the encoding buffer size to, say, 32B. But in the end there is no known-in-advance size for the encoding. It could be 4 bytes or 1MB. On top of that, if a buffer is created with 32B and a 2MB encoding is written to it, the buffer is now 2MB and will be re-used for (likely) smaller encodings, so we go back to the initial problem.

The final solution is therefore to NOT use a `sync.Pool` and let the GC handle the buffers, since the encoding size cannot be predicted ahead of compilation.

Lesson learnt: **do not use a sync.Pool of buffers if the amount of bytes written to a buffer can vary a lot**

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/trie/... github.com/ChainSafe/gossamer/internal/trie/... 
```

## Issues

#1936 

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
