### PR TITLE
chore(trie): add trie heap usage workflow step

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Run unit tests
         run: go test -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
 
+      - name: Trie memory test
+        run: |
+          sed -i 's/const skip = true/const skip = false/g' ./lib/trie/mem_test.go
+          go test -run ^Test_Trie_MemoryUsage$ ./lib/trie
+          sed -i 's/const skip = false/const skip = true/g' ./lib/trie/mem_test.go
+
       - name: Test State - Race
         run: make test-state-race
 

--- a/lib/trie/mem_test.go
+++ b/lib/trie/mem_test.go
@@ -43,8 +43,8 @@ func Test_Trie_MemoryUsage(t *testing.T) {
 	// Check heap memory usage - it should be 2X
 	filledTrieHeap := getHeapUsage()
 	ratio := getApproximateRatio(halfFilledTrieHeap, filledTrieHeap)
-	assert.Greater(t, ratio, 1.5)
-	assert.Less(t, ratio, 2.1)
+	assert.Greater(t, ratio, 1.6)
+	assert.Less(t, ratio, 1.7)
 
 	// Snapshot the trie
 	triesMap["second"] = triesMap["first"].Snapshot()
@@ -55,8 +55,8 @@ func Test_Trie_MemoryUsage(t *testing.T) {
 	// Check heap memory usage - it should be 3X
 	halfMutatedTrieHeap := getHeapUsage()
 	ratio = getApproximateRatio(halfFilledTrieHeap, halfMutatedTrieHeap)
-	assert.Greater(t, ratio, 2.0)
-	assert.Less(t, ratio, 3.1)
+	assert.Greater(t, ratio, 2.2)
+	assert.Less(t, ratio, 2.4)
 
 	// Remove the older trie from our reference
 	delete(triesMap, "first")
@@ -64,8 +64,8 @@ func Test_Trie_MemoryUsage(t *testing.T) {
 	// Check heap memory usage - it should be 2X
 	prunedTrieHeap := getHeapUsage()
 	ratio = getApproximateRatio(halfFilledTrieHeap, prunedTrieHeap)
-	assert.Greater(t, ratio, 1.5)
-	assert.Less(t, ratio, 2.1)
+	assert.Greater(t, ratio, 1.6)
+	assert.Less(t, ratio, 1.7)
 
 	// Dummy calls - has to be after prunedTrieHeap for
 	// GC to keep them

--- a/lib/trie/mem_test.go
+++ b/lib/trie/mem_test.go
@@ -109,6 +109,6 @@ func mutateTrieLeavesAtPrefix(trie *Trie,
 			newValue[i], newValue[j] = newValue[j], newValue[i]
 		}
 
-		trie.Put(key, value)
+		trie.Put(key, newValue)
 	}
 }

--- a/lib/trie/mem_test.go
+++ b/lib/trie/mem_test.go
@@ -16,7 +16,7 @@ func Test_Trie_MemoryUsage(t *testing.T) {
 	// Set skip to false to run the test.
 	// This test should be run on its own since it interacts
 	// with the Go garbage collector.
-	const skip = true
+	const skip = false
 	if skip {
 		t.SkipNow()
 	}
@@ -102,11 +102,15 @@ func mutateTrieLeavesAtPrefix(trie *Trie,
 	for keyString, value := range originalKV {
 		key := append(prefix, []byte(keyString)...) //skipcq: CRT-D0001
 
-		// Reverse value byte slice
-		newValue := make([]byte, len(value))
-		copy(newValue, value)
-		for i, j := 0, len(newValue)-1; i < j; i, j = i+1, j-1 {
-			newValue[i], newValue[j] = newValue[j], newValue[i]
+		var newValue []byte
+		if len(value) == 0 {
+			newValue = []byte{1}
+		} else {
+			newValue = make([]byte, len(value))
+			copy(newValue, value)
+			for i := range newValue {
+				newValue[i]++
+			}
 		}
 
 		trie.Put(key, newValue)

--- a/lib/trie/mem_test.go
+++ b/lib/trie/mem_test.go
@@ -65,7 +65,7 @@ func Test_Trie_MemoryUsage(t *testing.T) {
 	prunedTrieHeap := getHeapUsage()
 	ratio = getApproximateRatio(halfFilledTrieHeap, prunedTrieHeap)
 	assert.Greater(t, ratio, 1.6)
-	assert.Less(t, ratio, 1.7)
+	assert.Less(t, ratio, 1.8)
 
 	// Dummy calls - has to be after prunedTrieHeap for
 	// GC to keep them

--- a/lib/trie/mem_test.go
+++ b/lib/trie/mem_test.go
@@ -16,7 +16,7 @@ func Test_Trie_MemoryUsage(t *testing.T) {
 	// Set skip to false to run the test.
 	// This test should be run on its own since it interacts
 	// with the Go garbage collector.
-	const skip = false
+	const skip = true
 	if skip {
 		t.SkipNow()
 	}


### PR DESCRIPTION
## Changes

- Fix `mutateTrieLeavesAtPrefix` (shame on previous me!)
- Fix `mutateTrieLeavesAtPrefix` to work with empty values
- Tigthen ratio brackets to newer values
- Add trie memory workflow step

## Tests

## Issues


## Primary Reviewer

@timwu20
