### PR TITLE
fix(lib/babe): use slot start time in handleSlot

### DIFF
--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -478,19 +478,13 @@ func (b *Service) getParentForBlockAuthoring(slotNum uint64) (*types.Header, err
 	return parent, nil
 }
 
-func (b *Service) handleSlot(epoch, slotNum uint64,
+func (b *Service) handleSlot(epoch uint64, slot Slot,
 	authorityIndex uint32,
 	preRuntimeDigest *types.PreRuntimeDigest,
 ) error {
-	currentSlot := Slot{
-		start:    time.Now(),
-		duration: b.constants.slotDuration,
-		number:   slotNum,
-	}
-
-	parent, err := b.getParentForBlockAuthoring(slotNum)
+	parent, err := b.getParentForBlockAuthoring(slot.number)
 	if err != nil {
-		return fmt.Errorf("could not get parent for claiming slot %d: %w", slotNum, err)
+		return fmt.Errorf("could not get parent for claiming slot %d: %w", slot.number, err)
 	}
 	b.storageState.Lock()
 	defer b.storageState.Unlock()
@@ -510,14 +504,14 @@ func (b *Service) handleSlot(epoch, slotNum uint64,
 
 	rt.SetContextStorage(ts)
 
-	block, err := b.buildBlock(parent, currentSlot, rt, authorityIndex, preRuntimeDigest)
+	block, err := b.buildBlock(parent, slot, rt, authorityIndex, preRuntimeDigest)
 	if err != nil {
 		return err
 	}
 
 	logger.Infof(
 		"built block %d with hash %s, state root %s, epoch %d and slot %d",
-		block.Header.Number, block.Header.Hash(), block.Header.StateRoot, epoch, slotNum)
+		block.Header.Number, block.Header.Hash(), block.Header.StateRoot, epoch, slot.number)
 	logger.Tracef(
 		"built block with parent hash %s, header %s and body %s",
 		parent.Hash(), block.Header.String(), block.Body)

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -181,9 +181,14 @@ func TestService_HandleSlotWithLaggingSlot(t *testing.T) {
 
 	require.NoError(t, err)
 
+	slot = Slot{
+		start:    time.Now(),
+		duration: babeService.constants.slotDuration * time.Millisecond,
+		number:   bestBlockSlotNum - 1,
+	}
 	err = babeService.handleSlot(
 		babeService.epochHandler.epochNumber,
-		bestBlockSlotNum-1,
+		slot,
 		babeService.epochHandler.epochData.authorityIndex,
 		preRuntimeDigest)
 
@@ -285,7 +290,7 @@ func TestService_HandleSlotWithSameSlot(t *testing.T) {
 	// authored by someone else
 	err = babeServiceAlice.handleSlot(
 		testEpochIndex,
-		bestBlockSlotNum,
+		slot,
 		0,
 		preRuntimeDigest)
 	require.NoError(t, err)

--- a/lib/babe/epoch_handler.go
+++ b/lib/babe/epoch_handler.go
@@ -14,7 +14,8 @@ import (
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 )
 
-type handleSlotFunc = func(epoch, slotNum uint64, authorityIndex uint32, preRuntimeDigest *types.PreRuntimeDigest) error
+type handleSlotFunc = func(epoch uint64, slot Slot, authorityIndex uint32,
+	preRuntimeDigest *types.PreRuntimeDigest) error
 
 var (
 	errEpochPast = errors.New("cannot run epoch that has already passed")
@@ -129,7 +130,12 @@ func (h *epochHandler) run(ctx context.Context, errCh chan<- error) {
 				panic(fmt.Sprintf("no VRF proof for authoring slot! slot=%d", swt.slotNum))
 			}
 
-			err := h.handleSlot(h.epochNumber, swt.slotNum, h.epochData.authorityIndex, h.slotToPreRuntimeDigest[swt.slotNum])
+			currentSlot := Slot{
+				start:    swt.startTime,
+				duration: h.constants.slotDuration,
+				number:   swt.slotNum,
+			}
+			err := h.handleSlot(h.epochNumber, currentSlot, h.epochData.authorityIndex, h.slotToPreRuntimeDigest[swt.slotNum])
 			if err != nil {
 				logger.Warnf("failed to handle slot %d: %s", swt.slotNum, err)
 				continue

--- a/lib/babe/epoch_handler_test.go
+++ b/lib/babe/epoch_handler_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNewEpochHandler(t *testing.T) {
-	testHandleSlotFunc := func(epoch, slotNum uint64, authorityIndex uint32,
+	testHandleSlotFunc := func(epoch uint64, slot Slot, authorityIndex uint32,
 		preRuntimeDigest *types.PreRuntimeDigest,
 	) error {
 		return nil
@@ -52,14 +52,14 @@ func TestEpochHandler_run(t *testing.T) {
 	startSlot := getCurrentSlot(sd)
 
 	var callsToHandleSlot, firstExecutedSlot uint64
-	testHandleSlotFunc := func(epoch, slotNum uint64, authorityIndex uint32,
+	testHandleSlotFunc := func(epoch uint64, slot Slot, authorityIndex uint32,
 		preRuntimeDigest *types.PreRuntimeDigest,
 	) error {
 		require.Equal(t, uint64(1), epoch)
 		if callsToHandleSlot == 0 {
-			firstExecutedSlot = slotNum
+			firstExecutedSlot = slot.number
 		} else {
-			require.Equal(t, firstExecutedSlot+callsToHandleSlot, slotNum)
+			require.Equal(t, firstExecutedSlot+callsToHandleSlot, slot.number)
 		}
 		require.Equal(t, uint32(0), authorityIndex)
 		require.NotNil(t, preRuntimeDigest)


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Pass in slot to slot handler rather than declare it in the function
- Instead of using time.Now() use the slot start time as the start field of Slot

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration lib/babe
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@EclesioMeloJunior 
