### PR TITLE
fix(blocktree): stop and prune runtimes from memory

### DIFF
--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -289,8 +289,10 @@ func (bt *BlockTree) Prune(finalised Hash) (pruned []Hash) {
 	}
 
 	for _, hash := range pruned {
-		instance := bt.runtimes.get(hash)
-		instance.Stop()
+		runtimeFromFork := bt.runtimes.get(hash)
+		if runtimeFromFork != finalisedBlockRuntime {
+			runtimeFromFork.Stop()
+		}
 		bt.runtimes.delete(hash)
 	}
 

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -267,6 +267,9 @@ func (bt *BlockTree) Prune(finalised Hash) (pruned []Hash) {
 	// accessible through the storage as WASM blob.
 	previousFinalisedBlock := bt.root
 	newCanonicalChainBlocksCount := n.number - previousFinalisedBlock.number
+	if previousFinalisedBlock.number == 0 { // include the genesis block
+		newCanonicalChainBlocksCount++
+	}
 	canonicalChainBlock := n
 	newCanonicalChainBlockHashes := make([]Hash, newCanonicalChainBlocksCount)
 	for i := int(newCanonicalChainBlocksCount) - 1; i >= 0; i-- {

--- a/lib/blocktree/blocktree.go
+++ b/lib/blocktree/blocktree.go
@@ -271,6 +271,8 @@ func (bt *BlockTree) Prune(finalised Hash) (pruned []Hash) {
 	}
 
 	for _, hash := range pruned {
+		instance := bt.runtimes.get(hash)
+		instance.Stop()
 		bt.runtimes.delete(hash)
 	}
 

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -558,6 +558,7 @@ func Test_BlockTree_Prune(t *testing.T) {
 			number: 100,
 		}
 		rootRuntime := NewMockRuntime(ctrl)
+		rootRuntime.EXPECT().Stop()
 
 		blockTree := &BlockTree{
 			root:   rootNode,
@@ -570,7 +571,6 @@ func Test_BlockTree_Prune(t *testing.T) {
 				currentBlockHashes: []Hash{{1}},
 			},
 		}
-		rootRuntime.EXPECT().Stop()
 
 		// {1} -> {2}
 		parent := rootNode
@@ -582,7 +582,6 @@ func Test_BlockTree_Prune(t *testing.T) {
 		parent.addChild(newNode)
 		blockTree.leaves.replace(parent, newNode)
 		blockTree.runtimes.set(common.Hash{2}, rootRuntime)
-		rootRuntime.EXPECT().Stop()
 
 		// {1} -> {2} -> {3}
 		parent = newNode
@@ -618,7 +617,6 @@ func Test_BlockTree_Prune(t *testing.T) {
 		parent.addChild(newNode)
 		blockTree.leaves.replace(parent, newNode)
 		blockTree.runtimes.set(common.Hash{5}, rootRuntime)
-		rootRuntime.EXPECT().Stop()
 
 		// {1} -> {2} -> {3} -> {4}
 		//            -> {5} -> {6}

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -382,38 +383,269 @@ func Test_BlockTree_LowestCommonAncestor_SameChain(t *testing.T) {
 }
 
 func Test_BlockTree_Prune(t *testing.T) {
-	var bt *BlockTree
-	var branches []testBranch
+	t.Parallel()
 
-	for {
-		bt, branches = createTestBlockTree(t, testHeader, 5)
-		if len(branches) > 0 && len(bt.getNode(branches[0].hash).children) > 1 {
-			break
-		}
-	}
+	t.Run("finalised_hash_is_root_hash", func(t *testing.T) {
+		t.Parallel()
 
-	blockTreeCopy := bt.DeepCopy()
-
-	// pick some block to finalise
-	finalised := bt.root.children[0].children[0].children[0]
-	pruned := bt.Prune(finalised.hash)
-
-	for _, prunedHash := range pruned {
-		prunedNode := blockTreeCopy.getNode(prunedHash)
-		if prunedNode.isDescendantOf(finalised) {
-			t.Fatal("pruned node that's descendant of finalised node!!")
+		blockTree := &BlockTree{
+			root: &node{
+				hash: Hash{1},
+			},
 		}
 
-		if finalised.isDescendantOf(prunedNode) {
-			t.Fatal("pruned an ancestor of the finalised node!!")
-		}
-	}
+		pruned := blockTree.Prune(Hash{1})
 
-	require.NotEqual(t, 0, len(bt.leaves.nodes()))
-	for _, leaf := range bt.leaves.nodes() {
-		require.NotEqual(t, leaf.hash, finalised.hash)
-		require.True(t, leaf.isDescendantOf(finalised))
-	}
+		assert.Empty(t, pruned)
+	})
+
+	t.Run("node_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		blockTree := &BlockTree{
+			root:   &node{},
+			leaves: newEmptyLeafMap(),
+		}
+
+		pruned := blockTree.Prune(Hash{1})
+
+		assert.Empty(t, pruned)
+	})
+
+	t.Run("nothing_to_prune", func(t *testing.T) {
+		t.Parallel()
+
+		rootNode := &node{
+			hash:   common.Hash{1},
+			number: 0,
+		}
+		rootRuntime := NewMockRuntime(nil)
+		blockTree := &BlockTree{
+			root:     rootNode,
+			leaves:   newEmptyLeafMap(),
+			runtimes: newHashToRuntime(),
+		}
+		blockTree.runtimes.set(common.Hash{1}, rootRuntime)
+
+		// {1} -> {2}
+		parent := rootNode
+		newNode := &node{
+			parent: parent,
+			hash:   common.Hash{2},
+			number: 1,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		blockTree.runtimes.set(common.Hash{2}, rootRuntime)
+
+		pruned := blockTree.Prune(common.Hash{2})
+		assert.Empty(t, pruned)
+
+		expectedHashToRuntime := &hashToRuntime{
+			mapping: map[common.Hash]Runtime{
+				{1}: rootRuntime,
+				{2}: rootRuntime,
+			},
+		}
+		assert.Equal(t, blockTree.runtimes, expectedHashToRuntime)
+	})
+
+	t.Run("prune_canonical_runtimes", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		rootNode := &node{
+			hash:   common.Hash{1},
+			number: 0,
+		}
+		rootRuntime := NewMockRuntime(ctrl)
+		blockTree := &BlockTree{
+			root:     rootNode,
+			leaves:   newEmptyLeafMap(),
+			runtimes: newHashToRuntime(),
+		}
+		blockTree.runtimes.set(common.Hash{1}, rootRuntime)
+
+		// {1} -> {2}
+		parent := rootNode
+		newNode := &node{
+			parent: parent,
+			hash:   common.Hash{2},
+			number: 1,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		leafRuntime := NewMockRuntime(ctrl)
+		blockTree.runtimes.set(common.Hash{2}, leafRuntime)
+
+		// Previous runtime is pruned
+		rootRuntime.EXPECT().Stop()
+
+		pruned := blockTree.Prune(common.Hash{2})
+		assert.Empty(t, pruned)
+
+		expectedHashToRuntime := &hashToRuntime{
+			mapping: map[common.Hash]Runtime{
+				{2}: rootRuntime,
+			},
+		}
+		assert.Equal(t, blockTree.runtimes, expectedHashToRuntime)
+	})
+
+	t.Run("prune_fork", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		rootNode := &node{
+			hash:   common.Hash{1},
+			number: 0,
+		}
+		rootRuntime := NewMockRuntime(ctrl)
+		blockTree := &BlockTree{
+			root:     rootNode,
+			leaves:   newEmptyLeafMap(),
+			runtimes: newHashToRuntime(),
+		}
+		blockTree.runtimes.set(common.Hash{1}, rootRuntime)
+
+		// {1} -> {2}
+		parent := rootNode
+		newNode := &node{
+			parent: parent,
+			hash:   common.Hash{2},
+			number: 1,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		blockTree.runtimes.set(common.Hash{2}, rootRuntime)
+
+		// {1} -> {2}
+		//     -> {3}
+		parent = rootNode
+		newNode = &node{
+			parent: parent,
+			hash:   common.Hash{3},
+			number: 1,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		blockTree.runtimes.set(common.Hash{3}, rootRuntime)
+
+		pruned := blockTree.Prune(common.Hash{2})
+		assert.Equal(t, []common.Hash{{3}}, pruned)
+
+		expectedHashToRuntime := &hashToRuntime{
+			mapping: map[common.Hash]Runtime{
+				{1}: rootRuntime,
+				{2}: rootRuntime,
+			},
+		}
+		assert.Equal(t, blockTree.runtimes, expectedHashToRuntime)
+	})
+
+	t.Run("complex_example", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+
+		rootNode := &node{
+			hash:   common.Hash{1},
+			number: 100,
+		}
+		rootRuntime := NewMockRuntime(ctrl)
+		blockTree := &BlockTree{
+			root:     rootNode,
+			leaves:   newEmptyLeafMap(),
+			runtimes: newHashToRuntime(),
+		}
+		rootRuntime.EXPECT().Stop()
+		blockTree.runtimes.set(common.Hash{1}, rootRuntime)
+
+		// {1} -> {2}
+		parent := rootNode
+		newNode := &node{
+			parent: parent,
+			hash:   common.Hash{2},
+			number: 101,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		rootRuntime.EXPECT().Stop()
+		blockTree.runtimes.set(common.Hash{2}, rootRuntime)
+
+		// {1} -> {2} -> {3}
+		parent = newNode
+		newNode = &node{
+			parent: parent,
+			hash:   common.Hash{3},
+			number: 102,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		lastCanonicalRuntime := NewMockRuntime(ctrl)
+		blockTree.runtimes.set(common.Hash{3}, lastCanonicalRuntime)
+
+		// {1} -> {2} -> {3} -> {4}
+		parent = newNode
+		newNode = &node{
+			parent: parent,
+			hash:   common.Hash{4},
+			number: 103,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		blockTree.runtimes.set(common.Hash{4}, lastCanonicalRuntime)
+
+		// {1} -> {2} -> {3} -> {4}
+		//            -> {5}
+		parent = blockTree.getNode(common.Hash{2})
+		newNode = &node{
+			parent: parent,
+			hash:   common.Hash{5},
+			number: 102,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		rootRuntime.EXPECT().Stop()
+		blockTree.runtimes.set(common.Hash{5}, rootRuntime)
+
+		// {1} -> {2} -> {3} -> {4}
+		//            -> {5} -> {6}
+		parent = blockTree.getNode(common.Hash{5})
+		newNode = &node{
+			parent: parent,
+			hash:   common.Hash{6},
+			number: 103,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		blockTree.runtimes.set(common.Hash{6}, lastCanonicalRuntime)
+
+		// {1} -> {2} -> {3} -> {4}
+		//            -> {5} -> {6}
+		//						-> {7}
+		parent = blockTree.getNode(common.Hash{5})
+		newNode = &node{
+			parent: parent,
+			hash:   common.Hash{7},
+			number: 102,
+		}
+		parent.addChild(newNode)
+		blockTree.leaves.replace(parent, newNode)
+		forkedRuntime := NewMockRuntime(ctrl)
+		forkedRuntime.EXPECT().Stop()
+		blockTree.runtimes.set(common.Hash{7}, forkedRuntime)
+
+		pruned := blockTree.Prune(common.Hash{4})
+		assert.Equal(t, []common.Hash{{5}, {6}, {7}}, pruned)
+
+		expectedHashToRuntime := &hashToRuntime{
+			mapping: map[common.Hash]Runtime{
+				{3}: lastCanonicalRuntime,
+				{4}: lastCanonicalRuntime,
+			},
+		}
+		assert.Equal(t, blockTree.runtimes, expectedHashToRuntime)
+	})
 }
 
 func Test_BlockTree_GetHashByNumber(t *testing.T) {

--- a/lib/blocktree/hashtoruntime.go
+++ b/lib/blocktree/hashtoruntime.go
@@ -4,12 +4,20 @@
 package blocktree
 
 import (
+	"fmt"
 	"sync"
 )
 
 type hashToRuntime struct {
 	mutex   sync.RWMutex
 	mapping map[Hash]Runtime
+	// finalisedRuntime is the current finalised block runtime pointer.
+	finalisedRuntime Runtime
+	// currentBlockHashes holds block hashes from the canonical chain
+	// for which the current finalised block runtime is being used.
+	// This is used to prune the mapping of block hash to runtime
+	// when a new runtime makes it at block finalisation.
+	currentBlockHashes []Hash
 }
 
 func newHashToRuntime() *hashToRuntime {
@@ -34,4 +42,72 @@ func (h *hashToRuntime) delete(hash Hash) {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
 	delete(h.mapping, hash)
+}
+
+// onFinalisation handles pruning and recording on block finalisation.
+// newCanonicalBlockHashes is the block hashes of the blocks newly finalised.
+// The last element is the finalised block block hash.
+func (h *hashToRuntime) onFinalisation(newCanonicalBlockHashes, prunedForkBlockHashes []Hash) {
+	h.mutex.Lock()
+	defer h.mutex.Unlock()
+
+	finalisedBlockHash := newCanonicalBlockHashes[len(newCanonicalBlockHashes)-1]
+	newFinalisedRuntime, ok := h.mapping[finalisedBlockHash]
+	if !ok {
+		panic(fmt.Sprintf("runtime not found for finalised block hash %s", finalisedBlockHash))
+	}
+
+	// Prune runtimes from pruned forks
+	for _, blockHash := range prunedForkBlockHashes {
+		runtimeFromFork, ok := h.mapping[blockHash]
+		if !ok {
+			panic(fmt.Sprintf("runtime not found for pruned forked block hash %s", blockHash))
+		}
+		if runtimeFromFork != newFinalisedRuntime {
+			runtimeFromFork.Stop()
+		}
+		delete(h.mapping, blockHash)
+	}
+
+	if h.finalisedRuntime == newFinalisedRuntime {
+		// Runtime from the previous finalised block is the same
+		// as the runtime for the new finalised block.
+		// Note this logic assumes the same runtime pointer won't
+		// be re-used on a runtime upgrade.
+		h.currentBlockHashes = append(h.currentBlockHashes, newCanonicalBlockHashes...)
+		return
+	}
+
+	// Runtime from the previous finalised block is different
+	// from the runtime for the new finalised block.
+	if h.finalisedRuntime != nil {
+		h.finalisedRuntime.Stop()
+	}
+	h.finalisedRuntime = newFinalisedRuntime
+
+	// Clear all block hashes using the previous finalised runtime
+	for _, blockHash := range h.currentBlockHashes {
+		delete(h.mapping, blockHash)
+	}
+
+	// Check each new canonical chain block hash and prune all but the
+	// new finalised block corresponding runtime.
+	for i, blockHash := range newCanonicalBlockHashes {
+		runtime, ok := h.mapping[blockHash]
+		if !ok {
+			panic(fmt.Sprintf("runtime not found for canonical chain block block hash %s", blockHash))
+		}
+
+		if runtime == newFinalisedRuntime {
+			// The block has the new finalised block runtime so stop stopping runtimes and pruning
+			// block hashes from the mapping.
+			// Reset the current block hashes to the remaining new canonical chain block hashes.
+			h.currentBlockHashes = h.currentBlockHashes[:0] // empty slice but keep its capacity
+			h.currentBlockHashes = append(h.currentBlockHashes, newCanonicalBlockHashes[i:]...)
+			break
+		}
+
+		runtime.Stop()
+		delete(h.mapping, blockHash)
+	}
 }

--- a/lib/blocktree/hashtoruntime.go
+++ b/lib/blocktree/hashtoruntime.go
@@ -46,7 +46,7 @@ func (h *hashToRuntime) delete(hash Hash) {
 
 // onFinalisation handles pruning and recording on block finalisation.
 // newCanonicalBlockHashes is the block hashes of the blocks newly finalised.
-// The last element is the finalised block block hash.
+// The last element is the finalised block hash.
 func (h *hashToRuntime) onFinalisation(newCanonicalBlockHashes, prunedForkBlockHashes []Hash) {
 	h.mutex.Lock()
 	defer h.mutex.Unlock()
@@ -95,7 +95,7 @@ func (h *hashToRuntime) onFinalisation(newCanonicalBlockHashes, prunedForkBlockH
 	for i, blockHash := range newCanonicalBlockHashes {
 		runtime, ok := h.mapping[blockHash]
 		if !ok {
-			panic(fmt.Sprintf("runtime not found for canonical chain block block hash %s", blockHash))
+			panic(fmt.Sprintf("runtime not found for canonical chain block hash %s", blockHash))
 		}
 
 		if runtime == newFinalisedRuntime {

--- a/lib/blocktree/hashtoruntime_test.go
+++ b/lib/blocktree/hashtoruntime_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -154,6 +155,147 @@ func Test_hashToRuntime_delete(t *testing.T) {
 			htr.delete(testCase.hash)
 
 			assert.Equal(t, testCase.expectedHtr, htr)
+		})
+	}
+}
+
+func Test_hashToRuntime_onFinalisation(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		makeParameters          func(ctrl *gomock.Controller) (initial, expected *hashToRuntime)
+		newCanonicalBlockHashes []Hash
+		prunedForkBlockHashes   []Hash
+		panicString             string
+	}{
+		"new_finalised_runtime_not_found": {
+			makeParameters: func(ctrl *gomock.Controller) (initial, expected *hashToRuntime) {
+				return &hashToRuntime{}, nil
+			},
+			newCanonicalBlockHashes: []Hash{{1}},
+			panicString: "runtime not found for finalised block hash " +
+				"0x0100000000000000000000000000000000000000000000000000000000000000",
+		},
+		"pruned_fork_runtime_not_found": {
+			makeParameters: func(ctrl *gomock.Controller) (initial, expected *hashToRuntime) {
+				finalisedRuntime := NewMockRuntime(ctrl)
+				return &hashToRuntime{
+					mapping: map[Hash]Runtime{
+						{1}: finalisedRuntime,
+					},
+				}, nil
+			},
+			newCanonicalBlockHashes: []Hash{{1}},
+			prunedForkBlockHashes:   []Hash{{2}},
+			panicString: "runtime not found for pruned forked block hash " +
+				"0x0200000000000000000000000000000000000000000000000000000000000000",
+		},
+		"prune_fork_runtimes_only": {
+			makeParameters: func(ctrl *gomock.Controller) (initial, expected *hashToRuntime) {
+				finalisedRuntime := NewMockRuntime(ctrl)
+				prunedForkRuntime := NewMockRuntime(ctrl)
+				prunedForkRuntime.EXPECT().Stop().Times(2)
+				initial = &hashToRuntime{
+					finalisedRuntime:   finalisedRuntime,
+					currentBlockHashes: []Hash{{0}},
+					mapping: map[Hash]Runtime{
+						{1}: finalisedRuntime,
+						{2}: finalisedRuntime,
+						{3}: prunedForkRuntime,
+						{4}: prunedForkRuntime,
+					},
+				}
+				expected = &hashToRuntime{
+					finalisedRuntime:   finalisedRuntime,
+					currentBlockHashes: []Hash{{0}, {1}},
+					mapping: map[Hash]Runtime{
+						{1}: finalisedRuntime,
+					},
+				}
+				return initial, expected
+			},
+			newCanonicalBlockHashes: []Hash{{1}},
+			prunedForkBlockHashes:   []Hash{{2}, {3}, {4}},
+		},
+		"new_canonical_block_hash_not_found": {
+			makeParameters: func(ctrl *gomock.Controller) (initial, expected *hashToRuntime) {
+				newFinalisedRuntime := NewMockRuntime(ctrl)
+				initial = &hashToRuntime{
+					mapping: map[Hash]Runtime{
+						// missing {1}
+						{2}: newFinalisedRuntime,
+					},
+				}
+				return initial, nil
+			},
+			newCanonicalBlockHashes: []Hash{{1}, {2}},
+			panicString: "runtime not found for canonical chain block hash " +
+				"0x0100000000000000000000000000000000000000000000000000000000000000",
+		},
+		"prune_fork_and_canonical_runtimes": {
+			makeParameters: func(ctrl *gomock.Controller) (initial, expected *hashToRuntime) {
+				finalisedRuntime := NewMockRuntime(ctrl)
+				unfinalisedRuntime := NewMockRuntime(ctrl)
+				newFinalisedRuntime := NewMockRuntime(ctrl)
+				prunedForkRuntime := NewMockRuntime(ctrl)
+
+				finalisedRuntime.EXPECT().Stop().Times(1 + 2)
+				unfinalisedRuntime.EXPECT().Stop().Times(2)
+				prunedForkRuntime.EXPECT().Stop().Times(2)
+
+				initial = &hashToRuntime{
+					finalisedRuntime:   finalisedRuntime,
+					currentBlockHashes: []Hash{{0}, {1}},
+					mapping: map[Hash]Runtime{
+						// Previously finalised chain
+						{0}: finalisedRuntime,
+						{1}: finalisedRuntime,
+						// Newly finalised chain
+						{2}: finalisedRuntime,
+						{3}: unfinalisedRuntime,
+						{4}: unfinalisedRuntime,
+						{5}: newFinalisedRuntime,
+						{6}: newFinalisedRuntime,
+						// Runtimes from forks
+						{100}: prunedForkRuntime,
+						{101}: prunedForkRuntime,
+						{102}: finalisedRuntime,
+						{103}: newFinalisedRuntime,
+					},
+				}
+				expected = &hashToRuntime{
+					finalisedRuntime:   newFinalisedRuntime,
+					currentBlockHashes: []Hash{{5}, {6}},
+					mapping: map[Hash]Runtime{
+						{5}: newFinalisedRuntime,
+						{6}: newFinalisedRuntime,
+					},
+				}
+				return initial, expected
+			},
+			newCanonicalBlockHashes: []Hash{{2}, {3}, {4}, {5}, {6}},
+			prunedForkBlockHashes:   []Hash{{100}, {101}, {102}, {103}},
+		},
+	}
+
+	for name, testCase := range testCases {
+		testCase := testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			htr, expectedHtr := testCase.makeParameters(ctrl)
+
+			if testCase.panicString != "" {
+				assert.PanicsWithValue(t, testCase.panicString, func() {
+					htr.onFinalisation(testCase.newCanonicalBlockHashes, testCase.prunedForkBlockHashes)
+				})
+				return
+			}
+
+			htr.onFinalisation(testCase.newCanonicalBlockHashes, testCase.prunedForkBlockHashes)
+
+			assert.Equal(t, expectedHtr, htr)
 		})
 	}
 }

--- a/lib/blocktree/hashtoruntime_test.go
+++ b/lib/blocktree/hashtoruntime_test.go
@@ -194,7 +194,7 @@ func Test_hashToRuntime_onFinalisation(t *testing.T) {
 			makeParameters: func(ctrl *gomock.Controller) (initial, expected *hashToRuntime) {
 				finalisedRuntime := NewMockRuntime(ctrl)
 				prunedForkRuntime := NewMockRuntime(ctrl)
-				prunedForkRuntime.EXPECT().Stop().Times(2)
+				prunedForkRuntime.EXPECT().Stop()
 				initial = &hashToRuntime{
 					finalisedRuntime:   finalisedRuntime,
 					currentBlockHashes: []Hash{{0}},
@@ -239,9 +239,9 @@ func Test_hashToRuntime_onFinalisation(t *testing.T) {
 				newFinalisedRuntime := NewMockRuntime(ctrl)
 				prunedForkRuntime := NewMockRuntime(ctrl)
 
-				finalisedRuntime.EXPECT().Stop().Times(1 + 2)
-				unfinalisedRuntime.EXPECT().Stop().Times(2)
-				prunedForkRuntime.EXPECT().Stop().Times(2)
+				finalisedRuntime.EXPECT().Stop()
+				unfinalisedRuntime.EXPECT().Stop()
+				prunedForkRuntime.EXPECT().Stop()
 
 				initial = &hashToRuntime{
 					finalisedRuntime:   finalisedRuntime,


### PR DESCRIPTION
## Changes

- [x] Stop runtimes from forks before pruning them
- [x] Stop and prune runtimes from the canonical chain, on finalisation for runtimes different than the finalised block runtime
- [x] Add unit test for the blocktree `Prune` method

Note this PR breaks RPC calls `payment_Queryinfo`, `runtime_getVersion` and `runtime_getMetadata` which no longer have access to historical runtimes.

## Tests


```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/blocktree
```

## Issues

Fixes #2767 

Sibling issue to fix next is #3066 to re-establish the 3 RPC calls working for blocks older than the last finalised block.

## Primary Reviewer

@timwu20 
