### PR TITLE
fix(dot/network): `findPeers` returns on timeout if a peer is found

### DIFF
--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -177,14 +177,14 @@ func (d *discovery) advertise() {
 }
 
 func (d *discovery) checkPeerCount() {
-	timer := time.NewTicker(connectToPeersTimeout)
-	defer timer.Stop()
+	ticker := time.NewTicker(connectToPeersTimeout)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-d.ctx.Done():
 			return
-		case <-timer.C:
+		case <-ticker.C:
 			if len(d.h.Network().Peers()) > d.minPeers {
 				continue
 			}
@@ -217,10 +217,6 @@ func (d *discovery) findPeers() {
 			logger.Tracef("found new peer %s via DHT", peer.ID)
 			d.h.Peerstore().AddAddrs(peer.ID, peer.Addrs, peerstore.PermanentAddrTTL)
 			d.handler.AddPeer(0, peer.ID)
-
-			if !timer.Stop() {
-				<-timer.C
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Changes

It appears the `findPeers` is bugged as far as I have seen (kinda randomly)

Previously it was waiting for the timeout timer to expire OR for a peer to be found. If a peer would be found, it would stop the timer which would lead to an infinite loop waiting on new peers. I think what we want is to collect peers during the timer timeout, especially since `findPeers` is called by `checkPeerCount` with a ticker.

This PR changes it to NOT stop the timer when finding a peer, such that the function `findPeers` returns when the timer expires.

## Tests

## Issues

## Primary Reviewer

@EclesioMeloJunior 
