### PR TITLE
chore(all): dependency inject databases and tables

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot"
 	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/dot/state"
@@ -897,8 +899,9 @@ func updateDotConfigFromGenesisJSONRaw(tomlCfg ctoml.Config, cfg *dot.Config) {
 
 // updateDotConfigFromGenesisData updates the configuration from genesis data of an initialised node
 func updateDotConfigFromGenesisData(ctx *cli.Context, cfg *dot.Config) error {
-	// initialise database using data directory
-	db, err := utils.SetupDatabase(cfg.Global.BasePath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(cfg.Global.BasePath, "db"),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create database: %s", err)
 	}

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/chain/kusama"
 	"github.com/ChainSafe/gossamer/chain/polkadot"
 	"github.com/ChainSafe/gossamer/dot"
@@ -820,7 +821,9 @@ func TestUpdateConfigFromGenesisData(t *testing.T) {
 
 	cfg.Init.Genesis = genFile
 
-	db, err := utils.SetupDatabase(cfg.Global.BasePath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(cfg.Global.BasePath, "db"),
+	})
 	require.NoError(t, err)
 
 	gen, err := genesis.NewGenesisFromJSONRaw(genFile)

--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -225,7 +226,9 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 		if stateSrvc != nil {
 			nodeStorage.BaseDB = stateSrvc.Base
 		} else {
-			nodeStorage.BaseDB, err = utils.SetupDatabase(filepath.Join(testDatadirPath, "offline_storage"), false)
+			nodeStorage.BaseDB, err = chaindb.NewBadgerDB(&chaindb.Config{
+				DataDir: filepath.Join(testDatadirPath, "offline_storage", "db"),
+			})
 			require.NoError(t, err)
 		}
 

--- a/dot/interfaces.go
+++ b/dot/interfaces.go
@@ -76,3 +76,9 @@ type runtimeInterface interface {
 		equivocationProof types.GrandpaEquivocationProof, keyOwnershipProof types.GrandpaOpaqueKeyOwnershipProof,
 	) error
 }
+
+type basicStorage interface {
+	Put(key []byte, value []byte) error
+	Get(key []byte) ([]byte, error)
+	Del(key []byte) error
+}

--- a/dot/mock_node_builder_test.go
+++ b/dot/mock_node_builder_test.go
@@ -151,18 +151,18 @@ func (mr *MocknodeBuilderIfaceMockRecorder) createRPCService(params interface{})
 }
 
 // createRuntimeStorage mocks base method.
-func (m *MocknodeBuilderIface) createRuntimeStorage(st *state.Service) (*runtime.NodeStorage, error) {
+func (m *MocknodeBuilderIface) createRuntimeStorage(base, persistent basicStorage) (*runtime.NodeStorage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "createRuntimeStorage", st)
+	ret := m.ctrl.Call(m, "createRuntimeStorage", base, persistent)
 	ret0, _ := ret[0].(*runtime.NodeStorage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // createRuntimeStorage indicates an expected call of createRuntimeStorage.
-func (mr *MocknodeBuilderIfaceMockRecorder) createRuntimeStorage(st interface{}) *gomock.Call {
+func (mr *MocknodeBuilderIfaceMockRecorder) createRuntimeStorage(base, persistent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createRuntimeStorage", reflect.TypeOf((*MocknodeBuilderIface)(nil).createRuntimeStorage), st)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "createRuntimeStorage", reflect.TypeOf((*MocknodeBuilderIface)(nil).createRuntimeStorage), base, persistent)
 }
 
 // createStateService mocks base method.

--- a/dot/node.go
+++ b/dot/node.go
@@ -96,7 +96,9 @@ func (*nodeBuilder) isNodeInitialised(basepath string) error {
 		return fmt.Errorf("cannot find key registry in database directory: %w", err)
 	}
 
-	db, err := utils.SetupDatabase(basepath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(basepath, "db"),
+	})
 	if err != nil {
 		return fmt.Errorf("cannot setup database: %w", err)
 	}
@@ -195,8 +197,9 @@ func (*nodeBuilder) initNode(cfg *Config) error {
 
 // LoadGlobalNodeName returns the stored global node name from database
 func LoadGlobalNodeName(basepath string) (nodename string, err error) {
-	// initialise database using data directory
-	db, err := utils.SetupDatabase(basepath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(basepath, "db"),
+	})
 	if err != nil {
 		return "", err
 	}
@@ -432,7 +435,9 @@ func setupTelemetry(cfg *Config, genesisData *genesis.Data) (mailer Telemetry, e
 
 // stores the global node name to reuse
 func storeGlobalNodeName(name, basepath string) (err error) {
-	db, err := utils.SetupDatabase(basepath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(basepath, "db"),
+	})
 	if err != nil {
 		return err
 	}

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/core"
 	digest "github.com/ChainSafe/gossamer/dot/digest"
 	network "github.com/ChainSafe/gossamer/dot/network"
@@ -32,7 +33,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 	gomock "github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -211,7 +211,9 @@ func TestInitNode_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// confirm database was setup
-	db, err := utils.SetupDatabase(cfg.Global.BasePath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(cfg.Global.BasePath, "db"),
+	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
 }
@@ -226,7 +228,9 @@ func TestInitNode_GenesisSpec(t *testing.T) {
 	err := InitNode(cfg)
 	require.NoError(t, err)
 	// confirm database was setup
-	db, err := utils.SetupDatabase(cfg.Global.BasePath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(cfg.Global.BasePath, "db"),
+	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
 }

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -117,7 +117,7 @@ func TestNewNode(t *testing.T) {
 		return stateSrvc, nil
 	})
 
-	m.EXPECT().createRuntimeStorage(gomock.AssignableToTypeOf(&state.Service{})).Return(&runtime.
+	m.EXPECT().createRuntimeStorage(gomock.AssignableToTypeOf(&state.BaseState{}), gomock.Any()).Return(&runtime.
 		NodeStorage{}, nil)
 	m.EXPECT().loadRuntime(dotConfig, &runtime.NodeStorage{}, gomock.AssignableToTypeOf(&state.Service{}),
 		ks, gomock.AssignableToTypeOf(&network.Service{})).Return(nil)

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -216,6 +216,8 @@ func TestInitNode_Integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
+	err = db.Close()
+	require.NoError(t, err)
 }
 
 func TestInitNode_GenesisSpec(t *testing.T) {
@@ -233,6 +235,8 @@ func TestInitNode_GenesisSpec(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, db)
+	err = db.Close()
+	require.NoError(t, err)
 }
 
 func TestNodeInitializedIntegration(t *testing.T) {

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/internal/log"
@@ -53,7 +54,9 @@ func TestLoadGlobalNodeName(t *testing.T) {
 	t.Parallel()
 
 	basePath := t.TempDir()
-	db, err := utils.SetupDatabase(basePath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(basePath, "db"),
+	})
 	require.NoError(t, err)
 
 	basestate := state.NewBaseState(db)

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -53,7 +53,7 @@ func useInstanceFromGenesis(t *testing.T, rtStorage *storage.TrieState) (instanc
 		Storage: rtStorage,
 		LogLvl:  log.Warn,
 		NodeStorage: runtime.NodeStorage{
-			BaseDB: runtime.NewInMemoryDB(t),
+			BaseDB: newDatabase(t),
 		},
 	}
 
@@ -77,9 +77,9 @@ func useInstanceFromRuntimeV0929(t *testing.T, rtStorage *storage.TrieState) (in
 		Storage:  rtStorage,
 		Keystore: keystore.NewGlobalKeystore(),
 		NodeStorage: runtime.NodeStorage{
-			LocalStorage:      runtime.NewInMemoryDB(t),
-			PersistentStorage: runtime.NewInMemoryDB(t),
-			BaseDB:            runtime.NewInMemoryDB(t),
+			LocalStorage:      newDatabase(t),
+			PersistentStorage: newDatabase(t),
+			BaseDB:            newDatabase(t),
 		},
 	}
 

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/golang/mock/gomock"
 
@@ -366,7 +365,9 @@ func newTestStateService(t *testing.T) *state.Service {
 	if stateSrvc != nil {
 		rtCfg.NodeStorage.BaseDB = stateSrvc.Base
 	} else {
-		rtCfg.NodeStorage.BaseDB, err = utils.SetupDatabase(filepath.Join(testDatadirPath, "offline_storage"), false)
+		rtCfg.NodeStorage.BaseDB, err = database.NewBadgerDB(&database.Config{
+			DataDir: filepath.Join(testDatadirPath, "offline_storage", "db"),
+		})
 		require.NoError(t, err)
 	}
 

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/babe"
@@ -42,7 +43,12 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 	_, genesisTrie, genesisHeader := newWestendLocalGenesisWithTrieAndHeader(t)
 	tries := state.NewTries()
 	tries.SetTrie(&genesisTrie)
-	bs, err := state.NewBlockStateFromGenesis(db, tries, &genesisHeader, telemetryMock)
+
+	baseState := state.NewBaseState(db)
+	const blockPrefix = "block"
+	blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+	bs, err := state.NewBlockStateFromGenesis(blockStateDatabase,
+		baseState, tries, &genesisHeader, telemetryMock)
 	require.NoError(t, err)
 	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)
 	require.NoError(t, err)

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -50,7 +50,11 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 	bs, err := state.NewBlockStateFromGenesis(blockStateDatabase,
 		baseState, tries, &genesisHeader, telemetryMock)
 	require.NoError(t, err)
-	es, err := state.NewEpochStateFromGenesis(db, bs, genesisBABEConfig)
+
+	const epochPrefix = "epoch"
+	epochStateDatabase := chaindb.NewTable(db, epochPrefix)
+	es, err := state.NewEpochStateFromGenesis(epochStateDatabase,
+		baseState, bs, genesisBABEConfig)
 	require.NoError(t, err)
 	return bs, es
 }

--- a/dot/rpc/modules/dev_integration_test.go
+++ b/dot/rpc/modules/dev_integration_test.go
@@ -38,7 +38,7 @@ func newState(t *testing.T) (*state.BlockState, *state.EpochState) {
 	telemetryMock := NewMockTelemetry(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	db := state.NewInMemoryDB(t)
+	db := newDatabase(t)
 
 	_, genesisTrie, genesisHeader := newWestendLocalGenesisWithTrieAndHeader(t)
 	tries := state.NewTries()

--- a/dot/rpc/modules/helpers_test.go
+++ b/dot/rpc/modules/helpers_test.go
@@ -21,7 +21,8 @@ func newDatabase(t *testing.T) chaindb.Database {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = db.Close()
+		err := db.Close()
+		require.NoError(t, err)
 	})
 	return db
 }

--- a/dot/rpc/modules/helpers_test.go
+++ b/dot/rpc/modules/helpers_test.go
@@ -5,6 +5,7 @@ package modules
 import (
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
@@ -13,6 +14,17 @@ import (
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/require"
 )
+
+func newDatabase(t *testing.T) chaindb.Database {
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		InMemory: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}
 
 func stringToHex(s string) (hex string) {
 	return common.BytesToHex([]byte(s))

--- a/dot/services.go
+++ b/dot/services.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/runtime"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
-	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // BlockProducer to produce blocks
@@ -51,10 +50,6 @@ type rpcServiceSettings struct {
 	system        *system.Service
 	blockFinality *grandpa.Service
 	syncer        *sync.Service
-}
-
-func newInMemoryDB() (*chaindb.BadgerDB, error) {
-	return utils.SetupDatabase("", true)
 }
 
 // createStateService creates the state service and initialise state database
@@ -98,7 +93,7 @@ func startStateService(cfg *Config, stateSrvc *state.Service) error {
 
 func (nodeBuilder) createRuntimeStorage(base, persistentStorage basicStorage) (
 	*runtime.NodeStorage, error) {
-	localStorage, err := newInMemoryDB()
+	localStorage, err := chaindb.NewBadgerDB(&chaindb.Config{InMemory: true})
 	if err != nil {
 		return nil, err
 	}

--- a/dot/services.go
+++ b/dot/services.go
@@ -96,7 +96,8 @@ func startStateService(cfg *Config, stateSrvc *state.Service) error {
 	return nil
 }
 
-func (nodeBuilder) createRuntimeStorage(st *state.Service) (*runtime.NodeStorage, error) {
+func (nodeBuilder) createRuntimeStorage(base, persistentStorage basicStorage) (
+	*runtime.NodeStorage, error) {
 	localStorage, err := newInMemoryDB()
 	if err != nil {
 		return nil, err
@@ -104,8 +105,8 @@ func (nodeBuilder) createRuntimeStorage(st *state.Service) (*runtime.NodeStorage
 
 	return &runtime.NodeStorage{
 		LocalStorage:      localStorage,
-		PersistentStorage: chaindb.NewTable(st.DB(), "offlinestorage"),
-		BaseDB:            st.Base,
+		PersistentStorage: persistentStorage,
+		BaseDB:            base,
 	}, nil
 }
 

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	core "github.com/ChainSafe/gossamer/dot/core"
 	digest "github.com/ChainSafe/gossamer/dot/digest"
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -438,6 +439,8 @@ func newStateServiceWithoutMock(t *testing.T) *state.Service {
 	err = stateSrvc.SetupBase()
 	require.NoError(t, err)
 
+	const epochPrefix = "epoch"
+	epochStateDatabase := chaindb.NewTable(stateSrvc.DB(), epochPrefix)
 	genesisBABEConfig := &types.BabeConfiguration{
 		SlotDuration:       1000,
 		EpochLength:        200,
@@ -447,7 +450,8 @@ func newStateServiceWithoutMock(t *testing.T) *state.Service {
 		Randomness:         [32]byte{},
 		SecondarySlots:     0,
 	}
-	epochState, err := state.NewEpochStateFromGenesis(stateSrvc.DB(), stateSrvc.Block, genesisBABEConfig)
+	epochState, err := state.NewEpochStateFromGenesis(epochStateDatabase,
+		stateSrvc.Base, stateSrvc.Block, genesisBABEConfig)
 	require.NoError(t, err)
 
 	stateSrvc.Epoch = epochState

--- a/dot/services_integration_test.go
+++ b/dot/services_integration_test.go
@@ -590,7 +590,8 @@ func TestCreateRPCService(t *testing.T) {
 	ed25519Keyring, _ := keystore.NewEd25519Keyring()
 	ks.Gran.Insert(ed25519Keyring.Alice())
 
-	ns, err := builder.createRuntimeStorage(stateSrvc)
+	persistentStorage := chaindb.NewTable(stateSrvc.DB(), "offlinestorage")
+	ns, err := builder.createRuntimeStorage(stateSrvc.Base, persistentStorage)
 	require.NoError(t, err)
 	err = builder.loadRuntime(cfg, ns, stateSrvc, ks, networkSrvc)
 	require.NoError(t, err)
@@ -636,7 +637,8 @@ func TestCreateBABEService_Integration(t *testing.T) {
 	require.NoError(t, err)
 	ks.Babe.Insert(kr.Alice())
 
-	ns, err := builder.createRuntimeStorage(stateSrvc)
+	persistentStorage := chaindb.NewTable(stateSrvc.DB(), "offlinestorage")
+	ns, err := builder.createRuntimeStorage(stateSrvc.Base, persistentStorage)
 	require.NoError(t, err)
 	err = builder.loadRuntime(cfg, ns, stateSrvc, ks, &network.Service{})
 	require.NoError(t, err)
@@ -671,7 +673,8 @@ func TestCreateGrandpaService(t *testing.T) {
 	require.NoError(t, err)
 	ks.Gran.Insert(kr.Alice())
 
-	ns, err := builder.createRuntimeStorage(stateSrvc)
+	persistentStorage := chaindb.NewTable(stateSrvc.DB(), "offlinestorage")
+	ns, err := builder.createRuntimeStorage(stateSrvc.Base, persistentStorage)
 	require.NoError(t, err)
 
 	err = builder.loadRuntime(cfg, ns, stateSrvc, ks, &network.Service{})
@@ -747,7 +750,8 @@ func TestNewWebSocketServer(t *testing.T) {
 	ed25519Keyring, _ := keystore.NewEd25519Keyring()
 	ks.Gran.Insert(ed25519Keyring.Alice())
 
-	ns, err := builder.createRuntimeStorage(stateSrvc)
+	persistentStorage := chaindb.NewTable(stateSrvc.DB(), "offlinestorage")
+	ns, err := builder.createRuntimeStorage(stateSrvc.Base, persistentStorage)
 	require.NoError(t, err)
 	err = builder.loadRuntime(cfg, ns, stateSrvc, ks, networkSrvc)
 	require.NoError(t, err)

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -6,6 +6,7 @@ package dot
 import (
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/internal/log"
@@ -142,6 +143,8 @@ func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 	err = stateSrvc.SetupBase()
 	require.NoError(t, err)
 
+	const epochPrefix = "epoch"
+	epochStateDatabase := chaindb.NewTable(stateSrvc.DB(), epochPrefix)
 	genesisBABEConfig := &types.BabeConfiguration{
 		SlotDuration:       1000,
 		EpochLength:        200,
@@ -151,7 +154,8 @@ func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 		Randomness:         [32]byte{},
 		SecondarySlots:     0,
 	}
-	epochState, err := state.NewEpochStateFromGenesis(stateSrvc.DB(), stateSrvc.Block, genesisBABEConfig)
+	epochState, err := state.NewEpochStateFromGenesis(epochStateDatabase,
+		stateSrvc.Base, stateSrvc.Block, genesisBABEConfig)
 	require.NoError(t, err)
 
 	stateSrvc.Epoch = epochState

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -44,7 +44,8 @@ func Test_createRuntimeStorage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := builder.createRuntimeStorage(tt.service)
+			persistentStorage := chaindb.NewTable(tt.service.DB(), "offlinestorage")
+			got, err := builder.createRuntimeStorage(stateSrvc.Base, persistentStorage)
 			assert.ErrorIs(t, err, tt.err)
 			assert.Equal(t, tt.expectedBaseDB, got.BaseDB)
 			assert.NotNil(t, got.LocalStorage)

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -99,31 +99,6 @@ func Test_createSystemService(t *testing.T) {
 	}
 }
 
-func Test_newInMemoryDB(t *testing.T) {
-	tests := []struct {
-		name      string
-		expectNil bool
-		err       error
-	}{
-		{
-			name:      "working example",
-			expectNil: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := newInMemoryDB()
-			assert.ErrorIs(t, err, tt.err)
-
-			if tt.expectNil {
-				assert.Nil(t, got)
-			} else {
-				assert.NotNil(t, got)
-			}
-		})
-	}
-}
-
 func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 	t.Helper()
 

--- a/dot/state/base_test.go
+++ b/dot/state/base_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestTrie_StoreAndLoadFromDB(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	tt := trie.NewEmptyTrie()
 
 	generator := newGenerator()
@@ -41,7 +41,7 @@ func TestTrie_StoreAndLoadFromDB(t *testing.T) {
 }
 
 func TestStoreAndLoadGenesisData(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	base := NewBaseState(db)
 
 	bootnodes := common.StringArrayToBytes([]string{
@@ -65,7 +65,7 @@ func TestStoreAndLoadGenesisData(t *testing.T) {
 }
 
 func TestLoadStoreEpochLength(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	base := NewBaseState(db)
 
 	length := uint64(2222)
@@ -78,7 +78,7 @@ func TestLoadStoreEpochLength(t *testing.T) {
 }
 
 func TestLoadAndStoreSlotDuration(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	base := NewBaseState(db)
 
 	d := uint64(3000)

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -53,7 +53,6 @@ var (
 type BlockState struct {
 	bt        *blocktree.BlockTree
 	baseState *BaseState
-	dbPath    string
 	db        BlockStateDatabase
 	sync.RWMutex
 	genesisHash       common.Hash
@@ -73,11 +72,11 @@ type BlockState struct {
 }
 
 // NewBlockState will create a new BlockState backed by the database located at basePath
-func NewBlockState(db *chaindb.BadgerDB, trs *Tries, telemetry Telemetry) (*BlockState, error) {
-	bs := &BlockState{
-		dbPath:                     db.Path(),
-		baseState:                  NewBaseState(db),
-		db:                         chaindb.NewTable(db, blockPrefix),
+func NewBlockState(db BlockStateDatabase, baseState *BaseState,
+	trs *Tries, telemetry Telemetry) (bs *BlockState, err error) {
+	bs = &BlockState{
+		baseState:                  baseState,
+		db:                         db,
 		unfinalisedBlocks:          newHashToBlockMap(),
 		tries:                      trs,
 		imported:                   make(map[chan *types.Block]struct{}),

--- a/dot/state/block.go
+++ b/dot/state/block.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	// blockPrefix is the prefix to use for the block state
+	// key value database.
 	blockPrefix = "block"
 )
 
@@ -103,13 +105,13 @@ func NewBlockState(db BlockStateDatabase, baseState *BaseState,
 }
 
 // NewBlockStateFromGenesis initialises a BlockState from a genesis header,
-// saving it to the database located at basePath
-func NewBlockStateFromGenesis(db *chaindb.BadgerDB, trs *Tries, header *types.Header,
-	telemetryMailer Telemetry) (*BlockState, error) {
+// saving it to the database.
+func NewBlockStateFromGenesis(db BlockStateDatabase, baseState *BaseState,
+	trs *Tries, header *types.Header, telemetryMailer Telemetry) (*BlockState, error) {
 	bs := &BlockState{
 		bt:                         blocktree.NewBlockTreeFromRoot(header),
-		baseState:                  NewBaseState(db),
-		db:                         chaindb.NewTable(db, blockPrefix),
+		baseState:                  baseState,
+		db:                         db,
 		unfinalisedBlocks:          newHashToBlockMap(),
 		tries:                      trs,
 		imported:                   make(map[chan *types.Block]struct{}),

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -35,7 +35,11 @@ func TestConcurrencySetHeader(t *testing.T) {
 		go func(index int) {
 			defer pend.Done()
 
-			bs, err := NewBlockStateFromGenesis(dbs[index], tries, testGenesisHeader, telemetryMock)
+			db := dbs[index]
+			baseState := NewBaseState(db)
+			blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+			bs, err := NewBlockStateFromGenesis(blockStateDatabase,
+				baseState, tries, testGenesisHeader, telemetryMock)
 			require.NoError(t, err)
 
 			header := &types.Header{

--- a/dot/state/block_race_test.go
+++ b/dot/state/block_race_test.go
@@ -24,7 +24,7 @@ func TestConcurrencySetHeader(t *testing.T) {
 	threads := runtime.NumCPU()
 	dbs := make([]*chaindb.BadgerDB, threads)
 	for i := 0; i < threads; i++ {
-		dbs[i] = NewInMemoryDB(t)
+		dbs[i] = newInMemoryDB(t)
 	}
 
 	tries := newTriesEmpty()

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -752,7 +752,9 @@ func TestRange(t *testing.T) {
 
 				db := NewInMemoryDB(t)
 
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -782,7 +784,9 @@ func TestRange(t *testing.T) {
 
 				db := NewInMemoryDB(t)
 
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -811,8 +815,9 @@ func TestRange(t *testing.T) {
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 				db := NewInMemoryDB(t)
-
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -843,7 +848,9 @@ func TestRange(t *testing.T) {
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 				db := NewInMemoryDB(t)
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 
 				mockedDb := NewMockBlockStateDatabase(ctrl)
 				// cannot assert the exact hash type since the block header
@@ -878,8 +885,9 @@ func TestRange(t *testing.T) {
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 				db := NewInMemoryDB(t)
-
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -910,8 +918,9 @@ func TestRange(t *testing.T) {
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 				db := NewInMemoryDB(t)
-
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -943,8 +952,9 @@ func TestRange(t *testing.T) {
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 				db := NewInMemoryDB(t)
-
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -976,8 +986,9 @@ func TestRange(t *testing.T) {
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
 				db := NewInMemoryDB(t)
-
-				blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+				baseState := NewBaseState(db)
+				blockState, err := NewBlockStateFromGenesis(db, baseState,
+					newTriesEmpty(), genesisHeader, telemetryMock)
 				require.NoError(t, err)
 
 				return blockState
@@ -1074,8 +1085,9 @@ func Test_loadHeaderFromDisk_WithGenesisBlock(t *testing.T) {
 		StateRoot: trie.EmptyHash,
 		Digest:    types.NewDigest(),
 	}
-
-	blockState, err := NewBlockStateFromGenesis(db, newTriesEmpty(), genesisHeader, telemetryMock)
+	baseState := NewBaseState(db)
+	blockState, err := NewBlockStateFromGenesis(db, baseState,
+		newTriesEmpty(), genesisHeader, telemetryMock)
 	require.NoError(t, err)
 
 	header, err := blockState.loadHeaderFromDatabase(genesisHeader.Hash())

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -32,7 +32,7 @@ func newTestBlockState(t *testing.T, tries *Tries) *BlockState {
 	telemetryMock := NewMockTelemetry(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	header := testGenesisHeader
 
 	baseState := NewBaseState(db)
@@ -750,7 +750,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
@@ -782,7 +782,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
@@ -814,7 +814,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
 					newTriesEmpty(), genesisHeader, telemetryMock)
@@ -847,7 +847,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
 					newTriesEmpty(), genesisHeader, telemetryMock)
@@ -884,7 +884,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
 					newTriesEmpty(), genesisHeader, telemetryMock)
@@ -917,7 +917,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
 					newTriesEmpty(), genesisHeader, telemetryMock)
@@ -951,7 +951,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
 					newTriesEmpty(), genesisHeader, telemetryMock)
@@ -985,7 +985,7 @@ func TestRange(t *testing.T) {
 				telemetryMock := NewMockTelemetry(ctrl)
 				telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-				db := NewInMemoryDB(t)
+				db := newInMemoryDB(t)
 				baseState := NewBaseState(db)
 				blockState, err := NewBlockStateFromGenesis(db, baseState,
 					newTriesEmpty(), genesisHeader, telemetryMock)
@@ -1078,7 +1078,7 @@ func Test_loadHeaderFromDisk_WithGenesisBlock(t *testing.T) {
 	telemetryMock := NewMockTelemetry(ctrl)
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 
 	genesisHeader := &types.Header{
 		Number:    0,

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -35,7 +35,10 @@ func newTestBlockState(t *testing.T, tries *Tries) *BlockState {
 	db := NewInMemoryDB(t)
 	header := testGenesisHeader
 
-	bs, err := NewBlockStateFromGenesis(db, tries, header, telemetryMock)
+	baseState := NewBaseState(db)
+	blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+	bs, err := NewBlockStateFromGenesis(blockStateDatabase,
+		baseState, tries, header, telemetryMock)
 	require.NoError(t, err)
 
 	// loads in-memory tries with genesis state root, should be deleted

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -133,9 +133,7 @@ func NewEpochStateFromGenesis(db *chaindb.BadgerDB, blockState *BlockState,
 }
 
 // NewEpochState returns a new EpochState
-func NewEpochState(db *chaindb.BadgerDB, blockState *BlockState) (*EpochState, error) {
-	baseState := NewBaseState(db)
-
+func NewEpochState(baseState *BaseState, db GetPutter, blockState *BlockState) (*EpochState, error) {
 	epochLength, err := baseState.loadEpochLength()
 	if err != nil {
 		return nil, err
@@ -149,7 +147,7 @@ func NewEpochState(db *chaindb.BadgerDB, blockState *BlockState) (*EpochState, e
 	return &EpochState{
 		baseState:      baseState,
 		blockState:     blockState,
-		db:             chaindb.NewTable(db, epochPrefix),
+		db:             db,
 		epochLength:    epochLength,
 		skipToEpoch:    skipToEpoch,
 		nextEpochData:  make(nextEpochMap[types.NextEpochData]),

--- a/dot/state/epoch.go
+++ b/dot/state/epoch.go
@@ -67,17 +67,14 @@ type EpochState struct {
 }
 
 // NewEpochStateFromGenesis returns a new EpochState given information for the first epoch, fetched from the runtime
-func NewEpochStateFromGenesis(db *chaindb.BadgerDB, blockState *BlockState,
+func NewEpochStateFromGenesis(db GetPutter, baseState *BaseState, blockState *BlockState,
 	genesisConfig *types.BabeConfiguration) (*EpochState, error) {
-	baseState := NewBaseState(db)
-
 	err := baseState.storeFirstSlot(1) // this may change once the first block is imported
 	if err != nil {
 		return nil, err
 	}
 
-	epochDB := chaindb.NewTable(db, epochPrefix)
-	err = epochDB.Put(currentEpochKey, []byte{0, 0, 0, 0, 0, 0, 0, 0})
+	err = db.Put(currentEpochKey, []byte{0, 0, 0, 0, 0, 0, 0, 0})
 	if err != nil {
 		return nil, err
 	}
@@ -87,9 +84,9 @@ func NewEpochStateFromGenesis(db *chaindb.BadgerDB, blockState *BlockState,
 	}
 
 	s := &EpochState{
-		baseState:      NewBaseState(db),
+		baseState:      baseState,
 		blockState:     blockState,
-		db:             epochDB,
+		db:             db,
 		epochLength:    genesisConfig.EpochLength,
 		nextEpochData:  make(nextEpochMap[types.NextEpochData]),
 		nextConfigData: make(nextEpochMap[types.NextConfigData]),

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
@@ -30,13 +31,12 @@ var genesisBABEConfig = &types.BabeConfiguration{
 func newEpochStateFromGenesis(t *testing.T) *EpochState {
 	db := NewInMemoryDB(t)
 	blockState := newTestBlockState(t, newTriesEmpty())
-	s, err := NewEpochStateFromGenesis(db, blockState, genesisBABEConfig)
+	baseState := NewBaseState(db)
+	epochStateDatabase := chaindb.NewTable(db, epochPrefix)
+	s, err := NewEpochStateFromGenesis(epochStateDatabase,
+		baseState, blockState, genesisBABEConfig)
 	require.NoError(t, err)
 	return s
-}
-
-func TestNewEpochStateFromGenesis(t *testing.T) {
-	_ = newEpochStateFromGenesis(t)
 }
 
 func TestEpochState_CurrentEpoch(t *testing.T) {

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -29,7 +29,7 @@ var genesisBABEConfig = &types.BabeConfiguration{
 }
 
 func newEpochStateFromGenesis(t *testing.T) *EpochState {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	blockState := newTestBlockState(t, newTriesEmpty())
 	baseState := NewBaseState(db)
 	epochStateDatabase := chaindb.NewTable(db, epochPrefix)

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -72,9 +72,9 @@ func NewGrandpaStateFromGenesis(db GetPutDeleter, bs *BlockState,
 }
 
 // NewGrandpaState returns a new GrandpaState
-func NewGrandpaState(db *chaindb.BadgerDB, bs *BlockState) *GrandpaState {
+func NewGrandpaState(db GetPutDeleter, bs *BlockState) *GrandpaState {
 	return &GrandpaState{
-		db:                   chaindb.NewTable(db, grandpaPrefix),
+		db:                   db,
 		blockState:           bs,
 		scheduledChangeRoots: new(changeTree),
 		forcedChanges:        new(orderedPendingChanges),

--- a/dot/state/grandpa.go
+++ b/dot/state/grandpa.go
@@ -43,11 +43,10 @@ type GrandpaState struct {
 }
 
 // NewGrandpaStateFromGenesis returns a new GrandpaState given the grandpa genesis authorities
-func NewGrandpaStateFromGenesis(db *chaindb.BadgerDB, bs *BlockState,
+func NewGrandpaStateFromGenesis(db GetPutDeleter, bs *BlockState,
 	genesisAuthorities []types.GrandpaVoter) (*GrandpaState, error) {
-	grandpaDB := chaindb.NewTable(db, grandpaPrefix)
 	s := &GrandpaState{
-		db:                   grandpaDB,
+		db:                   db,
 		blockState:           bs,
 		scheduledChangeRoots: new(changeTree),
 		forcedChanges:        new(orderedPendingChanges),

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -129,7 +129,10 @@ func testBlockState(t *testing.T, db *chaindb.BadgerDB) *BlockState {
 	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
 	header := testGenesisHeader
 
-	bs, err := NewBlockStateFromGenesis(db, newTriesEmpty(), header, telemetryMock)
+	baseState := NewBaseState(db)
+	blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+	bs, err := NewBlockStateFromGenesis(blockStateDatabase,
+		baseState, newTriesEmpty(), header, telemetryMock)
 	require.NoError(t, err)
 
 	// loads in-memory tries with genesis state root, should be deleted

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -28,8 +28,13 @@ var (
 	}
 )
 
-func TestNewGrandpaStateFromGenesis(t *testing.T) {
+func newInMemoryGrandpaDatabase(t *testing.T) chaindb.Database {
 	db := NewInMemoryDB(t)
+	return chaindb.NewTable(db, grandpaPrefix)
+}
+
+func TestNewGrandpaStateFromGenesis(t *testing.T) {
+	db := newInMemoryGrandpaDatabase(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -47,7 +52,7 @@ func TestNewGrandpaStateFromGenesis(t *testing.T) {
 }
 
 func TestGrandpaState_SetNextChange(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryGrandpaDatabase(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -64,7 +69,7 @@ func TestGrandpaState_SetNextChange(t *testing.T) {
 }
 
 func TestGrandpaState_IncrementSetID(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryGrandpaDatabase(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -74,7 +79,7 @@ func TestGrandpaState_IncrementSetID(t *testing.T) {
 }
 
 func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
-	db := NewInMemoryDB(t)
+	db := newInMemoryGrandpaDatabase(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -107,8 +112,8 @@ func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
 }
 
 func TestGrandpaState_LatestRound(t *testing.T) {
-	db := NewInMemoryDB(t)
-	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
+	grandpaDatabase := newInMemoryGrandpaDatabase(t)
+	gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, nil, testAuths)
 	require.NoError(t, err)
 
 	r, err := gs.GetLatestRound()
@@ -154,7 +159,8 @@ func TestAddScheduledChangesKeepTheRightForkTree(t *testing.T) { //nolint:tparal
 	db := NewInMemoryDB(t)
 	blockState := testBlockState(t, db)
 
-	gs, err := NewGrandpaStateFromGenesis(db, blockState, nil)
+	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+	gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, nil)
 	require.NoError(t, err)
 
 	/*
@@ -290,7 +296,8 @@ func TestForcedScheduledChangesOrder(t *testing.T) {
 	db := NewInMemoryDB(t)
 	blockState := testBlockState(t, db)
 
-	gs, err := NewGrandpaStateFromGenesis(db, blockState, nil)
+	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+	gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, nil)
 	require.NoError(t, err)
 
 	aliceHeaders := issueBlocksWithBABEPrimary(t, keyring.KeyAlice, gs.blockState,
@@ -356,7 +363,8 @@ func TestShouldNotAddMoreThanOneForcedChangeInTheSameFork(t *testing.T) {
 	db := NewInMemoryDB(t)
 	blockState := testBlockState(t, db)
 
-	gs, err := NewGrandpaStateFromGenesis(db, blockState, nil)
+	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+	gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, nil)
 	require.NoError(t, err)
 
 	aliceHeaders := issueBlocksWithBABEPrimary(t, keyring.KeyAlice, gs.blockState,
@@ -534,7 +542,8 @@ func TestNextGrandpaAuthorityChange(t *testing.T) {
 			db := NewInMemoryDB(t)
 			blockState := testBlockState(t, db)
 
-			gs, err := NewGrandpaStateFromGenesis(db, blockState, nil)
+			grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+			gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, nil)
 			require.NoError(t, err)
 
 			const sizeOfChain = 10
@@ -736,7 +745,8 @@ func TestApplyForcedChanges(t *testing.T) {
 			blockState := testBlockState(t, db)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
-			gs, err := NewGrandpaStateFromGenesis(db, blockState, voters)
+			grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+			gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, voters)
 			require.NoError(t, err)
 
 			forks := tt.generateForks(t, blockState)
@@ -858,7 +868,8 @@ func TestApplyScheduledChangesKeepDescendantForcedChanges(t *testing.T) {
 			blockState := testBlockState(t, db)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
-			gs, err := NewGrandpaStateFromGenesis(db, blockState, voters)
+			grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+			gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, voters)
 			require.NoError(t, err)
 
 			forks := tt.generateForks(t, gs.blockState)
@@ -1087,7 +1098,8 @@ func TestApplyScheduledChangeGetApplicableChange(t *testing.T) {
 			blockState := testBlockState(t, db)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
-			gs, err := NewGrandpaStateFromGenesis(db, blockState, voters)
+			grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+			gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, voters)
 			require.NoError(t, err)
 
 			forks := tt.generateForks(t, gs.blockState)
@@ -1317,7 +1329,8 @@ func TestApplyScheduledChange(t *testing.T) {
 			require.NoError(t, err)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
-			gs, err := NewGrandpaStateFromGenesis(db, blockState, voters)
+			grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+			gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, voters)
 			require.NoError(t, err)
 
 			forks := tt.generateForks(t, gs.blockState)

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -28,13 +28,8 @@ var (
 	}
 )
 
-func newInMemoryGrandpaDatabase(t *testing.T) chaindb.Database {
-	db := newInMemoryDB(t)
-	return chaindb.NewTable(db, grandpaPrefix)
-}
-
 func TestNewGrandpaStateFromGenesis(t *testing.T) {
-	db := newInMemoryGrandpaDatabase(t)
+	db := newInMemoryDB(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -52,7 +47,7 @@ func TestNewGrandpaStateFromGenesis(t *testing.T) {
 }
 
 func TestGrandpaState_SetNextChange(t *testing.T) {
-	db := newInMemoryGrandpaDatabase(t)
+	db := newInMemoryDB(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -69,7 +64,7 @@ func TestGrandpaState_SetNextChange(t *testing.T) {
 }
 
 func TestGrandpaState_IncrementSetID(t *testing.T) {
-	db := newInMemoryGrandpaDatabase(t)
+	db := newInMemoryDB(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -79,7 +74,7 @@ func TestGrandpaState_IncrementSetID(t *testing.T) {
 }
 
 func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
-	db := newInMemoryGrandpaDatabase(t)
+	db := newInMemoryDB(t)
 	gs, err := NewGrandpaStateFromGenesis(db, nil, testAuths)
 	require.NoError(t, err)
 
@@ -112,7 +107,7 @@ func TestGrandpaState_GetSetIDByBlockNumber(t *testing.T) {
 }
 
 func TestGrandpaState_LatestRound(t *testing.T) {
-	grandpaDatabase := newInMemoryGrandpaDatabase(t)
+	grandpaDatabase := newInMemoryDB(t)
 	gs, err := NewGrandpaStateFromGenesis(grandpaDatabase, nil, testAuths)
 	require.NoError(t, err)
 

--- a/dot/state/grandpa_test.go
+++ b/dot/state/grandpa_test.go
@@ -29,7 +29,7 @@ var (
 )
 
 func newInMemoryGrandpaDatabase(t *testing.T) chaindb.Database {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	return chaindb.NewTable(db, grandpaPrefix)
 }
 
@@ -156,7 +156,7 @@ func TestAddScheduledChangesKeepTheRightForkTree(t *testing.T) { //nolint:tparal
 	keyring, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	blockState := testBlockState(t, db)
 
 	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
@@ -293,7 +293,7 @@ func TestForcedScheduledChangesOrder(t *testing.T) {
 	keyring, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	blockState := testBlockState(t, db)
 
 	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
@@ -360,7 +360,7 @@ func TestShouldNotAddMoreThanOneForcedChangeInTheSameFork(t *testing.T) {
 	keyring, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
 
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 	blockState := testBlockState(t, db)
 
 	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
@@ -539,7 +539,7 @@ func TestNextGrandpaAuthorityChange(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			db := NewInMemoryDB(t)
+			db := newInMemoryDB(t)
 			blockState := testBlockState(t, db)
 
 			grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
@@ -741,7 +741,7 @@ func TestApplyForcedChanges(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			db := NewInMemoryDB(t)
+			db := newInMemoryDB(t)
 			blockState := testBlockState(t, db)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
@@ -864,7 +864,7 @@ func TestApplyScheduledChangesKeepDescendantForcedChanges(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			db := NewInMemoryDB(t)
+			db := newInMemoryDB(t)
 			blockState := testBlockState(t, db)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
@@ -1094,7 +1094,7 @@ func TestApplyScheduledChangeGetApplicableChange(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			db := NewInMemoryDB(t)
+			db := newInMemoryDB(t)
 			blockState := testBlockState(t, db)
 
 			voters := types.NewGrandpaVotersFromAuthorities(genesisAuths)
@@ -1322,7 +1322,7 @@ func TestApplyScheduledChange(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			db := NewInMemoryDB(t)
+			db := newInMemoryDB(t)
 			blockState := testBlockState(t, db)
 
 			genesisAuths, err := types.GrandpaAuthoritiesRawToAuthorities(genesisGrandpaVoters)

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -24,7 +24,8 @@ func newInMemoryDB(t *testing.T) *chaindb.BadgerDB {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = db.Close()
+		err := db.Close()
+		require.NoError(t, err)
 	})
 
 	return db

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
@@ -16,6 +17,18 @@ import (
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/require"
 )
+
+func newInMemoryDB(t *testing.T) *chaindb.BadgerDB {
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		InMemory: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+
+	return db
+}
 
 func newTriesEmpty() *Tries {
 	return &Tries{

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -79,7 +79,9 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to create storage state from trie: %s", err)
 	}
 
-	epochState, err := NewEpochStateFromGenesis(db, blockState, babeCfg)
+	epochStateDatabase := chaindb.NewTable(db, epochPrefix)
+	epochState, err := NewEpochStateFromGenesis(epochStateDatabase,
+		baseState, blockState, babeCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create epoch state: %s", err)
 	}

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -89,7 +89,8 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to load grandpa authorities: %w", err)
 	}
 
-	grandpaState, err := NewGrandpaStateFromGenesis(db, blockState, grandpaAuths)
+	grandpaDatabase := chaindb.NewTable(db, grandpaPrefix)
+	grandpaState, err := NewGrandpaStateFromGenesis(grandpaDatabase, blockState, grandpaAuths)
 	if err != nil {
 		return fmt.Errorf("failed to create grandpa state: %s", err)
 	}

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -40,7 +40,9 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to clear database: %s", err)
 	}
 
-	if err = t.WriteDirty(chaindb.NewTable(db, storagePrefix)); err != nil {
+	storageDatabase := chaindb.NewTable(db, storagePrefix)
+	err = t.WriteDirty(storageDatabase)
+	if err != nil {
 		return fmt.Errorf("failed to write genesis trie to database: %w", err)
 	}
 
@@ -58,7 +60,8 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 	rt.Stop()
 
 	// write initial genesis values to database
-	if err = s.storeInitialValues(gen.GenesisData(), t); err != nil {
+	err = s.storeInitialValues(storageDatabase, gen.GenesisData(), t)
+	if err != nil {
 		return fmt.Errorf("failed to write genesis values to database: %s", err)
 	}
 
@@ -138,9 +141,10 @@ func loadGrandpaAuthorities(t *trie.Trie) ([]types.GrandpaVoter, error) {
 }
 
 // storeInitialValues writes initial genesis values to the state database
-func (s *Service) storeInitialValues(data *genesis.Data, t *trie.Trie) error {
+func (s *Service) storeInitialValues(storageDatabase NewBatcher,
+	data *genesis.Data, t *trie.Trie) error {
 	// write genesis trie to database
-	if err := t.WriteDirty(chaindb.NewTable(s.db, storagePrefix)); err != nil {
+	if err := t.WriteDirty(storageDatabase); err != nil {
 		return fmt.Errorf("failed to write trie to database: %s", err)
 	}
 

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -65,8 +65,10 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 	tries := NewTries()
 	tries.SetTrie(t)
 
-	// create block state from genesis block
-	blockState, err := NewBlockStateFromGenesis(db, tries, header, s.Telemetry)
+	baseState := NewBaseState(db)
+	blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+	blockState, err := NewBlockStateFromGenesis(blockStateDatabase,
+		baseState, tries, header, s.Telemetry)
 	if err != nil {
 		return fmt.Errorf("failed to create block state from genesis: %s", err)
 	}

--- a/dot/state/initialize.go
+++ b/dot/state/initialize.go
@@ -14,7 +14,6 @@ import (
 	rtstorage "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 )
 
 // Initialise initialises the genesis state of the DB using the given storage trie.
@@ -28,8 +27,10 @@ func (s *Service) Initialise(gen *genesis.Genesis, header *types.Header, t *trie
 		return fmt.Errorf("failed to read basepath: %s", err)
 	}
 
-	// initialise database using data directory
-	db, err := utils.SetupDatabase(basepath, s.isMemDB)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir:  filepath.Join(basepath, "db"),
+		InMemory: s.isMemDB,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create database: %s", err)
 	}

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -34,9 +34,12 @@ type OfflinePruner struct {
 // NewOfflinePruner creates an instance of OfflinePruner.
 func NewOfflinePruner(inputDBPath string,
 	retainBlockNum uint32) (pruner *OfflinePruner, err error) {
-	db, err := utils.LoadChainDB(inputDBPath)
+	cfg := &chaindb.Config{
+		DataDir: inputDBPath,
+	}
+	db, err := chaindb.NewBadgerDB(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load DB %w", err)
+		return nil, fmt.Errorf("creating badger database: %w", err)
 	}
 
 	tries := NewTries()

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -44,7 +44,9 @@ func NewOfflinePruner(inputDBPath string,
 
 	// create blockState state
 	// NewBlockState on pruner execution does not use telemetry
-	blockState, err := NewBlockState(db, tries, nil)
+	blockStateDB := chaindb.NewTable(db, blockPrefix)
+	baseState := NewBaseState(db)
+	blockState, err := NewBlockState(blockStateDB, baseState, tries, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block state: %w", err)
 	}

--- a/dot/state/offline_pruner.go
+++ b/dot/state/offline_pruner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/pb"
 )
@@ -160,9 +159,10 @@ func (p *OfflinePruner) SetBloomFilter() (err error) {
 
 // Prune starts streaming the data from input db to the pruned db.
 func (p *OfflinePruner) Prune() error {
-	inputDB, err := utils.LoadBadgerDB(p.inputDBPath)
+	opts := badger.DefaultOptions(p.inputDBPath)
+	inputDB, err := badger.Open(opts)
 	if err != nil {
-		return fmt.Errorf("failed to load DB %w", err)
+		return fmt.Errorf("opening input database: %w", err)
 	}
 	defer func() {
 		closeErr := inputDB.Close()

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -115,8 +115,9 @@ func (s *Service) Start() (err error) {
 	tries := NewTries()
 	tries.SetEmptyTrie()
 
-	// create block state
-	s.Block, err = NewBlockState(s.db, tries, s.Telemetry)
+	blockStateDB := chaindb.NewTable(s.db, blockPrefix)
+	baseState := NewBaseState(s.db)
+	s.Block, err = NewBlockState(blockStateDB, baseState, tries, s.Telemetry)
 	if err != nil {
 		return fmt.Errorf("failed to create block state: %w", err)
 	}

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -152,7 +152,8 @@ func (s *Service) Start() (err error) {
 		return fmt.Errorf("failed to create epoch state: %w", err)
 	}
 
-	s.Grandpa = NewGrandpaState(s.db, s.Block)
+	grandpaDatabase := chaindb.NewTable(s.db, grandpaPrefix)
+	s.Grandpa = NewGrandpaState(grandpaDatabase, s.Block)
 	num, _ := s.Block.BestBlockNumber()
 	logger.Infof(
 		"created state service with head %s, highest number %d and genesis hash %s",

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ChainSafe/gossamer/internal/metrics"
 	"github.com/ChainSafe/gossamer/lib/blocktree"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 
 	"github.com/ChainSafe/chaindb"
 )
@@ -94,8 +93,9 @@ func (s *Service) SetupBase() error {
 		return err
 	}
 
-	// initialise database
-	db, err := utils.SetupDatabase(basepath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(basepath, "db"),
+	})
 	if err != nil {
 		return err
 	}
@@ -259,11 +259,11 @@ func (s *Service) Stop() error {
 
 // Import imports the given state corresponding to the given header and sets the head of the chain
 // to it. Additionally, it uses the first slot to correctly set the epoch number of the block.
-func (s *Service) Import(header *types.Header, t *trie.Trie, firstSlot uint64) error {
-	var err error
-	// initialise database using data directory
+func (s *Service) Import(header *types.Header, t *trie.Trie, firstSlot uint64) (err error) {
 	if !s.isMemDB {
-		s.db, err = utils.SetupDatabase(s.dbPath, s.isMemDB)
+		s.db, err = chaindb.NewBadgerDB(&chaindb.Config{
+			DataDir: filepath.Join(s.dbPath, "db"),
+		})
 		if err != nil {
 			return fmt.Errorf("failed to create database: %w", err)
 		}

--- a/dot/state/service.go
+++ b/dot/state/service.go
@@ -146,8 +146,8 @@ func (s *Service) Start() (err error) {
 	// create transaction queue
 	s.Transaction = NewTransactionState(s.Telemetry)
 
-	// create epoch state
-	s.Epoch, err = NewEpochState(s.db, s.Block)
+	epochStateDatabase := chaindb.NewTable(s.db, epochPrefix)
+	s.Epoch, err = NewEpochState(baseState, epochStateDatabase, s.Block)
 	if err != nil {
 		return fmt.Errorf("failed to create epoch state: %w", err)
 	}
@@ -276,7 +276,9 @@ func (s *Service) Import(header *types.Header, t *trie.Trie, firstSlot uint64) e
 		db: chaindb.NewTable(s.db, storagePrefix),
 	}
 
-	epoch, err := NewEpochState(s.db, block)
+	baseState := NewBaseState(s.db)
+	epochStateDatabase := chaindb.NewTable(s.db, epochPrefix)
+	epoch, err := NewEpochState(baseState, epochStateDatabase, block)
 	if err != nil {
 		return err
 	}

--- a/dot/state/storage_notify_test.go
+++ b/dot/state/storage_notify_test.go
@@ -149,7 +149,7 @@ func Test_Example(t *testing.T) {
 	bValue := []byte("b-value")
 
 	// Open the DB.
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 
 	// Create the context here so we can cancel it after sending the writes.
 	ctx, cancel := context.WithCancel(context.Background())

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newTestStorageState(t *testing.T) *StorageState {
-	db := NewInMemoryDB(t)
+	db := newInMemoryDB(t)
 
 	tries := newTriesEmpty()
 	bs := newTestBlockState(t, tries)

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -172,6 +172,10 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 		DataDir: filepath.Join(basepath, "db"),
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err = db.Close()
+		require.NoError(t, err)
+	})
 
 	_, genTrie, genHeader := newWestendDevGenesisWithTrieAndHeader(t)
 

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	runtime "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/golang/mock/gomock"
 
 	"github.com/stretchr/testify/require"
@@ -168,7 +168,9 @@ func TestStorage_StoreTrie_NotSyncing(t *testing.T) {
 func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 	// initialise database using data directory
 	basepath := t.TempDir()
-	db, err := utils.SetupDatabase(basepath, false)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(basepath, "db"),
+	})
 	require.NoError(t, err)
 
 	_, genTrie, genHeader := newWestendDevGenesisWithTrieAndHeader(t)

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -166,10 +165,8 @@ func TestStorage_StoreTrie_NotSyncing(t *testing.T) {
 }
 
 func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
-	// initialise database using data directory
-	basepath := t.TempDir()
 	db, err := chaindb.NewBadgerDB(&chaindb.Config{
-		DataDir: filepath.Join(basepath, "db"),
+		DataDir: t.TempDir(),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/dot/state/storage_test.go
+++ b/dot/state/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/telemetry"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/internal/trie/node"
@@ -193,7 +194,10 @@ func TestGetStorageChildAndGetStorageFromChild(t *testing.T) {
 
 	tries := newTriesEmpty()
 
-	blockState, err := NewBlockStateFromGenesis(db, tries, &genHeader, telemetryMock)
+	baseState := NewBaseState(db)
+	blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+	blockState, err := NewBlockStateFromGenesis(blockStateDatabase,
+		baseState, tries, &genHeader, telemetryMock)
 	require.NoError(t, err)
 
 	storage, err := NewStorageState(db, blockState, tries)

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	runtime "github.com/ChainSafe/gossamer/lib/runtime/storage"
@@ -21,19 +20,6 @@ import (
 )
 
 var inc, _ = time.ParseDuration("1s")
-
-// NewInMemoryDB creates a new in-memory database
-func NewInMemoryDB(t *testing.T) *chaindb.BadgerDB {
-	db, err := chaindb.NewBadgerDB(&chaindb.Config{
-		InMemory: true,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
-
-	return db
-}
 
 func createPrimaryBABEDigest(t testing.TB) scale.VaryingDataTypeSlice {
 	babeDigest := types.NewBabeDigest()

--- a/dot/state/test_helpers.go
+++ b/dot/state/test_helpers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	runtime "github.com/ChainSafe/gossamer/lib/runtime/storage"
 	"github.com/ChainSafe/gossamer/lib/trie"
-	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 
 	"github.com/stretchr/testify/require"
@@ -25,9 +24,9 @@ var inc, _ = time.ParseDuration("1s")
 
 // NewInMemoryDB creates a new in-memory database
 func NewInMemoryDB(t *testing.T) *chaindb.BadgerDB {
-	testDatadirPath := t.TempDir()
-
-	db, err := utils.SetupDatabase(testDatadirPath, true)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		InMemory: true,
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = db.Close()

--- a/dot/sync/syncer_integration_test.go
+++ b/dot/sync/syncer_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/internal/log"
@@ -69,7 +70,9 @@ func newTestSyncer(t *testing.T) *Service {
 	if stateSrvc != nil {
 		rtCfg.NodeStorage.BaseDB = stateSrvc.Base
 	} else {
-		rtCfg.NodeStorage.BaseDB, err = utils.SetupDatabase(filepath.Join(testDatadirPath, "offline_storage"), false)
+		rtCfg.NodeStorage.BaseDB, err = chaindb.NewBadgerDB(&chaindb.Config{
+			DataDir: filepath.Join(testDatadirPath, "offline_storage", "db"),
+		})
 		require.NoError(t, err)
 	}
 

--- a/lib/babe/helpers_test.go
+++ b/lib/babe/helpers_test.go
@@ -199,7 +199,8 @@ func createTestService(t *testing.T, cfg ServiceConfig, genesis genesis.Genesis,
 
 	// Allow for epoch state to be made from custom babe config
 	if babeConfig != nil {
-		dbSrv.Epoch, err = state.NewEpochStateFromGenesis(dbSrv.DB(), dbSrv.Block, babeConfig)
+		dbSrv.Epoch, err = state.NewEpochStateFromGenesis(dbSrv.DB(),
+			dbSrv.Base, dbSrv.Block, babeConfig)
 		require.NoError(t, err)
 	}
 	cfg.BlockState = dbSrv.Block

--- a/lib/babe/helpers_test.go
+++ b/lib/babe/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/core"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -120,7 +121,9 @@ func newTestCoreService(t *testing.T, cfg *core.Config, genesis genesis.Genesis,
 		if stateSrvc != nil {
 			nodeStorage.BaseDB = stateSrvc.Base
 		} else {
-			nodeStorage.BaseDB, err = utils.SetupDatabase(filepath.Join(testDatadirPath, "offline_storage"), false)
+			nodeStorage.BaseDB, err = chaindb.NewBadgerDB(&chaindb.Config{
+				DataDir: filepath.Join(testDatadirPath, "offline_storage", "db"),
+			})
 			require.NoError(t, err)
 		}
 

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -544,7 +544,6 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 
 	inMemoryDB, err := chaindb.NewBadgerDB(&chaindb.Config{
 		InMemory: true,
-		DataDir:  t.TempDir(),
 	})
 	require.NoError(t, err)
 

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -548,7 +548,10 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	epochState, err := state.NewEpochStateFromGenesis(inMemoryDB, stateService.Block, epochBABEConfig)
+	const epochPrefix = "epoch"
+	epochStateDatabase := chaindb.NewTable(inMemoryDB, epochPrefix)
+	epochState, err := state.NewEpochStateFromGenesis(epochStateDatabase,
+		stateService.Base, stateService.Block, epochBABEConfig)
 	require.NoError(t, err)
 
 	digestHandler, err := digest.NewHandler(log.DoNotChange, stateService.Block, epochState, stateService.Grandpa)

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -546,6 +546,10 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 		InMemory: true,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := inMemoryDB.Close()
+		require.NoError(t, err)
+	})
 
 	const epochPrefix = "epoch"
 	epochStateDatabase := chaindb.NewTable(inMemoryDB, epochPrefix)

--- a/lib/grandpa/helpers_integration_test.go
+++ b/lib/grandpa/helpers_integration_test.go
@@ -156,7 +156,9 @@ func newTestState(t *testing.T) *state.Service {
 	require.NoError(t, err)
 	block.StoreRuntime(block.BestBlockHash(), rt)
 
-	grandpa, err := state.NewGrandpaStateFromGenesis(db, nil, newTestVoters(t))
+	const grandpaDBPrefix = "grandpa"
+	grandpaDatabase := chaindb.NewTable(db, grandpaDBPrefix)
+	grandpa, err := state.NewGrandpaStateFromGenesis(grandpaDatabase, nil, newTestVoters(t))
 	require.NoError(t, err)
 
 	return &state.Service{

--- a/lib/grandpa/helpers_integration_test.go
+++ b/lib/grandpa/helpers_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -140,7 +141,11 @@ func newTestState(t *testing.T) *state.Service {
 	_, genTrie, _ := newWestendDevGenesisWithTrieAndHeader(t)
 	tries := state.NewTries()
 	tries.SetTrie(&genTrie)
-	block, err := state.NewBlockStateFromGenesis(db, tries, testGenesisHeader, telemetryMock)
+	baseState := state.NewBaseState(db)
+	const blockPrefix = "block"
+	blockStateDatabase := chaindb.NewTable(db, blockPrefix)
+	block, err := state.NewBlockStateFromGenesis(blockStateDatabase,
+		baseState, tries, testGenesisHeader, telemetryMock)
 	require.NoError(t, err)
 
 	var rtCfg wasmer.Config

--- a/lib/grandpa/helpers_integration_test.go
+++ b/lib/grandpa/helpers_integration_test.go
@@ -139,7 +139,10 @@ func newTestState(t *testing.T) *state.Service {
 	})
 	require.NoError(t, err)
 
-	t.Cleanup(func() { db.Close() })
+	t.Cleanup(func() {
+		err = db.Close()
+		require.NoError(t, err)
+	})
 
 	_, genTrie, _ := newWestendDevGenesisWithTrieAndHeader(t)
 	tries := state.NewTries()

--- a/lib/grandpa/helpers_integration_test.go
+++ b/lib/grandpa/helpers_integration_test.go
@@ -6,6 +6,7 @@
 package grandpa
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -133,7 +134,9 @@ func newTestState(t *testing.T) *state.Service {
 
 	testDatadirPath := t.TempDir()
 
-	db, err := utils.SetupDatabase(testDatadirPath, true)
+	db, err := chaindb.NewBadgerDB(&chaindb.Config{
+		DataDir: filepath.Join(testDatadirPath, "db"),
+	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() { db.Close() })

--- a/lib/runtime/test_helpers.go
+++ b/lib/runtime/test_helpers.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/babe/inherents"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -31,22 +30,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
-
-// NewInMemoryDB creates a new in-memory database
-func NewInMemoryDB(t *testing.T) *chaindb.BadgerDB {
-	testDatadirPath := t.TempDir()
-
-	db, err := chaindb.NewBadgerDB(&chaindb.Config{
-		DataDir:  testDatadirPath,
-		InMemory: true,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
-
-	return db
-}
 
 var (
 	ErrRuntimeUnknown  = errors.New("runtime is not known")

--- a/lib/runtime/wasmer/exports_test.go
+++ b/lib/runtime/wasmer/exports_test.go
@@ -235,7 +235,7 @@ func TestNodeRuntime_ValidateTransaction(t *testing.T) {
 	}
 
 	nodeStorage := runtime.NodeStorage{}
-	nodeStorage.BaseDB = runtime.NewInMemoryDB(t)
+	nodeStorage.BaseDB = newDatabase(t)
 	cfg.NodeStorage = nodeStorage
 
 	rt, err := NewRuntimeFromGenesis(cfg)

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ChainSafe/chaindb"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/common/types"
 	"github.com/ChainSafe/gossamer/lib/crypto"
@@ -1793,10 +1792,7 @@ func Test_ext_trie_blake2_256_root_version_1(t *testing.T) {
 func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	t.Parallel()
 
-	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
-		InMemory: true,
-	})
-	require.NoError(t, err)
+	memdb := newDatabase(t)
 
 	otherTrie := trie.NewEmptyTrie()
 	otherTrie.Put([]byte("simple"), []byte("cat"))

--- a/lib/runtime/wasmer/imports_test.go
+++ b/lib/runtime/wasmer/imports_test.go
@@ -1793,11 +1793,8 @@ func Test_ext_trie_blake2_256_root_version_1(t *testing.T) {
 func Test_ext_trie_blake2_256_verify_proof_version_1(t *testing.T) {
 	t.Parallel()
 
-	tmp := t.TempDir()
-
 	memdb, err := chaindb.NewBadgerDB(&chaindb.Config{
 		InMemory: true,
-		DataDir:  tmp,
 	})
 	require.NoError(t, err)
 

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -90,7 +90,8 @@ func newDatabase(t *testing.T) chaindb.Database {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		_ = db.Close()
+		err = db.Close()
+		require.NoError(t, err)
 	})
 	return db
 }

--- a/lib/runtime/wasmer/test_helpers.go
+++ b/lib/runtime/wasmer/test_helpers.go
@@ -86,7 +86,6 @@ func setupConfig(t *testing.T, ctrl *gomock.Controller, tt *trie.Trie, lvl log.L
 
 func newDatabase(t *testing.T) chaindb.Database {
 	db, err := chaindb.NewBadgerDB(&chaindb.Config{
-		DataDir:  t.TempDir(),
 		InMemory: true,
 	})
 	require.NoError(t, err)

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -22,7 +22,7 @@ func newTestDB(t *testing.T) chaindb.Database {
 		err := database.Close()
 		require.NoError(t, err)
 	})
-	return chaindb.NewTable(database, "trie")
+	return database
 }
 
 func Test_Trie_Store_Load(t *testing.T) {

--- a/lib/trie/database_test.go
+++ b/lib/trie/database_test.go
@@ -18,6 +18,10 @@ func newTestDB(t *testing.T) chaindb.Database {
 	}
 	database, err := chaindb.NewBadgerDB(chainDBConfig)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := database.Close()
+		require.NoError(t, err)
+	})
 	return chaindb.NewTable(database, "trie")
 }
 

--- a/lib/trie/proof/proof_test.go
+++ b/lib/trie/proof/proof_test.go
@@ -37,6 +37,11 @@ func Test_Generate_Verify(t *testing.T) {
 		InMemory: true,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := database.Close()
+		require.NoError(t, err)
+	})
+
 	err = trie.WriteDirty(database)
 	require.NoError(t, err)
 

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ChainSafe/chaindb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -267,13 +266,11 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 }
 
 func TestTrieDiff(t *testing.T) {
-	db := newTestDB(t)
+	storageDB := newTestDB(t)
 	t.Cleanup(func() {
-		err := db.Close()
+		err := storageDB.Close()
 		require.NoError(t, err)
 	})
-
-	storageDB := chaindb.NewTable(db, "storage")
 
 	trie := NewEmptyTrie()
 

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -281,7 +281,7 @@ func TestTrieDiff(t *testing.T) {
 
 	storageDB := chaindb.NewTable(db, "storage")
 	t.Cleanup(func() {
-		err = storageDB.Close()
+		err := storageDB.Close()
 		require.NoError(t, err)
 	})
 

--- a/lib/trie/trie_endtoend_test.go
+++ b/lib/trie/trie_endtoend_test.go
@@ -267,23 +267,13 @@ func TestDeleteOddKeyLengths(t *testing.T) {
 }
 
 func TestTrieDiff(t *testing.T) {
-	cfg := &chaindb.Config{
-		DataDir: t.TempDir(),
-	}
-
-	db, err := chaindb.NewBadgerDB(cfg)
-	require.NoError(t, err)
-
+	db := newTestDB(t)
 	t.Cleanup(func() {
-		err = db.Close()
+		err := db.Close()
 		require.NoError(t, err)
 	})
 
 	storageDB := chaindb.NewTable(db, "storage")
-	t.Cleanup(func() {
-		err := storageDB.Close()
-		require.NoError(t, err)
-	})
 
 	trie := NewEmptyTrie()
 
@@ -300,7 +290,7 @@ func TestTrieDiff(t *testing.T) {
 	}
 
 	newTrie := trie.Snapshot()
-	err = trie.WriteDirty(storageDB)
+	err := trie.WriteDirty(storageDB)
 	require.NoError(t, err)
 
 	tests = []keyValues{

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/chaindb"
-	"github.com/dgraph-io/badger/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -252,16 +251,4 @@ func GetProjectRootPath() (rootPath string, err error) {
 	}
 
 	return rootPath, nil
-}
-
-// LoadBadgerDB load the db at the given path.
-func LoadBadgerDB(basePath string) (*badger.DB, error) {
-	opts := badger.DefaultOptions(basePath)
-	// Open already existing DB
-	db, err := badger.Open(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	return db, nil
 }

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -254,21 +254,6 @@ func GetProjectRootPath() (rootPath string, err error) {
 	return rootPath, nil
 }
 
-// LoadChainDB load the db at the given path.
-func LoadChainDB(basePath string) (*chaindb.BadgerDB, error) {
-	cfg := &chaindb.Config{
-		DataDir: basePath,
-	}
-
-	// Open already existing DB
-	db, err := chaindb.NewBadgerDB(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return db, nil
-}
-
 // LoadBadgerDB load the db at the given path.
 func LoadBadgerDB(basePath string) (*badger.DB, error) {
 	opts := badger.DefaultOptions(basePath)

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -14,20 +14,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ChainSafe/chaindb"
 	"github.com/stretchr/testify/require"
 )
 
 // DefaultDatabaseDir directory inside basepath where database contents are stored
 const DefaultDatabaseDir = "db"
-
-// SetupDatabase will return an instance of database based on basepath
-func SetupDatabase(basepath string, inMemory bool) (*chaindb.BadgerDB, error) {
-	return chaindb.NewBadgerDB(&chaindb.Config{
-		DataDir:  filepath.Join(basepath, DefaultDatabaseDir),
-		InMemory: inMemory,
-	})
-}
 
 // PathExists returns true if the named file or directory exists, otherwise false
 func PathExists(p string) bool {


### PR DESCRIPTION
## Changes

Improves codebase health + simplify migration to newer database interface

- Dependency inject to `storeInitialValues`
- Dependency inject to `createRuntimeStorage`
- Dependency inject to `NewGrandpaState`
- Dependency inject to `NewEpochStateFromGenesis`
- Dependency inject to `NewEpochState`
- Dependency inject to `NewGrandpaStateFromGenesis`
- Dependency inject to `NewBlockStateFromGenesis`
- Dependency inject to `NewBlockState`
- Remove `LoadChainDB`, `LoadBadgerDB`, `runtime.NewInMemoryDB` and `utils.SetupDatabase`, `newInMemoryGrandpaDatabase`
- Minor test database setup simplifications
  - dot/state: make `newInMemoryDB` test only
  - Remove unneeded datadir setting for in memory databases
  - Add test `.Close()` no error assertions
  - Add missing test database `.Close()` calls
  - Use in memory database when amount is not big (`TestTrieDiff`)
  - Do not create unneeded `trie` table in `lib/trie`'s `newTestDB`
  - `dot/state`: use `t.TempDir()` as data dir directly
  - lib/trie: do not create table for TestTrieDiff

## Tests

## Issues

Fixes #2981 

## Primary Reviewer
