### PR TITLE
dot/types: add equivocation vdt

### DIFF
--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -207,7 +207,7 @@ type GrandpaEquivocation struct {
 // GrandpaEquivocationVote is a custom vdt type for a grandpa equivocation
 type GrandpaEquivocationVote scale.VaryingDataType
 
-// Set will set a VaryingDataTypeValue using the underlying VaryingDataType
+// Set sets a VaryingDataTypeValue using the underlying VaryingDataType
 func (ge *GrandpaEquivocationVote) Set(value scale.VaryingDataTypeValue) (err error) {
 	vdt := scale.VaryingDataType(*ge)
 	err = vdt.Set(value)

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -193,3 +193,20 @@ type GrandpaVote struct {
 func (v *GrandpaVote) String() string {
 	return fmt.Sprintf("hash=%s number=%d", v.Hash, v.Number)
 }
+
+// NewGrandpaEquivocation returns a new VaryingDataType to represent a grandpa Equivocation
+func NewGrandpaEquivocation() scale.VaryingDataType {
+	return scale.MustNewVaryingDataType(PreVoteEquivocation{}, PreCommitEquivocation{})
+}
+
+// PreVoteEquivocation equivocation type for a prevote
+type PreVoteEquivocation GrandpaSignedVote
+
+// Index returns VDT index
+func (PreVoteEquivocation) Index() uint { return 0 }
+
+// PreCommitEquivocation equivocation type for a precommit
+type PreCommitEquivocation GrandpaSignedVote
+
+// Index returns VDT index
+func (PreCommitEquivocation) Index() uint { return 1 }

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -194,9 +194,34 @@ func (v *GrandpaVote) String() string {
 	return fmt.Sprintf("hash=%s number=%d", v.Hash, v.Number)
 }
 
+// GrandpaEquivocation is a custom vdt type for a grandpa equivocation
+type GrandpaEquivocation scale.VaryingDataType
+
+// Set will set a VaryingDataTypeValue using the underlying VaryingDataType
+func (ge *GrandpaEquivocation) Set(val scale.VaryingDataTypeValue) (err error) {
+	vdt := scale.VaryingDataType(*ge)
+	err = vdt.Set(val)
+	if err != nil {
+		return err
+	}
+	*ge = GrandpaEquivocation(vdt)
+	return nil
+}
+
+// Value will return the value from the underlying VaryingDataType
+func (ge *GrandpaEquivocation) Value() (val scale.VaryingDataTypeValue, err error) {
+	vdt := scale.VaryingDataType(*ge)
+	return vdt.Value()
+}
+
 // NewGrandpaEquivocation returns a new VaryingDataType to represent a grandpa Equivocation
-func NewGrandpaEquivocation() scale.VaryingDataType {
-	return scale.MustNewVaryingDataType(PreVoteEquivocation{}, PreCommitEquivocation{})
+func NewGrandpaEquivocation() *GrandpaEquivocation {
+	vdt, err := scale.NewVaryingDataType(PreVoteEquivocation{}, PreCommitEquivocation{})
+	if err != nil {
+		panic(err)
+	}
+	ge := GrandpaEquivocation(vdt)
+	return &ge
 }
 
 // PreVoteEquivocation equivocation type for a prevote

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -198,9 +198,9 @@ func (v *GrandpaVote) String() string {
 type GrandpaEquivocation scale.VaryingDataType
 
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
-func (ge *GrandpaEquivocation) Set(val scale.VaryingDataTypeValue) (err error) {
+func (ge *GrandpaEquivocation) Set(value scale.VaryingDataTypeValue) (err error) {
 	vdt := scale.VaryingDataType(*ge)
-	err = vdt.Set(val)
+	err = vdt.Set(value)
 	if err != nil {
 		return err
 	}
@@ -209,17 +209,14 @@ func (ge *GrandpaEquivocation) Set(val scale.VaryingDataTypeValue) (err error) {
 }
 
 // Value will return the value from the underlying VaryingDataType
-func (ge *GrandpaEquivocation) Value() (val scale.VaryingDataTypeValue, err error) {
+func (ge *GrandpaEquivocation) Value() (value scale.VaryingDataTypeValue, err error) {
 	vdt := scale.VaryingDataType(*ge)
 	return vdt.Value()
 }
 
 // NewGrandpaEquivocation returns a new VaryingDataType to represent a grandpa Equivocation
 func NewGrandpaEquivocation() *GrandpaEquivocation {
-	vdt, err := scale.NewVaryingDataType(PreVoteEquivocation{}, PreCommitEquivocation{})
-	if err != nil {
-		panic(err)
-	}
+	vdt := scale.MustNewVaryingDataType(PreVoteEquivocation{}, PreCommitEquivocation{})
 	ge := GrandpaEquivocation(vdt)
 	return &ge
 }

--- a/dot/types/grandpa.go
+++ b/dot/types/grandpa.go
@@ -194,41 +194,51 @@ func (v *GrandpaVote) String() string {
 	return fmt.Sprintf("hash=%s number=%d", v.Hash, v.Number)
 }
 
-// GrandpaEquivocation is a custom vdt type for a grandpa equivocation
-type GrandpaEquivocation scale.VaryingDataType
+// GrandpaEquivocation is used to create a proof of equivocation
+type GrandpaEquivocation struct {
+	RoundNumber     uint64
+	ID              ed25519.PublicKey
+	FirstVote       GrandpaVote
+	FirstSignature  [64]byte
+	SecondVote      GrandpaVote
+	SecondSignature [64]byte
+}
+
+// GrandpaEquivocationVote is a custom vdt type for a grandpa equivocation
+type GrandpaEquivocationVote scale.VaryingDataType
 
 // Set will set a VaryingDataTypeValue using the underlying VaryingDataType
-func (ge *GrandpaEquivocation) Set(value scale.VaryingDataTypeValue) (err error) {
+func (ge *GrandpaEquivocationVote) Set(value scale.VaryingDataTypeValue) (err error) {
 	vdt := scale.VaryingDataType(*ge)
 	err = vdt.Set(value)
 	if err != nil {
 		return err
 	}
-	*ge = GrandpaEquivocation(vdt)
+	*ge = GrandpaEquivocationVote(vdt)
 	return nil
 }
 
 // Value will return the value from the underlying VaryingDataType
-func (ge *GrandpaEquivocation) Value() (value scale.VaryingDataTypeValue, err error) {
+func (ge *GrandpaEquivocationVote) Value() (value scale.VaryingDataTypeValue, err error) {
 	vdt := scale.VaryingDataType(*ge)
 	return vdt.Value()
 }
 
 // NewGrandpaEquivocation returns a new VaryingDataType to represent a grandpa Equivocation
-func NewGrandpaEquivocation() *GrandpaEquivocation {
+func NewGrandpaEquivocation() *GrandpaEquivocationVote {
 	vdt := scale.MustNewVaryingDataType(PreVoteEquivocation{}, PreCommitEquivocation{})
-	ge := GrandpaEquivocation(vdt)
+	ge := GrandpaEquivocationVote(vdt)
 	return &ge
 }
 
 // PreVoteEquivocation equivocation type for a prevote
-type PreVoteEquivocation GrandpaSignedVote
+type PreVoteEquivocation GrandpaEquivocation
 
 // Index returns VDT index
 func (PreVoteEquivocation) Index() uint { return 0 }
 
 // PreCommitEquivocation equivocation type for a precommit
-type PreCommitEquivocation GrandpaSignedVote
+type PreCommitEquivocation GrandpaEquivocation
 
 // Index returns VDT index
 func (PreCommitEquivocation) Index() uint { return 1 }

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestEncodeAndDecodeEquivocationPreVote(t *testing.T) {
+	// TODO refactor this test to use encoded bytes from substrate
 	testFirstVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
 		Number: 999,

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -12,6 +12,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestEncodeAndDecodeEquivocationPreVote(t *testing.T) {
+	exp := common.MustHexToBytes("0x000a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
+	var testVote = GrandpaVote{
+		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
+		Number: 999,
+	}
+	var testSignature = [64]byte{1, 2, 3, 4}
+	var testAuthorityID = [32]byte{5, 6, 7, 8}
+
+	sv := GrandpaSignedVote{
+		Vote:        testVote,
+		Signature:   testSignature,
+		AuthorityID: testAuthorityID,
+	}
+
+	equivPreVote := PreVoteEquivocation(sv)
+	equivVote := NewGrandpaEquivocation()
+	err := equivVote.Set(equivPreVote)
+	require.NoError(t, err)
+	enc, err := scale.Marshal(equivVote)
+	require.NoError(t, err)
+	require.Equal(t, exp, enc)
+
+	res := NewGrandpaEquivocation()
+	err = scale.Unmarshal(enc, &res)
+	require.NoError(t, err)
+	require.Equal(t, equivVote, res)
+}
+
 func TestEncodeGrandpaVote(t *testing.T) {
 	exp := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000")
 	var testVote = GrandpaVote{

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestEncodeAndDecodeEquivocationPreVote(t *testing.T) {
+	t.Parallel()
 	// TODO refactor this test to use encoded bytes from substrate
 	testFirstVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
@@ -53,6 +54,7 @@ func TestEncodeAndDecodeEquivocationPreVote(t *testing.T) {
 }
 
 func TestEncodeGrandpaVote(t *testing.T) {
+	t.Parallel()
 	expectedEncoding := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000")
 	testVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
@@ -71,6 +73,7 @@ func TestEncodeGrandpaVote(t *testing.T) {
 }
 
 func TestEncodeSignedVote(t *testing.T) {
+	t.Parallel()
 	expectedEncoding := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
 	testVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
@@ -95,6 +98,7 @@ func TestEncodeSignedVote(t *testing.T) {
 }
 
 func TestGrandpaAuthoritiesRawToAuthorities(t *testing.T) {
+	t.Parallel()
 	expectedEncoding := common.MustHexToBytes("0x08eea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d714103640000000000000000b64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d7170100000000000000") //nolint:lll
 	authA, _ := common.HexToHash("0xeea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d71410364")
 	authB, _ := common.HexToHash("0xb64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d717")

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -13,78 +13,78 @@ import (
 )
 
 func TestEncodeAndDecodeEquivocationPreVote(t *testing.T) {
-	exp := common.MustHexToBytes("0x000a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
-	var testVote = GrandpaVote{
+	expectedEncoding := common.MustHexToBytes("0x000a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
+	testVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
 		Number: 999,
 	}
-	var testSignature = [64]byte{1, 2, 3, 4}
-	var testAuthorityID = [32]byte{5, 6, 7, 8}
+	testSignature := [64]byte{1, 2, 3, 4}
+	testAuthorityID := [32]byte{5, 6, 7, 8}
 
-	sv := GrandpaSignedVote{
+	signedVote := GrandpaSignedVote{
 		Vote:        testVote,
 		Signature:   testSignature,
 		AuthorityID: testAuthorityID,
 	}
 
-	equivPreVote := PreVoteEquivocation(sv)
+	equivPreVote := PreVoteEquivocation(signedVote)
 	equivVote := NewGrandpaEquivocation()
 	err := equivVote.Set(equivPreVote)
 	require.NoError(t, err)
-	enc, err := scale.Marshal(*equivVote)
+	encoding, err := scale.Marshal(*equivVote)
 	require.NoError(t, err)
-	require.Equal(t, exp, enc)
+	require.Equal(t, expectedEncoding, encoding)
 
-	res := NewGrandpaEquivocation()
-	err = scale.Unmarshal(enc, res)
+	grandpaEquivocation := NewGrandpaEquivocation()
+	err = scale.Unmarshal(encoding, grandpaEquivocation)
 	require.NoError(t, err)
-	require.Equal(t, equivVote, res)
+	require.Equal(t, equivVote, grandpaEquivocation)
 }
 
 func TestEncodeGrandpaVote(t *testing.T) {
-	exp := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000")
-	var testVote = GrandpaVote{
+	expectedEncoding := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000")
+	testVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
 		Number: 999,
 	}
 
-	enc, err := scale.Marshal(testVote)
+	encoding, err := scale.Marshal(testVote)
 	require.NoError(t, err)
-	require.Equal(t, exp, enc)
+	require.Equal(t, expectedEncoding, encoding)
 
-	dec := GrandpaVote{}
-	err = scale.Unmarshal(enc, &dec)
+	grandpaVote := GrandpaVote{}
+	err = scale.Unmarshal(encoding, &grandpaVote)
 	require.NoError(t, err)
-	require.Equal(t, testVote, dec)
+	require.Equal(t, testVote, grandpaVote)
 
 }
 
 func TestEncodeSignedVote(t *testing.T) {
-	exp := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
-	var testVote = GrandpaVote{
+	expectedEncoding := common.MustHexToBytes("0x0a0b0c0d00000000000000000000000000000000000000000000000000000000e7030000010203040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000506070800000000000000000000000000000000000000000000000000000000") //nolint:lll
+	testVote := GrandpaVote{
 		Hash:   common.Hash{0xa, 0xb, 0xc, 0xd},
 		Number: 999,
 	}
-	var testSignature = [64]byte{1, 2, 3, 4}
-	var testAuthorityID = [32]byte{5, 6, 7, 8}
+	testSignature := [64]byte{1, 2, 3, 4}
+	testAuthorityID := [32]byte{5, 6, 7, 8}
 
-	sv := GrandpaSignedVote{
+	signedVote := GrandpaSignedVote{
 		Vote:        testVote,
 		Signature:   testSignature,
 		AuthorityID: testAuthorityID,
 	}
-	enc, err := scale.Marshal(sv)
+	encoding, err := scale.Marshal(signedVote)
 	require.NoError(t, err)
-	require.Equal(t, exp, enc)
+	require.Equal(t, expectedEncoding, encoding)
 
-	res := GrandpaSignedVote{}
-	err = scale.Unmarshal(enc, &res)
+	grandpaSignedVote := GrandpaSignedVote{}
+	err = scale.Unmarshal(encoding, &grandpaSignedVote)
 	require.NoError(t, err)
-	require.Equal(t, sv, res)
+	require.Equal(t, signedVote, grandpaSignedVote)
 }
 
 func TestGrandpaAuthoritiesRawToAuthorities(t *testing.T) {
-	exp := common.MustHexToBytes("0x08eea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d714103640000000000000000b64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d7170100000000000000") //nolint:lll
+	expectedEncoding := common.MustHexToBytes("0x08eea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d714103640000000000000000b64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d7170100000000000000") //nolint:lll
 	authA, _ := common.HexToHash("0xeea1eabcac7d2c8a6459b7322cf997874482bfc3d2ec7a80888a3a7d71410364")
 	authB, _ := common.HexToHash("0xb64994460e59b30364cad3c92e3df6052f9b0ebbb8f88460c194dc5794d6d717")
 
@@ -93,21 +93,21 @@ func TestGrandpaAuthoritiesRawToAuthorities(t *testing.T) {
 		{Key: authB, ID: 1},
 	}
 
-	enc, err := scale.Marshal(auths)
+	encoding, err := scale.Marshal(auths)
 	require.NoError(t, err)
-	require.Equal(t, exp, enc)
+	require.Equal(t, expectedEncoding, encoding)
 
-	dec := []GrandpaAuthoritiesRaw{}
-	err = scale.Unmarshal(enc, &dec)
+	grandpaAuthoritiesRaw := []GrandpaAuthoritiesRaw{}
+	err = scale.Unmarshal(encoding, &grandpaAuthoritiesRaw)
 	require.NoError(t, err)
-	require.Equal(t, auths, dec)
+	require.Equal(t, auths, grandpaAuthoritiesRaw)
 
-	authoritys, err := GrandpaAuthoritiesRawToAuthorities(dec)
+	authorities, err := GrandpaAuthoritiesRawToAuthorities(grandpaAuthoritiesRaw)
 	require.NoError(t, err)
-	require.Equal(t, auths[0].ID, authoritys[0].Weight)
+	require.Equal(t, auths[0].ID, authorities[0].Weight)
 
-	a := Authority{}
-	err = a.FromRawEd25519(dec[1])
+	authority := Authority{}
+	err = authority.FromRawEd25519(grandpaAuthoritiesRaw[1])
 	require.NoError(t, err)
-	require.Equal(t, a, authoritys[1])
+	require.Equal(t, authority, authorities[1])
 }

--- a/dot/types/grandpa_test.go
+++ b/dot/types/grandpa_test.go
@@ -31,12 +31,12 @@ func TestEncodeAndDecodeEquivocationPreVote(t *testing.T) {
 	equivVote := NewGrandpaEquivocation()
 	err := equivVote.Set(equivPreVote)
 	require.NoError(t, err)
-	enc, err := scale.Marshal(equivVote)
+	enc, err := scale.Marshal(*equivVote)
 	require.NoError(t, err)
 	require.Equal(t, exp, enc)
 
 	res := NewGrandpaEquivocation()
-	err = scale.Unmarshal(enc, &res)
+	err = scale.Unmarshal(enc, res)
 	require.NoError(t, err)
 	require.Equal(t, equivVote, res)
 }


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Add an equivocation type to create a wrapper around signed grandpa votes for proper encoding/decoding in runtime calls. This mimicks substrate as seen here https://crates.parity.io/sp_finality_grandpa/enum.Equivocation.html

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./dot/types 
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
#2933

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
