### PR TITLE
fix(peerset): check for incoming slot error

### DIFF
--- a/dot/peerset/peerset.go
+++ b/dot/peerset/peerset.go
@@ -641,8 +641,13 @@ func (ps *PeerSet) incoming(setID int, peers ...peer.ID) error {
 		} else {
 			err := state.tryAcceptIncoming(setID, pid)
 			if err != nil {
-				logger.Errorf("cannot accept incomming peer %s: %s", pid, err)
-				message.Status = Reject
+				if err == ErrIncomingSlotsUnavailable {
+					logger.Infof("cannot accept incoming peer %s: %s", pid, err)
+					message.Status = Reject
+				} else {
+					logger.Errorf("cannot accept incoming peer %s: %s", pid, err)
+					message.Status = Reject
+				}
 			} else {
 				logger.Debugf("incoming connection accepted from peer %s", pid)
 				message.Status = Accept

--- a/dot/peerset/peerset.go
+++ b/dot/peerset/peerset.go
@@ -5,6 +5,7 @@ package peerset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -641,13 +642,12 @@ func (ps *PeerSet) incoming(setID int, peers ...peer.ID) error {
 		} else {
 			err := state.tryAcceptIncoming(setID, pid)
 			if err != nil {
-				if err == ErrIncomingSlotsUnavailable {
-					logger.Infof("cannot accept incoming peer %s: %s", pid, err)
-					message.Status = Reject
+				if errors.Is(err, ErrIncomingSlotsUnavailable) {
+					logger.Debugf("cannot accept incoming peer %s: %s", pid, err)
 				} else {
 					logger.Errorf("cannot accept incoming peer %s: %s", pid, err)
-					message.Status = Reject
 				}
+				message.Status = Reject
 			} else {
 				logger.Debugf("incoming connection accepted from peer %s", pid)
 				message.Status = Accept


### PR DESCRIPTION
## Changes

- Added check for error `ErrIncomingSlotsUnavailable` and logging condition to Info logs, since this happens when the peer set has filled it's incoming slot allowance.
- Fix spelling of `incomming` to `incoming` in log message.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/peerset
```

## Issues
closes #2914 
<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
