### PR TITLE
fix(tests/polkadot_js): Use `westend-local` to run polkadot js test suite

### DIFF
--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -19,8 +19,6 @@ import (
 
 var polkadotSuite = "polkadot"
 
-// TODO: add test against latest dev runtime
-// See https://github.com/ChainSafe/gossamer/issues/2705
 func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 	if utils.MODE != polkadotSuite {
 		t.Log("Going to skip polkadot.js/api suite tests")
@@ -48,7 +46,7 @@ func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 	t.Log("starting gossamer for polkadot.js/api tests...")
 
 	tomlConfig := config.Default()
-	tomlConfig.Init.Genesis = libutils.GetDevV3SubstrateGenesisPath(t)
+	tomlConfig.Init.Genesis = libutils.GetWestendLocalRawGenesisPath(t)
 	tomlConfig.Core.BABELead = true
 	tomlConfig.RPC.WS = true
 	tomlConfig.RPC.Unsafe = true

--- a/tests/polkadotjs_test/test/test-polkadot.js
+++ b/tests/polkadotjs_test/test/test-polkadot.js
@@ -56,7 +56,8 @@ describe('Testing polkadot.js/api calls:', function () {
         it('call api.runtimeVersion', async function () {
             const runtimeVersion = await api.runtimeVersion;
             expect(runtimeVersion).to.be.not.null;
-            expect(runtimeVersion).to.have.property('specName').contains('westend')
+            expect(runtimeVersion).to.have.property('specName')
+                .contains('westend', `runtimeVersion.specName expected to contains: westend, got ${runtimeVersion.specName}`)
             expect(runtimeVersion).to.have.property('apis').lengthOf.above(10)
         });
 
@@ -116,7 +117,8 @@ describe('Testing polkadot.js/api calls:', function () {
     describe('api system', () => {
         it('call api.rpc.system.chain()', async function () {
             const chain = await api.rpc.system.chain();
-            expect(chain).to.contain('Gossamer');
+            expect(chain).to
+                .contain('Westend', `api.rpc.system.chain() expected to contains: Westend, got ${chain}`);
         });
 
         it('call api.rpc.system.properties()', async function () {

--- a/tests/polkadotjs_test/test/test-polkadot.js
+++ b/tests/polkadotjs_test/test/test-polkadot.js
@@ -56,7 +56,7 @@ describe('Testing polkadot.js/api calls:', function () {
         it('call api.runtimeVersion', async function () {
             const runtimeVersion = await api.runtimeVersion;
             expect(runtimeVersion).to.be.not.null;
-            expect(runtimeVersion).to.have.property('specName').contains('node')
+            expect(runtimeVersion).to.have.property('specName').contains('westend')
             expect(runtimeVersion).to.have.property('apis').lengthOf.above(10)
         });
 

--- a/tests/polkadotjs_test/test/test-polkadot.js
+++ b/tests/polkadotjs_test/test/test-polkadot.js
@@ -56,8 +56,7 @@ describe('Testing polkadot.js/api calls:', function () {
         it('call api.runtimeVersion', async function () {
             const runtimeVersion = await api.runtimeVersion;
             expect(runtimeVersion).to.be.not.null;
-            expect(runtimeVersion).to.have.property('specName')
-                .contains('westend', `runtimeVersion.specName expected to contains: westend, got ${runtimeVersion.specName}`)
+            expect(runtimeVersion).to.have.property('specName').contains('westend');
             expect(runtimeVersion).to.have.property('apis').lengthOf.above(10)
         });
 
@@ -117,8 +116,7 @@ describe('Testing polkadot.js/api calls:', function () {
     describe('api system', () => {
         it('call api.rpc.system.chain()', async function () {
             const chain = await api.rpc.system.chain();
-            expect(chain).to
-                .contain('Westend', `api.rpc.system.chain() expected to contains: Westend, got ${chain}`);
+            expect(chain).to.contain('Westend')
         });
 
         it('call api.rpc.system.properties()', async function () {


### PR DESCRIPTION
## Changes

- Fix assertion problems in the polkadot.js test suite

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
MODE=polkadot go test -timeout 10m -run ^TestStartGossamerAndPolkadotAPI$ github.com/ChainSafe/gossamer/tests/polkadotjs_test --tags=integration -v
```

## Issues

- Closes #3023

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@jimjbrettj 