### PR TITLE
fix(lib/grandpa):`logger.Errorf` message format typo

### DIFF
--- a/lib/grandpa/grandpa.go
+++ b/lib/grandpa/grandpa.go
@@ -1281,7 +1281,7 @@ func verifyCommitMessageJustification(commitMessage CommitMessage, setID uint64,
 
 		err := verifyJustification(justification, commitMessage.Round, setID, precommit, authorityKeySet)
 		if err != nil {
-			logger.Errorf("verifying justification: %", err)
+			logger.Errorf("verifying justification: %s", err)
 			continue
 		}
 


### PR DESCRIPTION
## Changes

Fix a typo in the `logger.Errorf` message

## Tests

<!-- Detail how to run relevant tests to the changes -->

N/A
## Issues
N/A

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
