### PR TITLE
fix(staging): revise datadog-agent start process

### DIFF
--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -13,13 +13,11 @@ RUN ["sh", "-c", "DD_AGENT_MAJOR_VERSION=7 DD_INSTALL_ONLY=true DD_API_KEY=${DD_
 WORKDIR /gossamer
 
 COPY . .
-
 RUN ["sh", "-c", "mv .github/workflows/staging/openmetrics.d/${chain}-conf.yaml /etc/datadog-agent/conf.d/openmetrics.d/conf.yaml"]
-RUN service datadog-agent start
 
 RUN go get ./...
 RUN go install -trimpath github.com/ChainSafe/gossamer/cmd/gossamer
 
 RUN ["sh", "-c", "gossamer init --chain=${chain}"]
-ENTRYPOINT ["sh", "-c", "service datadog-agent restart && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]
+ENTRYPOINT ["sh", "-c", "service datadog-agent start && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]
 EXPOSE 7001 8546 8540 9876 6060


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- move `datadog-agent start` to beginning on entrypoint 
- this is how we do it in the devnet folder

## Tests

<!-- Detail how to run relevant tests to the changes -->
- push to staging and ensure docker builds image successfully
- ensure nodes are updated on staging

## Primary Reviewer

<!-- Tag a code owner to review your PR -->
@qdm12  
