### PR TITLE
chore(trie): update copy settings fields and comments

### DIFF
--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -6,25 +6,23 @@ package node
 var (
 	// DefaultCopySettings contains the following copy settings:
 	// - children are NOT deep copied recursively
-	// - the HashDigest field is left empty on the copy
-	// - the Encoding field is left empty on the copy
-	// - the key field is deep copied
+	// - the Merkle value field is left empty on the copy
+	// - the partial key field is deep copied
 	// - the storage value field is deep copied
 	DefaultCopySettings = CopySettings{
-		CopyKey:          true,
+		CopyPartialKey:   true,
 		CopyStorageValue: true,
 	}
 
 	// DeepCopySettings returns the following copy settings:
 	// - children are deep copied recursively
-	// - the HashDigest field is deep copied
-	// - the Encoding field is deep copied
-	// - the key field is deep copied
+	// - the Merkle value field is deep copied
+	// - the partial key field is deep copied
 	// - the storage value field is deep copied
 	DeepCopySettings = CopySettings{
 		CopyChildren:     true,
-		CopyCached:       true,
-		CopyKey:          true,
+		CopyMerkleValue:  true,
+		CopyPartialKey:   true,
 		CopyStorageValue: true,
 	}
 )
@@ -36,16 +34,16 @@ type CopySettings struct {
 	// children of the node. This is false by default and should only be used
 	// in tests since it is quite inefficient.
 	CopyChildren bool
-	// CopyCached can be set to true to deep copy the cached digest
-	// and encoding fields on the current node copied.
+	// CopyMerkleValue can be set to true to deep copy the Merkle value
+	// field on the current node copied.
 	// This is false by default because in production, a node is copied
-	// when it is about to be mutated, hence making its cached fields
-	// no longer valid.
-	CopyCached bool
-	// CopyKey can be set to true to deep copy the key field of
-	// the node. This is useful when false if the key is about to
+	// when it is about to be mutated, hence making its cached Merkle value
+	// field no longer valid.
+	CopyMerkleValue bool
+	// CopyPartialKey can be set to true to deep copy the partial key field of
+	// the node. This is useful when false if the partial key is about to
 	// be assigned after the Copy operation, to save a memory operation.
-	CopyKey bool
+	CopyPartialKey bool
 	// CopyStorageValue can be set to true to deep copy the storage value field of
 	// the node. This is useful when false if the storage value is about to
 	// be assigned after the Copy operation, to save a memory operation.
@@ -66,9 +64,9 @@ func (n *Node) Copy(settings CopySettings) *Node {
 		if settings.CopyChildren {
 			// Copy all fields of children if we deep copy children
 			childSettings := settings
-			childSettings.CopyKey = true
+			childSettings.CopyPartialKey = true
 			childSettings.CopyStorageValue = true
-			childSettings.CopyCached = true
+			childSettings.CopyMerkleValue = true
 			cpy.Children = make([]*Node, ChildrenCapacity)
 			for i, child := range n.Children {
 				if child == nil {
@@ -82,7 +80,7 @@ func (n *Node) Copy(settings CopySettings) *Node {
 		}
 	}
 
-	if settings.CopyKey && n.PartialKey != nil {
+	if settings.CopyPartialKey && n.PartialKey != nil {
 		cpy.PartialKey = make([]byte, len(n.PartialKey))
 		copy(cpy.PartialKey, n.PartialKey)
 	}
@@ -94,7 +92,7 @@ func (n *Node) Copy(settings CopySettings) *Node {
 		copy(cpy.StorageValue, n.StorageValue)
 	}
 
-	if settings.CopyCached {
+	if settings.CopyMerkleValue {
 		if n.MerkleValue != nil {
 			cpy.MerkleValue = make([]byte, len(n.MerkleValue))
 			copy(cpy.MerkleValue, n.MerkleValue)

--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -53,7 +53,7 @@ type CopySettings struct {
 // Copy deep copies the node.
 // Setting copyChildren to true will deep copy
 // children as well.
-func (n *Node) Copy(settings CopySettings) *Node {
+func (n *Node) Copy(settings CopySettings) *Node { //skipcq: GO-W1029
 	cpy := &Node{
 		Dirty:       n.Dirty,
 		Generation:  n.Generation,

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -50,7 +50,7 @@ func NewTrie(root *Node) *Trie {
 func (t *Trie) Snapshot() (newTrie *Trie) {
 	childTries := make(map[common.Hash]*Trie, len(t.childTries))
 	rootCopySettings := node.DefaultCopySettings
-	rootCopySettings.CopyCached = true
+	rootCopySettings.CopyMerkleValue = true
 	for rootHash, childTrie := range t.childTries {
 		childTries[rootHash] = &Trie{
 			generation:          childTrie.generation + 1,
@@ -166,7 +166,7 @@ func (t *Trie) DeepCopy() (trieCopy *Trie) {
 // RootNode returns a copy of the root node of the trie.
 func (t *Trie) RootNode() *Node {
 	copySettings := node.DefaultCopySettings
-	copySettings.CopyCached = true
+	copySettings.CopyMerkleValue = true
 	return t.root.Copy(copySettings)
 }
 

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -568,7 +568,7 @@ func (t *Trie) GetKeysWithPrefix(prefixLE []byte) (keysLE [][]byte) {
 		prefixNibbles = bytes.TrimSuffix(prefixNibbles, []byte{0})
 	}
 
-	prefix := []byte{}
+	prefix := []byte(nil)
 	key := prefixNibbles
 	return getKeysWithPrefix(t.root, prefix, key, keysLE)
 }


### PR DESCRIPTION
## Changes

- `CopyCached` -> `CopyMerkleValue` (since we don't cache the encoding anymore)
- `CopyKey` -> `CopyPartialKey`
- ~`CopyValue` -> `CopyStorageValue`~
- Update comments

## Tests

## Issues

## Primary Reviewer

@jimjbrettj 