### PR TITLE
chore(mocks): move `go:generate mockgen` to `mocks_generate_test.go`

### DIFF
--- a/devnet/cmd/scale-down-ecs-service/mocks_generate_test.go
+++ b/devnet/cmd/scale-down-ecs-service/mocks_generate_test.go
@@ -1,0 +1,6 @@
+// Copyright 2023 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package main
+
+//go:generate mockgen -destination=mocks_test.go -package=$GOPACKAGE github.com/ChainSafe/gossamer/devnet/cmd/scale-down-ecs-service/internal ECSAPI

--- a/devnet/cmd/scale-down-ecs-service/service_scaler_test.go
+++ b/devnet/cmd/scale-down-ecs-service/service_scaler_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/golang/mock/gomock"
 )
 
-//go:generate mockgen -destination=mocks_test.go -package=$GOPACKAGE github.com/ChainSafe/gossamer/devnet/cmd/scale-down-ecs-service/internal ECSAPI
-
 func Test_serviceScaler_findServiceArns(t *testing.T) {
 	ctrl := gomock.NewController(t)
 

--- a/dot/digest/interfaces.go
+++ b/dot/digest/interfaces.go
@@ -19,8 +19,6 @@ type BlockState interface {
 	FreeFinalisedNotifierChannel(ch chan *types.FinalisationInfo)
 }
 
-//go:generate mockgen -destination=mock_epoch_state_test.go -package $GOPACKAGE . EpochState
-
 // EpochState is the interface for state.EpochState
 type EpochState interface {
 	GetEpochForBlock(header *types.Header) (uint64, error)

--- a/dot/digest/mocks_generate_test.go
+++ b/dot/digest/mocks_generate_test.go
@@ -5,3 +5,4 @@ package digest
 
 //go:generate mockgen -destination=mock_telemetry_test.go -package $GOPACKAGE . Telemetry
 //go:generate mockgen -destination=mock_grandpa_test.go -package $GOPACKAGE . GrandpaState
+//go:generate mockgen -destination=mock_epoch_state_test.go -package $GOPACKAGE . EpochState

--- a/dot/mocks_generate_test.go
+++ b/dot/mocks_generate_test.go
@@ -1,0 +1,9 @@
+// Copyright 2023 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package dot
+
+//go:generate mockgen -destination=mocks_test.go -package=$GOPACKAGE . ServiceRegisterer
+//go:generate mockgen -destination=mock_block_state_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/dot/network BlockState
+//go:generate mockgen -source=node.go -destination=mock_node_builder_test.go -package=$GOPACKAGE
+//go:generate mockgen -destination=mock_service_builder_test.go -package $GOPACKAGE . ServiceBuilder

--- a/dot/network/mocks_generate_test.go
+++ b/dot/network/mocks_generate_test.go
@@ -6,3 +6,4 @@ package network
 //go:generate mockgen -destination=mock_telemetry_test.go -package $GOPACKAGE . Telemetry
 //go:generate mockgen -destination=mock_syncer_test.go -package $GOPACKAGE . Syncer
 //go:generate mockgen -destination=mock_block_state_test.go -package $GOPACKAGE . BlockState
+//go:generate mockgen -destination=mock_transaction_handler_test.go -package $GOPACKAGE . TransactionHandler

--- a/dot/network/transaction_integration_test.go
+++ b/dot/network/transaction_integration_test.go
@@ -28,7 +28,6 @@ func TestDecodeTransactionHandshake(t *testing.T) {
 	require.Equal(t, testHandshake, msg)
 }
 
-//go:generate mockgen -destination=mock_transaction_handler_test.go -package $GOPACKAGE . TransactionHandler
 func TestHandleTransactionMessage(t *testing.T) {
 	t.Parallel()
 

--- a/dot/node.go
+++ b/dot/node.go
@@ -48,8 +48,6 @@ type Node struct {
 	metricsServer   *metrics.Server
 }
 
-//go:generate mockgen -source=node.go -destination=mock_node_builder_test.go -package=$GOPACKAGE
-
 type nodeBuilderIface interface {
 	isNodeInitialised(basepath string) error
 	initNode(config *Config) error

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -95,10 +95,6 @@ func TestLoadGlobalNodeName(t *testing.T) {
 	}
 }
 
-//go:generate mockgen -destination=mocks_test.go -package=$GOPACKAGE . ServiceRegisterer
-
-//go:generate mockgen -destination=mock_block_state_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/dot/network BlockState
-
 func setConfigTestDefaults(t *testing.T, cfg *network.Config) {
 	t.Helper()
 	ctrl := gomock.NewController(t)

--- a/dot/rpc/http_test.go
+++ b/dot/rpc/http_test.go
@@ -294,9 +294,6 @@ func externalIP() (string, error) {
 	return "", errors.New("are you connected to the network?")
 }
 
-//go:generate mockgen -destination=mock_telemetry_test.go -package $GOPACKAGE . Telemetry
-//go:generate mockgen -destination=mock_network_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/dot/core Network
-
 func newCoreServiceTest(t *testing.T) *core.Service {
 	t.Helper()
 

--- a/dot/rpc/mocks_generate_test.go
+++ b/dot/rpc/mocks_generate_test.go
@@ -4,3 +4,5 @@
 package rpc
 
 //go:generate mockgen -destination=mocks_test.go -package=$GOPACKAGE . API,TransactionStateAPI
+//go:generate mockgen -destination=mock_telemetry_test.go -package $GOPACKAGE . Telemetry
+//go:generate mockgen -destination=mock_network_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/dot/core Network

--- a/dot/services_test.go
+++ b/dot/services_test.go
@@ -122,8 +122,6 @@ func Test_newInMemoryDB(t *testing.T) {
 	}
 }
 
-//go:generate mockgen -destination=mock_service_builder_test.go -package $GOPACKAGE . ServiceBuilder
-
 func newStateService(t *testing.T, ctrl *gomock.Controller) *state.Service {
 	t.Helper()
 

--- a/dot/state/mocks_generate_test.go
+++ b/dot/state/mocks_generate_test.go
@@ -4,3 +4,5 @@
 package state
 
 //go:generate mockgen -destination=mocks_test.go -package $GOPACKAGE . Telemetry,BlockStateDatabase,Observer
+//go:generate mockgen -destination=mock_gauge_test.go -package $GOPACKAGE github.com/prometheus/client_golang/prometheus Gauge
+//go:generate mockgen -destination=mock_counter_test.go -package $GOPACKAGE github.com/prometheus/client_golang/prometheus Counter

--- a/dot/state/tries_test.go
+++ b/dot/state/tries_test.go
@@ -66,9 +66,6 @@ func Test_Tries_SetTrie(t *testing.T) {
 	assert.Equal(t, expectedTries, tries)
 }
 
-//go:generate mockgen -destination=mock_gauge_test.go -package $GOPACKAGE github.com/prometheus/client_golang/prometheus Gauge
-//go:generate mockgen -destination=mock_counter_test.go -package $GOPACKAGE github.com/prometheus/client_golang/prometheus Counter
-
 func Test_Tries_softSet(t *testing.T) {
 	t.Parallel()
 

--- a/internal/httpserver/mocks_generate_test.go
+++ b/internal/httpserver/mocks_generate_test.go
@@ -1,0 +1,6 @@
+// Copyright 2023 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package httpserver
+
+//go:generate mockgen -destination=logger_mock_test.go -package $GOPACKAGE . Logger

--- a/internal/httpserver/server_test.go
+++ b/internal/httpserver/server_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//go:generate mockgen -destination=logger_mock_test.go -package $GOPACKAGE . Logger
-
 func Test_New(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)

--- a/internal/pprof/mocks_generate_test.go
+++ b/internal/pprof/mocks_generate_test.go
@@ -1,0 +1,7 @@
+// Copyright 2023 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package pprof
+
+//go:generate mockgen -destination=logger_mock_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/internal/httpserver Logger
+//go:generate mockgen -destination=runner_mock_test.go -package $GOPACKAGE . Runner

--- a/internal/pprof/server_test.go
+++ b/internal/pprof/server_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//go:generate mockgen -destination=logger_mock_test.go -package $GOPACKAGE github.com/ChainSafe/gossamer/internal/httpserver Logger
-
 func Test_Server(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)

--- a/internal/pprof/service_test.go
+++ b/internal/pprof/service_test.go
@@ -30,8 +30,6 @@ func Test_NewService(t *testing.T) {
 	assert.NotNil(t, service.done)
 }
 
-//go:generate mockgen -destination=runner_mock_test.go -package $GOPACKAGE . Runner
-
 func Test_Service_StartStop_success(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trie/node/buffer.go
+++ b/internal/trie/node/buffer.go
@@ -5,9 +5,6 @@ package node
 
 import "io"
 
-//go:generate mockgen -destination=buffer_mock_test.go -package $GOPACKAGE . Buffer
-//go:generate mockgen -destination=writer_mock_test.go -package $GOPACKAGE io Writer
-
 // Buffer is an interface with some methods of *bytes.Buffer.
 type Buffer interface {
 	io.Writer

--- a/internal/trie/node/key_test.go
+++ b/internal/trie/node/key_test.go
@@ -19,8 +19,6 @@ func repeatBytes(n int, b byte) (slice []byte) {
 	return slice
 }
 
-//go:generate mockgen -destination=reader_mock_test.go -package $GOPACKAGE io Reader
-
 type readCall struct {
 	buffArgCap int
 	read       []byte

--- a/internal/trie/node/mocks_generate_test.go
+++ b/internal/trie/node/mocks_generate_test.go
@@ -1,0 +1,8 @@
+// Copyright 2023 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package node
+
+//go:generate mockgen -destination=buffer_mock_test.go -package $GOPACKAGE . Buffer
+//go:generate mockgen -destination=writer_mock_test.go -package $GOPACKAGE io Writer
+//go:generate mockgen -destination=reader_mock_test.go -package $GOPACKAGE io Reader

--- a/lib/babe/mocks_generate_test.go
+++ b/lib/babe/mocks_generate_test.go
@@ -4,3 +4,4 @@
 package babe
 
 //go:generate mockgen -destination=mock_telemetry_test.go -package $GOPACKAGE . Telemetry
+//go:generate mockgen -destination=mock_state_test.go -package $GOPACKAGE . BlockState,ImportedBlockNotifierManager,StorageState,TransactionState,EpochState,BlockImportHandler

--- a/lib/babe/state.go
+++ b/lib/babe/state.go
@@ -14,8 +14,6 @@ import (
 	"github.com/ChainSafe/gossamer/lib/transaction"
 )
 
-//go:generate mockgen -destination=mock_state_test.go -package $GOPACKAGE . BlockState,ImportedBlockNotifierManager,StorageState,TransactionState,EpochState,BlockImportHandler
-
 // BlockState interface for block state methods
 type BlockState interface {
 	BestBlockHash() common.Hash

--- a/lib/services/mocks_generate_test.go
+++ b/lib/services/mocks_generate_test.go
@@ -1,0 +1,6 @@
+// Copyright 2023 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package services
+
+//go:generate mockgen -destination=mocks_test.go -package $GOPACKAGE . Service

--- a/lib/services/services.go
+++ b/lib/services/services.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 )
 
-//go:generate mockgen -destination=mocks_test.go -package $GOPACKAGE . Service
-
 // Service must be implemented by all services
 type Service interface {
 	Start() error


### PR DESCRIPTION
## Changes

Grouping all `//go:generate mockgen` instructions in `mocks_generate_test.go` files.

This:
- removes ambiguity as to where to place mock generation commands (in test files, above interfaces, duplicate them etc.)
- allow to further refactor mock generation and interfaces re-structuration


## Tests

## Issues


## Primary Reviewer

@jimjbrettj 