### PR TITLE
chore(dot/state): rename `Set` method to `Put` to match trie method name

### DIFF
--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -107,9 +107,9 @@ func createTestService(t *testing.T, genesisFilePath string,
 	cfgRuntime, err := wasmer.NewRuntimeFromGenesis(rtCfg)
 	require.NoError(t, err)
 
-	cfgRuntime.(*wasmer.Instance).GetContext().Storage.Set(aliceBalanceKey, encodedAccountInfo)
+	cfgRuntime.(*wasmer.Instance).GetContext().Storage.Put(aliceBalanceKey, encodedAccountInfo)
 	// this key is System.UpgradedToDualRefCount -> set to true since all accounts have been upgraded to v0.9 format
-	cfgRuntime.(*wasmer.Instance).GetContext().Storage.Set(common.UpgradedToDualRefKey, []byte{1})
+	cfgRuntime.(*wasmer.Instance).GetContext().Storage.Put(common.UpgradedToDualRefKey, []byte{1})
 
 	cfgBlockState.StoreRuntime(cfgBlockState.BestBlockHash(), cfgRuntime)
 

--- a/dot/core/service_integration_test.go
+++ b/dot/core/service_integration_test.go
@@ -543,7 +543,7 @@ func TestService_HandleRuntimeChanges(t *testing.T) {
 	testRuntime, err := os.ReadFile(updateNodeRuntimeWasmPath)
 	require.NoError(t, err)
 
-	ts.Set(common.CodeKey, testRuntime)
+	ts.Put(common.CodeKey, testRuntime)
 	rtUpdateBhash := newBlockRTUpdate.Header.Hash()
 
 	// update runtime for new block
@@ -625,7 +625,7 @@ func TestService_HandleRuntimeChangesAfterCodeSubstitutes(t *testing.T) {
 	ts, err = s.storageState.TrieState(nil)
 	require.NoError(t, err)
 
-	ts.Set(common.CodeKey, testRuntime)
+	ts.Put(common.CodeKey, testRuntime)
 	rtUpdateBhash := newBlock.Header.Hash()
 
 	// update runtime for new block

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -66,7 +66,7 @@ func useInstanceFromRuntimeV0910(t *testing.T, rtStorage *storage.TrieState) (in
 	bytes, err := os.ReadFile(testRuntimeFilePath)
 	require.NoError(t, err)
 
-	rtStorage.Set(common.CodeKey, bytes)
+	rtStorage.Put(common.CodeKey, bytes)
 
 	cfg := wasmer.Config{
 		Role:     0,

--- a/dot/rpc/modules/childstate_integration_test.go
+++ b/dot/rpc/modules/childstate_integration_test.go
@@ -244,8 +244,8 @@ func setupChildStateStorage(t *testing.T) (*ChildStateModule, common.Hash) {
 	tr, err := st.Storage.TrieState(nil)
 	require.NoError(t, err)
 
-	tr.Set([]byte(":first_key"), []byte(":value1"))
-	tr.Set([]byte(":second_key"), []byte(":second_value"))
+	tr.Put([]byte(":first_key"), []byte(":value1"))
+	tr.Put([]byte(":second_key"), []byte(":second_value"))
 
 	childTr := trie.NewEmptyTrie()
 	childTr.Put([]byte(":child_first"), []byte(":child_first_value"))

--- a/dot/rpc/modules/childstate_test.go
+++ b/dot/rpc/modules/childstate_test.go
@@ -23,8 +23,8 @@ func createTestTrieState(t *testing.T) (*trie.Trie, common.Hash) {
 	_, genesisTrie, _ := newTestGenesisWithTrieAndHeader(t)
 	tr := rtstorage.NewTrieState(&genesisTrie)
 
-	tr.Set([]byte(":first_key"), []byte(":value1"))
-	tr.Set([]byte(":second_key"), []byte(":second_value"))
+	tr.Put([]byte(":first_key"), []byte(":value1"))
+	tr.Put([]byte(":second_key"), []byte(":second_value"))
 
 	childTr := trie.NewEmptyTrie()
 	childTr.Put([]byte(":child_first"), []byte(":child_first_value"))

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -543,8 +543,8 @@ func setupStateModule(t *testing.T) (*StateModule, *common.Hash, *common.Hash) {
 	ts, err := chain.Storage.TrieState(nil)
 	require.NoError(t, err)
 
-	ts.Set([]byte(`:key2`), []byte(`value2`))
-	ts.Set([]byte(`:key1`), []byte(`value1`))
+	ts.Put([]byte(`:key2`), []byte(`value2`))
+	ts.Put([]byte(`:key1`), []byte(`value1`))
 	ts.SetChildStorage([]byte(`:child1`), []byte(`:key1`), []byte(`:childValue1`))
 
 	sr1, err := ts.Root()

--- a/dot/rpc/modules/system_integration_test.go
+++ b/dot/rpc/modules/system_integration_test.go
@@ -304,7 +304,7 @@ func setupSystemModule(t *testing.T) *SystemModule {
 
 	aliceAcctEncoded, err := scale.Marshal(aliceAcctInfo)
 	require.NoError(t, err)
-	ts.Set(aliceAcctStoKey, aliceAcctEncoded)
+	ts.Put(aliceAcctStoKey, aliceAcctEncoded)
 
 	err = chain.Storage.StoreTrie(ts, nil)
 	require.NoError(t, err)

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -46,7 +46,7 @@ func TestStorageState_RegisterStorageObserver(t *testing.T) {
 	ss.RegisterStorageObserver(mockobs)
 	defer ss.UnregisterStorageObserver(mockobs)
 
-	ts.Set([]byte("mackcom"), []byte("wuz here"))
+	ts.Put([]byte("mackcom"), []byte("wuz here"))
 	err = ss.StoreTrie(ts, nil)
 	require.NoError(t, err)
 
@@ -81,7 +81,7 @@ func TestStorageState_RegisterStorageObserver_Multi(t *testing.T) {
 	key1 := []byte("key1")
 	value1 := []byte("value1")
 
-	ts.Set(key1, value1)
+	ts.Put(key1, value1)
 
 	err = ss.StoreTrie(ts, nil)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestStorageState_RegisterStorageObserver_Multi_Filter(t *testing.T) {
 		ss.RegisterStorageObserver(mockobs)
 	}
 
-	ts.Set(key1, value1)
+	ts.Put(key1, value1)
 	err = ss.StoreTrie(ts, nil)
 	require.NoError(t, err)
 

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -57,7 +57,7 @@ func TestStorage_GetStorageByBlockHash(t *testing.T) {
 
 	key := []byte("testkey")
 	value := []byte("testvalue")
-	ts.Set(key, value)
+	ts.Put(key, value)
 
 	root, err := ts.Root()
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestStorage_TrieState(t *testing.T) {
 	storage := newTestStorageState(t)
 	ts, err := storage.TrieState(&trie.EmptyHash)
 	require.NoError(t, err)
-	ts.Set([]byte("noot"), []byte("washere"))
+	ts.Put([]byte("noot"), []byte("washere"))
 
 	root, err := ts.Root()
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestStorage_LoadFromDB(t *testing.T) {
 	}
 
 	for _, kv := range trieKV {
-		ts.Set(kv.key, kv.value)
+		ts.Put(kv.key, kv.value)
 	}
 
 	root, err := ts.Root()
@@ -158,7 +158,7 @@ func TestStorage_StoreTrie_NotSyncing(t *testing.T) {
 
 	key := []byte("testkey")
 	value := []byte("testvalue")
-	ts.Set(key, value)
+	ts.Put(key, value)
 
 	err = storage.StoreTrie(ts, nil)
 	require.NoError(t, err)
@@ -189,7 +189,7 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 
 	testChildTrie.Put([]byte("keyInsidechild"), []byte("voila"))
 
-	err = genTrie.PutChild([]byte("keyToChild"), testChildTrie)
+	err = genTrie.SetChild([]byte("keyToChild"), testChildTrie)
 	require.NoError(t, err)
 
 	tries := newTriesEmpty()

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -244,7 +244,7 @@ func generateBlockWithRandomTrie(t *testing.T, serv *Service,
 	rand := time.Now().UnixNano()
 	key := []byte("testKey" + fmt.Sprint(rand))
 	value := []byte("testValue" + fmt.Sprint(rand))
-	trieState.Set(key, value)
+	trieState.Put(key, value)
 
 	trieStateRoot, err := trieState.Root()
 	require.NoError(t, err)

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -50,7 +50,7 @@ type Instance interface {
 
 // Storage interface
 type Storage interface {
-	Set(key []byte, value []byte)
+	Put(key []byte, value []byte)
 	Get(key []byte) []byte
 	Root() (common.Hash, error)
 	SetChild(keyToChild []byte, child *trie.Trie) error

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -67,8 +67,8 @@ func (s *TrieState) RollbackStorageTransaction() {
 	s.oldTrie = nil
 }
 
-// Set sets a key-value pair in the trie
-func (s *TrieState) Set(key, value []byte) {
+// Put puts thread safely a value at the specified key in the trie.
+func (s *TrieState) Put(key, value []byte) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.t.Put(key, value)
@@ -142,7 +142,7 @@ func (s *TrieState) TrieEntries() map[string][]byte {
 func (s *TrieState) SetChild(keyToChild []byte, child *trie.Trie) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	return s.t.PutChild(keyToChild, child)
+	return s.t.SetChild(keyToChild, child)
 }
 
 // SetChildStorage sets a key-value pair in a child trie

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -27,7 +27,7 @@ var testCases = []string{
 func TestTrieState_SetGet(t *testing.T) {
 	testFunc := func(ts *TrieState) {
 		for _, tc := range testCases {
-			ts.Set([]byte(tc), []byte(tc))
+			ts.Put([]byte(tc), []byte(tc))
 		}
 
 		for _, tc := range testCases {
@@ -43,7 +43,7 @@ func TestTrieState_SetGet(t *testing.T) {
 func TestTrieState_Delete(t *testing.T) {
 	testFunc := func(ts *TrieState) {
 		for _, tc := range testCases {
-			ts.Set([]byte(tc), []byte(tc))
+			ts.Put([]byte(tc), []byte(tc))
 		}
 
 		ts.Delete([]byte(testCases[0]))
@@ -58,7 +58,7 @@ func TestTrieState_Delete(t *testing.T) {
 func TestTrieState_Root(t *testing.T) {
 	testFunc := func(ts *TrieState) {
 		for _, tc := range testCases {
-			ts.Set([]byte(tc), []byte(tc))
+			ts.Put([]byte(tc), []byte(tc))
 		}
 
 		expected := ts.MustRoot()
@@ -79,7 +79,7 @@ func TestTrieState_ClearPrefix(t *testing.T) {
 	}
 
 	for i, key := range keys {
-		ts.Set([]byte(key), []byte{byte(i)})
+		ts.Put([]byte(key), []byte{byte(i)})
 	}
 
 	ts.ClearPrefix([]byte("noo"))
@@ -131,7 +131,7 @@ func TestTrieState_NextKey(t *testing.T) {
 	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	for _, tc := range testCases {
-		ts.Set([]byte(tc), []byte(tc))
+		ts.Put([]byte(tc), []byte(tc))
 	}
 
 	sort.Slice(testCases, func(i, j int) bool {
@@ -152,12 +152,12 @@ func TestTrieState_CommitStorageTransaction(t *testing.T) {
 	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	for _, tc := range testCases {
-		ts.Set([]byte(tc), []byte(tc))
+		ts.Put([]byte(tc), []byte(tc))
 	}
 
 	ts.BeginStorageTransaction()
 	testValue := []byte("noot")
-	ts.Set([]byte(testCases[0]), testValue)
+	ts.Put([]byte(testCases[0]), testValue)
 	ts.CommitStorageTransaction()
 
 	val := ts.Get([]byte(testCases[0]))
@@ -168,12 +168,12 @@ func TestTrieState_RollbackStorageTransaction(t *testing.T) {
 	ts := &TrieState{t: trie.NewEmptyTrie()}
 
 	for _, tc := range testCases {
-		ts.Set([]byte(tc), []byte(tc))
+		ts.Put([]byte(tc), []byte(tc))
 	}
 
 	ts.BeginStorageTransaction()
 	testValue := []byte("noot")
-	ts.Set([]byte(testCases[0]), testValue)
+	ts.Put([]byte(testCases[0]), testValue)
 	ts.RollbackStorageTransaction()
 
 	val := ts.Get([]byte(testCases[0]))

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -332,9 +332,9 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	encBal, err := scale.Marshal(accInfo)
 	require.NoError(t, err)
 
-	rt.(*Instance).ctx.Storage.Set(aliceBalanceKey, encBal)
+	rt.(*Instance).ctx.Storage.Put(aliceBalanceKey, encBal)
 	// this key is System.UpgradedToDualRefCount -> set to true since all accounts have been upgraded to v0.9 format
-	rt.(*Instance).ctx.Storage.Set(common.UpgradedToDualRefKey, []byte{1})
+	rt.(*Instance).ctx.Storage.Put(common.UpgradedToDualRefKey, []byte{1})
 
 	genesisHeader := &types.Header{
 		Number:    0,

--- a/lib/runtime/wasmer/helpers.go
+++ b/lib/runtime/wasmer/helpers.go
@@ -260,6 +260,6 @@ func storageAppend(storage runtime.Storage, key, valueToAppend []byte) error {
 	}
 
 	logger.Debugf("resulting value: 0x%x", value)
-	storage.Set(key, value)
+	storage.Put(key, value)
 	return nil
 }

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -2044,7 +2044,7 @@ func ext_storage_set_version_1(context unsafe.Pointer, keySpan, valueSpan C.int6
 	logger.Debugf(
 		"key 0x%x has value 0x%x",
 		key, value)
-	storage.Set(key, cp)
+	storage.Put(key, cp)
 }
 
 //export ext_storage_start_transaction_version_1

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -187,7 +187,7 @@ func Test_ext_storage_clear_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Put(testkey, []byte{1})
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -372,10 +372,10 @@ func Test_ext_storage_clear_prefix_version_1_hostAPI(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("static")
-	inst.ctx.Storage.Set(testkey, []byte("Inverse"))
+	inst.ctx.Storage.Put(testkey, []byte("Inverse"))
 
 	testkey2 := []byte("even-keeled")
-	inst.ctx.Storage.Set(testkey2, []byte("Future-proofed"))
+	inst.ctx.Storage.Put(testkey2, []byte("Future-proofed"))
 
 	enc, err := scale.Marshal(testkey[:3])
 	require.NoError(t, err)
@@ -395,10 +395,10 @@ func Test_ext_storage_clear_prefix_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Put(testkey, []byte{1})
 
 	testkey2 := []byte("spaghet")
-	inst.ctx.Storage.Set(testkey2, []byte{2})
+	inst.ctx.Storage.Put(testkey2, []byte{2})
 
 	enc, err := scale.Marshal(testkey[:3])
 	require.NoError(t, err)
@@ -418,20 +418,20 @@ func Test_ext_storage_clear_prefix_version_2(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Put(testkey, []byte{1})
 
 	testkey2 := []byte("noot1")
-	inst.ctx.Storage.Set(testkey2, []byte{1})
+	inst.ctx.Storage.Put(testkey2, []byte{1})
 
 	testkey3 := []byte("noot2")
-	inst.ctx.Storage.Set(testkey3, []byte{1})
+	inst.ctx.Storage.Put(testkey3, []byte{1})
 
 	testkey4 := []byte("noot3")
-	inst.ctx.Storage.Set(testkey4, []byte{1})
+	inst.ctx.Storage.Put(testkey4, []byte{1})
 
 	testkey5 := []byte("spaghet")
 	testValue5 := []byte{2}
-	inst.ctx.Storage.Set(testkey5, testValue5)
+	inst.ctx.Storage.Put(testkey5, testValue5)
 
 	enc, err := scale.Marshal(testkey[:3])
 	require.NoError(t, err)
@@ -492,7 +492,7 @@ func Test_ext_storage_get_version_1(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte{1, 2}
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Put(testkey, testvalue)
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -538,7 +538,7 @@ func Test_ext_storage_exists_version_1(t *testing.T) {
 			instance := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 			if testCase.value != nil {
-				instance.ctx.Storage.Set(testCase.key, testCase.value)
+				instance.ctx.Storage.Put(testCase.key, testCase.value)
 			}
 
 			encodedKey, err := scale.Marshal(testCase.key)
@@ -561,10 +561,10 @@ func Test_ext_storage_next_key_version_1(t *testing.T) {
 	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
 	testkey := []byte("noot")
-	inst.ctx.Storage.Set(testkey, []byte{1})
+	inst.ctx.Storage.Put(testkey, []byte{1})
 
 	nextkey := []byte("oot")
-	inst.ctx.Storage.Set(nextkey, []byte{1})
+	inst.ctx.Storage.Put(nextkey, []byte{1})
 
 	enc, err := scale.Marshal(testkey)
 	require.NoError(t, err)
@@ -585,7 +585,7 @@ func Test_ext_storage_read_version_1(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte("washere")
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Put(testkey, testvalue)
 
 	testoffset := uint32(2)
 	testBufferSize := uint32(100)
@@ -614,7 +614,7 @@ func Test_ext_storage_read_version_1_again(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte("_was_here_")
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Put(testkey, testvalue)
 
 	testoffset := uint32(8)
 	testBufferSize := uint32(5)
@@ -644,7 +644,7 @@ func Test_ext_storage_read_version_1_OffsetLargerThanValue(t *testing.T) {
 
 	testkey := []byte("noot")
 	testvalue := []byte("washere")
-	inst.ctx.Storage.Set(testkey, testvalue)
+	inst.ctx.Storage.Put(testkey, testvalue)
 
 	testoffset := uint32(len(testvalue))
 	testBufferSize := uint32(8)

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -15,10 +15,10 @@ var ChildStorageKeyPrefix = []byte(":child_storage:default:")
 
 var ErrChildTrieDoesNotExist = errors.New("child trie does not exist")
 
-// PutChild inserts a child trie into the main trie at key :child_storage:[keyToChild]
+// SetChild inserts a child trie into the main trie at key :child_storage:[keyToChild]
 // A child trie is added as a node (K, V) in the main trie. K is the child storage key
 // associated to the child trie, and V is the root hash of the child trie.
-func (t *Trie) PutChild(keyToChild []byte, child *Trie) error {
+func (t *Trie) SetChild(keyToChild []byte, child *Trie) error {
 	childHash, err := child.Hash()
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func (t *Trie) PutIntoChild(keyToChild, key, value []byte) error {
 	delete(t.childTries, origChildHash)
 	t.childTries[childHash] = child
 
-	return t.PutChild(keyToChild, child)
+	return t.SetChild(keyToChild, child)
 }
 
 // GetFromChild retrieves a key-value pair from the child trie located

--- a/lib/trie/child_storage_test.go
+++ b/lib/trie/child_storage_test.go
@@ -14,7 +14,7 @@ func TestPutAndGetChild(t *testing.T) {
 	childTrie := buildSmallTrie()
 	parentTrie := NewEmptyTrie()
 
-	err := parentTrie.PutChild(childKey, childTrie)
+	err := parentTrie.SetChild(childKey, childTrie)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestPutAndGetFromChild(t *testing.T) {
 	childTrie := buildSmallTrie()
 	parentTrie := NewEmptyTrie()
 
-	err := parentTrie.PutChild(childKey, childTrie)
+	err := parentTrie.SetChild(childKey, childTrie)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -295,7 +295,7 @@ func Test_Trie_PutChild_Store_Load(t *testing.T) {
 	}
 
 	for _, keyToChildTrie := range keysToChildTries {
-		err := trie.PutChild(keyToChildTrie, childTrie)
+		err := trie.SetChild(keyToChildTrie, childTrie)
 		require.NoError(t, err)
 
 		err = trie.WriteDirty(db)


### PR DESCRIPTION
## Changes

For consistency with trie method `Put`, this changes `TrieState`'s method name from `Set` to `Put`.

## Tests


## Issues

## Primary Reviewer
