### PR TITLE
feat(pkg/scale): `VaryingDataTypeValue` String method

### DIFF
--- a/dot/types/babe_digest.go
+++ b/dot/types/babe_digest.go
@@ -64,6 +64,12 @@ func (d *BabePrimaryPreDigest) ToPreRuntimeDigest() (*PreRuntimeDigest, error) {
 // Index returns VDT index
 func (BabePrimaryPreDigest) Index() uint { return 1 }
 
+func (d BabePrimaryPreDigest) String() string {
+	return fmt.Sprintf("BabePrimaryPreDigest{AuthorityIndex=%d, SlotNumber=%d, "+
+		"VRFOutput=0x%x, VRFProof=0x%x}",
+		d.AuthorityIndex, d.SlotNumber, d.VRFOutput, d.VRFProof)
+}
+
 // BabeSecondaryPlainPreDigest is included in a block built by a secondary slot authorized producer
 type BabeSecondaryPlainPreDigest struct {
 	AuthorityIndex uint32
@@ -85,6 +91,11 @@ func (d *BabeSecondaryPlainPreDigest) ToPreRuntimeDigest() (*PreRuntimeDigest, e
 
 // Index returns VDT index
 func (BabeSecondaryPlainPreDigest) Index() uint { return 2 }
+
+func (d BabeSecondaryPlainPreDigest) String() string {
+	return fmt.Sprintf("BabeSecondaryPlainPreDigest{AuthorityIndex=%d, SlotNumber: %d}",
+		d.AuthorityIndex, d.SlotNumber)
+}
 
 // BabeSecondaryVRFPreDigest is included in a block built by a secondary slot authorized producer
 type BabeSecondaryVRFPreDigest struct {
@@ -113,6 +124,12 @@ func (d *BabeSecondaryVRFPreDigest) ToPreRuntimeDigest() (*PreRuntimeDigest, err
 
 // Index returns VDT index
 func (BabeSecondaryVRFPreDigest) Index() uint { return 3 }
+
+func (d BabeSecondaryVRFPreDigest) String() string {
+	return fmt.Sprintf("BabeSecondaryVRFPreDigest{AuthorityIndex=%d, SlotNumber=%d, "+
+		"VrfOutput=0x%x, VrfProof=0x%x",
+		d.AuthorityIndex, d.SlotNumber, d.VrfOutput, d.VrfProof)
+}
 
 // toPreRuntimeDigest returns the VaryingDataTypeValue as a PreRuntimeDigest
 func toPreRuntimeDigest(value scale.VaryingDataTypeValue) (*PreRuntimeDigest, error) {

--- a/dot/types/consensus_digest.go
+++ b/dot/types/consensus_digest.go
@@ -29,6 +29,10 @@ type GrandpaScheduledChange struct {
 // Index returns VDT index
 func (GrandpaScheduledChange) Index() uint { return 1 }
 
+func (g GrandpaScheduledChange) String() string {
+	return fmt.Sprintf("GrandpaScheduledChange{Auths=%v, Delay=%d", g.Auths, g.Delay)
+}
+
 // GrandpaForcedChange represents a GRANDPA forced authority change
 type GrandpaForcedChange struct {
 	// BestFinalizedBlock is specified by the governance mechanism, defines
@@ -42,6 +46,11 @@ type GrandpaForcedChange struct {
 // Index returns VDT index
 func (GrandpaForcedChange) Index() uint { return 2 }
 
+func (g GrandpaForcedChange) String() string {
+	return fmt.Sprintf("GrandpaForcedChange{BestFinalizedBlock=%d, Auths=%v, Delay=%d",
+		g.BestFinalizedBlock, g.Auths, g.Delay)
+}
+
 // GrandpaOnDisabled represents a GRANDPA authority being disabled
 type GrandpaOnDisabled struct {
 	ID uint64
@@ -49,6 +58,10 @@ type GrandpaOnDisabled struct {
 
 // Index returns VDT index
 func (GrandpaOnDisabled) Index() uint { return 3 }
+
+func (g GrandpaOnDisabled) String() string {
+	return fmt.Sprintf("GrandpaOnDisabled{ID=%d}", g.ID)
+}
 
 // GrandpaPause represents an authority set pause
 type GrandpaPause struct {
@@ -58,6 +71,10 @@ type GrandpaPause struct {
 // Index returns VDT index
 func (GrandpaPause) Index() uint { return 4 }
 
+func (g GrandpaPause) String() string {
+	return fmt.Sprintf("GrandpaPause{Delay=%d}", g.Delay)
+}
+
 // GrandpaResume represents an authority set resume
 type GrandpaResume struct {
 	Delay uint32
@@ -65,6 +82,10 @@ type GrandpaResume struct {
 
 // Index returns VDT index
 func (GrandpaResume) Index() uint { return 5 }
+
+func (g GrandpaResume) String() string {
+	return fmt.Sprintf("GrandpaResume{Delay=%d}", g.Delay)
+}
 
 // NextEpochData is the digest that contains the data for the upcoming BABE epoch.
 // It is included in the first block of every epoch to describe the next epoch.
@@ -101,6 +122,10 @@ type BABEOnDisabled struct {
 // Index returns VDT index
 func (BABEOnDisabled) Index() uint { return 2 }
 
+func (b BABEOnDisabled) String() string {
+	return fmt.Sprintf("BABEOnDisabled{ID=%d}", b.ID)
+}
+
 // NextConfigData is the digest that contains changes to the BABE configuration.
 // It is potentially included in the first block of an epoch to describe the next epoch.
 type NextConfigData struct {
@@ -111,6 +136,11 @@ type NextConfigData struct {
 
 // Index returns VDT index
 func (NextConfigData) Index() uint { return 3 }
+
+func (d NextConfigData) String() string {
+	return fmt.Sprintf("NextConfigData{C1=%d, C2=%d, SecondarySlots=%d}",
+		d.C1, d.C2, d.SecondarySlots)
+}
 
 // ToConfigData returns the NextConfigData as ConfigData
 func (d *NextConfigData) ToConfigData() *ConfigData {

--- a/dot/types/digest.go
+++ b/dot/types/digest.go
@@ -48,7 +48,7 @@ type ChangesTrieRootDigest struct {
 func (ChangesTrieRootDigest) Index() uint { return 2 }
 
 // String returns the digest as a string
-func (d *ChangesTrieRootDigest) String() string {
+func (d ChangesTrieRootDigest) String() string {
 	return fmt.Sprintf("ChangesTrieRootDigest Hash=%s", d.Hash)
 }
 
@@ -70,7 +70,7 @@ func NewBABEPreRuntimeDigest(data []byte) *PreRuntimeDigest {
 }
 
 // String returns the digest as a string
-func (d *PreRuntimeDigest) String() string {
+func (d PreRuntimeDigest) String() string {
 	return fmt.Sprintf("PreRuntimeDigest ConsensusEngineID=%s Data=0x%x", d.ConsensusEngineID.ToBytes(), d.Data)
 }
 
@@ -98,6 +98,6 @@ type SealDigest struct {
 func (SealDigest) Index() uint { return 5 }
 
 // String returns the digest as a string
-func (d *SealDigest) String() string {
+func (d SealDigest) String() string {
 	return fmt.Sprintf("SealDigest ConsensusEngineID=%s Data=0x%x", d.ConsensusEngineID.ToBytes(), d.Data)
 }

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -17,6 +17,10 @@ type GrandpaAuthoritiesRaw struct {
 	ID  uint64
 }
 
+func (g GrandpaAuthoritiesRaw) String() string {
+	return fmt.Sprintf("GrandpaAuthoritiesRaw{Key=0x%x, ID=%d}", g.Key, g.ID)
+}
+
 // FromRawEd25519 sets the Authority given GrandpaAuthoritiesRaw. It converts the byte representations of
 // the authority public keys into a ed25519.PublicKey.
 func (a *Authority) FromRawEd25519(raw GrandpaAuthoritiesRaw) error {
@@ -189,7 +193,6 @@ type GrandpaVote struct {
 	Number uint32
 }
 
-// String returns the Vote as a string
-func (v *GrandpaVote) String() string {
+func (v GrandpaVote) String() string {
 	return fmt.Sprintf("hash=%s number=%d", v.Hash, v.Number)
 }

--- a/lib/babe/errors.go
+++ b/lib/babe/errors.go
@@ -130,17 +130,23 @@ type Other string
 // Index returns VDT index
 func (Other) Index() uint { return 0 }
 
+func (o Other) String() string { return string(o) }
+
 // CannotLookup Failed to lookup some data
 type CannotLookup struct{}
 
 // Index returns VDT index
 func (CannotLookup) Index() uint { return 1 }
 
+func (CannotLookup) String() string { return "cannot lookup" }
+
 // BadOrigin A bad origin
 type BadOrigin struct{}
 
 // Index returns VDT index
 func (BadOrigin) Index() uint { return 2 }
+
+func (BadOrigin) String() string { return "bad origin" }
 
 // Module A custom error in a module
 type Module struct {
@@ -152,8 +158,12 @@ type Module struct {
 // Index returns VDT index
 func (Module) Index() uint { return 3 }
 
-func (err Module) string() string {
-	return fmt.Sprintf("index: %d code: %d message: %x", err.Idx, err.Err, *err.Message)
+func (err Module) String() string {
+	message := "nil"
+	if err.Message != nil {
+		message = *err.Message
+	}
+	return fmt.Sprintf("Module{Idx=%d, Err=%d Message=%s", err.Idx, err.Err, message)
 }
 
 // ValidityCannotLookup Could not lookup some information that is required to validate the transaction
@@ -162,11 +172,15 @@ type ValidityCannotLookup struct{}
 // Index returns VDT index
 func (ValidityCannotLookup) Index() uint { return 0 }
 
+func (ValidityCannotLookup) String() string { return "validity cannot lookup" }
+
 // NoUnsignedValidator No validator found for the given unsigned transaction
 type NoUnsignedValidator struct{}
 
 // Index returns VDT index
 func (NoUnsignedValidator) Index() uint { return 1 }
+
+func (NoUnsignedValidator) String() string { return "no unsigned validator" }
 
 // UnknownCustom Any other custom unknown validity that is not covered
 type UnknownCustom uint8
@@ -174,11 +188,15 @@ type UnknownCustom uint8
 // Index returns VDT index
 func (UnknownCustom) Index() uint { return 2 }
 
+func (uc UnknownCustom) String() string { return fmt.Sprintf("UnknownCustom(%d)", uc) }
+
 // Call The call of the transaction is not expected
 type Call struct{}
 
 // Index returns VDT index
 func (Call) Index() uint { return 0 }
+
+func (Call) String() string { return "call" }
 
 // Payment General error to do with the inability to pay some fees (e.g. account balance too low)
 type Payment struct{}
@@ -186,11 +204,15 @@ type Payment struct{}
 // Index returns VDT index
 func (Payment) Index() uint { return 1 }
 
+func (Payment) String() string { return "payment" }
+
 // Future General error to do with the transaction not yet being valid (e.g. nonce too high)
 type Future struct{}
 
 // Index returns VDT index
 func (Future) Index() uint { return 2 }
+
+func (Future) String() string { return "future" }
 
 // Stale General error to do with the transaction being outdated (e.g. nonce too low)
 type Stale struct{}
@@ -198,11 +220,15 @@ type Stale struct{}
 // Index returns VDT index
 func (Stale) Index() uint { return 3 }
 
+func (Stale) String() string { return "stale" }
+
 // BadProof General error to do with the transaction’s proofs (e.g. signature)
 type BadProof struct{}
 
 // Index returns VDT index
 func (BadProof) Index() uint { return 4 }
+
+func (BadProof) String() string { return "bad proof" }
 
 // AncientBirthBlock The transaction birth block is ancient
 type AncientBirthBlock struct{}
@@ -210,11 +236,15 @@ type AncientBirthBlock struct{}
 // Index returns VDT index
 func (AncientBirthBlock) Index() uint { return 5 }
 
+func (AncientBirthBlock) String() string { return "ancient birth block" }
+
 // ExhaustsResources The transaction would exhaust the resources of current block
 type ExhaustsResources struct{}
 
 // Index returns VDT index
 func (ExhaustsResources) Index() uint { return 6 }
+
+func (ExhaustsResources) String() string { return "exhausts resources" }
 
 // InvalidCustom Any other custom invalid validity that is not covered
 type InvalidCustom uint8
@@ -222,17 +252,23 @@ type InvalidCustom uint8
 // Index returns VDT index
 func (InvalidCustom) Index() uint { return 7 }
 
+func (ic InvalidCustom) String() string { return fmt.Sprintf("InvalidCustom(%d)", ic) }
+
 // BadMandatory An extrinsic with a Mandatory dispatch resulted in Error
 type BadMandatory struct{}
 
 // Index returns VDT index
 func (BadMandatory) Index() uint { return 8 }
 
+func (BadMandatory) String() string { return "bad mandatory" }
+
 // MandatoryDispatch A transaction with a mandatory dispatch
 type MandatoryDispatch struct{}
 
 // Index returns VDT index
 func (MandatoryDispatch) Index() uint { return 9 }
+
+func (MandatoryDispatch) String() string { return "mandatory dispatch" }
 
 func determineErrType(vdt scale.VaryingDataType) error {
 	vdtVal, err := vdt.Value()
@@ -247,7 +283,7 @@ func determineErrType(vdt scale.VaryingDataType) error {
 	case BadOrigin:
 		return &DispatchOutcomeError{"bad origin"}
 	case Module:
-		return &DispatchOutcomeError{fmt.Sprintf("custom module error: %s", val.string())}
+		return &DispatchOutcomeError{fmt.Sprintf("custom module error: %s", val)}
 	case Call:
 		return &TransactionValidityError{errUnexpectedTxCall}
 	case Payment:

--- a/lib/babe/errors_test.go
+++ b/lib/babe/errors_test.go
@@ -23,12 +23,12 @@ func TestApplyExtrinsicErrors(t *testing.T) {
 		{
 			name:     "Dispatch custom module error empty",
 			test:     []byte{0, 1, 3, 4, 5, 1, 0},
-			expected: "dispatch outcome error: custom module error: index: 4 code: 5 message: ",
+			expected: "dispatch outcome error: custom module error: Module{Idx=4, Err=5 Message=",
 		},
 		{
 			name:     "Dispatch custom module error",
 			test:     []byte{0, 1, 3, 4, 5, 1, 0x04, 0x65},
-			expected: "dispatch outcome error: custom module error: index: 4 code: 5 message: 65",
+			expected: "dispatch outcome error: custom module error: Module{Idx=4, Err=5 Message=e",
 		},
 		{
 			name:     "Dispatch unknown error",

--- a/lib/babe/parachain_inherents.go
+++ b/lib/babe/parachain_inherents.go
@@ -14,6 +14,8 @@ import (
 // signature could be one of Ed25519 signature, Sr25519 signature or ECDSA/SECP256k1 signature.
 type signature [64]byte
 
+func (s signature) String() string { return fmt.Sprintf("0x%x", s[:]) }
+
 // validityAttestation is an implicit or explicit attestation to the validity of a parachain
 // candidate.
 type validityAttestation scale.VaryingDataType
@@ -45,12 +47,20 @@ func (implicit) Index() uint { //skipcq
 	return 1
 }
 
+func (i implicit) String() string { //skipcq:SCC-U1000
+	return fmt.Sprintf("implicit(%s)", validatorSignature(i))
+}
+
 // explicit is for explicit attestation.
 type explicit validatorSignature //skipcq
 
 // Index returns VDT index
 func (explicit) Index() uint { //skipcq
 	return 2
+}
+
+func (e explicit) String() string { //skipcq:SCC-U1000
+	return fmt.Sprintf("explicit(%s)", validatorSignature(e))
 }
 
 // newValidityAttestation creates a ValidityAttestation varying data type.
@@ -95,6 +105,10 @@ func (validDisputeStatementKind) Index() uint { //skipcq
 	return 0
 }
 
+func (validDisputeStatementKind) String() string { //skipcq:SCC-U1000
+	return "valid dispute statement kind"
+}
+
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
 func (v *validDisputeStatementKind) Set(val scale.VaryingDataTypeValue) (err error) { //skipcq
 	// cast to VaryingDataType to use VaryingDataType.Set method
@@ -122,12 +136,20 @@ func (explicitValidDisputeStatementKind) Index() uint { //skipcq
 	return 0
 }
 
+func (explicitValidDisputeStatementKind) String() string { //skipcq:SCC-U1000
+	return "explicit valid dispute statement kind"
+}
+
 // backingSeconded is a seconded statement on a candidate from the backing phase.
 type backingSeconded common.Hash //skipcq
 
 // Index returns VDT index
 func (backingSeconded) Index() uint { //skipcq
 	return 1
+}
+
+func (b backingSeconded) String() string { //skipcq:SCC-U1000
+	return fmt.Sprintf("backingSeconded(%s)", common.Hash(b))
 }
 
 // backingValid is a valid statement on a candidate from the backing phase.
@@ -138,6 +160,10 @@ func (backingValid) Index() uint { //skipcq
 	return 2
 }
 
+func (b backingValid) String() string { //skipcq:SCC-U1000
+	return fmt.Sprintf("backingValid(%s)", common.Hash(b))
+}
+
 // approvalChecking is an approval vote from the approval checking phase.
 type approvalChecking struct{} //skipcq
 
@@ -146,12 +172,18 @@ func (approvalChecking) Index() uint { //skipcq
 	return 3
 }
 
+func (a approvalChecking) String() string { return "approval checking" } //skipcq:SCC-U1000
+
 // invalidDisputeStatementKind is a kind of statements of invalidity on a candidate.
 type invalidDisputeStatementKind scale.VaryingDataType //skipcq
 
 // Index returns VDT index
 func (invalidDisputeStatementKind) Index() uint { //skipcq
 	return 1
+}
+
+func (invalidDisputeStatementKind) String() string { //skipcq:SCC-U1000
+	return "invalid dispute statement kind"
 }
 
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
@@ -179,6 +211,10 @@ type explicitInvalidDisputeStatementKind struct{} //skipcq
 // Index returns VDT index
 func (explicitInvalidDisputeStatementKind) Index() uint { //skipcq
 	return 0
+}
+
+func (explicitInvalidDisputeStatementKind) String() string { //skipcq:SCC-U1000
+	return "explicit invalid dispute statement kind"
 }
 
 // newDisputeStatement create a new DisputeStatement varying data type.
@@ -313,6 +349,8 @@ type validatorIndex uint32
 
 // validatorSignature is the signature with which parachain validators sign blocks.
 type validatorSignature signature
+
+func (v validatorSignature) String() string { return signature(v).String() }
 
 // statement about the candidate.
 // Used as translation of `Vec<(DisputeStatement, ValidatorIndex, ValidatorSignature)>` from rust to go

--- a/lib/grandpa/message.go
+++ b/lib/grandpa/message.go
@@ -87,6 +87,15 @@ type VersionedNeighbourPacket scale.VaryingDataType
 // Index returns VDT index
 func (VersionedNeighbourPacket) Index() uint { return 2 }
 
+func (vnp VersionedNeighbourPacket) String() string {
+	val, err := vnp.Value()
+	if err != nil {
+		return "VersionedNeighbourPacket()"
+	}
+
+	return fmt.Sprintf("VersionedNeighbourPacket(%s)", val)
+}
+
 func newVersionedNeighbourPacket() VersionedNeighbourPacket {
 	vdt := scale.MustNewVaryingDataType(NeighbourPacketV1{})
 
@@ -122,6 +131,10 @@ type NeighbourPacketV1 struct {
 // Index returns VDT index
 func (NeighbourPacketV1) Index() uint { return 1 }
 
+func (m NeighbourPacketV1) String() string {
+	return fmt.Sprintf("NeighbourPacketV1{Round=%d, SetID=%d, Number=%d}", m.Round, m.SetID, m.Number)
+}
+
 // ToConsensusMessage converts the NeighbourMessage into a network-level consensus message
 func (m *NeighbourPacketV1) ToConsensusMessage() (*network.ConsensusMessage, error) {
 	versionedNeighbourPacket := newVersionedNeighbourPacket()
@@ -152,6 +165,10 @@ type AuthData struct {
 	AuthorityID ed25519.PublicKeyBytes
 }
 
+func (a *AuthData) String() string {
+	return fmt.Sprintf("AuthData{Signature=0x%x, AuthorityID=%s}", a.Signature, a.AuthorityID)
+}
+
 // CommitMessage represents a network finalisation message
 type CommitMessage struct {
 	Round      uint64
@@ -179,10 +196,15 @@ func (s *Service) newCommitMessage(header *types.Header, round, setID uint64) (*
 // Index returns VDT index
 func (CommitMessage) Index() uint { return 1 }
 
+func (m CommitMessage) String() string {
+	return fmt.Sprintf("CommitMessage{Round=%d, SetID=%d, Vote={%s}, Precommits=%v, AuthData=%v}",
+		m.Round, m.SetID, m.Vote, m.Precommits, m.AuthData)
+}
+
 // ToConsensusMessage converts the CommitMessage into a network-level consensus message
-func (f *CommitMessage) ToConsensusMessage() (*ConsensusMessage, error) {
+func (m *CommitMessage) ToConsensusMessage() (*ConsensusMessage, error) {
 	msg := newGrandpaMessage()
-	err := msg.Set(*f)
+	err := msg.Set(*m)
 	if err != nil {
 		return nil, err
 	}
@@ -245,6 +267,10 @@ func newCatchUpRequest(round, setID uint64) *CatchUpRequest {
 // Index returns VDT index
 func (CatchUpRequest) Index() uint { return 3 }
 
+func (r CatchUpRequest) String() string {
+	return fmt.Sprintf("CatchUpRequest{Round=%d, SetID=%d}", r.Round, r.SetID)
+}
+
 // ToConsensusMessage converts the catchUpRequest into a network-level consensus message
 func (r *CatchUpRequest) ToConsensusMessage() (*ConsensusMessage, error) {
 	msg := newGrandpaMessage()
@@ -301,6 +327,12 @@ func (s *Service) newCatchUpResponse(round, setID uint64) (*CatchUpResponse, err
 
 // Index returns VDT index
 func (CatchUpResponse) Index() uint { return 4 }
+
+func (r CatchUpResponse) String() string {
+	return fmt.Sprintf("CatchUpResponse{SetID=%d, Round=%d, PreVoteJustification=%v, "+
+		"PreCommitJustification=%v, Hash=%s, Number=%d}",
+		r.SetID, r.Round, r.PreVoteJustification, r.PreCommitJustification, r.Hash, r.Number)
+}
 
 // ToConsensusMessage converts the catchUpResponse into a network-level consensus message
 func (r *CatchUpResponse) ToConsensusMessage() (*ConsensusMessage, error) {

--- a/lib/runtime/invalid_transaction.go
+++ b/lib/runtime/invalid_transaction.go
@@ -17,6 +17,8 @@ func (InvalidTransaction) Index() uint {
 	return 0
 }
 
+func (i InvalidTransaction) String() string { return i.Error() }
+
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
 func (i *InvalidTransaction) Set(val scale.VaryingDataTypeValue) (err error) {
 	vdt := scale.VaryingDataType(*i)
@@ -63,6 +65,8 @@ type Call struct{}
 // Index returns the VDT index
 func (Call) Index() uint { return 0 }
 
+func (c Call) String() string { return c.Error() }
+
 // Error returns the error message associated with the Call
 func (Call) Error() string {
 	return "call of the transaction is not expected"
@@ -73,6 +77,8 @@ type Payment struct{}
 
 // Index returns the VDT index
 func (Payment) Index() uint { return 1 }
+
+func (p Payment) String() string { return p.Error() }
 
 // Error returns the error message associated with the Payment
 func (Payment) Error() string {
@@ -85,6 +91,8 @@ type Future struct{}
 // Index returns the VDT index
 func (Future) Index() uint { return 2 }
 
+func (f Future) String() string { return f.Error() }
+
 // Error returns the error message associated with the Future
 func (Future) Error() string {
 	return "invalid transaction"
@@ -95,6 +103,8 @@ type Stale struct{}
 
 // Index returns the VDT index
 func (Stale) Index() uint { return 3 }
+
+func (s Stale) String() string { return s.Error() }
 
 // Error returns the error message associated with the Stale
 func (Stale) Error() string {
@@ -107,6 +117,8 @@ type BadProof struct{}
 // Index returns the VDT index
 func (BadProof) Index() uint { return 4 }
 
+func (b BadProof) String() string { return b.Error() }
+
 // Error returns the error message associated with the BadProof
 func (BadProof) Error() string {
 	return "bad proof"
@@ -117,6 +129,8 @@ type AncientBirthBlock struct{}
 
 // Index returns the VDT index
 func (AncientBirthBlock) Index() uint { return 5 }
+
+func (a AncientBirthBlock) String() string { return a.Error() }
 
 // Error returns the error message associated with the AncientBirthBlock
 func (AncientBirthBlock) Error() string {
@@ -129,6 +143,8 @@ type ExhaustsResources struct{}
 // Index returns the VDT index
 func (ExhaustsResources) Index() uint { return 6 }
 
+func (e ExhaustsResources) String() string { return e.Error() }
+
 // Error returns the error message associated with the ExhaustsResources
 func (ExhaustsResources) Error() string {
 	return "exhausts resources"
@@ -139,6 +155,8 @@ type InvalidCustom uint8
 
 // Index returns the VDT index
 func (InvalidCustom) Index() uint { return 7 }
+
+func (i InvalidCustom) String() string { return i.Error() }
 
 // Error returns the error message associated with the InvalidCustom
 func (i InvalidCustom) Error() string {
@@ -151,6 +169,8 @@ type BadMandatory struct{}
 // Index returns the VDT index
 func (BadMandatory) Index() uint { return 8 }
 
+func (b BadMandatory) String() string { return b.Error() }
+
 // Error returns the error message associated with the BadMandatory
 func (BadMandatory) Error() string {
 	return "mandatory dispatch error"
@@ -161,6 +181,8 @@ type MandatoryDispatch struct{}
 
 // Index returns the VDT index
 func (MandatoryDispatch) Index() uint { return 9 }
+
+func (m MandatoryDispatch) String() string { return m.Error() }
 
 // Error returns the error message associated with the MandatoryDispatch
 func (MandatoryDispatch) Error() string {

--- a/lib/runtime/unknown_transaction.go
+++ b/lib/runtime/unknown_transaction.go
@@ -17,6 +17,8 @@ func (UnknownTransaction) Index() uint {
 	return 1
 }
 
+func (u UnknownTransaction) String() string { return u.Error() }
+
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
 func (u *UnknownTransaction) Set(val scale.VaryingDataTypeValue) (err error) {
 	vdt := scale.VaryingDataType(*u)
@@ -61,6 +63,8 @@ type ValidityCannotLookup struct{}
 // Index returns the VDT index
 func (ValidityCannotLookup) Index() uint { return 0 }
 
+func (v ValidityCannotLookup) String() string { return v.Error() }
+
 // Error returns the error message associated with the ValidityCannotLookup
 func (ValidityCannotLookup) Error() string {
 	return "lookup failed"
@@ -72,6 +76,8 @@ type NoUnsignedValidator struct{}
 // Index returns the VDT index
 func (NoUnsignedValidator) Index() uint { return 1 }
 
+func (n NoUnsignedValidator) String() string { return n.Error() }
+
 // Error returns the error message associated with the NoUnsignedValidator
 func (NoUnsignedValidator) Error() string {
 	return "validator not found"
@@ -82,6 +88,8 @@ type UnknownCustom uint8
 
 // Index returns the VDT index
 func (UnknownCustom) Index() uint { return 2 }
+
+func (m UnknownCustom) String() string { return m.Error() }
 
 // Error returns the error message associated with the UnknownCustom
 func (m UnknownCustom) Error() string {

--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1226,14 +1226,14 @@ func ext_default_child_storage_storage_kill_version_2(context unsafe.Pointer,
 }
 
 type noneRemain uint32
+
+func (noneRemain) Index() uint       { return 0 }
+func (nr noneRemain) String() string { return fmt.Sprintf("noneRemain(%d)", nr) }
+
 type someRemain uint32
 
-func (noneRemain) Index() uint {
-	return 0
-}
-func (someRemain) Index() uint {
-	return 1
-}
+func (someRemain) Index() uint       { return 1 }
+func (sr someRemain) String() string { return fmt.Sprintf("someRemain(%d)", sr) }
 
 //export ext_default_child_storage_storage_kill_version_3
 func ext_default_child_storage_storage_kill_version_3(context unsafe.Pointer,

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -10,6 +10,7 @@ import (
 // VaryingDataTypeValue is used to represent scale encodable types of an associated VaryingDataType
 type VaryingDataTypeValue interface {
 	Index() uint
+	String() string
 }
 
 // VaryingDataTypeSlice is used to represent []VaryingDataType. SCALE requires knowledge

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -75,6 +75,13 @@ func (vdt *VaryingDataType) Value() (VaryingDataTypeValue, error) {
 	return vdt.value, nil
 }
 
+func (vdt VaryingDataType) String() string {
+	if vdt.value == nil {
+		return "VaryingDataType(nil)"
+	}
+	return vdt.value.String()
+}
+
 // NewVaryingDataType is constructor for VaryingDataType
 func NewVaryingDataType(values ...VaryingDataTypeValue) (vdt VaryingDataType, err error) {
 	if len(values) == 0 {

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -5,6 +5,7 @@ package scale
 
 import (
 	"fmt"
+	"strings"
 )
 
 // VaryingDataTypeValue is used to represent scale encodable types of an associated VaryingDataType
@@ -32,6 +33,14 @@ func (vdts *VaryingDataTypeSlice) Add(values ...VaryingDataTypeValue) (err error
 		vdts.Types = append(vdts.Types, copied)
 	}
 	return
+}
+
+func (vdts VaryingDataTypeSlice) String() string {
+	stringTypes := make([]string, len(vdts.Types))
+	for i, vdt := range vdts.Types {
+		stringTypes[i] = vdt.String()
+	}
+	return "[" + strings.Join(stringTypes, ", ") + "]"
 }
 
 // NewVaryingDataTypeSlice is constructor for VaryingDataTypeSlice

--- a/pkg/scale/varying_data_type.go
+++ b/pkg/scale/varying_data_type.go
@@ -11,7 +11,6 @@ import (
 // VaryingDataTypeValue is used to represent scale encodable types of an associated VaryingDataType
 type VaryingDataTypeValue interface {
 	Index() uint
-	String() string
 }
 
 // VaryingDataTypeSlice is used to represent []VaryingDataType. SCALE requires knowledge
@@ -88,7 +87,11 @@ func (vdt VaryingDataType) String() string {
 	if vdt.value == nil {
 		return "VaryingDataType(nil)"
 	}
-	return vdt.value.String()
+	stringer, ok := vdt.value.(fmt.Stringer)
+	if !ok {
+		return fmt.Sprintf("VaryingDataType(%v)", vdt.value)
+	}
+	return stringer.String()
 }
 
 // NewVaryingDataType is constructor for VaryingDataType

--- a/pkg/scale/varying_data_type_example_test.go
+++ b/pkg/scale/varying_data_type_example_test.go
@@ -21,6 +21,10 @@ func (MyStruct) Index() uint {
 	return 1
 }
 
+func (m MyStruct) String() string {
+	return fmt.Sprintf("MyStruct{Baz: %t, Bar: %d, Foo: %x}", m.Baz, m.Bar, m.Foo)
+}
+
 type MyOtherStruct struct {
 	Foo string
 	Bar uint64
@@ -31,11 +35,17 @@ func (MyOtherStruct) Index() uint {
 	return 2
 }
 
+func (m MyOtherStruct) String() string {
+	return fmt.Sprintf("MyOtherStruct{Foo: %s, Bar: %d, Baz: %d}", m.Foo, m.Bar, m.Baz)
+}
+
 type MyInt16 int16
 
 func (MyInt16) Index() uint {
 	return 3
 }
+
+func (m MyInt16) String() string { return fmt.Sprintf("MyInt16(%d)", m) }
 
 func ExampleVaryingDataType() {
 	vdt, err := scale.NewVaryingDataType(MyStruct{}, MyOtherStruct{}, MyInt16(0))

--- a/pkg/scale/varying_data_type_nested_example_test.go
+++ b/pkg/scale/varying_data_type_nested_example_test.go
@@ -52,6 +52,14 @@ func (ChildVDT) Index() uint {
 	return 1
 }
 
+func (cvdt ChildVDT) String() string {
+	value, err := cvdt.Value()
+	if err != nil {
+		return "ChildVDT()"
+	}
+	return fmt.Sprintf("ChildVDT(%s)", value)
+}
+
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
 func (cvdt *ChildVDT) Set(val scale.VaryingDataTypeValue) (err error) {
 	// cast to VaryingDataType to use VaryingDataType.Set method
@@ -91,6 +99,16 @@ func (OtherChildVDT) Index() uint {
 	return 2
 }
 
+func (cvdt OtherChildVDT) String() string {
+	vdt := scale.VaryingDataType(cvdt)
+	vdtPtr := &vdt
+	value, err := vdtPtr.Value()
+	if err != nil {
+		return "OtherChildVDT()"
+	}
+	return fmt.Sprintf("OtherChildVDT(%s)", value)
+}
+
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
 func (cvdt *OtherChildVDT) Set(val scale.VaryingDataTypeValue) (err error) {
 	// cast to VaryingDataType to use VaryingDataType.Set method
@@ -125,6 +143,8 @@ func (ChildInt16) Index() uint {
 	return 1
 }
 
+func (c ChildInt16) String() string { return fmt.Sprintf("ChildInt16(%d)", c) }
+
 // ChildStruct is used as a VaryingDataTypeValue for ChildVDT and OtherChildVDT
 type ChildStruct struct {
 	A string
@@ -136,6 +156,10 @@ func (ChildStruct) Index() uint {
 	return 2
 }
 
+func (c ChildStruct) String() string {
+	return fmt.Sprintf("ChildStruct{A=%s, B=%t}", c.A, c.B)
+}
+
 // ChildString is used as a VaryingDataTypeValue for ChildVDT and OtherChildVDT
 type ChildString string
 
@@ -143,6 +167,8 @@ type ChildString string
 func (ChildString) Index() uint {
 	return 3
 }
+
+func (c ChildString) String() string { return fmt.Sprintf("ChildString(%s)", string(c)) }
 
 func Example() {
 	parent := NewParentVDT()
@@ -187,8 +213,8 @@ func Example() {
 	fmt.Println(reflect.DeepEqual(parent, dstParent))
 
 	// Output:
-	// parent.Value(): {value:888 cache:map[1:0 2:{A: B:false} 3:]}
-	// child.Value(): 888
+	// parent.Value(): ChildVDT(ChildInt16(888))
+	// child.Value(): ChildInt16(888)
 	// bytes: 01 01 78 03
 	// true
 }

--- a/pkg/scale/varying_data_type_nested_test.go
+++ b/pkg/scale/varying_data_type_nested_test.go
@@ -4,6 +4,7 @@
 package scale
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -37,6 +38,13 @@ func (childVDT) Index() uint {
 	return 1
 }
 
+func (c childVDT) String() string {
+	if c.value == nil {
+		return "childVDT(nil)"
+	}
+	return fmt.Sprintf("childVDT(%s)", c.value)
+}
+
 func mustNewChildVDT() childVDT {
 	vdt, err := NewVaryingDataType(VDTValue{}, VDTValue1{}, VDTValue2{}, VDTValue3(0))
 	if err != nil {
@@ -61,6 +69,13 @@ type childVDT1 VaryingDataType
 
 func (childVDT1) Index() uint {
 	return 2
+}
+
+func (c childVDT1) String() string {
+	if c.value == nil {
+		return "childVDT1(nil)"
+	}
+	return fmt.Sprintf("childVDT1(%s)", c.value)
 }
 
 func mustNewChildVDT1() childVDT1 {

--- a/pkg/scale/varying_data_type_test.go
+++ b/pkg/scale/varying_data_type_test.go
@@ -53,6 +53,8 @@ func (VDTValue) Index() uint {
 	return 1
 }
 
+func (VDTValue) String() string { return "" }
+
 type VDTValue1 struct {
 	O  **big.Int
 	P  *int
@@ -73,6 +75,8 @@ type VDTValue1 struct {
 func (VDTValue1) Index() uint {
 	return 2
 }
+
+func (VDTValue1) String() string { return "" }
 
 type VDTValue2 struct {
 	A MyStruct
@@ -99,11 +103,15 @@ func (VDTValue2) Index() uint {
 	return 3
 }
 
+func (VDTValue2) String() string { return "" }
+
 type VDTValue3 int16
 
 func (VDTValue3) Index() uint {
 	return 4
 }
+
+func (VDTValue3) String() string { return "" }
 
 var varyingDataTypeTests = tests{
 	{


### PR DESCRIPTION
## Changes

As proposed by Eclesio in https://github.com/ChainSafe/gossamer/pull/2965#discussion_r1028345455

1. ~`VaryingDataTypeValue` interface is now composed of `fmt.Stringer`~
2. Add missing `String() string` methods to types needing to implement `VaryingDataTypeValue`
3. Add `String() string` method on `VaryingDataType` struct
4. Add `String() string` method on `VaryingDataTypeSlice` struct

## Tests



## Issues

A few more steps towards #1945 

## Primary Reviewer

@EclesioMeloJunior 
