### PR TITLE
chore(all): review embedded mutex fields

### DIFF
--- a/dot/network/connmgr.go
+++ b/dot/network/connmgr.go
@@ -17,7 +17,6 @@ import (
 
 // ConnManager implements connmgr.ConnManager
 type ConnManager struct {
-	sync.Mutex
 	host              *host
 	min, max          int
 	connectHandler    func(peer.ID)

--- a/dot/peerset/peerset.go
+++ b/dot/peerset/peerset.go
@@ -619,12 +619,12 @@ func (ps *PeerSet) incoming(setID int, peers ...peer.ID) error {
 
 		var nodeReputation Reputation
 
-		state.RLock()
+		state.mutex.RLock()
 		node, has := state.nodes[pid]
 		if has {
 			nodeReputation = node.reputation
 		}
-		state.RUnlock()
+		state.mutex.RUnlock()
 
 		message := Message{
 			setID:  uint64(setID),

--- a/dot/peerset/peerset.go
+++ b/dot/peerset/peerset.go
@@ -170,7 +170,7 @@ func newReputationChange(value Reputation, reason string) ReputationChange {
 
 // PeerSet is a container for all the components of a peerSet.
 type PeerSet struct {
-	sync.Mutex
+	mutex     sync.Mutex
 	peerState *PeersState
 
 	reservedLock sync.RWMutex
@@ -270,8 +270,8 @@ func reputationTick(reput Reputation) Reputation {
 // updateTime updates the value of latestTimeUpdate and performs all the updates that
 // happen over time, such as Reputation increases for staying connected.
 func (ps *PeerSet) updateTime() error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	currTime := time.Now()
 	// identify the time difference between current time and last update time for peer reputation in seconds.

--- a/dot/peerset/peerset_test.go
+++ b/dot/peerset/peerset_test.go
@@ -352,8 +352,8 @@ func checkNodePeerExists(t *testing.T, ps *PeersState, pid peer.ID) {
 func checkReservedNodePeerExists(t *testing.T, ps *PeerSet, pid peer.ID) {
 	t.Helper()
 
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	_, exists := ps.reservedNode[pid]
 	require.True(t, exists)

--- a/dot/peerset/peerset_test.go
+++ b/dot/peerset/peerset_test.go
@@ -315,8 +315,8 @@ func TestSetReservePeer(t *testing.T) {
 }
 
 func getNodePeer(ps *PeersState, pid peer.ID) (node, bool) {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	n, exists := ps.nodes[pid]
 	if !exists {
@@ -330,8 +330,8 @@ func checkNodePeerMembershipState(t *testing.T, ps *PeersState, pid peer.ID,
 	setID int, ms MembershipState) {
 	t.Helper()
 
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	node, exists := ps.nodes[pid]
 
@@ -342,8 +342,8 @@ func checkNodePeerMembershipState(t *testing.T, ps *PeersState, pid peer.ID,
 func checkNodePeerExists(t *testing.T, ps *PeersState, pid peer.ID) {
 	t.Helper()
 
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	_, exists := ps.nodes[pid]
 	require.True(t, exists)
@@ -362,8 +362,8 @@ func checkReservedNodePeerExists(t *testing.T, ps *PeerSet, pid peer.ID) {
 func checkPeerIsInNoSlotsNode(t *testing.T, ps *PeersState, pid peer.ID, setID int) {
 	t.Helper()
 
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	_, exists := ps.sets[setID].noSlotNodes[pid]
 	require.True(t, exists)
@@ -372,8 +372,8 @@ func checkPeerIsInNoSlotsNode(t *testing.T, ps *PeersState, pid peer.ID, setID i
 func checkPeerStateSetNumOut(t *testing.T, ps *PeersState, setID int, expectedNumOut uint32) { //nolint:unparam
 	t.Helper()
 
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	gotNumOut := ps.sets[setID].numOut
 	require.Equal(t, expectedNumOut, gotNumOut)
@@ -382,8 +382,8 @@ func checkPeerStateSetNumOut(t *testing.T, ps *PeersState, setID int, expectedNu
 func checkPeerStateSetNumIn(t *testing.T, ps *PeersState, setID int, expectedNumIn uint32) { //nolint:unparam
 	t.Helper()
 
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	gotNumIn := ps.sets[setID].numIn
 	require.Equal(t, expectedNumIn, gotNumIn)
@@ -392,8 +392,8 @@ func checkPeerStateSetNumIn(t *testing.T, ps *PeersState, setID int, expectedNum
 func checkPeerStateNodeCount(t *testing.T, ps *PeersState, expectedCount int) {
 	t.Helper()
 
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	require.Equal(t, expectedCount, len(ps.nodes))
 }

--- a/dot/peerset/peerstate.go
+++ b/dot/peerset/peerstate.go
@@ -103,12 +103,12 @@ type PeersState struct {
 	// since, single Info can also manage the flow.
 	sets []Info
 
-	sync.RWMutex
+	mutex sync.RWMutex
 }
 
 func (ps *PeersState) getNode(p peer.ID) (*node, error) {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 	if n, ok := ps.nodes[p]; ok {
 		return n, nil
 	}
@@ -150,8 +150,8 @@ func (ps *PeersState) getSetLength() int {
 // peerStatus returns the status of peer based on its connection state
 // i.e. connectedPeer, notConnectedPeer or unknownPeer.
 func (ps *PeersState) peerStatus(set int, peerID peer.ID) string {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	node, has := ps.nodes[peerID]
 	if !has {
@@ -170,15 +170,15 @@ func (ps *PeersState) peerStatus(set int, peerID peer.ID) string {
 
 // peers return the list of all the peers we know of.
 func (ps *PeersState) peers() []peer.ID {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 	return maps.Keys(ps.nodes)
 }
 
 // sortedPeers returns the list of peers we are connected to of a specific set.
 func (ps *PeersState) sortedPeers(idx int) peer.IDSlice {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	if len(ps.sets) == 0 || len(ps.sets) < idx {
 		logger.Debug("peer state doesn't have info for the provided index")
@@ -216,8 +216,8 @@ func (ps *PeersState) sortedPeers(idx int) peer.IDSlice {
 }
 
 func (ps *PeersState) updateReputationByTick(peerID peer.ID) (newReputation Reputation, err error) {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	node, has := ps.nodes[peerID]
 	if !has {
@@ -235,8 +235,8 @@ func (ps *PeersState) updateReputationByTick(peerID peer.ID) (newReputation Repu
 func (ps *PeersState) addReputation(peerID peer.ID, change ReputationChange) (
 	newReputation Reputation, err error) {
 
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	node, has := ps.nodes[peerID]
 	if !has {
@@ -251,8 +251,8 @@ func (ps *PeersState) addReputation(peerID peer.ID, change ReputationChange) (
 
 // highestNotConnectedPeer returns the peer with the highest Reputation and that we are not connected to.
 func (ps *PeersState) highestNotConnectedPeer(set int) (highestPeerID peer.ID) {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	maxRep := math.MinInt32
 	for peerID, node := range ps.nodes {
@@ -283,8 +283,8 @@ func (ps *PeersState) hasFreeIncomingSlot(set int) bool {
 // addNoSlotNode adds a node to the list of nodes that don't occupy slots.
 // has no effect if the node was already in the group.
 func (ps *PeersState) addNoSlotNode(idx int, peerID peer.ID) error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	if _, ok := ps.sets[idx].noSlotNodes[peerID]; ok {
 		logger.Debugf("peer %s already exists in no slot node", peerID)
@@ -310,8 +310,8 @@ func (ps *PeersState) addNoSlotNode(idx int, peerID peer.ID) error {
 }
 
 func (ps *PeersState) removeNoSlotNode(idx int, peerID peer.ID) error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	if _, ok := ps.sets[idx].noSlotNodes[peerID]; !ok {
 		logger.Debugf("peer %s is not in no-slot node map", peerID)
@@ -338,8 +338,8 @@ func (ps *PeersState) removeNoSlotNode(idx int, peerID peer.ID) error {
 // disconnect updates the node status to the notConnected state.
 // It should be called only when the node is in connected state.
 func (ps *PeersState) disconnect(idx int, peerID peer.ID) error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	info := ps.sets[idx]
 	node, has := ps.nodes[peerID]
@@ -370,8 +370,8 @@ func (ps *PeersState) disconnect(idx int, peerID peer.ID) error {
 // discover takes input for set id and create a node and insert in the list.
 // the initial Reputation of the peer will be 0 and ingoing notMember state.
 func (ps *PeersState) discover(set int, peerID peer.ID) {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	numSet := len(ps.sets)
 
@@ -384,8 +384,8 @@ func (ps *PeersState) discover(set int, peerID peer.ID) {
 }
 
 func (ps *PeersState) lastConnectedAndDiscovered(set int, peerID peer.ID) (time.Time, error) {
-	ps.RLock()
-	defer ps.RUnlock()
+	ps.mutex.RLock()
+	defer ps.mutex.RUnlock()
 
 	node, has := ps.nodes[peerID]
 	if !has {
@@ -401,8 +401,8 @@ func (ps *PeersState) lastConnectedAndDiscovered(set int, peerID peer.ID) (time.
 
 // forgetPeer removes the peer with reputation 0 from the peerSet.
 func (ps *PeersState) forgetPeer(set int, peerID peer.ID) error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	node, has := ps.nodes[peerID]
 	if !has {
@@ -438,8 +438,8 @@ func (ps *PeersState) forgetPeer(set int, peerID peer.ID) error {
 // If the slots are full, the node stays "not connected" and we return the error ErrOutgoingSlotsUnavailable.
 // non slot occupying nodes don't count towards the number of slots.
 func (ps *PeersState) tryOutgoing(setID int, peerID peer.ID) error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	_, isNoSlotNode := ps.sets[setID].noSlotNodes[peerID]
 
@@ -466,8 +466,8 @@ func (ps *PeersState) tryOutgoing(setID int, peerID peer.ID) error {
 // If the slots are full, the node stays "not connected" and we return Err.
 // non slot occupying nodes don't count towards the number of slots.
 func (ps *PeersState) tryAcceptIncoming(setID int, peerID peer.ID) error {
-	ps.Lock()
-	defer ps.Unlock()
+	ps.mutex.Lock()
+	defer ps.mutex.Unlock()
 
 	_, isNoSlotOccupied := ps.sets[setID].noSlotNodes[peerID]
 

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -51,11 +51,11 @@ var (
 // BlockState contains the historical block data of the blockchain, including block headers and bodies.
 // It wraps the blocktree (which contains unfinalised blocks) and the database (which contains finalised blocks).
 type BlockState struct {
-	bt        *blocktree.BlockTree
-	baseState *BaseState
-	dbPath    string
-	db        BlockStateDatabase
-	sync.RWMutex
+	bt                *blocktree.BlockTree
+	baseState         *BaseState
+	dbPath            string
+	db                BlockStateDatabase
+	mutex             sync.RWMutex
 	genesisHash       common.Hash
 	lastFinalised     common.Hash
 	unfinalisedBlocks *hashToBlockMap
@@ -380,8 +380,8 @@ func (bs *BlockState) GetBlockByNumber(num uint) (*types.Block, error) {
 
 // GetBlockByHash returns a block for a given hash
 func (bs *BlockState) GetBlockByHash(hash common.Hash) (*types.Block, error) {
-	bs.RLock()
-	defer bs.RUnlock()
+	bs.mutex.RLock()
+	defer bs.mutex.RUnlock()
 
 	block := bs.unfinalisedBlocks.getBlock(hash)
 	if block != nil {
@@ -413,8 +413,8 @@ func (bs *BlockState) SetHeader(header *types.Header) error {
 
 // HasBlockBody returns true if the db contains the block body
 func (bs *BlockState) HasBlockBody(hash common.Hash) (bool, error) {
-	bs.RLock()
-	defer bs.RUnlock()
+	bs.mutex.RLock()
+	defer bs.mutex.RUnlock()
 
 	if bs.unfinalisedBlocks.getBlock(hash) != nil {
 		return true, nil
@@ -471,8 +471,8 @@ func (bs *BlockState) CompareAndSetBlockData(bd *types.BlockData) error {
 
 // AddBlock adds a block to the blocktree and the DB with arrival time as current unix time
 func (bs *BlockState) AddBlock(block *types.Block) error {
-	bs.Lock()
-	defer bs.Unlock()
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
 	return bs.AddBlockWithArrivalTime(block, time.Now())
 }
 
@@ -495,8 +495,8 @@ func (bs *BlockState) AddBlockWithArrivalTime(block *types.Block, arrivalTime ti
 // AddBlockToBlockTree adds the given block to the blocktree. It does not write it to the database.
 // TODO: remove this func and usage from sync (after sync refactor?)
 func (bs *BlockState) AddBlockToBlockTree(block *types.Block) error {
-	bs.Lock()
-	defer bs.Unlock()
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
 
 	arrivalTime, err := bs.GetArrivalTime(block.Header.Hash())
 	if err != nil {

--- a/dot/state/block_finalisation.go
+++ b/dot/state/block_finalisation.go
@@ -38,8 +38,8 @@ func (bs *BlockState) NumberIsFinalised(num uint) (bool, error) {
 
 // GetFinalisedHeader returns the finalised block header by round and setID
 func (bs *BlockState) GetFinalisedHeader(round, setID uint64) (*types.Header, error) {
-	bs.Lock()
-	defer bs.Unlock()
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
 
 	h, err := bs.GetFinalisedHash(round, setID)
 	if err != nil {
@@ -116,8 +116,8 @@ func (bs *BlockState) GetHighestFinalisedHeader() (*types.Header, error) {
 
 // SetFinalisedHash sets the latest finalised block hash
 func (bs *BlockState) SetFinalisedHash(hash common.Hash, round, setID uint64) error {
-	bs.Lock()
-	defer bs.Unlock()
+	bs.mutex.Lock()
+	defer bs.mutex.Unlock()
 
 	has, err := bs.HasHeader(hash)
 	if err != nil {

--- a/dot/state/storage.go
+++ b/dot/state/storage.go
@@ -33,8 +33,8 @@ type StorageState struct {
 	blockState *BlockState
 	tries      *Tries
 
-	db GetNewBatcher
-	sync.RWMutex
+	db    GetNewBatcher
+	mutex sync.RWMutex
 
 	// change notifiers
 	observerListMutex sync.RWMutex
@@ -56,6 +56,12 @@ func NewStorageState(db *chaindb.BadgerDB, blockState *BlockState,
 		pruner:       &pruner.ArchiveNode{},
 	}, nil
 }
+
+// Lock locks the storage state for thread safe access.
+func (s *StorageState) Lock() { s.mutex.Lock() }
+
+// Unlock unlocks the storage state for thread safe access.
+func (s *StorageState) Unlock() { s.mutex.Unlock() }
 
 // StoreTrie stores the given trie in the StorageState and writes it to the database
 func (s *StorageState) StoreTrie(ts *rtstorage.TrieState, header *types.Header) error {

--- a/dot/sync/disjoint_block_set.go
+++ b/dot/sync/disjoint_block_set.go
@@ -92,7 +92,7 @@ func (b *pendingBlock) toBlockData() *types.BlockData {
 //
 // if the block is complete, we may not know of its parent.
 type disjointBlockSet struct {
-	sync.RWMutex
+	mutex sync.RWMutex
 	limit int
 
 	// map of block hash -> block data
@@ -128,8 +128,8 @@ func (s *disjointBlockSet) run(done <-chan struct{}) {
 }
 
 func (s *disjointBlockSet) clearBlocks() {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	for _, block := range s.blocks {
 		if s.timeNow().Sub(block.clearAt) > 0 {
@@ -149,8 +149,8 @@ func (s *disjointBlockSet) addToParentMap(parent, child common.Hash) {
 }
 
 func (s *disjointBlockSet) addHashAndNumber(hash common.Hash, number uint) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	if b, has := s.blocks[hash]; has {
 		b.clearAt = s.timeNow().Add(ttl)
@@ -166,8 +166,8 @@ func (s *disjointBlockSet) addHashAndNumber(hash common.Hash, number uint) error
 }
 
 func (s *disjointBlockSet) addHeader(header *types.Header) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	hash := header.Hash()
 	if b, has := s.blocks[hash]; has {
@@ -186,8 +186,8 @@ func (s *disjointBlockSet) addHeader(header *types.Header) error {
 }
 
 func (s *disjointBlockSet) addBlock(block *types.Block) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	hash := block.Header.Hash()
 	if b, has := s.blocks[hash]; has {
@@ -207,8 +207,8 @@ func (s *disjointBlockSet) addBlock(block *types.Block) error {
 }
 
 func (s *disjointBlockSet) addJustification(hash common.Hash, just []byte) error {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	b, has := s.blocks[hash]
 	if has {
@@ -222,8 +222,8 @@ func (s *disjointBlockSet) addJustification(hash common.Hash, just []byte) error
 }
 
 func (s *disjointBlockSet) removeBlock(hash common.Hash) {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.removeBlockInner(hash)
 }
 
@@ -258,33 +258,33 @@ func (s *disjointBlockSet) removeLowerBlocks(num uint) {
 }
 
 func (s *disjointBlockSet) hasBlock(hash common.Hash) bool {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	_, has := s.blocks[hash]
 	return has
 }
 
 func (s *disjointBlockSet) size() int {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return len(s.blocks)
 }
 
 func (s *disjointBlockSet) getChildren(hash common.Hash) map[common.Hash]struct{} {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.parentToChildren[hash]
 }
 
 func (s *disjointBlockSet) getBlock(hash common.Hash) *pendingBlock {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	return s.blocks[hash]
 }
 
 func (s *disjointBlockSet) getBlocks() []*pendingBlock {
-	s.RLock()
-	defer s.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 
 	blocks := make([]*pendingBlock, len(s.blocks))
 	i := 0

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -19,7 +19,7 @@ type workerState struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	sync.Mutex
+	mutex      sync.Mutex
 	nextWorker uint64
 	workers    map[uint64]*worker
 }
@@ -34,8 +34,8 @@ func newWorkerState() *workerState {
 }
 
 func (s *workerState) add(w *worker) {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	w.id = s.nextWorker
 	w.ctx = s.ctx
@@ -44,8 +44,8 @@ func (s *workerState) add(w *worker) {
 }
 
 func (s *workerState) delete(id uint64) {
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	delete(s.workers, id)
 }
 
@@ -53,8 +53,8 @@ func (s *workerState) reset() {
 	s.cancel()
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
-	s.Lock()
-	defer s.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 
 	for id := range s.workers {
 		delete(s.workers, id)

--- a/dot/telemetry/mailer.go
+++ b/dot/telemetry/mailer.go
@@ -24,7 +24,7 @@ type telemetryConnection struct {
 
 // Mailer can send messages to the telemetry servers.
 type Mailer struct {
-	mutex *sync.Mutex
+	mutex sync.Mutex
 
 	logger Logger
 
@@ -35,7 +35,6 @@ type Mailer struct {
 func BootstrapMailer(ctx context.Context, conns []*genesis.TelemetryEndpoint, logger Logger) (
 	mailer *Mailer, err error) {
 	mailer = &Mailer{
-		mutex:  new(sync.Mutex),
 		logger: logger,
 	}
 

--- a/dot/telemetry/mailer.go
+++ b/dot/telemetry/mailer.go
@@ -19,7 +19,7 @@ var ErrTimoutMessageSending = errors.New("timeout sending telemetry message")
 type telemetryConnection struct {
 	wsconn    *websocket.Conn
 	verbosity int
-	sync.Mutex
+	mutex     sync.Mutex
 }
 
 // Mailer can send messages to the telemetry servers.
@@ -90,8 +90,8 @@ func (m *Mailer) shipTelemetryMessage(msg json.Marshaler) {
 	}
 
 	for _, conn := range m.connections {
-		conn.Lock()
-		defer conn.Unlock()
+		conn.mutex.Lock()
+		defer conn.mutex.Unlock()
 
 		err = conn.wsconn.WriteMessage(websocket.TextMessage, msgBytes)
 		if err != nil {

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -46,7 +46,7 @@ type Service struct {
 	keypair *sr25519.Keypair // TODO: change to BABE keystore (#1864)
 
 	// State variables
-	sync.RWMutex
+	mutex sync.RWMutex
 	pause chan struct{}
 
 	telemetry Telemetry
@@ -251,8 +251,8 @@ func (b *Service) EpochLength() uint64 {
 
 // Pause pauses the service ie. halts block production
 func (b *Service) Pause() error {
-	b.Lock()
-	defer b.Unlock()
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
 
 	if b.IsPaused() {
 		return nil
@@ -264,8 +264,8 @@ func (b *Service) Pause() error {
 
 // Resume resumes the service ie. resumes block production
 func (b *Service) Resume() error {
-	b.Lock()
-	defer b.Unlock()
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
 
 	if !b.IsPaused() {
 		return nil
@@ -293,8 +293,8 @@ func (b *Service) Stop() error {
 		return nil
 	}
 
-	b.Lock()
-	defer b.Unlock()
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
 
 	if b.ctx.Err() != nil {
 		return errors.New("service already stopped")

--- a/lib/blocktree/leaves.go
+++ b/lib/blocktree/leaves.go
@@ -13,8 +13,8 @@ import (
 
 // leafMap provides quick lookup for existing leaves
 type leafMap struct {
-	sync.RWMutex
-	smap *sync.Map // map[common.Hash]*node
+	mutex sync.RWMutex
+	smap  *sync.Map // map[common.Hash]*node
 }
 
 func newEmptyLeafMap() *leafMap {
@@ -49,8 +49,8 @@ func (lm *leafMap) load(key Hash) (*node, error) {
 
 // Replace deletes the old node from the map and inserts the new one
 func (lm *leafMap) replace(oldNode, newNode *node) {
-	lm.Lock()
-	defer lm.Unlock()
+	lm.mutex.Lock()
+	defer lm.mutex.Unlock()
 	lm.smap.Delete(oldNode.hash)
 	lm.store(newNode.hash, newNode)
 }
@@ -58,8 +58,8 @@ func (lm *leafMap) replace(oldNode, newNode *node) {
 // highestLeaf searches the stored leaves to the find the one with the greatest number.
 // If there are two leaves with the same number, choose the one with the earliest arrival time.
 func (lm *leafMap) highestLeaf() *node {
-	lm.RLock()
-	defer lm.RUnlock()
+	lm.mutex.RLock()
+	defer lm.mutex.RUnlock()
 
 	var max uint
 
@@ -92,8 +92,8 @@ func (lm *leafMap) highestLeaf() *node {
 }
 
 func (lm *leafMap) toMap() map[common.Hash]*node {
-	lm.RLock()
-	defer lm.RUnlock()
+	lm.mutex.RLock()
+	defer lm.mutex.RUnlock()
 
 	mmap := make(map[common.Hash]*node)
 
@@ -108,8 +108,8 @@ func (lm *leafMap) toMap() map[common.Hash]*node {
 }
 
 func (lm *leafMap) nodes() []*node {
-	lm.RLock()
-	defer lm.RUnlock()
+	lm.mutex.RLock()
+	defer lm.mutex.RUnlock()
 
 	var nodes []*node
 
@@ -123,8 +123,8 @@ func (lm *leafMap) nodes() []*node {
 }
 
 func (lm *leafMap) bestBlock() *node {
-	lm.RLock()
-	defer lm.RUnlock()
+	lm.mutex.RLock()
+	defer lm.mutex.RUnlock()
 
 	// map of primary ancestor count -> *node
 	counts := make(map[int][]*node)

--- a/lib/crypto/sig_verifier.go
+++ b/lib/crypto/sig_verifier.go
@@ -29,7 +29,7 @@ type SignatureVerifier struct {
 	invalid bool // Set to true if any signature verification fails.
 	logger  Erroer
 	closeCh chan struct{}
-	sync.RWMutex
+	mutex   sync.RWMutex
 	sync.Once
 	sync.WaitGroup
 }
@@ -44,7 +44,6 @@ func NewSignatureVerifier(logger Erroer) *SignatureVerifier {
 		init:    false,
 		invalid: false,
 		logger:  logger,
-		RWMutex: sync.RWMutex{},
 		closeCh: make(chan struct{}),
 	}
 }
@@ -52,9 +51,9 @@ func NewSignatureVerifier(logger Erroer) *SignatureVerifier {
 // Start signature verification in batch.
 func (sv *SignatureVerifier) Start() {
 	// Update the init state.
-	sv.Lock()
+	sv.mutex.Lock()
 	sv.init = true
-	sv.Unlock()
+	sv.mutex.Unlock()
 
 	sv.WaitGroup.Add(1)
 
@@ -82,22 +81,22 @@ func (sv *SignatureVerifier) Start() {
 
 // IsStarted ...
 func (sv *SignatureVerifier) IsStarted() bool {
-	sv.RLock()
-	defer sv.RUnlock()
+	sv.mutex.RLock()
+	defer sv.mutex.RUnlock()
 	return sv.init
 }
 
 // IsInvalid ...
 func (sv *SignatureVerifier) IsInvalid() bool {
-	sv.RLock()
-	defer sv.RUnlock()
+	sv.mutex.RLock()
+	defer sv.mutex.RUnlock()
 	return sv.invalid
 }
 
 // Invalid ...
 func (sv *SignatureVerifier) Invalid() {
-	sv.RLock()
-	defer sv.RUnlock()
+	sv.mutex.RLock()
+	defer sv.mutex.RUnlock()
 	sv.invalid = true
 }
 
@@ -107,15 +106,15 @@ func (sv *SignatureVerifier) Add(s *SignatureInfo) {
 		return
 	}
 
-	sv.Lock()
-	defer sv.Unlock()
+	sv.mutex.Lock()
+	defer sv.mutex.Unlock()
 	sv.batch = append(sv.batch, s)
 }
 
 // Remove returns the first signature from the batch. Returns nil if batch is empty.
 func (sv *SignatureVerifier) Remove() *SignatureInfo {
-	sv.Lock()
-	defer sv.Unlock()
+	sv.mutex.Lock()
+	defer sv.mutex.Unlock()
 	if len(sv.batch) == 0 {
 		return nil
 	}
@@ -126,8 +125,8 @@ func (sv *SignatureVerifier) Remove() *SignatureInfo {
 
 // Reset reset the signature verifier for reuse.
 func (sv *SignatureVerifier) Reset() {
-	sv.Lock()
-	defer sv.Unlock()
+	sv.mutex.Lock()
+	defer sv.mutex.Unlock()
 	sv.init = false
 	sv.batch = make([]*SignatureInfo, 0)
 	sv.invalid = false
@@ -138,13 +137,13 @@ func (sv *SignatureVerifier) Reset() {
 func (sv *SignatureVerifier) Finish() bool {
 	for {
 		time.Sleep(100 * time.Millisecond)
-		sv.Lock()
+		sv.mutex.Lock()
 		if sv.invalid || len(sv.batch) == 0 {
 			close(sv.closeCh)
-			sv.Unlock()
+			sv.mutex.Unlock()
 			break
 		}
-		sv.RUnlock()
+		sv.mutex.RUnlock()
 	}
 	// Wait till start function to finish and then reset it.
 	sv.Wait()

--- a/lib/grandpa/commits_tracker.go
+++ b/lib/grandpa/commits_tracker.go
@@ -15,7 +15,7 @@ import (
 // its maximum capacity is reached.
 // It is NOT THREAD SAFE to use.
 type commitsTracker struct {
-	sync.Mutex
+	mutex *sync.Mutex
 	// map of commit block hash to linked list commit message.
 	mapping map[common.Hash]*list.Element
 	// double linked list of commit messages
@@ -28,6 +28,7 @@ type commitsTracker struct {
 // with the capacity specified.
 func newCommitsTracker(capacity int) commitsTracker {
 	return commitsTracker{
+		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,
@@ -38,8 +39,8 @@ func newCommitsTracker(capacity int) commitsTracker {
 // If the commit message tracker capacity is reached,
 // the oldest commit message is removed.
 func (ct *commitsTracker) add(commitMessage *CommitMessage) {
-	ct.Lock()
-	defer ct.Unlock()
+	ct.mutex.Lock()
+	defer ct.mutex.Unlock()
 
 	blockHash := commitMessage.Vote.Hash
 
@@ -80,8 +81,8 @@ func (ct *commitsTracker) cleanup() {
 // delete deletes all the vote messages for a particular
 // block hash from the vote messages tracker.
 func (ct *commitsTracker) delete(blockHash common.Hash) {
-	ct.Lock()
-	defer ct.Unlock()
+	ct.mutex.Lock()
+	defer ct.mutex.Unlock()
 
 	listElement, has := ct.mapping[blockHash]
 	if !has {
@@ -98,8 +99,8 @@ func (ct *commitsTracker) delete(blockHash common.Hash) {
 // does not exist in the tracker
 func (ct *commitsTracker) message(blockHash common.Hash) (
 	message *CommitMessage) {
-	ct.Lock()
-	defer ct.Unlock()
+	ct.mutex.Lock()
+	defer ct.mutex.Unlock()
 
 	listElement, ok := ct.mapping[blockHash]
 	if !ok {

--- a/lib/grandpa/commits_tracker.go
+++ b/lib/grandpa/commits_tracker.go
@@ -15,7 +15,7 @@ import (
 // its maximum capacity is reached.
 // It is NOT THREAD SAFE to use.
 type commitsTracker struct {
-	mutex *sync.Mutex
+	mutex sync.Mutex
 	// map of commit block hash to linked list commit message.
 	mapping map[common.Hash]*list.Element
 	// double linked list of commit messages
@@ -28,7 +28,6 @@ type commitsTracker struct {
 // with the capacity specified.
 func newCommitsTracker(capacity int) commitsTracker {
 	return commitsTracker{
-		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,

--- a/lib/grandpa/commits_tracker_test.go
+++ b/lib/grandpa/commits_tracker_test.go
@@ -48,15 +48,14 @@ func Test_newCommitsTracker(t *testing.T) {
 
 	const capacity = 1
 	expected := commitsTracker{
+		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,
 	}
-	vt := newCommitsTracker(capacity)
+	ct := newCommitsTracker(capacity)
 
-	assert.Equal(t, expected.mapping, vt.mapping)
-	assert.Equal(t, expected.linkedList, vt.linkedList)
-	assert.Equal(t, expected.capacity, vt.capacity)
+	assert.Equal(t, expected, ct)
 }
 
 // We cannot really unit test each method independently
@@ -202,6 +201,7 @@ func Test_commitsTracker_message(t *testing.T) {
 	}{
 		"non_existing_block_hash": {
 			commitsTracker: &commitsTracker{
+				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]*list.Element{
 					{1}: {},
 				},
@@ -210,6 +210,7 @@ func Test_commitsTracker_message(t *testing.T) {
 		},
 		"existing_block_hash": {
 			commitsTracker: &commitsTracker{
+				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]*list.Element{
 					{1}: {
 						Value: &CommitMessage{Round: 1},

--- a/lib/grandpa/commits_tracker_test.go
+++ b/lib/grandpa/commits_tracker_test.go
@@ -48,14 +48,13 @@ func Test_newCommitsTracker(t *testing.T) {
 
 	const capacity = 1
 	expected := commitsTracker{
-		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,
 	}
 	ct := newCommitsTracker(capacity)
 
-	assert.Equal(t, expected, ct)
+	assert.Equal(t, &expected, &ct)
 }
 
 // We cannot really unit test each method independently
@@ -201,7 +200,6 @@ func Test_commitsTracker_message(t *testing.T) {
 	}{
 		"non_existing_block_hash": {
 			commitsTracker: &commitsTracker{
-				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]*list.Element{
 					{1}: {},
 				},
@@ -210,7 +208,6 @@ func Test_commitsTracker_message(t *testing.T) {
 		},
 		"existing_block_hash": {
 			commitsTracker: &commitsTracker{
-				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]*list.Element{
 					{1}: {
 						Value: &CommitMessage{Round: 1},

--- a/lib/grandpa/votes_tracker.go
+++ b/lib/grandpa/votes_tracker.go
@@ -17,7 +17,7 @@ import (
 // its maximum capacity is reached.
 // It is NOT THREAD SAFE to use.
 type votesTracker struct {
-	mutex *sync.Mutex
+	mutex sync.Mutex
 	// map of vote block hash to authority ID (ed25519 public Key)
 	// to linked list element pointer
 	mapping map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element
@@ -30,7 +30,6 @@ type votesTracker struct {
 // with the capacity specified.
 func newVotesTracker(capacity int) votesTracker {
 	return votesTracker{
-		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,

--- a/lib/grandpa/votes_tracker_test.go
+++ b/lib/grandpa/votes_tracker_test.go
@@ -6,6 +6,7 @@ package grandpa
 import (
 	"container/list"
 	"sort"
+	"sync"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -64,15 +65,14 @@ func Test_newVotesTracker(t *testing.T) {
 
 	const capacity = 1
 	expected := votesTracker{
+		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,
 	}
 	vt := newVotesTracker(capacity)
 
-	assert.Equal(t, expected.mapping, vt.mapping)
-	assert.Equal(t, expected.linkedList, vt.linkedList)
-	assert.Equal(t, expected.capacity, vt.capacity)
+	assert.Equal(t, expected, vt)
 }
 
 // We cannot really unit test each method independently
@@ -280,6 +280,7 @@ func Test_votesTracker_messages(t *testing.T) {
 	}{
 		"non_existing_block_hash": {
 			votesTracker: &votesTracker{
+				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element{
 					{1}: {},
 				},
@@ -289,6 +290,7 @@ func Test_votesTracker_messages(t *testing.T) {
 		},
 		"existing_block_hash": {
 			votesTracker: &votesTracker{
+				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element{
 					{1}: {
 						ed25519.PublicKeyBytes{1}: {

--- a/lib/grandpa/votes_tracker_test.go
+++ b/lib/grandpa/votes_tracker_test.go
@@ -6,7 +6,6 @@ package grandpa
 import (
 	"container/list"
 	"sort"
-	"sync"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -65,14 +64,13 @@ func Test_newVotesTracker(t *testing.T) {
 
 	const capacity = 1
 	expected := votesTracker{
-		mutex:      &sync.Mutex{},
 		mapping:    make(map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element, capacity),
 		linkedList: list.New(),
 		capacity:   capacity,
 	}
 	vt := newVotesTracker(capacity)
 
-	assert.Equal(t, expected, vt)
+	assert.Equal(t, &expected, &vt)
 }
 
 // We cannot really unit test each method independently
@@ -280,7 +278,6 @@ func Test_votesTracker_messages(t *testing.T) {
 	}{
 		"non_existing_block_hash": {
 			votesTracker: &votesTracker{
-				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element{
 					{1}: {},
 				},
@@ -290,7 +287,6 @@ func Test_votesTracker_messages(t *testing.T) {
 		},
 		"existing_block_hash": {
 			votesTracker: &votesTracker{
-				mutex: &sync.Mutex{},
 				mapping: map[common.Hash]map[ed25519.PublicKeyBytes]*list.Element{
 					{1}: {
 						ed25519.PublicKeyBytes{1}: {

--- a/lib/transaction/priority_queue.go
+++ b/lib/transaction/priority_queue.go
@@ -82,7 +82,7 @@ type PriorityQueue struct {
 	currOrder    uint64
 	txs          map[common.Hash]*Item
 	pollInterval time.Duration
-	sync.Mutex
+	mutex        sync.Mutex
 }
 
 // NewPriorityQueue creates new instance of PriorityQueue
@@ -98,8 +98,8 @@ func NewPriorityQueue() *PriorityQueue {
 
 // RemoveExtrinsic removes an extrinsic from the queue
 func (spq *PriorityQueue) RemoveExtrinsic(ext types.Extrinsic) {
-	spq.Lock()
-	defer spq.Unlock()
+	spq.mutex.Lock()
+	defer spq.mutex.Unlock()
 
 	hash := ext.Hash()
 	item, ok := spq.txs[hash]
@@ -119,8 +119,8 @@ func (spq *PriorityQueue) Exists(extHash common.Hash) bool {
 
 // Push inserts a valid transaction with priority p into the queue
 func (spq *PriorityQueue) Push(txn *ValidTransaction) (common.Hash, error) {
-	spq.Lock()
-	defer spq.Unlock()
+	spq.mutex.Lock()
+	defer spq.mutex.Unlock()
 
 	hash := txn.Extrinsic.Hash()
 	if spq.txs[hash] != nil {
@@ -178,8 +178,8 @@ func (spq *PriorityQueue) PopWithTimer(timerCh <-chan time.Time) (transaction *V
 // Pop removes the transaction with has the highest priority value from the queue and returns it.
 // If there are multiple transaction with same priority value then it return them in FIFO order.
 func (spq *PriorityQueue) Pop() *ValidTransaction {
-	spq.Lock()
-	defer spq.Unlock()
+	spq.mutex.Lock()
+	defer spq.mutex.Unlock()
 	if spq.pq.Len() == 0 {
 		return nil
 	}
@@ -193,8 +193,8 @@ func (spq *PriorityQueue) Pop() *ValidTransaction {
 
 // Peek returns the next item without removing it from the queue
 func (spq *PriorityQueue) Peek() *ValidTransaction {
-	spq.Lock()
-	defer spq.Unlock()
+	spq.mutex.Lock()
+	defer spq.mutex.Unlock()
 	if spq.pq.Len() == 0 {
 		return nil
 	}
@@ -203,8 +203,8 @@ func (spq *PriorityQueue) Peek() *ValidTransaction {
 
 // Pending returns all the transactions currently in the queue
 func (spq *PriorityQueue) Pending() []*ValidTransaction {
-	spq.Lock()
-	defer spq.Unlock()
+	spq.mutex.Lock()
+	defer spq.mutex.Unlock()
 
 	var txns []*ValidTransaction
 	for idx := 0; idx < spq.pq.Len(); idx++ {
@@ -215,8 +215,8 @@ func (spq *PriorityQueue) Pending() []*ValidTransaction {
 
 // Len return the current length of the queue
 func (spq *PriorityQueue) Len() int {
-	spq.Lock()
-	defer spq.Unlock()
+	spq.mutex.Lock()
+	defer spq.mutex.Unlock()
 
 	return spq.pq.Len()
 }

--- a/pkg/scale/encode_test.go
+++ b/pkg/scale/encode_test.go
@@ -17,8 +17,8 @@ import (
 func Test_NewEncoder(t *testing.T) {
 	t.Parallel()
 
-	cache.Lock()
-	defer cache.Unlock()
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
 
 	writer := bytes.NewBuffer(nil)
 	encoder := NewEncoder(writer)

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -26,7 +26,7 @@ type fieldScaleIndices []fieldScaleIndex
 // fieldScaleIndicesCache stores the order of the fields per struct
 type fieldScaleIndicesCache struct {
 	cache map[string]fieldScaleIndices
-	sync.RWMutex
+	mutex sync.RWMutex
 }
 
 func (fsic *fieldScaleIndicesCache) fieldScaleIndices(in interface{}) (
@@ -36,9 +36,9 @@ func (fsic *fieldScaleIndicesCache) fieldScaleIndices(in interface{}) (
 	key := fmt.Sprintf("%s.%s", t.PkgPath(), t.Name())
 	if key != "." {
 		var ok bool
-		fsic.RLock()
+		fsic.mutex.RLock()
 		indices, ok = fsic.cache[key]
-		fsic.RUnlock()
+		fsic.mutex.RUnlock()
 		if ok {
 			return
 		}
@@ -83,9 +83,9 @@ func (fsic *fieldScaleIndicesCache) fieldScaleIndices(in interface{}) (
 	})
 
 	if key != "." {
-		fsic.Lock()
+		fsic.mutex.Lock()
 		fsic.cache[key] = indices
-		fsic.Unlock()
+		fsic.mutex.Unlock()
 	}
 	return
 }


### PR DESCRIPTION
## Changes

Why:
- Embedded fields do not show as unused when unused
- Embedded mutexes export Lock and Unlock methods which should often not be exported
- Better to name the field for readability/explicitness
- Embedded fields are annoying to navigate / ctrl+click in IDEs
- Embedding makes asserting entire struct more complicated
- There is no real need to embed fields most of the time, so why do it anyway

:warning: before merging, this should be added to eng wiki

Changes done:

- `dot/network`: remove unused embedded mutex in `ConnManager`
- Use named mutex field for:
  - lib/grandpa: `commitsTracker`, `votesTracker`
  - dot/network: `ConnManager`
  - dot/peerset: `PeerSet`, `PeerState`
  - dot/state: `BlockState`, `StorageState`
  - dot/state/pruner: `FullNode`
  - dot/sync: `chainSync`, `disjoingBlockSet`, `workerState`
  - dot/telemetry: `telemetryConnection`
  - lib/babe: `Service`
  - lib/blocktree: `BlockTree`, `leafMap`
  - lib/crypto: `SignatureVerifier`
  - lib/transaction: `PriorityQueue`
  - pkg/scale: `fieldScaleIndicesCache`
- dot/core: remove embedded mutex in `Service`, which was protecting... a channel?
  - Change service to use `stopCh` instead of context
  - Do not close block channel in stop method
  - Do not add to block queue in goroutine (bad backpressure)
  - Only exit from handleBlockAsync when stop channel gets closed

## Tests


## Issues

## Primary Reviewer
