### PR TITLE
chore: bump copyright notice year to 2022

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -1,4 +1,4 @@
-Copyright 2021 ChainSafe Systems (ON) Corp.
+Copyright 2022 ChainSafe Systems (ON) Corp.
 This file is part of gossamer.
 
 The gossamer library is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Changes

A bit late, but oh well better than 2021 -> 2023!

## Tests

## Issues

## Primary Reviewer

@danforbes 