### PR TITLE
feature (dot/network): add CLI flag --node-key, hex encoded libp2p node key

### DIFF
--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -688,6 +688,11 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 		cfg.PublicDNS = pubdns
 	}
 
+	// check --node-key flag ond update node configuration
+	if nodekey := ctx.GlobalString(NodeKeyFlag.Name); nodekey != "" {
+		cfg.NodeKey = nodekey
+	}
+
 	if len(cfg.PersistentPeers) == 0 {
 		cfg.PersistentPeers = []string(nil)
 	}

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -688,7 +688,7 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 		cfg.PublicDNS = pubdns
 	}
 
-	// check --node-key flag ond update node configuration
+	// check --node-key flag and update node configuration
 	if nodekey := ctx.GlobalString(NodeKeyFlag.Name); nodekey != "" {
 		cfg.NodeKey = nodekey
 	}

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -232,6 +232,11 @@ var (
 		Name:  "pubdns",
 		Usage: "Overrides public DNS used for peer to peer networking",
 	}
+	// NodeKeyFlag uses the supplied hex-encoded Ed25519 secret key seed for libp2p networking
+	NodeKeyFlag = cli.StringFlag{
+		Name:  "node-key",
+		Usage: "Overrides the secret key to use for libp2p",
+	}
 )
 
 // RPC service configuration flags
@@ -425,6 +430,7 @@ var (
 		NoMDNSFlag,
 		PublicIPFlag,
 		PublicDNSFlag,
+		NodeKeyFlag,
 
 		// rpc flags
 		RPCEnabledFlag,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -235,7 +235,7 @@ var (
 	// NodeKeyFlag uses the supplied hex-encoded Ed25519 secret key seed for libp2p networking
 	NodeKeyFlag = cli.StringFlag{
 		Name:  "node-key",
-		Usage: "Overrides the secret key to use for libp2p",
+		Usage: "Overrides the secret Ed25519 key to use for libp2p",
 	}
 )
 

--- a/dot/config.go
+++ b/dot/config.go
@@ -103,6 +103,7 @@ type NetworkConfig struct {
 	DiscoveryInterval time.Duration
 	PublicIP          string
 	PublicDNS         string
+	NodeKey           string
 }
 
 // CoreConfig is to marshal/unmarshal toml core config vars

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -6,6 +6,7 @@ package network
 import (
 	"crypto/ed25519"
 	"errors"
+	"fmt"
 	"path"
 	"time"
 
@@ -95,7 +96,7 @@ type Config struct {
 	// privateKey the private key for the network p2p identity
 	privateKey crypto.PrivKey
 
-	// private hex encoded Ed125519 key to build p2p identity
+	// NodeKey is the private hex encoded Ed125519 key to build the p2p identity.
 	NodeKey string
 
 	// telemetryInterval how often to send telemetry metrics
@@ -166,16 +167,16 @@ func (c *Config) checkState() (err error) {
 // using the random seed (if random seed is not set, creates new random key)
 func (c *Config) buildIdentity() error {
 	if c.NodeKey != "" {
-		pkBytes, err := common.HexToBytes("0x" + c.NodeKey)
+		privateKeySeed, err := common.HexToBytes("0x" + c.NodeKey)
 		if err != nil {
-			return err
+			return fmt.Errorf("parsing hex encoding of ed25519 private key: %w", err)
 		}
-		key := ed25519.NewKeyFromSeed(pkBytes)
-		pk, err := crypto.UnmarshalEd25519PrivateKey(key)
+		key := ed25519.NewKeyFromSeed(privateKeySeed)
+		privateKey, err := crypto.UnmarshalEd25519PrivateKey(key)
 		if err != nil {
-			return err
+			return fmt.Errorf("decoding ed25519 bytes: %w", err)
 		}
-		c.privateKey = pk
+		c.privateKey = privateKey
 		return nil
 	}
 	if c.RandSeed == 0 {

--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -4,7 +4,6 @@
 package network
 
 import (
-	"fmt"
 	"io"
 	"testing"
 
@@ -26,7 +25,6 @@ func TestBuildIdentity(t *testing.T) {
 
 	err := configA.buildIdentity()
 	require.NoError(t, err)
-	fmt.Printf("pri key %#v\n", configA.privateKey)
 	configB := &Config{
 		logger:   log.New(log.SetWriter(io.Discard)),
 		BasePath: testDir,
@@ -84,19 +82,4 @@ func TestBuild(t *testing.T) {
 	require.Equal(t, DefaultProtocolID, cfg.ProtocolID)
 	require.Equal(t, false, cfg.NoBootstrap)
 	require.Equal(t, false, cfg.NoMDNS)
-}
-
-func TestBuildKeyFromFile(t *testing.T) {
-	testDir := t.TempDir()
-
-	configA := &Config{
-		logger:   log.New(log.SetWriter(io.Discard)),
-		BasePath: testDir,
-		nodeKey:  "0x01020304",
-	}
-
-	err := configA.buildIdentity()
-	require.NoError(t, err)
-	pk1, err := configA.privateKey.Raw()
-	fmt.Printf("pri key %v, len %v\n", pk1, len(pk1))
 }

--- a/dot/network/config_test.go
+++ b/dot/network/config_test.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestBuildIdentity(t *testing.T) {
 
 	err := configA.buildIdentity()
 	require.NoError(t, err)
-
+	fmt.Printf("pri key %#v\n", configA.privateKey)
 	configB := &Config{
 		logger:   log.New(log.SetWriter(io.Discard)),
 		BasePath: testDir,
@@ -83,4 +84,19 @@ func TestBuild(t *testing.T) {
 	require.Equal(t, DefaultProtocolID, cfg.ProtocolID)
 	require.Equal(t, false, cfg.NoBootstrap)
 	require.Equal(t, false, cfg.NoMDNS)
+}
+
+func TestBuildKeyFromFile(t *testing.T) {
+	testDir := t.TempDir()
+
+	configA := &Config{
+		logger:   log.New(log.SetWriter(io.Discard)),
+		BasePath: testDir,
+		nodeKey:  "0x01020304",
+	}
+
+	err := configA.buildIdentity()
+	require.NoError(t, err)
+	pk1, err := configA.privateKey.Raw()
+	fmt.Printf("pri key %v, len %v\n", pk1, len(pk1))
 }

--- a/dot/services.go
+++ b/dot/services.go
@@ -307,6 +307,7 @@ func (nodeBuilder) createNetworkService(cfg *Config, stateSrvc *state.Service,
 		Telemetry:         telemetryMailer,
 		PublicDNS:         cfg.Network.PublicDNS,
 		Metrics:           metrics.NewIntervalConfig(cfg.Global.PublishMetrics),
+		NodeKey:           cfg.Network.NodeKey,
 	}
 
 	networkSrvc, err := network.NewService(&networkConfig)


### PR DESCRIPTION
## Changes
This PR introduces code that implements CLI flag `--node-key` which allows the user to pass in the secret Ed25519 key to use for libp2p networking.  The value is parsed as a hex-encoded Ed25519 secret key, i.e. 64 hex characters.  The node then uses that key for libp2p networking.  Warning, secrets provided as command-line arguments are easily exposed, so use of this option should be limited to development and testing.  This was introduced to enable setting this key in a manner that is used by ZombieNet  (https://github.com/paritytech/zombienet) testing framework.
<!-- Brief list of functional changes -->


## Issues
Work done researching issue #2843.
<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
