### PR TITLE
fix(wasmer): `ext_storage_exists_version_1` for empty values

### DIFF
--- a/lib/runtime/wasmer/imports.go
+++ b/lib/runtime/wasmer/imports.go
@@ -1910,8 +1910,8 @@ func ext_storage_exists_version_1(context unsafe.Pointer, keySpan C.int64_t) C.i
 	key := asMemorySlice(instanceContext, keySpan)
 	logger.Debugf("key: 0x%x", key)
 
-	val := storage.Get(key)
-	if len(val) > 0 {
+	value := storage.Get(key)
+	if value != nil {
 		return 1
 	}
 


### PR DESCRIPTION
## Changes

- If the value is `[]byte{}`, the key exists (leaf node, branch with value)
- If the value is `[]byte(nil)`, the key does not exist (node not found or branch without value)
- Change unit test to be cases-based and add case

## Tests


```sh
go test -run ^Test_ext_storage_exists_version_1$ github.com/ChainSafe/gossamer/lib/runtime/wasmer
```

## Issues

## Primary Reviewer

@timwu20 