### PR TITLE
chore: fix `encodeArray` comment removing wrong explanation

### DIFF
--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -213,7 +213,8 @@ func (es *encodeState) encodeSlice(in interface{}) (err error) {
 }
 
 // encodeArray encodes an interface where the underlying type is an array
-// it writes the encoded length of the Array to the Encoder, then encodes and writes each value in the Array
+// it encodes and writes each value in the Array. Arrays of known size do not 
+// have the length prepended since you know the length when decoding
 func (es *encodeState) encodeArray(in interface{}) (err error) {
 	v := reflect.ValueOf(in)
 	for i := 0; i < v.Len(); i++ {

--- a/pkg/scale/encode.go
+++ b/pkg/scale/encode.go
@@ -213,7 +213,7 @@ func (es *encodeState) encodeSlice(in interface{}) (err error) {
 }
 
 // encodeArray encodes an interface where the underlying type is an array
-// it encodes and writes each value in the Array. Arrays of known size do not 
+// it encodes and writes each value in the Array. Arrays of known size do not
 // have the length prepended since you know the length when decoding
 func (es *encodeState) encodeArray(in interface{}) (err error) {
 	v := reflect.ValueOf(in)


### PR DESCRIPTION
## Changes

- The `encodeArray` comment was describing it wrong

## Tests
N/A

## Issues

Closes #2975

## Primary Reviewer

@timwu20
