### PR TITLE
fix(trie): differentiate `[]byte(nil)` and `[]byte{}` for storage values

### DIFF
--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -180,9 +180,9 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	))
 
 	trieRoot := &node.Node{
-		PartialKey: []byte{1, 2},
-		SubValue:   []byte{3, 4},
-		Dirty:      true,
+		PartialKey:   []byte{1, 2},
+		StorageValue: []byte{3, 4},
+		Dirty:        true,
 	}
 	testChildTrie := trie.NewTrie(trieRoot)
 

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -113,7 +113,8 @@ func TestStorage_LoadFromDB(t *testing.T) {
 	trieKV := []struct {
 		key   []byte
 		value []byte
-	}{{},
+	}{
+		{value: []byte{}},
 		{[]byte("key1"), []byte("value1")},
 		{[]byte("key2"), []byte("value2")},
 		{[]byte("xyzKey1"), []byte("xyzValue1")},
@@ -147,7 +148,7 @@ func TestStorage_LoadFromDB(t *testing.T) {
 
 	entries, err := storage.Entries(&root)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(entries))
+	require.Equal(t, 4, len(entries))
 }
 
 func TestStorage_StoreTrie_NotSyncing(t *testing.T) {

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -201,15 +201,15 @@ func Test_Tries_get(t *testing.T) {
 			tries: &Tries{
 				rootToTrie: map[common.Hash]*trie.Trie{
 					{1, 2, 3}: trie.NewTrie(&node.Node{
-						PartialKey: []byte{1, 2, 3},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{1, 2, 3},
+						StorageValue: []byte{1},
 					}),
 				},
 			},
 			root: common.Hash{1, 2, 3},
 			trie: trie.NewTrie(&node.Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			}),
 		},
 		"not found in map": {

--- a/internal/trie/node/README.md
+++ b/internal/trie/node/README.md
@@ -21,10 +21,10 @@ The header is then concatenated with the partial key of the node, encoded as Lit
 
 The remaining bytes appended depend on the node variant.
 
-- For leaves, the SCALE-encoded leaf value is appended.
+- For leaves, the SCALE-encoded leaf storage value is appended.
 - For branches, the following elements are concatenated in this order and appended to the previous header+partial key:
   - Children bitmap (2 bytes)
-  - SCALE-encoded node value
+  - SCALE-encoded node storage value
   - Hash(Encoding(Child[0]))
   - Hash(Encoding(Child[1]))
   - ...

--- a/internal/trie/node/branch_encode_test.go
+++ b/internal/trie/node/branch_encode_test.go
@@ -35,8 +35,8 @@ func populateChildren(valueSize, depth int) (children []*Node) {
 	if depth == 0 {
 		for i := range children {
 			children[i] = &Node{
-				PartialKey: someValue,
-				SubValue:   someValue,
+				PartialKey:   someValue,
+				StorageValue: someValue,
 			}
 		}
 		return children
@@ -44,9 +44,9 @@ func populateChildren(valueSize, depth int) (children []*Node) {
 
 	for i := range children {
 		children[i] = &Node{
-			PartialKey: someValue,
-			SubValue:   someValue,
-			Children:   populateChildren(valueSize, depth-1),
+			PartialKey:   someValue,
+			StorageValue: someValue,
+			Children:     populateChildren(valueSize, depth-1),
 		}
 	}
 
@@ -65,7 +65,7 @@ func Test_encodeChildrenOpportunisticParallel(t *testing.T) {
 		"no children": {},
 		"first child not nil": {
 			children: []*Node{
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
 			},
 			writes: []writeCall{
 				{
@@ -78,7 +78,7 @@ func Test_encodeChildrenOpportunisticParallel(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
 			},
 			writes: []writeCall{
 				{
@@ -88,8 +88,8 @@ func Test_encodeChildrenOpportunisticParallel(t *testing.T) {
 		},
 		"first two children not nil": {
 			children: []*Node{
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
-				{PartialKey: []byte{3}, SubValue: []byte{4}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
+				{PartialKey: []byte{3}, StorageValue: []byte{4}},
 			},
 			writes: []writeCall{
 				{
@@ -105,7 +105,7 @@ func Test_encodeChildrenOpportunisticParallel(t *testing.T) {
 				nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil,
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
 				nil, nil, nil, nil,
 			},
 			writes: []writeCall{
@@ -192,7 +192,7 @@ func Test_encodeChildrenSequentially(t *testing.T) {
 		"no children": {},
 		"first child not nil": {
 			children: []*Node{
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
 			},
 			writes: []writeCall{
 				{written: []byte{16}},
@@ -204,7 +204,7 @@ func Test_encodeChildrenSequentially(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
 			},
 			writes: []writeCall{
 				{written: []byte{16}},
@@ -213,8 +213,8 @@ func Test_encodeChildrenSequentially(t *testing.T) {
 		},
 		"first two children not nil": {
 			children: []*Node{
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
-				{PartialKey: []byte{3}, SubValue: []byte{4}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
+				{PartialKey: []byte{3}, StorageValue: []byte{4}},
 			},
 			writes: []writeCall{
 				{written: []byte{16}},
@@ -228,7 +228,7 @@ func Test_encodeChildrenSequentially(t *testing.T) {
 				nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil,
-				{PartialKey: []byte{1}, SubValue: []byte{2}},
+				{PartialKey: []byte{1}, StorageValue: []byte{2}},
 				nil, nil, nil, nil,
 			},
 			writes: []writeCall{
@@ -306,8 +306,8 @@ func Test_encodeChild(t *testing.T) {
 		},
 		"leaf child": {
 			child: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			writes: []writeCall{
 				{written: []byte{16}},
@@ -316,11 +316,11 @@ func Test_encodeChild(t *testing.T) {
 		},
 		"branch child": {
 			child: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 				Children: []*Node{
 					nil, nil, {PartialKey: []byte{5},
-						SubValue: []byte{6},
+						StorageValue: []byte{6},
 					},
 				},
 			},

--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -9,7 +9,7 @@ var (
 	// - the HashDigest field is left empty on the copy
 	// - the Encoding field is left empty on the copy
 	// - the key field is deep copied
-	// - the value field is deep copied
+	// - the storage value field is deep copied
 	DefaultCopySettings = CopySettings{
 		CopyKey:          true,
 		CopyStorageValue: true,
@@ -20,7 +20,7 @@ var (
 	// - the HashDigest field is deep copied
 	// - the Encoding field is deep copied
 	// - the key field is deep copied
-	// - the value field is deep copied
+	// - the storage value field is deep copied
 	DeepCopySettings = CopySettings{
 		CopyChildren:     true,
 		CopyCached:       true,
@@ -46,8 +46,8 @@ type CopySettings struct {
 	// the node. This is useful when false if the key is about to
 	// be assigned after the Copy operation, to save a memory operation.
 	CopyKey bool
-	// CopyStorageValue can be set to true to deep copy the value field of
-	// the node. This is useful when false if the value is about to
+	// CopyStorageValue can be set to true to deep copy the storage value field of
+	// the node. This is useful when false if the storage value is about to
 	// be assigned after the Copy operation, to save a memory operation.
 	CopyStorageValue bool
 }
@@ -87,8 +87,8 @@ func (n *Node) Copy(settings CopySettings) *Node {
 		copy(cpy.PartialKey, n.PartialKey)
 	}
 
-	// nil and []byte{} values for branches result in a different node encoding,
-	// so we ensure to keep the `nil` value.
+	// nil and []byte{} storage values for branches result in a different node encoding,
+	// so we ensure to keep the `nil` storage value.
 	if settings.CopyStorageValue && n.StorageValue != nil {
 		cpy.StorageValue = make([]byte, len(n.StorageValue))
 		copy(cpy.StorageValue, n.StorageValue)

--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -89,9 +89,9 @@ func (n *Node) Copy(settings CopySettings) *Node {
 
 	// nil and []byte{} values for branches result in a different node encoding,
 	// so we ensure to keep the `nil` value.
-	if settings.CopyValue && n.SubValue != nil {
-		cpy.SubValue = make([]byte, len(n.SubValue))
-		copy(cpy.SubValue, n.SubValue)
+	if settings.CopyValue && n.StorageValue != nil {
+		cpy.StorageValue = make([]byte, len(n.StorageValue))
+		copy(cpy.StorageValue, n.StorageValue)
 	}
 
 	if settings.CopyCached {

--- a/internal/trie/node/copy.go
+++ b/internal/trie/node/copy.go
@@ -11,8 +11,8 @@ var (
 	// - the key field is deep copied
 	// - the value field is deep copied
 	DefaultCopySettings = CopySettings{
-		CopyKey:   true,
-		CopyValue: true,
+		CopyKey:          true,
+		CopyStorageValue: true,
 	}
 
 	// DeepCopySettings returns the following copy settings:
@@ -22,10 +22,10 @@ var (
 	// - the key field is deep copied
 	// - the value field is deep copied
 	DeepCopySettings = CopySettings{
-		CopyChildren: true,
-		CopyCached:   true,
-		CopyKey:      true,
-		CopyValue:    true,
+		CopyChildren:     true,
+		CopyCached:       true,
+		CopyKey:          true,
+		CopyStorageValue: true,
 	}
 )
 
@@ -46,10 +46,10 @@ type CopySettings struct {
 	// the node. This is useful when false if the key is about to
 	// be assigned after the Copy operation, to save a memory operation.
 	CopyKey bool
-	// CopyValue can be set to true to deep copy the value field of
+	// CopyStorageValue can be set to true to deep copy the value field of
 	// the node. This is useful when false if the value is about to
 	// be assigned after the Copy operation, to save a memory operation.
-	CopyValue bool
+	CopyStorageValue bool
 }
 
 // Copy deep copies the node.
@@ -67,7 +67,7 @@ func (n *Node) Copy(settings CopySettings) *Node {
 			// Copy all fields of children if we deep copy children
 			childSettings := settings
 			childSettings.CopyKey = true
-			childSettings.CopyValue = true
+			childSettings.CopyStorageValue = true
 			childSettings.CopyCached = true
 			cpy.Children = make([]*Node, ChildrenCapacity)
 			for i, child := range n.Children {
@@ -89,7 +89,7 @@ func (n *Node) Copy(settings CopySettings) *Node {
 
 	// nil and []byte{} values for branches result in a different node encoding,
 	// so we ensure to keep the `nil` value.
-	if settings.CopyValue && n.StorageValue != nil {
+	if settings.CopyStorageValue && n.StorageValue != nil {
 		cpy.StorageValue = make([]byte, len(n.StorageValue))
 		copy(cpy.StorageValue, n.StorageValue)
 	}

--- a/internal/trie/node/copy_test.go
+++ b/internal/trie/node/copy_test.go
@@ -38,12 +38,12 @@ func Test_Node_Copy(t *testing.T) {
 		},
 		"non empty branch": {
 			node: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3, 4},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
 				Children: padRightChildren([]*Node{
 					nil, nil, {
-						PartialKey: []byte{9},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{1},
 					},
 				}),
 				Dirty:       true,
@@ -51,12 +51,12 @@ func Test_Node_Copy(t *testing.T) {
 			},
 			settings: DefaultCopySettings,
 			expectedNode: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3, 4},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
 				Children: padRightChildren([]*Node{
 					nil, nil, {
-						PartialKey: []byte{9},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{1},
 					},
 				}),
 				Dirty: true,
@@ -66,8 +66,8 @@ func Test_Node_Copy(t *testing.T) {
 			node: &Node{
 				Children: padRightChildren([]*Node{
 					nil, nil, {
-						PartialKey: []byte{9},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
@@ -77,20 +77,20 @@ func Test_Node_Copy(t *testing.T) {
 			expectedNode: &Node{
 				Children: padRightChildren([]*Node{
 					nil, nil, {
-						PartialKey: []byte{9},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
 		},
 		"deep copy branch": {
 			node: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3, 4},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
 				Children: padRightChildren([]*Node{
 					nil, nil, {
-						PartialKey: []byte{9},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{1},
 					},
 				}),
 				Dirty:       true,
@@ -98,12 +98,12 @@ func Test_Node_Copy(t *testing.T) {
 			},
 			settings: DeepCopySettings,
 			expectedNode: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3, 4},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
 				Children: padRightChildren([]*Node{
 					nil, nil, {
-						PartialKey: []byte{9},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{1},
 					},
 				}),
 				Dirty:       true,
@@ -112,31 +112,31 @@ func Test_Node_Copy(t *testing.T) {
 		},
 		"non empty leaf": {
 			node: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{3, 4},
-				Dirty:       true,
-				MerkleValue: []byte{5},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
+				Dirty:        true,
+				MerkleValue:  []byte{5},
 			},
 			settings: DefaultCopySettings,
 			expectedNode: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3, 4},
-				Dirty:      true,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
+				Dirty:        true,
 			},
 		},
 		"deep copy leaf": {
 			node: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{3, 4},
-				Dirty:       true,
-				MerkleValue: []byte{5},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
+				Dirty:        true,
+				MerkleValue:  []byte{5},
 			},
 			settings: DeepCopySettings,
 			expectedNode: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{3, 4},
-				Dirty:       true,
-				MerkleValue: []byte{5},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
+				Dirty:        true,
+				MerkleValue:  []byte{5},
 			},
 		},
 	}
@@ -150,7 +150,7 @@ func Test_Node_Copy(t *testing.T) {
 
 			assert.Equal(t, testCase.expectedNode, nodeCopy)
 			testForSliceModif(t, testCase.node.PartialKey, nodeCopy.PartialKey)
-			testForSliceModif(t, testCase.node.SubValue, nodeCopy.SubValue)
+			testForSliceModif(t, testCase.node.StorageValue, nodeCopy.StorageValue)
 			testForSliceModif(t, testCase.node.MerkleValue, nodeCopy.MerkleValue)
 
 			if testCase.node.Kind() == Branch {

--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -83,7 +83,7 @@ func decodeBranch(reader io.Reader, variant byte, partialKeyLength uint16) (
 	sd := scale.NewDecoder(reader)
 
 	if variant == branchWithValueVariant.bits {
-		err := sd.Decode(&node.SubValue)
+		err := sd.Decode(&node.StorageValue)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %s", ErrDecodeValue, err)
 		}
@@ -139,7 +139,7 @@ func decodeLeaf(reader io.Reader, partialKeyLength uint16) (node *Node, err erro
 	}
 
 	if len(value) > 0 {
-		node.SubValue = value
+		node.StorageValue = value
 	}
 
 	return node, nil

--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -13,11 +13,11 @@ import (
 )
 
 var (
-	// ErrDecodeValue is defined since no sentinel error is defined
+	// ErrDecodeStorageValue is defined since no sentinel error is defined
 	// in the scale package.
 	// TODO remove once the following issue is done:
 	// https://github.com/ChainSafe/gossamer/issues/2631 .
-	ErrDecodeValue        = errors.New("cannot decode value")
+	ErrDecodeStorageValue = errors.New("cannot decode value")
 	ErrReadChildrenBitmap = errors.New("cannot read children bitmap")
 	// ErrDecodeChildHash is defined since no sentinel error is defined
 	// in the scale package.
@@ -85,7 +85,7 @@ func decodeBranch(reader io.Reader, variant byte, partialKeyLength uint16) (
 	if variant == branchWithValueVariant.bits {
 		err := sd.Decode(&node.StorageValue)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", ErrDecodeValue, err)
+			return nil, fmt.Errorf("%w: %s", ErrDecodeStorageValue, err)
 		}
 	}
 
@@ -135,7 +135,7 @@ func decodeLeaf(reader io.Reader, partialKeyLength uint16) (node *Node, err erro
 	var value []byte
 	err = sd.Decode(&value)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return nil, fmt.Errorf("%w: %s", ErrDecodeValue, err)
+		return nil, fmt.Errorf("%w: %s", ErrDecodeStorageValue, err)
 	}
 
 	if len(value) > 0 {

--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -17,7 +17,7 @@ var (
 	// in the scale package.
 	// TODO remove once the following issue is done:
 	// https://github.com/ChainSafe/gossamer/issues/2631 .
-	ErrDecodeStorageValue = errors.New("cannot decode value")
+	ErrDecodeStorageValue = errors.New("cannot decode storage value")
 	ErrReadChildrenBitmap = errors.New("cannot read children bitmap")
 	// ErrDecodeChildHash is defined since no sentinel error is defined
 	// in the scale package.
@@ -62,7 +62,7 @@ func Decode(reader io.Reader) (n *Node, err error) {
 // Note that since the encoded branch stores the hash of the children nodes, we are not
 // reconstructing the child nodes from the encoding. This function instead stubs where the
 // children are known to be with an empty leaf. The children nodes hashes are then used to
-// find other values using the persistent database.
+// find other storage values using the persistent database.
 func decodeBranch(reader io.Reader, variant byte, partialKeyLength uint16) (
 	node *Node, err error) {
 	node = &Node{
@@ -132,14 +132,14 @@ func decodeLeaf(reader io.Reader, partialKeyLength uint16) (node *Node, err erro
 	}
 
 	sd := scale.NewDecoder(reader)
-	var value []byte
-	err = sd.Decode(&value)
+	var storageValue []byte
+	err = sd.Decode(&storageValue)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("%w: %s", ErrDecodeStorageValue, err)
 	}
 
-	if len(value) > 0 {
-		node.StorageValue = value
+	if len(storageValue) > 0 {
+		node.StorageValue = storageValue
 	}
 
 	return node, nil

--- a/internal/trie/node/decode.go
+++ b/internal/trie/node/decode.go
@@ -132,14 +132,9 @@ func decodeLeaf(reader io.Reader, partialKeyLength uint16) (node *Node, err erro
 	}
 
 	sd := scale.NewDecoder(reader)
-	var storageValue []byte
-	err = sd.Decode(&storageValue)
-	if err != nil && !errors.Is(err, io.EOF) {
+	err = sd.Decode(&node.StorageValue)
+	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrDecodeStorageValue, err)
-	}
-
-	if len(storageValue) > 0 {
-		node.StorageValue = storageValue
 	}
 
 	return node, nil

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -74,8 +74,8 @@ func Test_Decode(t *testing.T) {
 				),
 			),
 			n: &Node{
-				PartialKey: []byte{9},
-				SubValue:   []byte{1, 2, 3},
+				PartialKey:   []byte{9},
+				StorageValue: []byte{1, 2, 3},
 			},
 		},
 		"branch decoding error": {
@@ -211,8 +211,8 @@ func Test_decodeBranch(t *testing.T) {
 			variant:          branchWithValueVariant.bits,
 			partialKeyLength: 1,
 			branch: &Node{
-				PartialKey: []byte{9},
-				SubValue:   []byte{7, 8, 9},
+				PartialKey:   []byte{9},
+				StorageValue: []byte{7, 8, 9},
 				Children: padRightChildren([]*Node{
 					nil, nil, nil, nil, nil,
 					nil, nil, nil, nil, nil,
@@ -266,13 +266,13 @@ func Test_decodeBranch(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 3,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{2}, SubValue: []byte{2}},
+					{PartialKey: []byte{2}, StorageValue: []byte{2}},
 					{
-						PartialKey:  []byte{3},
-						SubValue:    []byte{3},
-						Descendants: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{3},
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{4}, SubValue: []byte{4}},
+							{PartialKey: []byte{4}, StorageValue: []byte{4}},
 						}),
 					},
 				}),
@@ -359,8 +359,8 @@ func Test_decodeLeaf(t *testing.T) {
 			variant:          leafVariant.bits,
 			partialKeyLength: 1,
 			leaf: &Node{
-				PartialKey: []byte{9},
-				SubValue:   []byte{1, 2, 3, 4, 5},
+				PartialKey:   []byte{9},
+				StorageValue: []byte{1, 2, 3, 4, 5},
 			},
 		},
 	}

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -198,7 +198,7 @@ func Test_decodeBranch(t *testing.T) {
 			),
 			variant:          branchWithValueVariant.bits,
 			partialKeyLength: 1,
-			errWrapped:       ErrDecodeValue,
+			errWrapped:       ErrDecodeStorageValue,
 			errMessage:       "cannot decode value: reading byte: EOF",
 		},
 		"success for branch with value": {
@@ -324,7 +324,7 @@ func Test_decodeLeaf(t *testing.T) {
 			}),
 			variant:          leafVariant.bits,
 			partialKeyLength: 1,
-			errWrapped:       ErrDecodeValue,
+			errWrapped:       ErrDecodeStorageValue,
 			errMessage:       "cannot decode value: unknown prefix for compact uint: 255",
 		},
 		"missing value data": {

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -334,19 +334,19 @@ func Test_decodeLeaf(t *testing.T) {
 			}),
 			variant:          leafVariant.bits,
 			partialKeyLength: 1,
-			leaf: &Node{
-				PartialKey: []byte{9},
-			},
+			errWrapped:       ErrDecodeStorageValue,
+			errMessage:       "cannot decode storage value: reading byte: EOF",
 		},
 		"empty storage value data": {
 			reader: bytes.NewBuffer(concatByteSlices([][]byte{
-				{9}, // key data
-				scaleEncodeByteSlice(t, nil),
+				{9},                               // key data
+				scaleEncodeByteSlice(t, []byte{}), // results to []byte{0}
 			})),
 			variant:          leafVariant.bits,
 			partialKeyLength: 1,
 			leaf: &Node{
-				PartialKey: []byte{9},
+				PartialKey:   []byte{9},
+				StorageValue: []byte{},
 			},
 		},
 		"success": {

--- a/internal/trie/node/decode_test.go
+++ b/internal/trie/node/decode_test.go
@@ -193,19 +193,19 @@ func Test_decodeBranch(t *testing.T) {
 				concatByteSlices([][]byte{
 					{9},    // key data
 					{0, 4}, // children bitmap
-					// missing encoded branch value
+					// missing encoded branch storage value
 				}),
 			),
 			variant:          branchWithValueVariant.bits,
 			partialKeyLength: 1,
 			errWrapped:       ErrDecodeStorageValue,
-			errMessage:       "cannot decode value: reading byte: EOF",
+			errMessage:       "cannot decode storage value: reading byte: EOF",
 		},
 		"success for branch with value": {
 			reader: bytes.NewBuffer(concatByteSlices([][]byte{
 				{9},                          // key data
 				{0, 4},                       // children bitmap
-				scaleEncodeBytes(t, 7, 8, 9), // branch value
+				scaleEncodeBytes(t, 7, 8, 9), // branch storage value
 				scaleEncodedChildHash,
 			})),
 			variant:          branchWithValueVariant.bits,
@@ -227,7 +227,7 @@ func Test_decodeBranch(t *testing.T) {
 			reader: bytes.NewBuffer(concatByteSlices([][]byte{
 				{1},                        // key data
 				{0b0000_0001, 0b0000_0000}, // children bitmap
-				scaleEncodeBytes(t, 1),     // branch value
+				scaleEncodeBytes(t, 1),     // branch storage value
 				{0},                        // garbage inlined node
 			})),
 			variant:          branchWithValueVariant.bits,
@@ -244,19 +244,19 @@ func Test_decodeBranch(t *testing.T) {
 				scaleEncodeByteSlice(t, concatByteSlices([][]byte{
 					{leafVariant.bits | 1}, // partial key length of 1
 					{2},                    // key data
-					scaleEncodeBytes(t, 2), // value data
+					scaleEncodeBytes(t, 2), // storage value data
 				})),
 				// top level inlined branch less than 32 bytes
 				scaleEncodeByteSlice(t, concatByteSlices([][]byte{
 					{branchWithValueVariant.bits | 1}, // partial key length of 1
 					{3},                               // key data
 					{0b0000_0001, 0b0000_0000},        // children bitmap
-					scaleEncodeBytes(t, 3),            // branch value
+					scaleEncodeBytes(t, 3),            // branch storage value
 					// bottom level leaf
 					scaleEncodeByteSlice(t, concatByteSlices([][]byte{
 						{leafVariant.bits | 1}, // partial key length of 1
 						{4},                    // key data
-						scaleEncodeBytes(t, 4), // value data
+						scaleEncodeBytes(t, 4), // storage value data
 					})),
 				})),
 			})),
@@ -320,17 +320,17 @@ func Test_decodeLeaf(t *testing.T) {
 		"value decoding error": {
 			reader: bytes.NewBuffer([]byte{
 				9,        // key data
-				255, 255, // bad value data
+				255, 255, // bad storage value data
 			}),
 			variant:          leafVariant.bits,
 			partialKeyLength: 1,
 			errWrapped:       ErrDecodeStorageValue,
-			errMessage:       "cannot decode value: unknown prefix for compact uint: 255",
+			errMessage:       "cannot decode storage value: unknown prefix for compact uint: 255",
 		},
-		"missing value data": {
+		"missing storage value data": {
 			reader: bytes.NewBuffer([]byte{
 				9, // key data
-				// missing value data
+				// missing storage value data
 			}),
 			variant:          leafVariant.bits,
 			partialKeyLength: 1,
@@ -338,7 +338,7 @@ func Test_decodeLeaf(t *testing.T) {
 				PartialKey: []byte{9},
 			},
 		},
-		"empty value data": {
+		"empty storage value data": {
 			reader: bytes.NewBuffer(concatByteSlices([][]byte{
 				{9}, // key data
 				scaleEncodeByteSlice(t, nil),
@@ -353,7 +353,7 @@ func Test_decodeLeaf(t *testing.T) {
 			reader: bytes.NewBuffer(
 				concatByteSlices([][]byte{
 					{9},                                // key data
-					scaleEncodeBytes(t, 1, 2, 3, 4, 5), // value data
+					scaleEncodeBytes(t, 1, 2, 3, 4, 5), // storage value data
 				}),
 			),
 			variant:          leafVariant.bits,

--- a/internal/trie/node/dirty.go
+++ b/internal/trie/node/dirty.go
@@ -6,7 +6,7 @@ package node
 // SetDirty sets the dirty status to true for the node.
 func (n *Node) SetDirty() {
 	n.Dirty = true
-	// A node is marked dirty if its key or value is modified.
+	// A node is marked dirty if its partial key or storage value is modified.
 	// This means its Merkle value field is no longer valid.
 	n.MerkleValue = nil
 }

--- a/internal/trie/node/encode.go
+++ b/internal/trie/node/encode.go
@@ -37,9 +37,10 @@ func (n *Node) Encode(buffer Buffer) (err error) {
 		}
 	}
 
-	// Only encode node storage value if the node is a leaf or
-	// the node is a branch with a non empty storage value.
-	if !nodeIsBranch || (nodeIsBranch && n.StorageValue != nil) {
+	// Only encode node storage value if the node has a storage value,
+	// even if it is empty. Do not encode if the branch is without value.
+	// Note leaves and branches with value cannot have a `nil` storage value.
+	if n.StorageValue != nil {
 		encoder := scale.NewEncoder(buffer)
 		err = encoder.Encode(n.StorageValue)
 		if err != nil {

--- a/internal/trie/node/encode.go
+++ b/internal/trie/node/encode.go
@@ -37,13 +37,13 @@ func (n *Node) Encode(buffer Buffer) (err error) {
 		}
 	}
 
-	// Only encode node value if the node is a leaf or
-	// the node is a branch with a non empty value.
+	// Only encode node storage value if the node is a leaf or
+	// the node is a branch with a non empty storage value.
 	if !nodeIsBranch || (nodeIsBranch && n.StorageValue != nil) {
 		encoder := scale.NewEncoder(buffer)
 		err = encoder.Encode(n.StorageValue)
 		if err != nil {
-			return fmt.Errorf("scale encoding value: %w", err)
+			return fmt.Errorf("scale encoding storage value: %w", err)
 		}
 	}
 

--- a/internal/trie/node/encode.go
+++ b/internal/trie/node/encode.go
@@ -39,9 +39,9 @@ func (n *Node) Encode(buffer Buffer) (err error) {
 
 	// Only encode node value if the node is a leaf or
 	// the node is a branch with a non empty value.
-	if !nodeIsBranch || (nodeIsBranch && n.SubValue != nil) {
+	if !nodeIsBranch || (nodeIsBranch && n.StorageValue != nil) {
 		encoder := scale.NewEncoder(buffer)
-		err = encoder.Encode(n.SubValue)
+		err = encoder.Encode(n.StorageValue)
 		if err != nil {
 			return fmt.Errorf("scale encoding value: %w", err)
 		}

--- a/internal/trie/node/encode_decode_test.go
+++ b/internal/trie/node/encode_decode_test.go
@@ -52,8 +52,8 @@ func Test_Branch_Encode_Decode(t *testing.T) {
 				PartialKey: []byte{5},
 				Children: padRightChildren([]*Node{
 					{
-						PartialKey: []byte{9},
-						SubValue:   []byte{10},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{10},
 					},
 				}),
 			},
@@ -62,8 +62,8 @@ func Test_Branch_Encode_Decode(t *testing.T) {
 				Descendants: 1,
 				Children: padRightChildren([]*Node{
 					{
-						PartialKey: []byte{9},
-						SubValue:   []byte{10},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{10},
 					},
 				}),
 			},
@@ -81,7 +81,7 @@ func Test_Branch_Encode_Decode(t *testing.T) {
 							10, 11, 12, 13,
 							14, 15, 16, 17,
 						},
-						SubValue: []byte{
+						StorageValue: []byte{
 							10, 11, 12, 13,
 							14, 15, 16, 17,
 							10, 11, 12, 13,

--- a/internal/trie/node/encode_test.go
+++ b/internal/trie/node/encode_test.go
@@ -60,7 +60,7 @@ func Test_Node_Encode(t *testing.T) {
 			wrappedErr: errTest,
 			errMessage: "cannot write LE key to buffer: test error",
 		},
-		"leaf buffer write error for encoded value": {
+		"leaf buffer write error for encoded storage value": {
 			node: &Node{
 				PartialKey:   []byte{1, 2, 3},
 				StorageValue: []byte{4, 5, 6},
@@ -78,7 +78,7 @@ func Test_Node_Encode(t *testing.T) {
 				},
 			},
 			wrappedErr: errTest,
-			errMessage: "scale encoding value: test error",
+			errMessage: "scale encoding storage value: test error",
 		},
 		"leaf success": {
 			node: &Node{
@@ -95,15 +95,15 @@ func Test_Node_Encode(t *testing.T) {
 			},
 			expectedEncoding: []byte{1, 2, 3},
 		},
-		"leaf with empty value success": {
+		"leaf with empty storage value success": {
 			node: &Node{
 				PartialKey: []byte{1, 2, 3},
 			},
 			writes: []writeCall{
 				{written: []byte{leafVariant.bits | 3}}, // partial key length 3
 				{written: []byte{0x01, 0x23}},           // partial key
-				{written: []byte{0}},                    // node value encoded length
-				{written: nil},                          // node value
+				{written: []byte{0}},                    // node storage value encoded length
+				{written: nil},                          // node storage value
 			},
 			expectedEncoding: []byte{1, 2, 3},
 		},
@@ -163,7 +163,7 @@ func Test_Node_Encode(t *testing.T) {
 			wrappedErr: errTest,
 			errMessage: "cannot write children bitmap to buffer: test error",
 		},
-		"buffer write error for value": {
+		"buffer write error for storage value": {
 			node: &Node{
 				PartialKey:   []byte{1, 2, 3},
 				StorageValue: []byte{100},
@@ -182,13 +182,13 @@ func Test_Node_Encode(t *testing.T) {
 				{ // children bitmap
 					written: []byte{136, 0},
 				},
-				{ // value
+				{ // storage value
 					written: []byte{4},
 					err:     errTest,
 				},
 			},
 			wrappedErr: errTest,
-			errMessage: "scale encoding value: test error",
+			errMessage: "scale encoding storage value: test error",
 		},
 		"buffer write error for children encoding": {
 			node: &Node{
@@ -209,7 +209,7 @@ func Test_Node_Encode(t *testing.T) {
 				{ // children bitmap
 					written: []byte{136, 0},
 				},
-				// value
+				// storage value
 				{written: []byte{4}},
 				{written: []byte{100}},
 				{ // children
@@ -241,7 +241,7 @@ func Test_Node_Encode(t *testing.T) {
 				{ // children bitmap
 					written: []byte{136, 0},
 				},
-				// value
+				// storage value
 				{written: []byte{4}},
 				{written: []byte{100}},
 				{ // first children

--- a/internal/trie/node/encode_test.go
+++ b/internal/trie/node/encode_test.go
@@ -45,8 +45,8 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"leaf buffer write error for encoded key": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			writes: []writeCall{
 				{
@@ -62,8 +62,8 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"leaf buffer write error for encoded value": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{4, 5, 6},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{4, 5, 6},
 			},
 			writes: []writeCall{
 				{
@@ -82,8 +82,8 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"leaf success": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{4, 5, 6},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{4, 5, 6},
 			},
 			writes: []writeCall{
 				{
@@ -123,9 +123,9 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"buffer write error for encoded key": {
 			node: &Node{
-				Children:   make([]*Node, ChildrenCapacity),
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{100},
+				Children:     make([]*Node, ChildrenCapacity),
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{100},
 			},
 			writes: []writeCall{
 				{ // header
@@ -141,11 +141,11 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"buffer write error for children bitmap": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{100},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{100},
 				Children: []*Node{
-					nil, nil, nil, {PartialKey: []byte{9}, SubValue: []byte{1}},
-					nil, nil, nil, {PartialKey: []byte{11}, SubValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{9}, StorageValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{11}, StorageValue: []byte{1}},
 				},
 			},
 			writes: []writeCall{
@@ -165,11 +165,11 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"buffer write error for value": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{100},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{100},
 				Children: []*Node{
-					nil, nil, nil, {PartialKey: []byte{9}, SubValue: []byte{1}},
-					nil, nil, nil, {PartialKey: []byte{11}, SubValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{9}, StorageValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{11}, StorageValue: []byte{1}},
 				},
 			},
 			writes: []writeCall{
@@ -192,11 +192,11 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"buffer write error for children encoding": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{100},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{100},
 				Children: []*Node{
-					nil, nil, nil, {PartialKey: []byte{9}, SubValue: []byte{1}},
-					nil, nil, nil, {PartialKey: []byte{11}, SubValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{9}, StorageValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{11}, StorageValue: []byte{1}},
 				},
 			},
 			writes: []writeCall{
@@ -224,11 +224,11 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"success with children encoding": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{100},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{100},
 				Children: []*Node{
-					nil, nil, nil, {PartialKey: []byte{9}, SubValue: []byte{1}},
-					nil, nil, nil, {PartialKey: []byte{11}, SubValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{9}, StorageValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{11}, StorageValue: []byte{1}},
 				},
 			},
 			writes: []writeCall{
@@ -256,8 +256,8 @@ func Test_Node_Encode(t *testing.T) {
 			node: &Node{
 				PartialKey: []byte{1, 2, 3},
 				Children: []*Node{
-					nil, nil, nil, {PartialKey: []byte{9}, SubValue: []byte{1}},
-					nil, nil, nil, {PartialKey: []byte{11}, SubValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{9}, StorageValue: []byte{1}},
+					nil, nil, nil, {PartialKey: []byte{11}, StorageValue: []byte{1}},
 				},
 			},
 			writes: []writeCall{

--- a/internal/trie/node/encode_test.go
+++ b/internal/trie/node/encode_test.go
@@ -97,13 +97,14 @@ func Test_Node_Encode(t *testing.T) {
 		},
 		"leaf with empty storage value success": {
 			node: &Node{
-				PartialKey: []byte{1, 2, 3},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{},
 			},
 			writes: []writeCall{
 				{written: []byte{leafVariant.bits | 3}}, // partial key length 3
 				{written: []byte{0x01, 0x23}},           // partial key
 				{written: []byte{0}},                    // node storage value encoded length
-				{written: nil},                          // node storage value
+				{written: []byte{}},                     // node storage value
 			},
 			expectedEncoding: []byte{1, 2, 3},
 		},

--- a/internal/trie/node/hash_test.go
+++ b/internal/trie/node/hash_test.go
@@ -185,8 +185,8 @@ func Test_Node_CalculateMerkleValue(t *testing.T) {
 		},
 		"small encoding": {
 			node: Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			merkleValue: []byte{0x41, 0x1, 0x4, 0x1},
 		},
@@ -231,9 +231,9 @@ func Test_Node_CalculateRootMerkleValue(t *testing.T) {
 		},
 		"cached merkle value not 32 bytes": {
 			node: Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				MerkleValue: []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				MerkleValue:  []byte{1},
 			},
 			merkleValue: []byte{
 				0x60, 0x51, 0x6d, 0xb, 0xb6, 0xe1, 0xbb, 0xfb,
@@ -243,8 +243,8 @@ func Test_Node_CalculateRootMerkleValue(t *testing.T) {
 		},
 		"root small encoding": {
 			node: Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			merkleValue: []byte{
 				0x60, 0x51, 0x6d, 0xb, 0xb6, 0xe1, 0xbb, 0xfb,
@@ -283,8 +283,8 @@ func Test_Node_EncodeAndHash(t *testing.T) {
 	}{
 		"small leaf encoding": {
 			node: Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			expectedNode: Node{
 				MerkleValue: []byte{0x41, 0x1, 0x4, 0x2},
@@ -294,8 +294,8 @@ func Test_Node_EncodeAndHash(t *testing.T) {
 		},
 		"large leaf encoding": {
 			node: Node{
-				PartialKey: repeatBytes(65, 7),
-				SubValue:   []byte{0x01},
+				PartialKey:   repeatBytes(65, 7),
+				StorageValue: []byte{0x01},
 			},
 			expectedNode: Node{
 				MerkleValue: []byte{0xd2, 0x1d, 0x43, 0x7, 0x18, 0x17, 0x1b, 0xf1, 0x45, 0x9c, 0xe5, 0x8f, 0xd7, 0x79, 0x82, 0xb, 0xc8, 0x5c, 0x8, 0x47, 0xfe, 0x6c, 0x99, 0xc5, 0xe9, 0x57, 0x87, 0x7, 0x1d, 0x2e, 0x24, 0x5d}, //nolint:lll
@@ -316,9 +316,9 @@ func Test_Node_EncodeAndHash(t *testing.T) {
 		},
 		"small branch encoding": {
 			node: Node{
-				Children:   make([]*Node, ChildrenCapacity),
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				Children:     make([]*Node, ChildrenCapacity),
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			expectedNode: Node{
 				Children:    make([]*Node, ChildrenCapacity),
@@ -371,8 +371,8 @@ func Test_Node_EncodeAndHashRoot(t *testing.T) {
 	}{
 		"small leaf encoding": {
 			node: Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			expectedNode: Node{
 				MerkleValue: []byte{0x60, 0x51, 0x6d, 0xb, 0xb6, 0xe1, 0xbb, 0xfb, 0x12, 0x93, 0xf1, 0xb2, 0x76, 0xea, 0x95, 0x5, 0xe9, 0xf4, 0xa4, 0xe7, 0xd9, 0x8f, 0x62, 0xd, 0x5, 0x11, 0x5e, 0xb, 0x85, 0x27, 0x4a, 0xe1}, //nolint:lll
@@ -382,9 +382,9 @@ func Test_Node_EncodeAndHashRoot(t *testing.T) {
 		},
 		"small branch encoding": {
 			node: Node{
-				Children:   make([]*Node, ChildrenCapacity),
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				Children:     make([]*Node, ChildrenCapacity),
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			expectedNode: Node{
 				Children:    make([]*Node, ChildrenCapacity),

--- a/internal/trie/node/header.go
+++ b/internal/trie/node/header.go
@@ -20,7 +20,7 @@ func encodeHeader(node *Node, writer io.Writer) (err error) {
 	var variant variant
 	if node.Kind() == Leaf {
 		variant = leafVariant
-	} else if node.SubValue == nil {
+	} else if node.StorageValue == nil {
 		variant = branchVariant
 	} else {
 		variant = branchWithValueVariant

--- a/internal/trie/node/header_test.go
+++ b/internal/trie/node/header_test.go
@@ -34,8 +34,8 @@ func Test_encodeHeader(t *testing.T) {
 		},
 		"branch with value": {
 			node: &Node{
-				SubValue: []byte{},
-				Children: make([]*Node, ChildrenCapacity),
+				StorageValue: []byte{},
+				Children:     make([]*Node, ChildrenCapacity),
 			},
 			writes: []writeCall{
 				{written: []byte{branchWithValueVariant.bits}},
@@ -111,7 +111,7 @@ func Test_encodeHeader(t *testing.T) {
 			errMessage: "test error",
 		},
 		"leaf with no key": {
-			node: &Node{SubValue: []byte{1}},
+			node: &Node{StorageValue: []byte{1}},
 			writes: []writeCall{
 				{written: []byte{leafVariant.bits}},
 			},

--- a/internal/trie/node/node.go
+++ b/internal/trie/node/node.go
@@ -58,7 +58,7 @@ func (n Node) StringNode() (stringNode *gotree.Node) {
 	stringNode.Appendf("Generation: %d", n.Generation)
 	stringNode.Appendf("Dirty: %t", n.Dirty)
 	stringNode.Appendf("Key: " + bytesToString(n.PartialKey))
-	stringNode.Appendf("Value: " + bytesToString(n.StorageValue))
+	stringNode.Appendf("Storage value: " + bytesToString(n.StorageValue))
 	if n.Descendants > 0 { // must be a branch
 		stringNode.Appendf("Descendants: %d", n.Descendants)
 	}

--- a/internal/trie/node/node.go
+++ b/internal/trie/node/node.go
@@ -16,8 +16,8 @@ import (
 // Node is a node in the trie and can be a leaf or a branch.
 type Node struct {
 	// PartialKey is the partial key bytes in nibbles (0 to f in hexadecimal)
-	PartialKey []byte
-	SubValue   []byte
+	PartialKey   []byte
+	StorageValue []byte
 	// Generation is incremented on every trie Snapshot() call.
 	// Each node also contain a certain Generation number,
 	// which is updated to match the trie Generation once they are
@@ -58,7 +58,7 @@ func (n Node) StringNode() (stringNode *gotree.Node) {
 	stringNode.Appendf("Generation: %d", n.Generation)
 	stringNode.Appendf("Dirty: %t", n.Dirty)
 	stringNode.Appendf("Key: " + bytesToString(n.PartialKey))
-	stringNode.Appendf("Value: " + bytesToString(n.SubValue))
+	stringNode.Appendf("Value: " + bytesToString(n.StorageValue))
 	if n.Descendants > 0 { // must be a branch
 		stringNode.Appendf("Descendants: %d", n.Descendants)
 	}

--- a/internal/trie/node/node_test.go
+++ b/internal/trie/node/node_test.go
@@ -16,7 +16,7 @@ func Test_Node_String(t *testing.T) {
 		node *Node
 		s    string
 	}{
-		"leaf with value smaller than 1024": {
+		"leaf with storage value smaller than 1024": {
 			node: &Node{
 				PartialKey:   []byte{1, 2},
 				StorageValue: []byte{3, 4},
@@ -26,10 +26,10 @@ func Test_Node_String(t *testing.T) {
 ├── Generation: 0
 ├── Dirty: true
 ├── Key: 0x0102
-├── Value: 0x0304
+├── Storage value: 0x0304
 └── Merkle value: nil`,
 		},
-		"leaf with value higher than 1024": {
+		"leaf with storage value higher than 1024": {
 			node: &Node{
 				PartialKey:   []byte{1, 2},
 				StorageValue: make([]byte, 1025),
@@ -39,10 +39,10 @@ func Test_Node_String(t *testing.T) {
 ├── Generation: 0
 ├── Dirty: true
 ├── Key: 0x0102
-├── Value: 0x0000000000000000...0000000000000000
+├── Storage value: 0x0000000000000000...0000000000000000
 └── Merkle value: nil`,
 		},
-		"branch with value smaller than 1024": {
+		"branch with storage value smaller than 1024": {
 			node: &Node{
 				PartialKey:   []byte{1, 2},
 				StorageValue: []byte{3, 4},
@@ -65,7 +65,7 @@ func Test_Node_String(t *testing.T) {
 ├── Generation: 0
 ├── Dirty: true
 ├── Key: 0x0102
-├── Value: 0x0304
+├── Storage value: 0x0304
 ├── Descendants: 3
 ├── Merkle value: nil
 ├── Child 3
@@ -73,14 +73,14 @@ func Test_Node_String(t *testing.T) {
 |       ├── Generation: 0
 |       ├── Dirty: false
 |       ├── Key: nil
-|       ├── Value: nil
+|       ├── Storage value: nil
 |       └── Merkle value: nil
 ├── Child 7
 |   └── Branch
 |       ├── Generation: 0
 |       ├── Dirty: false
 |       ├── Key: nil
-|       ├── Value: nil
+|       ├── Storage value: nil
 |       ├── Descendants: 1
 |       ├── Merkle value: nil
 |       └── Child 0
@@ -88,17 +88,17 @@ func Test_Node_String(t *testing.T) {
 |               ├── Generation: 0
 |               ├── Dirty: false
 |               ├── Key: nil
-|               ├── Value: nil
+|               ├── Storage value: nil
 |               └── Merkle value: nil
 └── Child 11
     └── Leaf
         ├── Generation: 0
         ├── Dirty: false
         ├── Key: nil
-        ├── Value: nil
+        ├── Storage value: nil
         └── Merkle value: nil`,
 		},
-		"branch with value higher than 1024": {
+		"branch with storage value higher than 1024": {
 			node: &Node{
 				PartialKey:   []byte{1, 2},
 				StorageValue: make([]byte, 1025),
@@ -121,7 +121,7 @@ func Test_Node_String(t *testing.T) {
 ├── Generation: 0
 ├── Dirty: true
 ├── Key: 0x0102
-├── Value: 0x0000000000000000...0000000000000000
+├── Storage value: 0x0000000000000000...0000000000000000
 ├── Descendants: 3
 ├── Merkle value: nil
 ├── Child 3
@@ -129,14 +129,14 @@ func Test_Node_String(t *testing.T) {
 |       ├── Generation: 0
 |       ├── Dirty: false
 |       ├── Key: nil
-|       ├── Value: nil
+|       ├── Storage value: nil
 |       └── Merkle value: nil
 ├── Child 7
 |   └── Branch
 |       ├── Generation: 0
 |       ├── Dirty: false
 |       ├── Key: nil
-|       ├── Value: nil
+|       ├── Storage value: nil
 |       ├── Descendants: 1
 |       ├── Merkle value: nil
 |       └── Child 0
@@ -144,14 +144,14 @@ func Test_Node_String(t *testing.T) {
 |               ├── Generation: 0
 |               ├── Dirty: false
 |               ├── Key: nil
-|               ├── Value: nil
+|               ├── Storage value: nil
 |               └── Merkle value: nil
 └── Child 11
     └── Leaf
         ├── Generation: 0
         ├── Dirty: false
         ├── Key: nil
-        ├── Value: nil
+        ├── Storage value: nil
         └── Merkle value: nil`,
 		},
 	}

--- a/internal/trie/node/node_test.go
+++ b/internal/trie/node/node_test.go
@@ -18,9 +18,9 @@ func Test_Node_String(t *testing.T) {
 	}{
 		"leaf with value smaller than 1024": {
 			node: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3, 4},
-				Dirty:      true,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
+				Dirty:        true,
 			},
 			s: `Leaf
 ├── Generation: 0
@@ -31,9 +31,9 @@ func Test_Node_String(t *testing.T) {
 		},
 		"leaf with value higher than 1024": {
 			node: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   make([]byte, 1025),
-				Dirty:      true,
+				PartialKey:   []byte{1, 2},
+				StorageValue: make([]byte, 1025),
+				Dirty:        true,
 			},
 			s: `Leaf
 ├── Generation: 0
@@ -44,10 +44,10 @@ func Test_Node_String(t *testing.T) {
 		},
 		"branch with value smaller than 1024": {
 			node: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{3, 4},
-				Dirty:       true,
-				Descendants: 3,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3, 4},
+				Dirty:        true,
+				Descendants:  3,
 				Children: []*Node{
 					nil, nil, nil,
 					{},
@@ -100,10 +100,10 @@ func Test_Node_String(t *testing.T) {
 		},
 		"branch with value higher than 1024": {
 			node: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    make([]byte, 1025),
-				Dirty:       true,
-				Descendants: 3,
+				PartialKey:   []byte{1, 2},
+				StorageValue: make([]byte, 1025),
+				Dirty:        true,
+				Descendants:  3,
 				Children: []*Node{
 					nil, nil, nil,
 					{},

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -185,7 +185,7 @@ func getFromDBAtNode(db chaindb.Database, n *Node, key []byte) (
 	value []byte, err error) {
 	if n.Kind() == node.Leaf {
 		if bytes.Equal(n.PartialKey, key) {
-			return n.SubValue, nil
+			return n.StorageValue, nil
 		}
 		return nil, nil
 	}
@@ -193,7 +193,7 @@ func getFromDBAtNode(db chaindb.Database, n *Node, key []byte) (
 	branch := n
 	// Key is equal to the key of this branch or is empty
 	if len(key) == 0 || bytes.Equal(branch.PartialKey, key) {
-		return branch.SubValue, nil
+		return branch.StorageValue, nil
 	}
 
 	commonPrefixLength := lenCommonPrefix(branch.PartialKey, key)

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -187,7 +187,7 @@ func Test_PopulateNodeHashes(t *testing.T) {
 			},
 		},
 		"leaf node without Merkle value": {
-			node:       &Node{PartialKey: []byte{1}, SubValue: []byte{2}},
+			node:       &Node{PartialKey: []byte{1}, StorageValue: []byte{2}},
 			panicValue: "node with partial key 0x01 has no Merkle value computed",
 		},
 		"inlined branch node": {

--- a/lib/trie/genesis_test.go
+++ b/lib/trie/genesis_test.go
@@ -37,8 +37,8 @@ func Test_Trie_GenesisBlock(t *testing.T) {
 		"non empty trie": {
 			trie: Trie{
 				root: &node.Node{
-					PartialKey: []byte{1, 2, 3},
-					SubValue:   []byte{4, 5, 6},
+					PartialKey:   []byte{1, 2, 3},
+					StorageValue: []byte{4, 5, 6},
 				},
 			},
 			genesisHeader: withHash(types.Header{

--- a/lib/trie/print_test.go
+++ b/lib/trie/print_test.go
@@ -22,9 +22,9 @@ func Test_Trie_String(t *testing.T) {
 		"leaf root": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{1, 2, 3},
-					SubValue:   []byte{3, 4, 5},
-					Generation: 1,
+					PartialKey:   []byte{1, 2, 3},
+					StorageValue: []byte{3, 4, 5},
+					Generation:   1,
 				},
 			},
 			s: `Leaf
@@ -37,20 +37,20 @@ func Test_Trie_String(t *testing.T) {
 		"branch root": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  nil,
-					SubValue:    []byte{1, 2},
-					Descendants: 2,
+					PartialKey:   nil,
+					StorageValue: []byte{1, 2},
+					Descendants:  2,
 					Children: []*Node{
 						{
-							PartialKey: []byte{1, 2, 3},
-							SubValue:   []byte{3, 4, 5},
-							Generation: 2,
+							PartialKey:   []byte{1, 2, 3},
+							StorageValue: []byte{3, 4, 5},
+							Generation:   2,
 						},
 						nil, nil,
 						{
-							PartialKey: []byte{1, 2, 3},
-							SubValue:   []byte{3, 4, 5},
-							Generation: 3,
+							PartialKey:   []byte{1, 2, 3},
+							StorageValue: []byte{3, 4, 5},
+							Generation:   3,
 						},
 					},
 				},

--- a/lib/trie/print_test.go
+++ b/lib/trie/print_test.go
@@ -31,7 +31,7 @@ func Test_Trie_String(t *testing.T) {
 ├── Generation: 1
 ├── Dirty: false
 ├── Key: 0x010203
-├── Value: 0x030405
+├── Storage value: 0x030405
 └── Merkle value: nil`,
 		},
 		"branch root": {
@@ -59,7 +59,7 @@ func Test_Trie_String(t *testing.T) {
 ├── Generation: 0
 ├── Dirty: false
 ├── Key: nil
-├── Value: 0x0102
+├── Storage value: 0x0102
 ├── Descendants: 2
 ├── Merkle value: nil
 ├── Child 0
@@ -67,14 +67,14 @@ func Test_Trie_String(t *testing.T) {
 |       ├── Generation: 2
 |       ├── Dirty: false
 |       ├── Key: 0x010203
-|       ├── Value: 0x030405
+|       ├── Storage value: 0x030405
 |       └── Merkle value: nil
 └── Child 3
     └── Leaf
         ├── Generation: 3
         ├── Dirty: false
         ├── Key: 0x010203
-        ├── Value: 0x030405
+        ├── Storage value: 0x030405
         └── Merkle value: nil`,
 		},
 	}

--- a/lib/trie/proof/generate_test.go
+++ b/lib/trie/proof/generate_test.go
@@ -26,7 +26,7 @@ func Test_Generate(t *testing.T) {
 	}
 
 	largeValue := generateBytes(t, 50)
-	assertLongEncoding(t, node.Node{SubValue: largeValue})
+	assertLongEncoding(t, node.Node{StorageValue: largeValue})
 
 	testCases := map[string]struct {
 		rootHash          []byte
@@ -56,8 +56,8 @@ func Test_Generate(t *testing.T) {
 			databaseBuilder: func(ctrl *gomock.Controller) Database {
 				mockDatabase := NewMockDatabase(ctrl)
 				encodedRoot := encodeNode(t, node.Node{
-					PartialKey: []byte{1},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1},
+					StorageValue: []byte{2},
 				})
 				mockDatabase.EXPECT().Get(someHash).
 					Return(encodedRoot, nil)
@@ -72,8 +72,8 @@ func Test_Generate(t *testing.T) {
 			databaseBuilder: func(ctrl *gomock.Controller) Database {
 				mockDatabase := NewMockDatabase(ctrl)
 				encodedRoot := encodeNode(t, node.Node{
-					PartialKey: []byte{1},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1},
+					StorageValue: []byte{2},
 				})
 				mockDatabase.EXPECT().Get(someHash).
 					Return(encodedRoot, nil)
@@ -81,8 +81,8 @@ func Test_Generate(t *testing.T) {
 			},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1},
+					StorageValue: []byte{2},
 				}),
 			},
 		},
@@ -92,13 +92,13 @@ func Test_Generate(t *testing.T) {
 			databaseBuilder: func(ctrl *gomock.Controller) Database {
 				mockDatabase := NewMockDatabase(ctrl)
 				encodedRoot := encodeNode(t, node.Node{
-					PartialKey: []byte{1},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1},
+					StorageValue: []byte{2},
 					Children: padRightChildren([]*node.Node{
 						nil, nil,
 						{
-							PartialKey: []byte{3},
-							SubValue:   []byte{4},
+							PartialKey:   []byte{3},
+							StorageValue: []byte{4},
 						},
 					}),
 				})
@@ -108,13 +108,13 @@ func Test_Generate(t *testing.T) {
 			},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1},
+					StorageValue: []byte{2},
 					Children: padRightChildren([]*node.Node{
 						nil, nil,
 						{
-							PartialKey: []byte{3},
-							SubValue:   []byte{4},
+							PartialKey:   []byte{3},
+							StorageValue: []byte{4},
 						},
 					}),
 				}),
@@ -129,13 +129,13 @@ func Test_Generate(t *testing.T) {
 				mockDatabase := NewMockDatabase(ctrl)
 
 				rootNode := node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{2},
 					Children: padRightChildren([]*node.Node{
 						nil, nil, nil,
 						{ // full key 1, 2, 3, 4
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 					}),
 				}
@@ -151,19 +151,19 @@ func Test_Generate(t *testing.T) {
 			},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{2},
 					Children: padRightChildren([]*node.Node{
 						nil, nil, nil,
 						{
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 					}),
 				}),
 				encodeNode(t, node.Node{
-					PartialKey: []byte{4},
-					SubValue:   largeValue,
+					PartialKey:   []byte{4},
+					StorageValue: largeValue,
 				}),
 			},
 		},
@@ -178,21 +178,21 @@ func Test_Generate(t *testing.T) {
 				mockDatabase := NewMockDatabase(ctrl)
 
 				rootNode := node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{2},
 					Children: padRightChildren([]*node.Node{
 						nil, nil, nil,
 						{ // full key 1, 2, 3, 4
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 						{ // full key 1, 2, 4, 4
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 						{ // full key 1, 2, 5, 5
-							PartialKey: []byte{5},
-							SubValue:   largeValue,
+							PartialKey:   []byte{5},
+							StorageValue: largeValue,
 						},
 					}),
 				}
@@ -212,31 +212,31 @@ func Test_Generate(t *testing.T) {
 			},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{2},
 					Children: padRightChildren([]*node.Node{
 						nil, nil, nil,
 						{ // full key 1, 2, 3, 4
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 						{ // full key 1, 2, 4, 4
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 						{ // full key 1, 2, 5, 5
-							PartialKey: []byte{5},
-							SubValue:   largeValue,
+							PartialKey:   []byte{5},
+							StorageValue: largeValue,
 						},
 					}),
 				}),
 				encodeNode(t, node.Node{
-					PartialKey: []byte{4},
-					SubValue:   largeValue,
+					PartialKey:   []byte{4},
+					StorageValue: largeValue,
 				}),
 				encodeNode(t, node.Node{
-					PartialKey: []byte{5},
-					SubValue:   largeValue,
+					PartialKey:   []byte{5},
+					StorageValue: largeValue,
 				}),
 			},
 		},
@@ -270,7 +270,7 @@ func Test_walkRoot(t *testing.T) {
 	t.Parallel()
 
 	largeValue := generateBytes(t, 40)
-	assertLongEncoding(t, node.Node{SubValue: largeValue})
+	assertLongEncoding(t, node.Node{StorageValue: largeValue})
 
 	testCases := map[string]struct {
 		parent            *node.Node
@@ -289,18 +289,18 @@ func Test_walkRoot(t *testing.T) {
 		// since it can only be caused by a buffer.Write error.
 		"parent leaf and empty full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			encodedProofNodes: [][]byte{encodeNode(t, node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			})},
 		},
 		"parent leaf and shorter full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			fullKey:    []byte{1},
 			errWrapped: ErrKeyNotFound,
@@ -308,8 +308,8 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"parent leaf and mismatching full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			fullKey:    []byte{1, 3},
 			errWrapped: ErrKeyNotFound,
@@ -317,8 +317,8 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"parent leaf and longer full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			fullKey:    []byte{1, 2, 3},
 			errWrapped: ErrKeyNotFound,
@@ -326,23 +326,23 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"branch and empty search key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{
-							PartialKey: []byte{4},
-							SubValue:   []byte{5},
+							PartialKey:   []byte{4},
+							StorageValue: []byte{5},
 						},
 					}),
 				}),
@@ -350,12 +350,12 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"branch and shorter full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
@@ -365,12 +365,12 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"branch and mismatching full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
@@ -380,24 +380,24 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"branch and matching search key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
 			fullKey: []byte{1, 2},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{
-							PartialKey: []byte{4},
-							SubValue:   []byte{5},
+							PartialKey:   []byte{4},
+							StorageValue: []byte{5},
 						},
 					}),
 				}),
@@ -405,24 +405,24 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"branch and matching search key for small leaf encoding": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{ // full key 1, 2, 0, 1, 2
-						PartialKey: []byte{1, 2},
-						SubValue:   []byte{3},
+						PartialKey:   []byte{1, 2},
+						StorageValue: []byte{3},
 					},
 				}),
 			},
 			fullKey: []byte{1, 2, 0, 1, 2},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{ // full key 1, 2, 0, 1, 2
-							PartialKey: []byte{1, 2},
-							SubValue:   []byte{3},
+							PartialKey:   []byte{1, 2},
+							StorageValue: []byte{3},
 						},
 					}),
 				}),
@@ -432,41 +432,41 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"branch and matching search key for large leaf encoding": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{ // full key 1, 2, 0, 1, 2
-						PartialKey: []byte{1, 2},
-						SubValue:   largeValue,
+						PartialKey:   []byte{1, 2},
+						StorageValue: largeValue,
 					},
 				}),
 			},
 			fullKey: []byte{1, 2, 0, 1, 2},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{ // full key 1, 2, 0, 1, 2
-							PartialKey: []byte{1, 2},
-							SubValue:   largeValue,
+							PartialKey:   []byte{1, 2},
+							StorageValue: largeValue,
 						},
 					}),
 				}),
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   largeValue,
+					PartialKey:   []byte{1, 2},
+					StorageValue: largeValue,
 				}),
 			},
 		},
 		"key not found at deeper level": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4, 5},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4, 5},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
@@ -476,24 +476,24 @@ func Test_walkRoot(t *testing.T) {
 		},
 		"found leaf at deeper level": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
 			fullKey: []byte{1, 2, 0x04},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{
-							PartialKey: []byte{4},
-							SubValue:   []byte{5},
+							PartialKey:   []byte{4},
+							StorageValue: []byte{5},
 						},
 					}),
 				}),
@@ -521,7 +521,7 @@ func Test_walk(t *testing.T) {
 	t.Parallel()
 
 	largeValue := generateBytes(t, 40)
-	assertLongEncoding(t, node.Node{SubValue: largeValue})
+	assertLongEncoding(t, node.Node{StorageValue: largeValue})
 
 	testCases := map[string]struct {
 		parent            *node.Node
@@ -540,18 +540,18 @@ func Test_walk(t *testing.T) {
 		// since it can only be caused by a buffer.Write error.
 		"parent leaf and empty full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   largeValue,
+				PartialKey:   []byte{1, 2},
+				StorageValue: largeValue,
 			},
 			encodedProofNodes: [][]byte{encodeNode(t, node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   largeValue,
+				PartialKey:   []byte{1, 2},
+				StorageValue: largeValue,
 			})},
 		},
 		"parent leaf and shorter full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			fullKey:    []byte{1},
 			errWrapped: ErrKeyNotFound,
@@ -559,8 +559,8 @@ func Test_walk(t *testing.T) {
 		},
 		"parent leaf and mismatching full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			fullKey:    []byte{1, 3},
 			errWrapped: ErrKeyNotFound,
@@ -568,8 +568,8 @@ func Test_walk(t *testing.T) {
 		},
 		"parent leaf and longer full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			fullKey:    []byte{1, 2, 3},
 			errWrapped: ErrKeyNotFound,
@@ -577,23 +577,23 @@ func Test_walk(t *testing.T) {
 		},
 		"branch and empty search key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   largeValue,
+				PartialKey:   []byte{1, 2},
+				StorageValue: largeValue,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   largeValue,
+					PartialKey:   []byte{1, 2},
+					StorageValue: largeValue,
 					Children: padRightChildren([]*node.Node{
 						{
-							PartialKey: []byte{4},
-							SubValue:   []byte{5},
+							PartialKey:   []byte{4},
+							StorageValue: []byte{5},
 						},
 					}),
 				}),
@@ -601,12 +601,12 @@ func Test_walk(t *testing.T) {
 		},
 		"branch and shorter full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
@@ -616,12 +616,12 @@ func Test_walk(t *testing.T) {
 		},
 		"branch and mismatching full key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
@@ -631,24 +631,24 @@ func Test_walk(t *testing.T) {
 		},
 		"branch and matching search key": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   largeValue,
+						PartialKey:   []byte{4},
+						StorageValue: largeValue,
 					},
 				}),
 			},
 			fullKey: []byte{1, 2},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 					}),
 				}),
@@ -656,24 +656,24 @@ func Test_walk(t *testing.T) {
 		},
 		"branch and matching search key for small leaf encoding": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   largeValue,
+				PartialKey:   []byte{1, 2},
+				StorageValue: largeValue,
 				Children: padRightChildren([]*node.Node{
 					{ // full key 1, 2, 0, 1, 2
-						PartialKey: []byte{1, 2},
-						SubValue:   []byte{3},
+						PartialKey:   []byte{1, 2},
+						StorageValue: []byte{3},
 					},
 				}),
 			},
 			fullKey: []byte{1, 2, 0, 1, 2},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   largeValue,
+					PartialKey:   []byte{1, 2},
+					StorageValue: largeValue,
 					Children: padRightChildren([]*node.Node{
 						{ // full key 1, 2, 0, 1, 2
-							PartialKey: []byte{1, 2},
-							SubValue:   []byte{3},
+							PartialKey:   []byte{1, 2},
+							StorageValue: []byte{3},
 						},
 					}),
 				}),
@@ -683,41 +683,41 @@ func Test_walk(t *testing.T) {
 		},
 		"branch and matching search key for large leaf encoding": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{ // full key 1, 2, 0, 1, 2
-						PartialKey: []byte{1, 2},
-						SubValue:   largeValue,
+						PartialKey:   []byte{1, 2},
+						StorageValue: largeValue,
 					},
 				}),
 			},
 			fullKey: []byte{1, 2, 0, 1, 2},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{ // full key 1, 2, 0, 1, 2
-							PartialKey: []byte{1, 2},
-							SubValue:   largeValue,
+							PartialKey:   []byte{1, 2},
+							StorageValue: largeValue,
 						},
 					}),
 				}),
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   largeValue,
+					PartialKey:   []byte{1, 2},
+					StorageValue: largeValue,
 				}),
 			},
 		},
 		"key not found at deeper level": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4, 5},
-						SubValue:   []byte{5},
+						PartialKey:   []byte{4, 5},
+						StorageValue: []byte{5},
 					},
 				}),
 			},
@@ -727,24 +727,24 @@ func Test_walk(t *testing.T) {
 		},
 		"found leaf at deeper level": {
 			parent: &node.Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{3},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{3},
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{4},
-						SubValue:   largeValue,
+						PartialKey:   []byte{4},
+						StorageValue: largeValue,
 					},
 				}),
 			},
 			fullKey: []byte{1, 2, 0x04},
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1, 2},
-					SubValue:   []byte{3},
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{3},
 					Children: padRightChildren([]*node.Node{
 						{
-							PartialKey: []byte{4},
-							SubValue:   largeValue,
+							PartialKey:   []byte{4},
+							StorageValue: largeValue,
 						},
 					}),
 				}),

--- a/lib/trie/proof/verify.go
+++ b/lib/trie/proof/verify.go
@@ -138,7 +138,7 @@ func loadProof(digestToEncoding map[string][]byte, n *node.Node) (err error) {
 		merkleValue := child.MerkleValue
 		encoding, ok := digestToEncoding[string(merkleValue)]
 		if !ok {
-			inlinedChild := len(child.SubValue) > 0 || child.HasChild()
+			inlinedChild := len(child.StorageValue) > 0 || child.HasChild()
 			if inlinedChild {
 				// The built proof trie is not used with a database, but just in case
 				// it becomes used with a database in the future, we set the dirty flag

--- a/lib/trie/proof/verify_test.go
+++ b/lib/trie/proof/verify_test.go
@@ -16,20 +16,20 @@ func Test_Verify(t *testing.T) {
 	t.Parallel()
 
 	leafA := node.Node{
-		PartialKey: []byte{1},
-		SubValue:   []byte{1},
+		PartialKey:   []byte{1},
+		StorageValue: []byte{1},
 	}
 
 	// leafB is a leaf encoding to more than 32 bytes
 	leafB := node.Node{
-		PartialKey: []byte{2},
-		SubValue:   generateBytes(t, 40),
+		PartialKey:   []byte{2},
+		StorageValue: generateBytes(t, 40),
 	}
 	assertLongEncoding(t, leafB)
 
 	branch := node.Node{
-		PartialKey: []byte{3, 4},
-		SubValue:   []byte{1},
+		PartialKey:   []byte{3, 4},
+		StorageValue: []byte{1},
 		Children: padRightChildren([]*node.Node{
 			&leafB,
 			nil,
@@ -119,20 +119,20 @@ func Test_buildTrie(t *testing.T) {
 	t.Parallel()
 
 	leafAShort := node.Node{
-		PartialKey: []byte{1},
-		SubValue:   []byte{2},
+		PartialKey:   []byte{1},
+		StorageValue: []byte{2},
 	}
 	assertShortEncoding(t, leafAShort)
 
 	leafBLarge := node.Node{
-		PartialKey: []byte{2},
-		SubValue:   generateBytes(t, 40),
+		PartialKey:   []byte{2},
+		StorageValue: generateBytes(t, 40),
 	}
 	assertLongEncoding(t, leafBLarge)
 
 	leafCLarge := node.Node{
-		PartialKey: []byte{3},
-		SubValue:   generateBytes(t, 40),
+		PartialKey:   []byte{3},
+		StorageValue: generateBytes(t, 40),
 	}
 	assertLongEncoding(t, leafCLarge)
 
@@ -164,9 +164,9 @@ func Test_buildTrie(t *testing.T) {
 			},
 			rootHash: blake2bNode(t, leafAShort),
 			expectedTrie: trie.NewTrie(&node.Node{
-				PartialKey: leafAShort.PartialKey,
-				SubValue:   leafAShort.SubValue,
-				Dirty:      true,
+				PartialKey:   leafAShort.PartialKey,
+				StorageValue: leafAShort.StorageValue,
+				Dirty:        true,
 			}),
 		},
 		"root proof encoding larger than 32 bytes": {
@@ -175,9 +175,9 @@ func Test_buildTrie(t *testing.T) {
 			},
 			rootHash: blake2bNode(t, leafBLarge),
 			expectedTrie: trie.NewTrie(&node.Node{
-				PartialKey: leafBLarge.PartialKey,
-				SubValue:   leafBLarge.SubValue,
-				Dirty:      true,
+				PartialKey:   leafBLarge.PartialKey,
+				StorageValue: leafBLarge.StorageValue,
+				Dirty:        true,
 			}),
 		},
 		"discard unused node": {
@@ -187,9 +187,9 @@ func Test_buildTrie(t *testing.T) {
 			},
 			rootHash: blake2bNode(t, leafAShort),
 			expectedTrie: trie.NewTrie(&node.Node{
-				PartialKey: leafAShort.PartialKey,
-				SubValue:   leafAShort.SubValue,
-				Dirty:      true,
+				PartialKey:   leafAShort.PartialKey,
+				StorageValue: leafAShort.StorageValue,
+				Dirty:        true,
 			}),
 		},
 		"multiple unordered nodes": {
@@ -221,24 +221,24 @@ func Test_buildTrie(t *testing.T) {
 				Dirty:       true,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: leafAShort.PartialKey,
-						SubValue:   leafAShort.SubValue,
-						Dirty:      true,
+						PartialKey:   leafAShort.PartialKey,
+						StorageValue: leafAShort.StorageValue,
+						Dirty:        true,
 					},
 					{
-						PartialKey: leafBLarge.PartialKey,
-						SubValue:   leafBLarge.SubValue,
-						Dirty:      true,
+						PartialKey:   leafBLarge.PartialKey,
+						StorageValue: leafBLarge.StorageValue,
+						Dirty:        true,
 					},
 					{
-						PartialKey: leafCLarge.PartialKey,
-						SubValue:   leafCLarge.SubValue,
-						Dirty:      true,
+						PartialKey:   leafCLarge.PartialKey,
+						StorageValue: leafCLarge.StorageValue,
+						Dirty:        true,
 					},
 					{
-						PartialKey: leafBLarge.PartialKey,
-						SubValue:   leafBLarge.SubValue,
-						Dirty:      true,
+						PartialKey:   leafBLarge.PartialKey,
+						StorageValue: leafBLarge.StorageValue,
+						Dirty:        true,
 					},
 				}),
 			}),
@@ -269,8 +269,8 @@ func Test_buildTrie(t *testing.T) {
 		"root not found": {
 			encodedProofNodes: [][]byte{
 				encodeNode(t, node.Node{
-					PartialKey: []byte{1},
-					SubValue:   []byte{2},
+					PartialKey:   []byte{1},
+					StorageValue: []byte{2},
 				}),
 			},
 			rootHash:   []byte{3},
@@ -308,8 +308,8 @@ func Test_loadProof(t *testing.T) {
 	largeValue := generateBytes(t, 40)
 
 	leafLarge := node.Node{
-		PartialKey: []byte{3},
-		SubValue:   largeValue,
+		PartialKey:   []byte{3},
+		StorageValue: largeValue,
 	}
 	assertLongEncoding(t, leafLarge)
 
@@ -322,67 +322,67 @@ func Test_loadProof(t *testing.T) {
 	}{
 		"leaf node": {
 			node: &node.Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			expectedNode: &node.Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 		},
 		"branch node with child hash not found": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{3}},
 				}),
 			},
 			merkleValueToEncoding: map[string][]byte{},
 			expectedNode: &node.Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
-				Dirty:      true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Dirty:        true,
 			},
 		},
 		"branch node with child hash found": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}},
 				}),
 			},
 			merkleValueToEncoding: map[string][]byte{
 				string([]byte{2}): encodeNode(t, node.Node{
-					PartialKey: []byte{3},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{3},
+					StorageValue: []byte{1},
 				}),
 			},
 			expectedNode: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{3},
-						SubValue:   []byte{1},
-						Dirty:      true,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Dirty:        true,
 					},
 				}),
 			},
 		},
 		"branch node with one child hash found and one not found": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 2,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  2,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}}, // found
 					{MerkleValue: []byte{3}}, // not found
@@ -390,59 +390,59 @@ func Test_loadProof(t *testing.T) {
 			},
 			merkleValueToEncoding: map[string][]byte{
 				string([]byte{2}): encodeNode(t, node.Node{
-					PartialKey: []byte{3},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{3},
+					StorageValue: []byte{1},
 				}),
 			},
 			expectedNode: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey: []byte{3},
-						SubValue:   []byte{1},
-						Dirty:      true,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Dirty:        true,
 					},
 				}),
 			},
 		},
 		"branch node with branch child hash": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 2,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  2,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}},
 				}),
 			},
 			merkleValueToEncoding: map[string][]byte{
 				string([]byte{2}): encodeNode(t, node.Node{
-					PartialKey: []byte{3},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{3},
+					StorageValue: []byte{1},
 					Children: padRightChildren([]*node.Node{
-						{PartialKey: []byte{4}, SubValue: []byte{2}},
+						{PartialKey: []byte{4}, StorageValue: []byte{2}},
 					}),
 				}),
 			},
 			expectedNode: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 3,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  3,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey:  []byte{3},
-						SubValue:    []byte{1},
-						Dirty:       true,
-						Descendants: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Dirty:        true,
+						Descendants:  1,
 						Children: padRightChildren([]*node.Node{
 							{
-								PartialKey: []byte{4},
-								SubValue:   []byte{2},
-								Dirty:      true,
+								PartialKey:   []byte{4},
+								StorageValue: []byte{2},
+								Dirty:        true,
 							},
 						}),
 					},
@@ -451,10 +451,10 @@ func Test_loadProof(t *testing.T) {
 		},
 		"child decoding error": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}},
 				}),
@@ -463,10 +463,10 @@ func Test_loadProof(t *testing.T) {
 				string([]byte{2}): getBadNodeEncoding(),
 			},
 			expectedNode: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}},
 				}),
@@ -478,20 +478,20 @@ func Test_loadProof(t *testing.T) {
 		},
 		"grand child": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}},
 				}),
 			},
 			merkleValueToEncoding: map[string][]byte{
 				string([]byte{2}): encodeNode(t, node.Node{
-					PartialKey:  []byte{2},
-					SubValue:    []byte{2},
-					Descendants: 1,
-					Dirty:       true,
+					PartialKey:   []byte{2},
+					StorageValue: []byte{2},
+					Descendants:  1,
+					Dirty:        true,
 					Children: padRightChildren([]*node.Node{
 						&leafLarge, // encoded to hash
 					}),
@@ -499,21 +499,21 @@ func Test_loadProof(t *testing.T) {
 				string(blake2bNode(t, leafLarge)): encodeNode(t, leafLarge),
 			},
 			expectedNode: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey:  []byte{2},
-						SubValue:    []byte{2},
-						Descendants: 1,
-						Dirty:       true,
+						PartialKey:   []byte{2},
+						StorageValue: []byte{2},
+						Descendants:  1,
+						Dirty:        true,
 						Children: padRightChildren([]*node.Node{
 							{
-								PartialKey: leafLarge.PartialKey,
-								SubValue:   leafLarge.SubValue,
-								Dirty:      true,
+								PartialKey:   leafLarge.PartialKey,
+								StorageValue: leafLarge.StorageValue,
+								Dirty:        true,
 							},
 						}),
 					},
@@ -523,20 +523,20 @@ func Test_loadProof(t *testing.T) {
 
 		"grand child load proof error": {
 			node: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{MerkleValue: []byte{2}},
 				}),
 			},
 			merkleValueToEncoding: map[string][]byte{
 				string([]byte{2}): encodeNode(t, node.Node{
-					PartialKey:  []byte{2},
-					SubValue:    []byte{2},
-					Descendants: 1,
-					Dirty:       true,
+					PartialKey:   []byte{2},
+					StorageValue: []byte{2},
+					Descendants:  1,
+					Dirty:        true,
 					Children: padRightChildren([]*node.Node{
 						&leafLarge, // encoded to hash
 					}),
@@ -544,16 +544,16 @@ func Test_loadProof(t *testing.T) {
 				string(blake2bNode(t, leafLarge)): getBadNodeEncoding(),
 			},
 			expectedNode: &node.Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
-				Dirty:       true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
+				Dirty:        true,
 				Children: padRightChildren([]*node.Node{
 					{
-						PartialKey:  []byte{2},
-						SubValue:    []byte{2},
-						Descendants: 1,
-						Dirty:       true,
+						PartialKey:   []byte{2},
+						StorageValue: []byte{2},
+						Descendants:  1,
+						Dirty:        true,
 						Children: padRightChildren([]*node.Node{
 							{
 								MerkleValue: blake2bNode(t, leafLarge),

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -376,7 +376,7 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 		}
 
 		copySettings := node.DefaultCopySettings
-		copySettings.CopyValue = false
+		copySettings.CopyStorageValue = false
 		parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
 		parentLeaf.StorageValue = value
 		mutated = true
@@ -1037,7 +1037,7 @@ func (t *Trie) deleteBranch(branch *Node, key []byte,
 	newParent *Node, deleted bool, nodesRemoved uint32) {
 	if len(key) == 0 || bytes.Equal(branch.PartialKey, key) {
 		copySettings := node.DefaultCopySettings
-		copySettings.CopyValue = false
+		copySettings.CopyStorageValue = false
 		branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
 		// we need to set to nil if the branch has the same generation
 		// as the current trie.

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -210,15 +210,15 @@ func entries(parent *Node, prefix []byte, kv map[string][]byte) map[string][]byt
 		parentKey := parent.PartialKey
 		fullKeyNibbles := concatenateSlices(prefix, parentKey)
 		keyLE := string(codec.NibblesToKeyLE(fullKeyNibbles))
-		kv[keyLE] = parent.SubValue
+		kv[keyLE] = parent.StorageValue
 		return kv
 	}
 
 	branch := parent
-	if branch.SubValue != nil {
+	if branch.StorageValue != nil {
 		fullKeyNibbles := concatenateSlices(prefix, branch.PartialKey)
 		keyLE := string(codec.NibblesToKeyLE(fullKeyNibbles))
-		kv[keyLE] = branch.SubValue
+		kv[keyLE] = branch.StorageValue
 	}
 
 	for i, child := range branch.Children {
@@ -285,7 +285,7 @@ func findNextKeyBranch(parentBranch *Node, prefix, searchKey []byte) (nextKey []
 	}
 
 	// search key is smaller than full key
-	if parentBranch.SubValue != nil {
+	if parentBranch.StorageValue != nil {
 		return fullKey
 	}
 	const startChildIndex = 0
@@ -350,10 +350,10 @@ func (t *Trie) insert(parent *Node, key, value []byte,
 		mutated = true
 		nodesCreated = 1
 		return &Node{
-			PartialKey: key,
-			SubValue:   value,
-			Generation: t.generation,
-			Dirty:      true,
+			PartialKey:   key,
+			StorageValue: value,
+			Generation:   t.generation,
+			Dirty:        true,
 		}, mutated, nodesCreated
 	}
 
@@ -370,7 +370,7 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 	newParent *Node, mutated bool, nodesCreated uint32) {
 	if bytes.Equal(parentLeaf.PartialKey, key) {
 		nodesCreated = 0
-		if bytes.Equal(parentLeaf.SubValue, value) {
+		if bytes.Equal(parentLeaf.StorageValue, value) {
 			mutated = false
 			return parentLeaf, mutated, nodesCreated
 		}
@@ -378,7 +378,7 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 		copySettings := node.DefaultCopySettings
 		copySettings.CopyValue = false
 		parentLeaf = t.prepLeafForMutation(parentLeaf, copySettings, deletedMerkleValues)
-		parentLeaf.SubValue = value
+		parentLeaf.StorageValue = value
 		mutated = true
 		return parentLeaf, mutated, nodesCreated
 	}
@@ -397,7 +397,7 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 
 	if len(key) == commonPrefixLength {
 		// key is included in parent leaf key
-		newBranchParent.SubValue = value
+		newBranchParent.StorageValue = value
 
 		if len(key) < len(parentLeafKey) {
 			// Move the current leaf parent as a child to the new branch.
@@ -418,7 +418,7 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 
 	if len(parentLeaf.PartialKey) == commonPrefixLength {
 		// the key of the parent leaf is at this new branch
-		newBranchParent.SubValue = parentLeaf.SubValue
+		newBranchParent.StorageValue = parentLeaf.StorageValue
 	} else {
 		// make the leaf a child of the new branch
 		copySettings := node.DefaultCopySettings
@@ -434,10 +434,10 @@ func (t *Trie) insertInLeaf(parentLeaf *Node, key, value []byte,
 	}
 	childIndex := key[commonPrefixLength]
 	newBranchParent.Children[childIndex] = &Node{
-		PartialKey: key[commonPrefixLength+1:],
-		SubValue:   value,
-		Generation: t.generation,
-		Dirty:      true,
+		PartialKey:   key[commonPrefixLength+1:],
+		StorageValue: value,
+		Generation:   t.generation,
+		Dirty:        true,
 	}
 	newBranchParent.Descendants++
 	nodesCreated++
@@ -451,12 +451,12 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 	copySettings := node.DefaultCopySettings
 
 	if bytes.Equal(key, parentBranch.PartialKey) {
-		if bytes.Equal(parentBranch.SubValue, value) {
+		if bytes.Equal(parentBranch.StorageValue, value) {
 			mutated = false
 			return parentBranch, mutated, 0
 		}
 		parentBranch = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
-		parentBranch.SubValue = value
+		parentBranch.StorageValue = value
 		mutated = true
 		return parentBranch, mutated, 0
 	}
@@ -470,10 +470,10 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 
 		if child == nil {
 			child = &Node{
-				PartialKey: remainingKey,
-				SubValue:   value,
-				Generation: t.generation,
-				Dirty:      true,
+				PartialKey:   remainingKey,
+				StorageValue: value,
+				Generation:   t.generation,
+				Dirty:        true,
 			}
 			nodesCreated = 1
 			parentBranch = t.prepBranchForMutation(parentBranch, copySettings, deletedMerkleValues)
@@ -516,7 +516,7 @@ func (t *Trie) insertInBranch(parentBranch *Node, key, value []byte,
 	newParentBranch.Descendants += 1 + parentBranch.Descendants
 
 	if len(key) <= commonPrefixLength {
-		newParentBranch.SubValue = value
+		newParentBranch.StorageValue = value
 	} else {
 		childIndex := key[commonPrefixLength]
 		remainingKey := key[commonPrefixLength+1:]
@@ -635,7 +635,7 @@ func addAllKeys(parent *Node, prefix []byte, keysLE [][]byte) (newKeysLE [][]byt
 		return keysLE
 	}
 
-	if parent.SubValue != nil {
+	if parent.StorageValue != nil {
 		keyLE := makeFullKeyLE(prefix, parent.PartialKey)
 		keysLE = append(keysLE, keyLE)
 	}
@@ -681,14 +681,14 @@ func retrieve(parent *Node, key []byte) (value []byte) {
 
 func retrieveFromLeaf(leaf *Node, key []byte) (value []byte) {
 	if bytes.Equal(leaf.PartialKey, key) {
-		return leaf.SubValue
+		return leaf.StorageValue
 	}
 	return nil
 }
 
 func retrieveFromBranch(branch *Node, key []byte) (value []byte) {
 	if len(key) == 0 || bytes.Equal(branch.PartialKey, key) {
-		return branch.SubValue
+		return branch.StorageValue
 	}
 
 	if len(branch.PartialKey) > len(key) && bytes.HasPrefix(branch.PartialKey, key) {
@@ -884,7 +884,7 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 		}
 
 		if nilChildren == node.ChildrenCapacity &&
-			branch.SubValue == nil {
+			branch.StorageValue == nil {
 			return nil, valuesDeleted, nodesRemoved
 		}
 
@@ -894,7 +894,7 @@ func (t *Trie) deleteNodesLimit(parent *Node, limit uint32,
 	}
 
 	nodesRemoved++
-	if branch.SubValue != nil {
+	if branch.StorageValue != nil {
 		valuesDeleted++
 	}
 
@@ -1041,7 +1041,7 @@ func (t *Trie) deleteBranch(branch *Node, key []byte,
 		branch = t.prepBranchForMutation(branch, copySettings, deletedMerkleValues)
 		// we need to set to nil if the branch has the same generation
 		// as the current trie.
-		branch.SubValue = nil
+		branch.StorageValue = nil
 		deleted = true
 		var branchChildMerged bool
 		newParent, branchChildMerged = handleDeletion(branch, key)
@@ -1102,16 +1102,16 @@ func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged 
 	default:
 		const branchChildMerged = false
 		return branch, branchChildMerged
-	case childrenCount == 0 && branch.SubValue != nil:
+	case childrenCount == 0 && branch.StorageValue != nil:
 		const branchChildMerged = false
 		commonPrefixLength := lenCommonPrefix(branch.PartialKey, key)
 		return &Node{
-			PartialKey: key[:commonPrefixLength],
-			SubValue:   branch.SubValue,
-			Dirty:      true,
-			Generation: branch.Generation,
+			PartialKey:   key[:commonPrefixLength],
+			StorageValue: branch.StorageValue,
+			Dirty:        true,
+			Generation:   branch.Generation,
 		}, branchChildMerged
-	case childrenCount == 1 && branch.SubValue == nil:
+	case childrenCount == 1 && branch.StorageValue == nil:
 		const branchChildMerged = true
 		childIndex := firstChildIndex
 		child := branch.Children[firstChildIndex]
@@ -1119,21 +1119,21 @@ func handleDeletion(branch *Node, key []byte) (newNode *Node, branchChildMerged 
 		if child.Kind() == node.Leaf {
 			newLeafKey := concatenateSlices(branch.PartialKey, intToByteSlice(childIndex), child.PartialKey)
 			return &Node{
-				PartialKey: newLeafKey,
-				SubValue:   child.SubValue,
-				Dirty:      true,
-				Generation: branch.Generation,
+				PartialKey:   newLeafKey,
+				StorageValue: child.StorageValue,
+				Dirty:        true,
+				Generation:   branch.Generation,
 			}, branchChildMerged
 		}
 
 		childBranch := child
 		newBranchKey := concatenateSlices(branch.PartialKey, intToByteSlice(childIndex), childBranch.PartialKey)
 		newBranch := &Node{
-			PartialKey: newBranchKey,
-			SubValue:   childBranch.SubValue,
-			Generation: branch.Generation,
-			Children:   make([]*node.Node, node.ChildrenCapacity),
-			Dirty:      true,
+			PartialKey:   newBranchKey,
+			StorageValue: childBranch.StorageValue,
+			Generation:   branch.Generation,
+			Children:     make([]*node.Node, node.ChildrenCapacity),
+			Dirty:        true,
 			// this is the descendants of the original branch minus one
 			Descendants: childBranch.Descendants,
 		}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -333,10 +333,10 @@ func (t *Trie) Put(keyLE, value []byte) {
 
 func (t *Trie) insertKeyLE(keyLE, value []byte, deletedMerkleValues map[string]struct{}) {
 	nibblesKey := codec.KeyLEToNibbles(keyLE)
-	if len(value) == 0 {
-		// Force value to be inserted to nil since we don't
-		// differentiate between nil and empty values.
-		value = nil
+	if value == nil {
+		// Force nil value to be inserted to []byte{} since `nil` means there
+		// is no value.
+		value = []byte{}
 	}
 	t.root, _, _ = t.insert(t.root, nibblesKey, value, deletedMerkleValues)
 }

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -517,10 +517,10 @@ func TestClearPrefix_Small(t *testing.T) {
 	ssTrie.ClearPrefix([]byte("noo"))
 
 	expectedRoot := &Node{
-		PartialKey: codec.KeyLEToNibbles([]byte("other")),
-		SubValue:   []byte("other"),
-		Generation: 1,
-		Dirty:      true,
+		PartialKey:   codec.KeyLEToNibbles([]byte("other")),
+		StorageValue: []byte("other"),
+		Generation:   1,
+		Dirty:        true,
 	}
 	require.Equal(t, expectedRoot, ssTrie.root)
 

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -106,11 +106,7 @@ func Fuzz_Trie_PutAndGet_Single(f *testing.F) {
 		trie := NewEmptyTrie()
 		trie.Put(key, value)
 		retrievedValue := trie.Get(key)
-		if retrievedValue == nil {
-			assert.Empty(t, value)
-		} else {
-			assert.Equal(t, value, retrievedValue)
-		}
+		assert.Equal(t, value, retrievedValue)
 	})
 }
 

--- a/lib/trie/trie_test.go
+++ b/lib/trie/trie_test.go
@@ -38,13 +38,13 @@ func Test_NewEmptyTrie(t *testing.T) {
 
 func Test_NewTrie(t *testing.T) {
 	root := &Node{
-		PartialKey: []byte{0},
-		SubValue:   []byte{17},
+		PartialKey:   []byte{0},
+		StorageValue: []byte{17},
 	}
 	expectedTrie := &Trie{
 		root: &Node{
-			PartialKey: []byte{0},
-			SubValue:   []byte{17},
+			PartialKey:   []byte{0},
+			StorageValue: []byte{17},
 		},
 		childTries:          make(map[common.Hash]*Trie),
 		deletedMerkleValues: map[string]struct{}{},
@@ -58,18 +58,18 @@ func Test_Trie_Snapshot(t *testing.T) {
 
 	trie := &Trie{
 		generation: 8,
-		root:       &Node{PartialKey: []byte{8}, SubValue: []byte{1}},
+		root:       &Node{PartialKey: []byte{8}, StorageValue: []byte{1}},
 		childTries: map[common.Hash]*Trie{
 			{1}: {
 				generation: 1,
-				root:       &Node{PartialKey: []byte{1}, SubValue: []byte{1}},
+				root:       &Node{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				deletedMerkleValues: map[string]struct{}{
 					"a": {},
 				},
 			},
 			{2}: {
 				generation: 2,
-				root:       &Node{PartialKey: []byte{2}, SubValue: []byte{1}},
+				root:       &Node{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				deletedMerkleValues: map[string]struct{}{
 					"b": {},
 				},
@@ -83,16 +83,16 @@ func Test_Trie_Snapshot(t *testing.T) {
 
 	expectedTrie := &Trie{
 		generation: 9,
-		root:       &Node{PartialKey: []byte{8}, SubValue: []byte{1}},
+		root:       &Node{PartialKey: []byte{8}, StorageValue: []byte{1}},
 		childTries: map[common.Hash]*Trie{
 			{1}: {
 				generation:          2,
-				root:                &Node{PartialKey: []byte{1}, SubValue: []byte{1}},
+				root:                &Node{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				deletedMerkleValues: map[string]struct{}{},
 			},
 			{2}: {
 				generation:          3,
-				root:                &Node{PartialKey: []byte{2}, SubValue: []byte{1}},
+				root:                &Node{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				deletedMerkleValues: map[string]struct{}{},
 			},
 		},
@@ -231,11 +231,11 @@ func Test_Trie_DeepCopy(t *testing.T) {
 		"filled trie": {
 			trieOriginal: &Trie{
 				generation: 1,
-				root:       &Node{PartialKey: []byte{1, 2}, SubValue: []byte{1}},
+				root:       &Node{PartialKey: []byte{1, 2}, StorageValue: []byte{1}},
 				childTries: map[common.Hash]*Trie{
 					{1, 2, 3}: {
 						generation: 2,
-						root:       &Node{PartialKey: []byte{1}, SubValue: []byte{1}},
+						root:       &Node{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						deletedMerkleValues: map[string]struct{}{
 							"a": {},
 							"b": {},
@@ -249,11 +249,11 @@ func Test_Trie_DeepCopy(t *testing.T) {
 			},
 			trieCopy: &Trie{
 				generation: 1,
-				root:       &Node{PartialKey: []byte{1, 2}, SubValue: []byte{1}},
+				root:       &Node{PartialKey: []byte{1, 2}, StorageValue: []byte{1}},
 				childTries: map[common.Hash]*Trie{
 					{1, 2, 3}: {
 						generation: 2,
-						root:       &Node{PartialKey: []byte{1}, SubValue: []byte{1}},
+						root:       &Node{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						deletedMerkleValues: map[string]struct{}{
 							"a": {},
 							"b": {},
@@ -287,13 +287,13 @@ func Test_Trie_RootNode(t *testing.T) {
 
 	trie := Trie{
 		root: &Node{
-			PartialKey: []byte{1, 2, 3},
-			SubValue:   []byte{1},
+			PartialKey:   []byte{1, 2, 3},
+			StorageValue: []byte{1},
 		},
 	}
 	expectedRoot := &Node{
-		PartialKey: []byte{1, 2, 3},
-		SubValue:   []byte{1},
+		PartialKey:   []byte{1, 2, 3},
+		StorageValue: []byte{1},
 	}
 
 	root := trie.RootNode()
@@ -340,8 +340,8 @@ func Test_Trie_Hash(t *testing.T) {
 		"leaf root": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{1, 2, 3},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{1, 2, 3},
+					StorageValue: []byte{1},
 				},
 			},
 			hash: common.Hash{
@@ -351,8 +351,8 @@ func Test_Trie_Hash(t *testing.T) {
 				0xa1, 0xd8, 0xa2, 0x29, 0x4e, 0x4a, 0xd9, 0xa3},
 			expectedTrie: Trie{
 				root: &Node{
-					PartialKey: []byte{1, 2, 3},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{1, 2, 3},
+					StorageValue: []byte{1},
 					MerkleValue: []byte{
 						0xa8, 0x13, 0x7c, 0xee, 0xb4, 0xad, 0xea, 0xac,
 						0x9e, 0x5b, 0x37, 0xe2, 0x8e, 0x7d, 0x64, 0x78,
@@ -365,11 +365,11 @@ func Test_Trie_Hash(t *testing.T) {
 		"branch root": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{1, 2, 3},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{1, 2, 3},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
-						{PartialKey: []byte{9}, SubValue: []byte{1}},
+						{PartialKey: []byte{9}, StorageValue: []byte{1}},
 					}),
 				},
 			},
@@ -380,8 +380,8 @@ func Test_Trie_Hash(t *testing.T) {
 				0xf0, 0xe, 0xd3, 0x39, 0x48, 0x21, 0xe3, 0xdd},
 			expectedTrie: Trie{
 				root: &Node{
-					PartialKey: []byte{1, 2, 3},
-					SubValue:   []byte("branch"),
+					PartialKey:   []byte{1, 2, 3},
+					StorageValue: []byte("branch"),
 					MerkleValue: []byte{
 						0xaa, 0x7e, 0x57, 0x48, 0xb0, 0x27, 0x4d, 0x18,
 						0xf5, 0x1c, 0xfd, 0x36, 0x4c, 0x4b, 0x56, 0x4a,
@@ -391,9 +391,9 @@ func Test_Trie_Hash(t *testing.T) {
 					Descendants: 1,
 					Children: padRightChildren([]*Node{
 						{
-							PartialKey:  []byte{9},
-							SubValue:    []byte{1},
-							MerkleValue: []byte{0x41, 0x09, 0x04, 0x01},
+							PartialKey:   []byte{9},
+							StorageValue: []byte{1},
+							MerkleValue:  []byte{0x41, 0x09, 0x04, 0x01},
 						},
 					}),
 				},
@@ -452,18 +452,18 @@ func Test_Trie_Entries(t *testing.T) {
 		t.Parallel()
 
 		root := &Node{
-			PartialKey:  []byte{0xa},
-			SubValue:    []byte("root"),
-			Descendants: 2,
+			PartialKey:   []byte{0xa},
+			StorageValue: []byte("root"),
+			Descendants:  2,
 			Children: padRightChildren([]*Node{
 				{ // index 0
-					PartialKey: []byte{2, 0xb},
-					SubValue:   []byte("leaf"),
+					PartialKey:   []byte{2, 0xb},
+					StorageValue: []byte("leaf"),
 				},
 				nil,
 				{ // index 2
-					PartialKey: []byte{0xb},
-					SubValue:   []byte("leaf"),
+					PartialKey:   []byte{0xb},
+					StorageValue: []byte("leaf"),
 				},
 			}),
 		}
@@ -485,37 +485,37 @@ func Test_Trie_Entries(t *testing.T) {
 		t.Parallel()
 
 		root := &Node{
-			PartialKey:  []byte{0xa, 0xb},
-			SubValue:    []byte("root"),
-			Descendants: 5,
+			PartialKey:   []byte{0xa, 0xb},
+			StorageValue: []byte("root"),
+			Descendants:  5,
 			Children: padRightChildren([]*Node{
 				nil, nil, nil,
 				{ // branch with value at child index 3
-					PartialKey:  []byte{0xb},
-					SubValue:    []byte("branch 1"),
-					Descendants: 1,
+					PartialKey:   []byte{0xb},
+					StorageValue: []byte("branch 1"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						nil, nil, nil,
 						{ // leaf at child index 3
-							PartialKey: []byte{0xc},
-							SubValue:   []byte("bottom leaf"),
+							PartialKey:   []byte{0xc},
+							StorageValue: []byte("bottom leaf"),
 						},
 					}),
 				},
 				nil, nil, nil,
 				{ // leaf at child index 7
-					PartialKey: []byte{0xd},
-					SubValue:   []byte("top leaf"),
+					PartialKey:   []byte{0xd},
+					StorageValue: []byte("top leaf"),
 				},
 				nil,
 				{ // branch without value at child index 9
-					PartialKey:  []byte{0xe},
-					SubValue:    []byte("branch 2"),
-					Descendants: 1,
+					PartialKey:   []byte{0xe},
+					StorageValue: []byte("branch 2"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						{ // leaf at child index 0
-							PartialKey: []byte{0xf},
-							SubValue:   []byte("bottom leaf 2"),
+							PartialKey:   []byte{0xf},
+							StorageValue: []byte("bottom leaf 2"),
 						}, nil, nil,
 					}),
 				},
@@ -578,8 +578,8 @@ func Test_Trie_NextKey(t *testing.T) {
 		"nil key returns root leaf": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{2},
+					StorageValue: []byte{1},
 				},
 			},
 			nextKey: []byte{2},
@@ -587,8 +587,8 @@ func Test_Trie_NextKey(t *testing.T) {
 		"key smaller than root leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{2},
+					StorageValue: []byte{1},
 				},
 			},
 			key:     []byte{0x10}, // 10 => [1, 0] in nibbles
@@ -626,8 +626,8 @@ func Test_nextKey(t *testing.T) {
 		"nil key returns root leaf": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{2},
+					StorageValue: []byte{1},
 				},
 			},
 			nextKey: []byte{2},
@@ -635,8 +635,8 @@ func Test_nextKey(t *testing.T) {
 		"key smaller than root leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{2},
+					StorageValue: []byte{1},
 				},
 			},
 			key:     []byte{1},
@@ -645,8 +645,8 @@ func Test_nextKey(t *testing.T) {
 		"key equal to root leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{2},
+					StorageValue: []byte{1},
 				},
 			},
 			key: []byte{2},
@@ -654,8 +654,8 @@ func Test_nextKey(t *testing.T) {
 		"key greater than root leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{2},
+					StorageValue: []byte{1},
 				},
 			},
 			key: []byte{3},
@@ -663,13 +663,13 @@ func Test_nextKey(t *testing.T) {
 		"key smaller than root branch full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{2},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{2},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						{
-							PartialKey: []byte{1},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{1},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -680,13 +680,13 @@ func Test_nextKey(t *testing.T) {
 		"key equal to root branch full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{2},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{2},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						{
-							PartialKey: []byte{1},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{1},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -696,15 +696,15 @@ func Test_nextKey(t *testing.T) {
 		"key smaller than leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{1},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{1},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						nil, nil,
 						{
 							// full key [1, 2, 3]
-							PartialKey: []byte{3},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{3},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -715,15 +715,15 @@ func Test_nextKey(t *testing.T) {
 		"key equal to leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{1},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{1},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						nil, nil,
 						{
 							// full key [1, 2, 3]
-							PartialKey: []byte{3},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{3},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -733,15 +733,15 @@ func Test_nextKey(t *testing.T) {
 		"key greater than leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{1},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{1},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						nil, nil,
 						{
 							// full key [1, 2, 3]
-							PartialKey: []byte{3},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{3},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -751,22 +751,22 @@ func Test_nextKey(t *testing.T) {
 		"next key branch with value": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{1},
-					SubValue:    []byte("top branch"),
-					Descendants: 2,
+					PartialKey:   []byte{1},
+					StorageValue: []byte("top branch"),
+					Descendants:  2,
 					Children: padRightChildren([]*Node{
 						nil, nil,
 						{
 							// full key [1, 2, 3]
-							PartialKey:  []byte{3},
-							SubValue:    []byte("branch 1"),
-							Descendants: 1,
+							PartialKey:   []byte{3},
+							StorageValue: []byte("branch 1"),
+							Descendants:  1,
 							Children: padRightChildren([]*Node{
 								nil, nil, nil, nil,
 								{
 									// full key [1, 2, 3, 4, 5]
-									PartialKey: []byte{0x5},
-									SubValue:   []byte("bottom leaf"),
+									PartialKey:   []byte{0x5},
+									StorageValue: []byte("bottom leaf"),
 								},
 							}),
 						},
@@ -791,8 +791,8 @@ func Test_nextKey(t *testing.T) {
 								nil, nil, nil, nil,
 								{
 									// full key [1, 2, 3, 4, 5]
-									PartialKey: []byte{0x5},
-									SubValue:   []byte("bottom leaf"),
+									PartialKey:   []byte{0x5},
+									StorageValue: []byte("bottom leaf"),
 								},
 							}),
 						},
@@ -811,15 +811,15 @@ func Test_nextKey(t *testing.T) {
 						nil, nil,
 						{
 							// full key [1, 2, 3]
-							PartialKey:  []byte{3},
-							SubValue:    []byte("bottom branch"),
-							Descendants: 1,
+							PartialKey:   []byte{3},
+							StorageValue: []byte("bottom branch"),
+							Descendants:  1,
 							Children: padRightChildren([]*Node{
 								nil, nil, nil, nil,
 								{
 									// full key [1, 2, 3, 4, 5]
-									PartialKey: []byte{0x5},
-									SubValue:   []byte("bottom leaf"),
+									PartialKey:   []byte{0x5},
+									StorageValue: []byte("bottom leaf"),
 								},
 							}),
 						},
@@ -838,15 +838,15 @@ func Test_nextKey(t *testing.T) {
 						nil, nil,
 						{
 							// full key [1, 2, 3]
-							PartialKey:  []byte{3},
-							SubValue:    []byte("bottom branch"),
-							Descendants: 1,
+							PartialKey:   []byte{3},
+							StorageValue: []byte("bottom branch"),
+							Descendants:  1,
 							Children: padRightChildren([]*Node{
 								nil, nil, nil, nil,
 								{
 									// full key [1, 2, 3, 4, 5]
-									PartialKey: []byte{0x5},
-									SubValue:   []byte("bottom leaf"),
+									PartialKey:   []byte{0x5},
+									StorageValue: []byte("bottom leaf"),
 								},
 							}),
 						},
@@ -859,11 +859,11 @@ func Test_nextKey(t *testing.T) {
 		"key smaller length and greater than root branch full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{2, 0},
-					SubValue:    []byte("branch"),
-					Descendants: 1,
+					PartialKey:   []byte{2, 0},
+					StorageValue: []byte("branch"),
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
-						{PartialKey: []byte{1}, SubValue: []byte{1}},
+						{PartialKey: []byte{1}, StorageValue: []byte{1}},
 					}),
 				},
 			},
@@ -872,8 +872,8 @@ func Test_nextKey(t *testing.T) {
 		"key smaller length and greater than root leaf full key": {
 			trie: Trie{
 				root: &Node{
-					PartialKey: []byte{2, 0},
-					SubValue:   []byte("leaf"),
+					PartialKey:   []byte{2, 0},
+					StorageValue: []byte("leaf"),
 				},
 			},
 			key: []byte{3},
@@ -908,8 +908,8 @@ func Test_Trie_Put(t *testing.T) {
 			trie: Trie{
 				generation: 1,
 				root: &Node{
-					PartialKey: []byte{1, 2, 0, 5},
-					SubValue:   []byte{1},
+					PartialKey:   []byte{1, 2, 0, 5},
+					StorageValue: []byte{1},
 				},
 			},
 			key:   []byte{0x12, 0x16},
@@ -923,16 +923,16 @@ func Test_Trie_Put(t *testing.T) {
 					Descendants: 2,
 					Children: padRightChildren([]*Node{
 						{
-							PartialKey: []byte{5},
-							SubValue:   []byte{1},
-							Generation: 1,
-							Dirty:      true,
+							PartialKey:   []byte{5},
+							StorageValue: []byte{1},
+							Generation:   1,
+							Dirty:        true,
 						},
 						{
-							PartialKey: []byte{6},
-							SubValue:   []byte{2},
-							Generation: 1,
-							Dirty:      true,
+							PartialKey:   []byte{6},
+							StorageValue: []byte{2},
+							Generation:   1,
+							Dirty:        true,
 						},
 					}),
 				},
@@ -973,10 +973,10 @@ func Test_Trie_insert(t *testing.T) {
 			key:   []byte{1},
 			value: []byte("leaf"),
 			newNode: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("leaf"),
-				Generation: 1,
-				Dirty:      true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("leaf"),
+				Generation:   1,
+				Dirty:        true,
 			},
 			mutated:      true,
 			nodesCreated: 1,
@@ -986,30 +986,30 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte("branch"),
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("branch"),
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{1, 0},
 			value: []byte("leaf"),
 			newNode: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte("branch"),
-				Generation:  1,
-				Dirty:       true,
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("branch"),
+				Generation:   1,
+				Dirty:        true,
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					{
-						PartialKey: []byte{},
-						SubValue:   []byte("leaf"),
-						Generation: 1,
-						Dirty:      true,
+						PartialKey:   []byte{},
+						StorageValue: []byte("leaf"),
+						Generation:   1,
+						Dirty:        true,
 					},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			mutated:      true,
@@ -1020,16 +1020,16 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("original leaf"),
+				PartialKey:   []byte{1},
+				StorageValue: []byte("original leaf"),
 			},
 			key:   []byte{1},
 			value: []byte("new leaf"),
 			newNode: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("new leaf"),
-				Generation: 1,
-				Dirty:      true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("new leaf"),
+				Generation:   1,
+				Dirty:        true,
 			},
 			mutated: true,
 		},
@@ -1038,14 +1038,14 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("same"),
+				PartialKey:   []byte{1},
+				StorageValue: []byte("same"),
 			},
 			key:   []byte{1},
 			value: []byte("same"),
 			newNode: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("same"),
+				PartialKey:   []byte{1},
+				StorageValue: []byte("same"),
 			},
 		},
 		"write leaf as child to parent leaf": {
@@ -1053,23 +1053,23 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("original leaf"),
+				PartialKey:   []byte{1},
+				StorageValue: []byte("original leaf"),
 			},
 			key:   []byte{1, 0},
 			value: []byte("leaf"),
 			newNode: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte("original leaf"),
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("original leaf"),
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{
-						PartialKey: []byte{},
-						SubValue:   []byte("leaf"),
-						Generation: 1,
-						Dirty:      true,
+						PartialKey:   []byte{},
+						StorageValue: []byte("leaf"),
+						Generation:   1,
+						Dirty:        true,
 					},
 				}),
 			},
@@ -1081,8 +1081,8 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte("original leaf"),
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte("original leaf"),
 			},
 			key:   []byte{2, 3},
 			value: []byte("leaf"),
@@ -1094,16 +1094,16 @@ func Test_Trie_insert(t *testing.T) {
 				Children: padRightChildren([]*Node{
 					nil,
 					{
-						PartialKey: []byte{2},
-						SubValue:   []byte("original leaf"),
-						Dirty:      true,
-						Generation: 1,
+						PartialKey:   []byte{2},
+						StorageValue: []byte("original leaf"),
+						Dirty:        true,
+						Generation:   1,
 					},
 					{
-						PartialKey: []byte{3},
-						SubValue:   []byte("leaf"),
-						Generation: 1,
-						Dirty:      true,
+						PartialKey:   []byte{3},
+						StorageValue: []byte("leaf"),
+						Generation:   1,
+						Dirty:        true,
 					},
 				}),
 			},
@@ -1115,16 +1115,16 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			key:   []byte{1},
 			value: []byte("leaf"),
 			newNode: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte("leaf"),
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("leaf"),
+				Dirty:        true,
+				Generation:   1,
 			},
 			mutated: true,
 		},
@@ -1133,24 +1133,24 @@ func Test_Trie_insert(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			key:   []byte{1},
 			value: []byte("leaf"),
 			newNode: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte("leaf"),
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte("leaf"),
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					nil, nil,
 					{
-						PartialKey: []byte{},
-						SubValue:   []byte{1},
-						Dirty:      true,
-						Generation: 1,
+						PartialKey:   []byte{},
+						StorageValue: []byte{1},
+						Dirty:        true,
+						Generation:   1,
 					},
 				}),
 			},
@@ -1193,91 +1193,91 @@ func Test_Trie_insertInBranch(t *testing.T) {
 	}{
 		"insert existing value to branch": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte("same"),
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte("same"),
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{2},
 			value: []byte("same"),
 			newNode: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte("same"),
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte("same"),
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 		},
 		"update with branch": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte("old"),
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte("old"),
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{2},
 			value: []byte("new"),
 			newNode: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte("new"),
-				Dirty:       true,
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte("new"),
+				Dirty:        true,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			mutated: true,
 		},
 		"update with leaf": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte("old"),
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte("old"),
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{2},
 			value: []byte("new"),
 			newNode: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte("new"),
-				Dirty:       true,
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte("new"),
+				Dirty:        true,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			mutated: true,
 		},
 		"add leaf as direct child": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{2, 3, 4, 5},
 			value: []byte{6},
 			newNode: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Dirty:       true,
-				Descendants: 2,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Dirty:        true,
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 					nil, nil,
 					{
-						PartialKey: []byte{4, 5},
-						SubValue:   []byte{6},
-						Dirty:      true,
+						PartialKey:   []byte{4, 5},
+						StorageValue: []byte{6},
+						Dirty:        true,
 					},
 				}),
 			},
@@ -1286,36 +1286,36 @@ func Test_Trie_insertInBranch(t *testing.T) {
 		},
 		"insert same leaf as existing direct child leaf": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{2, 0, 1},
 			value: []byte{1},
 			newNode: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 		},
 		"add leaf as nested child": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Descendants: 2,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					nil, nil, nil,
 					{
 						PartialKey:  []byte{4},
 						Descendants: 1,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{1}, SubValue: []byte{1}},
+							{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						}),
 					},
 				}),
@@ -1323,10 +1323,10 @@ func Test_Trie_insertInBranch(t *testing.T) {
 			key:   []byte{2, 3, 4, 5, 6},
 			value: []byte{6},
 			newNode: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Dirty:       true,
-				Descendants: 3,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Dirty:        true,
+				Descendants:  3,
 				Children: padRightChildren([]*Node{
 					nil, nil, nil,
 					{
@@ -1334,12 +1334,12 @@ func Test_Trie_insertInBranch(t *testing.T) {
 						Dirty:       true,
 						Descendants: 2,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{1}, SubValue: []byte{1}},
+							{PartialKey: []byte{1}, StorageValue: []byte{1}},
 							nil, nil, nil, nil,
 							{
-								PartialKey: []byte{6},
-								SubValue:   []byte{6},
-								Dirty:      true,
+								PartialKey:   []byte{6},
+								StorageValue: []byte{6},
+								Dirty:        true,
 							},
 						}),
 					},
@@ -1350,11 +1350,11 @@ func Test_Trie_insertInBranch(t *testing.T) {
 		},
 		"split branch for longer key": {
 			parent: &Node{
-				PartialKey:  []byte{2, 3},
-				SubValue:    []byte{5},
-				Descendants: 1,
+				PartialKey:   []byte{2, 3},
+				StorageValue: []byte{5},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{2, 4, 5, 6},
@@ -1366,18 +1366,18 @@ func Test_Trie_insertInBranch(t *testing.T) {
 				Children: padRightChildren([]*Node{
 					nil, nil, nil,
 					{
-						PartialKey:  []byte{},
-						SubValue:    []byte{5},
-						Dirty:       true,
-						Descendants: 1,
+						PartialKey:   []byte{},
+						StorageValue: []byte{5},
+						Dirty:        true,
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{1}, SubValue: []byte{1}},
+							{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						}),
 					},
 					{
-						PartialKey: []byte{5, 6},
-						SubValue:   []byte{6},
-						Dirty:      true,
+						PartialKey:   []byte{5, 6},
+						StorageValue: []byte{6},
+						Dirty:        true,
 					},
 				}),
 			},
@@ -1386,11 +1386,11 @@ func Test_Trie_insertInBranch(t *testing.T) {
 		},
 		"split root branch": {
 			parent: &Node{
-				PartialKey:  []byte{2, 3},
-				SubValue:    []byte{5},
-				Descendants: 1,
+				PartialKey:   []byte{2, 3},
+				StorageValue: []byte{5},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{3},
@@ -1402,18 +1402,18 @@ func Test_Trie_insertInBranch(t *testing.T) {
 				Children: padRightChildren([]*Node{
 					nil, nil,
 					{
-						PartialKey:  []byte{3},
-						SubValue:    []byte{5},
-						Dirty:       true,
-						Descendants: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{5},
+						Dirty:        true,
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{1}, SubValue: []byte{1}},
+							{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						}),
 					},
 					{
-						PartialKey: []byte{},
-						SubValue:   []byte{6},
-						Dirty:      true,
+						PartialKey:   []byte{},
+						StorageValue: []byte{6},
+						Dirty:        true,
 					},
 				}),
 			},
@@ -1422,29 +1422,29 @@ func Test_Trie_insertInBranch(t *testing.T) {
 		},
 		"update with leaf at empty key": {
 			parent: &Node{
-				PartialKey:  []byte{2},
-				SubValue:    []byte{5},
-				Descendants: 1,
+				PartialKey:   []byte{2},
+				StorageValue: []byte{5},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{},
 			value: []byte{6},
 			newNode: &Node{
-				PartialKey:  []byte{},
-				SubValue:    []byte{6},
-				Dirty:       true,
-				Descendants: 2,
+				PartialKey:   []byte{},
+				StorageValue: []byte{6},
+				Dirty:        true,
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					nil, nil,
 					{
-						PartialKey:  []byte{},
-						SubValue:    []byte{5},
-						Dirty:       true,
-						Descendants: 1,
+						PartialKey:   []byte{},
+						StorageValue: []byte{5},
+						Dirty:        true,
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{1}, SubValue: []byte{1}},
+							{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						}),
 					},
 				}),
@@ -1516,7 +1516,7 @@ func Test_LoadFromMap(t *testing.T) {
 			expectedTrie: Trie{
 				root: &Node{
 					PartialKey: []byte{00, 01},
-					SubValue: []byte{
+					StorageValue: []byte{
 						0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78,
 						0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78,
 						0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78,
@@ -1536,21 +1536,21 @@ func Test_LoadFromMap(t *testing.T) {
 			},
 			expectedTrie: Trie{
 				root: &Node{
-					PartialKey:  []byte{00, 01},
-					SubValue:    []byte{6},
-					Dirty:       true,
-					Descendants: 2,
+					PartialKey:   []byte{00, 01},
+					StorageValue: []byte{6},
+					Dirty:        true,
+					Descendants:  2,
 					Children: padRightChildren([]*Node{
 						nil, nil,
 						{
-							PartialKey: []byte{0},
-							SubValue:   []byte{7},
-							Dirty:      true,
+							PartialKey:   []byte{0},
+							StorageValue: []byte{7},
+							Dirty:        true,
 						},
 						{
-							PartialKey: []byte{0},
-							SubValue:   []byte{8},
-							Dirty:      true,
+							PartialKey:   []byte{0},
+							StorageValue: []byte{8},
+							Dirty:        true,
 						},
 					}),
 				},
@@ -1596,18 +1596,18 @@ func Test_Trie_GetKeysWithPrefix(t *testing.T) {
 							Descendants: 2,
 							Children: padRightChildren([]*Node{
 								{ // full key 0, 1, 0, 0, 4
-									PartialKey: []byte{4},
-									SubValue:   []byte{1},
+									PartialKey:   []byte{4},
+									StorageValue: []byte{1},
 								},
 								{ // full key 0, 1, 0, 1, 5
-									PartialKey: []byte{5},
-									SubValue:   []byte{1},
+									PartialKey:   []byte{5},
+									StorageValue: []byte{1},
 								},
 							}),
 						},
 						{ // full key 0, 1, 1, 9
-							PartialKey: []byte{9},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{9},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -1652,8 +1652,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 				PartialKey:  []byte{1, 2, 3},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{9, 8, 7},
@@ -1668,8 +1668,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 				PartialKey:  []byte{1, 2, 3},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{9, 8, 7},
@@ -1684,8 +1684,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 				PartialKey:  []byte{1, 2, 3},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			key:          []byte{1, 3},
@@ -1697,8 +1697,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 				PartialKey:  []byte{1, 2},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			key:          []byte{1, 2, 3},
@@ -1710,8 +1710,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 				PartialKey:  []byte{1, 2, 3},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{9, 8, 7},
@@ -1722,8 +1722,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 		},
 		"parent leaf with search key equal to common prefix": {
 			parent: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{9, 8, 7},
 			key:    []byte{1, 2, 3},
@@ -1733,8 +1733,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 		},
 		"parent leaf with empty search key": {
 			parent: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{9, 8, 7},
 			key:    []byte{},
@@ -1744,8 +1744,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 		},
 		"parent leaf with too deep search key": {
 			parent: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			prefix:       []byte{9, 8, 7},
 			key:          []byte{1, 2, 3, 4},
@@ -1754,8 +1754,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 		},
 		"parent leaf with shorter matching search key": {
 			parent: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{9, 8, 7},
 			key:    []byte{1, 2},
@@ -1765,8 +1765,8 @@ func Test_getKeysWithPrefix(t *testing.T) {
 		},
 		"parent leaf with not matching search key": {
 			parent: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			prefix:       []byte{9, 8, 7},
 			key:          []byte{1, 3, 3},
@@ -1803,8 +1803,8 @@ func Test_addAllKeys(t *testing.T) {
 		},
 		"leaf parent": {
 			parent: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{9, 8, 7},
 			keys:   [][]byte{{1}, {2}},
@@ -1816,8 +1816,8 @@ func Test_addAllKeys(t *testing.T) {
 				PartialKey:  []byte{1, 2, 3},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{9, 8, 7},
@@ -1828,12 +1828,12 @@ func Test_addAllKeys(t *testing.T) {
 		},
 		"parent branch with empty value": {
 			parent: &Node{
-				PartialKey:  []byte{1, 2, 3},
-				SubValue:    []byte{},
-				Descendants: 2,
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
-					{PartialKey: []byte{5}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
+					{PartialKey: []byte{5}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{9, 8, 7},
@@ -1869,21 +1869,21 @@ func Test_Trie_Get(t *testing.T) {
 		"some trie": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{0, 1},
-					SubValue:    []byte{1, 3},
-					Descendants: 3,
+					PartialKey:   []byte{0, 1},
+					StorageValue: []byte{1, 3},
+					Descendants:  3,
 					Children: padRightChildren([]*Node{
 						{ // full key 0, 1, 0, 3
-							PartialKey:  []byte{3},
-							SubValue:    []byte{1, 2},
-							Descendants: 1,
+							PartialKey:   []byte{3},
+							StorageValue: []byte{1, 2},
+							Descendants:  1,
 							Children: padRightChildren([]*Node{
-								{PartialKey: []byte{1}, SubValue: []byte{1}},
+								{PartialKey: []byte{1}, StorageValue: []byte{1}},
 							}),
 						},
 						{ // full key 0, 1, 1, 9
-							PartialKey: []byte{9},
-							SubValue:   []byte{1, 2, 3, 4, 5},
+							PartialKey:   []byte{9},
+							StorageValue: []byte{1, 2, 3, 4, 5},
 						},
 					}),
 				},
@@ -1918,26 +1918,26 @@ func Test_retrieve(t *testing.T) {
 		},
 		"leaf key match": {
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
 			},
 			key:   []byte{1},
 			value: []byte{2},
 		},
 		"leaf key mismatch": {
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{2},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{2},
 			},
 			key: []byte{1},
 		},
 		"branch key match": {
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key:   []byte{1},
@@ -1945,42 +1945,42 @@ func Test_retrieve(t *testing.T) {
 		},
 		"branch key with empty search key": {
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{2},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{2},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			value: []byte{2},
 		},
 		"branch key mismatch with shorter search key": {
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{2},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{2},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			key: []byte{1},
 		},
 		"bottom leaf in branch": {
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					nil, nil,
 					{ // full key 1, 2, 3
-						PartialKey:  []byte{3},
-						SubValue:    []byte{2},
-						Descendants: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{2},
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
 							nil, nil, nil, nil,
 							{ // full key 1, 2, 3, 4, 5
-								PartialKey: []byte{5},
-								SubValue:   []byte{3},
+								PartialKey:   []byte{5},
+								StorageValue: []byte{3},
 							},
 						}),
 					},
@@ -2026,14 +2026,14 @@ func Test_Trie_ClearPrefixLimit(t *testing.T) {
 		"clear prefix limit": {
 			trie: Trie{
 				root: &Node{
-					PartialKey:  []byte{1, 2},
-					SubValue:    []byte{1},
-					Descendants: 1,
+					PartialKey:   []byte{1, 2},
+					StorageValue: []byte{1},
+					Descendants:  1,
 					Children: padRightChildren([]*Node{
 						nil, nil, nil,
 						{
-							PartialKey: []byte{4},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{4},
+							StorageValue: []byte{1},
 						},
 					}),
 				},
@@ -2084,8 +2084,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 		},
 		"leaf parent with common prefix": {
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			prefix:        []byte{1},
 			limit:         1,
@@ -2095,8 +2095,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 		},
 		"leaf parent with key equal prefix": {
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			prefix:        []byte{1},
 			limit:         1,
@@ -2109,14 +2109,14 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{1, 3},
 			limit:  1,
 			newParent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			allDeleted: true,
 		},
@@ -2125,14 +2125,14 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{1, 2},
 			limit:  1,
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			allDeleted: true,
 		},
@@ -2141,8 +2141,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1, 2},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix:        []byte{1},
@@ -2156,8 +2156,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1, 2},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix:        []byte{1, 2},
@@ -2174,8 +2174,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1, 2},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 3},
@@ -2184,8 +2184,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1, 2},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			allDeleted: true,
@@ -2198,8 +2198,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 2, 3},
@@ -2208,8 +2208,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			allDeleted: true,
@@ -2222,8 +2222,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 2},
@@ -2232,19 +2232,19 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			allDeleted: true,
 		},
 		"branch with value with common prefix": {
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix:        []byte{1},
@@ -2255,11 +2255,11 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 		},
 		"branch with value with key equal prefix": {
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix:        []byte{1, 2},
@@ -2273,21 +2273,21 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 3},
 			limit:  1,
 			newParent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			allDeleted: true,
@@ -2297,21 +2297,21 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 2, 3},
 			limit:  1,
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			allDeleted: true,
@@ -2321,21 +2321,21 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 2},
 			limit:  1,
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 				}),
 			},
 			allDeleted: true,
@@ -2345,25 +2345,25 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1},
 			limit:  1,
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			valuesDeleted: 1,
@@ -2371,19 +2371,19 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 		},
 		"delete only child of branch": {
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0},
 			limit:  1,
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
-				Dirty:      true,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
 			},
 			valuesDeleted: 1,
 			nodesRemoved:  1,
@@ -2394,21 +2394,21 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1},
 			limit:  2,
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			valuesDeleted: 2,
 			nodesRemoved:  2,
@@ -2418,8 +2418,8 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix:        []byte{1},
@@ -2433,45 +2433,45 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 3,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  3,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 3
-						PartialKey:  []byte{3},
-						SubValue:    []byte{1},
-						Descendants: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
 							{ // full key 1, 0, 3, 0, 5
-								PartialKey: []byte{5},
-								SubValue:   []byte{1},
+								PartialKey:   []byte{5},
+								StorageValue: []byte{1},
 							},
 						}),
 					},
 					{
-						PartialKey: []byte{6},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{6},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
 			prefix: []byte{1, 0},
 			limit:  1,
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 3
-						PartialKey: []byte{3},
-						SubValue:   []byte{1},
-						Dirty:      true,
-						Generation: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Dirty:        true,
+						Generation:   1,
 					},
 					{
-						PartialKey: []byte{6},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{6},
+						StorageValue: []byte{1},
 						// Not modified so same generation as before
 					},
 				}),
@@ -2484,16 +2484,16 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey:  []byte{2},
-						SubValue:    []byte{1},
-						Descendants: 1,
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{1}, SubValue: []byte{1}},
+							{PartialKey: []byte{1}, StorageValue: []byte{1}},
 						}),
 					},
 				}),
@@ -2501,10 +2501,10 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 			prefix: []byte{1, 0, 2},
 			limit:  2,
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			valuesDeleted: 2,
 			nodesRemoved:  2,
@@ -2518,17 +2518,17 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0, 3},
 			limit:  3,
 			newParent: &Node{
-				PartialKey: []byte{1, 1, 4},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 1, 4},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			valuesDeleted: 1,
 			nodesRemoved:  2,
@@ -2542,17 +2542,17 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0},
 			limit:  3,
 			newParent: &Node{
-				PartialKey: []byte{1, 1, 4},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 1, 4},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			valuesDeleted: 1,
 			nodesRemoved:  2,
@@ -2563,20 +2563,20 @@ func Test_Trie_clearPrefixLimitAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
 				}),
 			},
 		},
@@ -2620,12 +2620,12 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			newNode: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 		},
 		"nil parent": {
@@ -2633,7 +2633,7 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 		},
 		"delete leaf": {
 			parent: &Node{
-				SubValue: []byte{1},
+				StorageValue: []byte{1},
 			},
 			limit:         2,
 			valuesDeleted: 1,
@@ -2653,9 +2653,9 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 		},
 		"delete branch with value": {
 			parent: &Node{
-				PartialKey:  []byte{3},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{3},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -2669,8 +2669,8 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 				PartialKey:  []byte{3},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			limit:         10,
@@ -2682,24 +2682,24 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{3},
-				SubValue:    []byte{1, 2, 3},
-				Descendants: 2,
+				PartialKey:   []byte{3},
+				StorageValue: []byte{1, 2, 3},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			limit: 1,
 			newNode: &Node{
-				PartialKey:  []byte{3},
-				SubValue:    []byte{1, 2, 3},
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 1,
+				PartialKey:   []byte{3},
+				StorageValue: []byte{1, 2, 3},
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			valuesDeleted: 1,
@@ -2710,20 +2710,20 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{3},
-				SubValue:    []byte{1, 2, 3},
-				Descendants: 2,
+				PartialKey:   []byte{3},
+				StorageValue: []byte{1, 2, 3},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			limit: 2,
 			newNode: &Node{
-				PartialKey: []byte{3},
-				SubValue:   []byte{1, 2, 3},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{3},
+				StorageValue: []byte{1, 2, 3},
+				Dirty:        true,
+				Generation:   1,
 			},
 			valuesDeleted: 2,
 			nodesRemoved:  2,
@@ -2737,19 +2737,19 @@ func Test_Trie_deleteNodesLimit(t *testing.T) {
 				Descendants: 3,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{1}, SubValue: []byte{1}},
+					{PartialKey: []byte{1}, StorageValue: []byte{1}},
 					nil,
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 					nil,
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
 				}),
 			},
 			limit: 2,
 			newNode: &Node{
-				PartialKey: []byte{3, 5, 3},
-				SubValue:   []byte{1},
-				Generation: 1,
-				Dirty:      true,
+				PartialKey:   []byte{3, 5, 3},
+				StorageValue: []byte{1},
+				Generation:   1,
+				Dirty:        true,
 			},
 			valuesDeleted: 2,
 			nodesRemoved:  3,
@@ -2786,12 +2786,12 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 	}{
 		"nil prefix": {
 			trie: Trie{
-				root: &Node{SubValue: []byte{1}},
+				root: &Node{StorageValue: []byte{1}},
 			},
 		},
 		"empty prefix": {
 			trie: Trie{
-				root: &Node{SubValue: []byte{1}},
+				root: &Node{StorageValue: []byte{1}},
 			},
 			prefix: []byte{},
 		},
@@ -2805,16 +2805,16 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 					Descendants: 3,
 					Children: padRightChildren([]*Node{
 						{ // full key in nibbles 1, 2, 0, 5
-							PartialKey: []byte{5},
-							SubValue:   []byte{1},
+							PartialKey:   []byte{5},
+							StorageValue: []byte{1},
 						},
 						{ // full key in nibbles 1, 2, 1, 6
-							PartialKey: []byte{6},
-							SubValue:   []byte("bottom branch"),
+							PartialKey:   []byte{6},
+							StorageValue: []byte("bottom branch"),
 							Children: padRightChildren([]*Node{
 								{ // full key in nibbles 1, 2, 1, 6, 0, 7
-									PartialKey: []byte{7},
-									SubValue:   []byte{1},
+									PartialKey:   []byte{7},
+									StorageValue: []byte{1},
 								},
 							}),
 						},
@@ -2824,9 +2824,9 @@ func Test_Trie_ClearPrefix(t *testing.T) {
 			prefix: []byte{0x12, 0x16},
 			expectedTrie: Trie{
 				root: &Node{
-					PartialKey: []byte{1, 2, 0, 5},
-					SubValue:   []byte{1},
-					Dirty:      true,
+					PartialKey:   []byte{1, 2, 0, 5},
+					StorageValue: []byte{1},
+					Dirty:        true,
 				},
 			},
 		},
@@ -2871,32 +2871,32 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0},
 			newParent: &Node{
-				PartialKey: []byte{1, 1, 4},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 1, 4},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			nodesRemoved: 2,
 		},
 		"nil parent": {},
 		"leaf parent with common prefix": {
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			prefix:       []byte{1},
 			nodesRemoved: 1,
 		},
 		"leaf parent with key equal prefix": {
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			prefix:       []byte{1},
 			nodesRemoved: 1,
@@ -2906,13 +2906,13 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{1, 3},
 			newParent: &Node{
-				PartialKey: []byte{1, 2},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
 			},
 		},
 		"leaf parent with key smaller than prefix": {
@@ -2920,20 +2920,20 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			prefix: []byte{1, 2},
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 		},
 		"branch parent with common prefix": {
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -2943,9 +2943,9 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 		},
 		"branch with key equal prefix": {
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -2958,18 +2958,18 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
 			},
 			prefix: []byte{1, 3},
 			newParent: &Node{
-				PartialKey:  []byte{1, 2},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1, 2},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -2980,18 +2980,18 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
 			},
 			prefix: []byte{1, 2, 3},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -3002,18 +3002,18 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
 			},
 			prefix: []byte{1, 2},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -3024,24 +3024,24 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0, 3},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{4}, SubValue: []byte{1}},
+					{PartialKey: []byte{4}, StorageValue: []byte{1}},
 				}),
 			},
 			nodesRemoved: 1,
@@ -3051,19 +3051,19 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}},
+					{PartialKey: []byte{3}, StorageValue: []byte{1}},
 				}),
 			},
 			prefix: []byte{1, 0},
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			nodesRemoved: 1,
 		},
@@ -3072,18 +3072,18 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 3
-						PartialKey:  []byte{3},
-						SubValue:    []byte{1},
-						Descendants: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Descendants:  1,
 						Children: padRightChildren([]*Node{
 							{ // full key 1, 0, 3, 0, 5
-								PartialKey: []byte{5},
-								SubValue:   []byte{1},
+								PartialKey:   []byte{5},
+								StorageValue: []byte{1},
 							},
 						}),
 					},
@@ -3091,17 +3091,17 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 			},
 			prefix: []byte{1, 0, 3, 0},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Dirty:       true,
-				Generation:  1,
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 3
-						PartialKey: []byte{3},
-						SubValue:   []byte{1},
-						Dirty:      true,
-						Generation: 1,
+						PartialKey:   []byte{3},
+						StorageValue: []byte{1},
+						Dirty:        true,
+						Generation:   1,
 					},
 				}),
 			},
@@ -3115,16 +3115,16 @@ func Test_Trie_clearPrefixAtNode(t *testing.T) {
 				PartialKey:  []byte{1},
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{3}, SubValue: []byte{1}}, // full key 1, 0, 3
-					{PartialKey: []byte{4}, SubValue: []byte{1}}, // full key 1, 1, 4
+					{PartialKey: []byte{3}, StorageValue: []byte{1}}, // full key 1, 0, 3
+					{PartialKey: []byte{4}, StorageValue: []byte{1}}, // full key 1, 1, 4
 				}),
 			},
 			prefix: []byte{1, 0, 3},
 			newParent: &Node{
-				PartialKey: []byte{1, 1, 4},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 1, 4},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			nodesRemoved: 2,
 		},
@@ -3158,12 +3158,12 @@ func Test_Trie_Delete(t *testing.T) {
 	}{
 		"nil key": {
 			trie: Trie{
-				root: &Node{SubValue: []byte{1}},
+				root: &Node{StorageValue: []byte{1}},
 			},
 		},
 		"empty key": {
 			trie: Trie{
-				root: &Node{SubValue: []byte{1}},
+				root: &Node{StorageValue: []byte{1}},
 			},
 		},
 		"empty trie": {
@@ -3177,17 +3177,17 @@ func Test_Trie_Delete(t *testing.T) {
 					Descendants: 3,
 					Children: padRightChildren([]*Node{
 						{
-							PartialKey: []byte{5},
-							SubValue:   []byte{97},
+							PartialKey:   []byte{5},
+							StorageValue: []byte{97},
 						},
 						{ // full key in nibbles 1, 2, 1, 6
-							PartialKey:  []byte{6},
-							SubValue:    []byte{98},
-							Descendants: 1,
+							PartialKey:   []byte{6},
+							StorageValue: []byte{98},
+							Descendants:  1,
 							Children: padRightChildren([]*Node{
 								{ // full key in nibbles 1, 2, 1, 6, 0, 7
-									PartialKey: []byte{7},
-									SubValue:   []byte{99},
+									PartialKey:   []byte{7},
+									StorageValue: []byte{99},
 								},
 							}),
 						},
@@ -3204,14 +3204,14 @@ func Test_Trie_Delete(t *testing.T) {
 					Descendants: 2,
 					Children: padRightChildren([]*Node{
 						{
-							PartialKey: []byte{5},
-							SubValue:   []byte{97},
+							PartialKey:   []byte{5},
+							StorageValue: []byte{97},
 						},
 						{ // full key in nibbles 1, 2, 1, 6
-							PartialKey: []byte{6, 0, 7},
-							SubValue:   []byte{99},
-							Dirty:      true,
-							Generation: 1,
+							PartialKey:   []byte{6, 0, 7},
+							StorageValue: []byte{99},
+							Dirty:        true,
+							Generation:   1,
 						},
 					}),
 				},
@@ -3256,16 +3256,16 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 		},
 		"leaf parent and nil key": {
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			updated:      true,
 			nodesRemoved: 1,
 		},
 		"leaf parent and empty key": {
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			key:          []byte{},
 			updated:      true,
@@ -3273,8 +3273,8 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 		},
 		"leaf parent matches key": {
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			key:          []byte{1},
 			updated:      true,
@@ -3285,13 +3285,13 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 			key: []byte{2},
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
 			},
 		},
 		"branch parent and nil key": {
@@ -3299,21 +3299,21 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
 			newParent: &Node{
-				PartialKey: []byte{1, 0, 2},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 0, 2},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			updated:      true,
 			nodesRemoved: 1,
@@ -3323,19 +3323,19 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			key: []byte{},
 			newParent: &Node{
-				PartialKey: []byte{1, 0, 2},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 0, 2},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			updated:      true,
 			nodesRemoved: 1,
@@ -3345,19 +3345,19 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			key: []byte{1},
 			newParent: &Node{
-				PartialKey: []byte{1, 0, 2},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 0, 2},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			updated:      true,
 			nodesRemoved: 1,
@@ -3367,22 +3367,22 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
 			key: []byte{1, 0, 2},
 			newParent: &Node{
-				PartialKey: []byte{1},
-				SubValue:   []byte{1},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Dirty:        true,
+				Generation:   1,
 			},
 			updated:      true,
 			nodesRemoved: 1,
@@ -3392,18 +3392,18 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
 			},
 			key: []byte{2},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{},
 				}),
@@ -3414,25 +3414,25 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
 			key: []byte{1, 0, 3},
 			newParent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 1,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 				}),
 			},
@@ -3446,21 +3446,21 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				Descendants: 1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 					{ // full key 1, 1, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{2},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{2},
 					},
 				}),
 			},
 			key: []byte{1, 0, 2},
 			newParent: &Node{
-				PartialKey: []byte{1, 1, 2},
-				SubValue:   []byte{2},
-				Dirty:      true,
-				Generation: 1,
+				PartialKey:   []byte{1, 1, 2},
+				StorageValue: []byte{2},
+				Dirty:        true,
+				Generation:   1,
 			},
 			updated:      true,
 			nodesRemoved: 2,
@@ -3470,12 +3470,12 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				generation: 1,
 			},
 			parent: &Node{
-				PartialKey:  []byte{1},
-				SubValue:    []byte{1},
-				Descendants: 2,
+				PartialKey:   []byte{1},
+				StorageValue: []byte{1},
+				Descendants:  2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			key: []byte{1},
@@ -3485,8 +3485,8 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				Dirty:       true,
 				Descendants: 2,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
-					{PartialKey: []byte{2}, SubValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
+					{PartialKey: []byte{2}, StorageValue: []byte{1}},
 				}),
 			},
 			updated: true,
@@ -3500,12 +3500,12 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				Descendants: 1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 					{ // full key 1, 1, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{2},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{2},
 					},
 				}),
 			},
@@ -3515,12 +3515,12 @@ func Test_Trie_deleteAtNode(t *testing.T) {
 				Descendants: 1,
 				Children: padRightChildren([]*Node{
 					{ // full key 1, 0, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{1},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{1},
 					},
 					{ // full key 1, 1, 2
-						PartialKey: []byte{2},
-						SubValue:   []byte{2},
+						PartialKey:   []byte{2},
+						StorageValue: []byte{2},
 					},
 				}),
 			},
@@ -3563,16 +3563,16 @@ func Test_handleDeletion(t *testing.T) {
 	}{
 		"branch with value and without children": {
 			branch: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{5, 6, 7},
-				Generation: 1,
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{5, 6, 7},
+				Generation:   1,
 			},
 			deletedKey: []byte{1, 2, 3, 4},
 			newNode: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{5, 6, 7},
-				Generation: 1,
-				Dirty:      true,
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{5, 6, 7},
+				Generation:   1,
+				Dirty:        true,
 			},
 		},
 		// branch without value and without children cannot happen
@@ -3580,21 +3580,21 @@ func Test_handleDeletion(t *testing.T) {
 		// remaining.
 		"branch with value and a single child": {
 			branch: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{5, 6, 7},
-				Generation: 1,
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{5, 6, 7},
+				Generation:   1,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{9}, SubValue: []byte{1}},
+					{PartialKey: []byte{9}, StorageValue: []byte{1}},
 				}),
 			},
 			newNode: &Node{
-				PartialKey: []byte{1, 2, 3},
-				SubValue:   []byte{5, 6, 7},
-				Generation: 1,
+				PartialKey:   []byte{1, 2, 3},
+				StorageValue: []byte{5, 6, 7},
+				Generation:   1,
 				Children: padRightChildren([]*Node{
 					nil,
-					{PartialKey: []byte{9}, SubValue: []byte{1}},
+					{PartialKey: []byte{9}, StorageValue: []byte{1}},
 				}),
 			},
 		},
@@ -3605,17 +3605,17 @@ func Test_handleDeletion(t *testing.T) {
 				Children: padRightChildren([]*Node{
 					nil,
 					{ // full key 1,2,3,1,9
-						PartialKey: []byte{9},
-						SubValue:   []byte{10},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{10},
 					},
 				}),
 			},
 			deletedKey: []byte{1, 2, 3, 4},
 			newNode: &Node{
-				PartialKey: []byte{1, 2, 3, 1, 9},
-				SubValue:   []byte{10},
-				Generation: 1,
-				Dirty:      true,
+				PartialKey:   []byte{1, 2, 3, 1, 9},
+				StorageValue: []byte{10},
+				Generation:   1,
+				Dirty:        true,
 			},
 			branchChildMerged: true,
 		},
@@ -3626,25 +3626,25 @@ func Test_handleDeletion(t *testing.T) {
 				Children: padRightChildren([]*Node{
 					nil,
 					{
-						PartialKey: []byte{9},
-						SubValue:   []byte{10},
+						PartialKey:   []byte{9},
+						StorageValue: []byte{10},
 						Children: padRightChildren([]*Node{
-							{PartialKey: []byte{7}, SubValue: []byte{1}},
+							{PartialKey: []byte{7}, StorageValue: []byte{1}},
 							nil,
-							{PartialKey: []byte{8}, SubValue: []byte{1}},
+							{PartialKey: []byte{8}, StorageValue: []byte{1}},
 						}),
 					},
 				}),
 			},
 			newNode: &Node{
-				PartialKey: []byte{1, 2, 3, 1, 9},
-				SubValue:   []byte{10},
-				Generation: 1,
-				Dirty:      true,
+				PartialKey:   []byte{1, 2, 3, 1, 9},
+				StorageValue: []byte{10},
+				Generation:   1,
+				Dirty:        true,
 				Children: padRightChildren([]*Node{
-					{PartialKey: []byte{7}, SubValue: []byte{1}},
+					{PartialKey: []byte{7}, StorageValue: []byte{1}},
 					nil,
-					{PartialKey: []byte{8}, SubValue: []byte{1}},
+					{PartialKey: []byte{8}, StorageValue: []byte{1}},
 				}),
 			},
 			branchChildMerged: true,

--- a/pkg/scale/decode.go
+++ b/pkg/scale/decode.go
@@ -592,9 +592,12 @@ func (ds *decodeState) decodeBytes(dstv reflect.Value) (err error) {
 	}
 
 	b := make([]byte, length)
-	_, err = ds.Read(b)
-	if err != nil {
-		return
+
+	if length > 0 {
+		_, err = ds.Read(b)
+		if err != nil {
+			return
+		}
 	}
 
 	in := dstv.Interface()


### PR DESCRIPTION
## Changes

Differentiate empty storage values `[]byte{}` with no storage value `[]byte(nil)`

- Leaves can have an empty storage value (`[]byte{}`), but cannot have no storage value
- Branch **with value** can have an empty storage value (`[]byte{}`), but cannot have no storage value
- Branch **without value** cannot have a value at all (`nil`)

Side fix: do not further read from scale decoder buffer when the slice length is `0`, to avoid returning an error (`io.EOF`)

## Tests


```sh
go test ./lib/trie/... ./internal/trie/... ./dot/state
```

## Issues

- Might solve #2937 
- Fix bug introduced in #2927 and other misconceptions from original code

## Primary Reviewer

@kishansagathiya 