### PR TITLE
chore(dot/core): use `westend-local` as default test runtime

### DIFF
--- a/dot/core/helpers_test.go
+++ b/dot/core/helpers_test.go
@@ -172,7 +172,7 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	var stateSrvc *state.Service
 	testDatadirPath := t.TempDir()
 
-	gen, genesisTrie, genesisHeader := newTestGenesisWithTrieAndHeader(t)
+	gen, genesisTrie, genesisHeader := newWestendLocalWithTrieAndHeader(t)
 
 	if cfg.BlockState == nil || cfg.StorageState == nil ||
 		cfg.TransactionState == nil || cfg.CodeSubstitutedState == nil {
@@ -257,11 +257,11 @@ func NewTestService(t *testing.T, cfg *Config) *Service {
 	return s
 }
 
-func newTestGenesisWithTrieAndHeader(t *testing.T) (
+func newWestendLocalWithTrieAndHeader(t *testing.T) (
 	gen genesis.Genesis, genesisTrie trie.Trie, genesisHeader types.Header) {
 	t.Helper()
 
-	genesisPath := utils.GetGssmrV3SubstrateGenesisRawPathTest(t)
+	genesisPath := utils.GetWestendLocalRawGenesisPath(t)
 	genPtr, err := genesis.NewGenesisFromJSONRaw(genesisPath)
 	require.NoError(t, err)
 	gen = *genPtr
@@ -280,7 +280,7 @@ func newTestGenesisWithTrieAndHeader(t *testing.T) (
 	return gen, genesisTrie, genesisHeader
 }
 
-func getGssmrRuntimeCode(t *testing.T) (code []byte) {
+func getWestendDevRuntimeCode(t *testing.T) (code []byte) {
 	t.Helper()
 
 	path := utils.GetWestendDevRawGenesisPath(t)

--- a/dot/core/messages_integration_test.go
+++ b/dot/core/messages_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/dot/state"
-	"github.com/ChainSafe/gossamer/dot/sync"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
@@ -165,7 +164,13 @@ func TestService_HandleTransactionMessage(t *testing.T) {
 	require.NoError(t, err)
 	rt.SetContextStorage(ts)
 
-	block := sync.BuildBlock(t, rt, genHeader, nil)
+	babeConfig, err := rt.BabeConfiguration()
+	require.NoError(t, err)
+
+	currentTimestamp := uint64(time.Now().UnixMilli())
+	currentSlot := currentTimestamp / babeConfig.SlotDuration
+
+	block := buildTestBlockWithoutExtrinsics(t, rt, genHeader, currentSlot, currentTimestamp)
 
 	err = s.handleBlock(block, ts)
 	require.NoError(t, err)

--- a/dot/core/service_test.go
+++ b/dot/core/service_test.go
@@ -180,7 +180,7 @@ func Test_Service_handleCodeSubstitution(t *testing.T) {
 	t.Parallel()
 
 	errTest := errors.New("test error")
-	validRuntimeCode := getGssmrRuntimeCode(t)
+	validRuntimeCode := getWestendDevRuntimeCode(t)
 
 	testCases := map[string]struct {
 		serviceBuilder func(ctrl *gomock.Controller) *Service


### PR DESCRIPTION
## Changes

- Update `dot/core` package to use `westend-local` as default runtime for testing

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -timeout 10m github.com/ChainSafe/gossamer/dot/core --tags=integration -v
```

## Issues

- Closes #3016

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@jimjbrettj
