### PR TITLE
chore(all): remove unneeded timer channel drains

### DIFF
--- a/dot/network/discovery.go
+++ b/dot/network/discovery.go
@@ -155,9 +155,7 @@ func (d *discovery) advertise() {
 
 		select {
 		case <-d.ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return
 		case <-timer.C:
 			logger.Debug("advertising ourselves in the DHT...")

--- a/dot/network/notifications.go
+++ b/dot/network/notifications.go
@@ -362,9 +362,7 @@ func (s *Service) sendHandshake(peer peer.ID, hs Handshake, info *notificationsP
 		closeOutboundStream(info, peer, stream)
 		return nil, errHandshakeTimeout
 	case hsResponse := <-s.readHandshake(stream, info.handshakeDecoder, info.maxSize):
-		if !hsTimer.Stop() {
-			<-hsTimer.C
-		}
+		hsTimer.Stop()
 
 		if hsResponse.err != nil {
 			logger.Tracef("failed to read handshake from peer %s using protocol %s: %s", peer, info.protocolID, hsResponse.err)

--- a/dot/network/transaction.go
+++ b/dot/network/transaction.go
@@ -146,9 +146,7 @@ func (s *Service) createBatchMessageHandler(txnBatchCh chan *batchMessage) Notif
 
 		select {
 		case txnBatchCh <- data:
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 		case <-timer.C:
 			logger.Debugf("transaction message %s for peer %s not included into batch", msg, peer)
 		}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -85,9 +85,7 @@ func (s *Server) Stop() (err error) {
 	select {
 	case err := <-s.done:
 		close(s.done)
-		if !timeout.Stop() {
-			<-timeout.C
-		}
+		timeout.Stop()
 		if err != nil {
 			return err
 		}

--- a/lib/babe/epoch_handler_test.go
+++ b/lib/babe/epoch_handler_test.go
@@ -92,9 +92,7 @@ func TestEpochHandler_run(t *testing.T) {
 	case <-timer.C:
 		require.Equal(t, epochLength-(firstExecutedSlot-startSlot), callsToHandleSlot)
 	case err := <-errCh:
-		if !timer.Stop() {
-			<-timer.C
-		}
+		timer.Stop()
 		require.NoError(t, err)
 	}
 }

--- a/lib/grandpa/finalisation.go
+++ b/lib/grandpa/finalisation.go
@@ -370,14 +370,8 @@ func (f *finalisationEngine) defineRoundVotes() error {
 	for !precommited {
 		select {
 		case <-f.stopCh:
-			if !determinePrevoteTimer.Stop() {
-				<-determinePrevoteTimer.C
-			}
-
-			if !determinePrecommitTimer.Stop() {
-				<-determinePrecommitTimer.C
-			}
-
+			determinePrevoteTimer.Stop()
+			determinePrecommitTimer.Stop()
 			return nil
 
 		case <-determinePrevoteTimer.C:
@@ -389,10 +383,7 @@ func (f *finalisationEngine) defineRoundVotes() error {
 			if alreadyCompletable {
 				f.actionCh <- alreadyFinalized
 
-				if !determinePrecommitTimer.Stop() {
-					<-determinePrecommitTimer.C
-				}
-
+				determinePrecommitTimer.Stop()
 				return nil
 			}
 

--- a/tests/rpc/system_integration_test.go
+++ b/tests/rpc/system_integration_test.go
@@ -50,9 +50,7 @@ func TestStableNetworkRPC(t *testing.T) { //nolint:tparallel
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return
 		}
 	}

--- a/tests/stress/helpers.go
+++ b/tests/stress/helpers.go
@@ -62,9 +62,7 @@ func compareChainHeadsWithRetry(ctx context.Context, nodes node.Nodes,
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return fmt.Errorf("%w: hashes=%v", err, hashes) // last error
 		}
 	}

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -553,9 +553,7 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 		select {
 		case <-timer.C:
 		case <-waitNoExtCtx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			require.NoError(t, waitNoExtCtx.Err())
 		}
 	}


### PR DESCRIPTION
## Changes

:sob: Sorry I've been wrong and annoying everyone with draining timer channels when stopping them...
Basically (duh) a channel is just like any other pointer, so if it goes out of scope it gets GC'd. There is no need to drain it, even if it's buffered, as long as it goes out of scope, it'll get GC'd. So that means timers don't need to have their channels drained. The only reason to drain them (the timer documentation isn't so clear on that) is to reset them, which we don't use at all in our codebase (except once where the timer already expired and was drained)

## Tests


## Issues


## Primary Reviewer
