### PR TITLE
feat(dot/types): moves `ParachainInherentData` type to `types` package

### DIFF
--- a/dot/types/parachain_inherents.go
+++ b/dot/types/parachain_inherents.go
@@ -1,12 +1,11 @@
 // Copyright 2022 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package babe
+package types
 
 import (
 	"fmt"
 
-	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
@@ -379,5 +378,5 @@ type ParachainInherentData struct {
 	// Sets of dispute votes for inclusion,
 	Disputes multiDisputeStatementSet `scale:"3"`
 	// The parent block header. Used for checking state proofs.
-	ParentHeader types.Header `scale:"4"`
+	ParentHeader Header `scale:"4"`
 }

--- a/dot/types/parachain_inherents_test.go
+++ b/dot/types/parachain_inherents_test.go
@@ -1,12 +1,11 @@
 // Copyright 2022 ChainSafe Systems (ON)
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package babe
+package types
 
 import (
 	"testing"
 
-	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/stretchr/testify/assert"
@@ -276,9 +275,8 @@ func TestParachainInherents(t *testing.T) {
 	// let mut inherents: sp_inherents::InherentData = sp_inherents::InherentData::new();
 	// inherents.put_data(*b"parachn0", &para_int).unwrap();
 	// println!("{:?}", inherents.encode());
-
 	parachainInherent := ParachainInherentData{
-		ParentHeader: types.Header{
+		ParentHeader: Header{
 			ParentHash:     common.MustBlake2bHash([]byte("1000")),
 			Number:         uint(2000),
 			StateRoot:      common.MustBlake2bHash([]byte("3000")),
@@ -291,8 +289,8 @@ func TestParachainInherents(t *testing.T) {
 
 	assert.Equal(t, expectedParaInherentsbytes, actualParaInherentBytes)
 
-	idata := types.NewInherentData()
-	err = idata.SetInherent(types.Parachn0, parachainInherent)
+	idata := NewInherentData()
+	err = idata.SetInherent(Parachn0, parachainInherent)
 	require.NoError(t, err)
 
 	actualInherentsBytes, err := idata.Encode()

--- a/lib/babe/build.go
+++ b/lib/babe/build.go
@@ -240,7 +240,7 @@ func buildBlockInherents(slot Slot, rt ExtrinsicHandler, parent *types.Header) (
 		return nil, err
 	}
 
-	parachainInherent := ParachainInherentData{
+	parachainInherent := types.ParachainInherentData{
 		ParentHeader: *parent,
 	}
 


### PR DESCRIPTION
## Changes

- Extract `ParachainInherentData` type from `lib/babe` package and moves it to `dot/types` package, this is needed since there is a bunch of tests that need it but cannot import due to cyclic dependency.

## Tests

<!-- Detail how to run relevant tests to the changes -->

N/A

## Issues

- Unblocks: https://github.com/ChainSafe/gossamer/pull/3047

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
@qdm12 
