### PR TITLE
feature(cmd/gossamer): add aliases for cli flags

### DIFF
--- a/cmd/gossamer/README.md
+++ b/cmd/gossamer/README.md
@@ -1,7 +1,7 @@
 # Gossamer `cmd` Package
 
 This package encapsulates the entry point to Gossamer - it uses the popular
-[`cli` package from `urfave`](https://github.com/urfave/cli/blob/master/docs/v1/manual.md) to expose a command-line
+[`cli` package from `urfave`](https://github.com/urfave/cli/blob/master/docs/v2/manual.md) to expose a command-line
 interface (CLI). The Gossamer CLI accepts several subcommands, each of which is associated with an "action"; these
 subcommands and their corresponding actions are defined in [`main.go`](main.go). When the Gossamer CLI is executed
 without a subcommand, the `gossamerAction` is invoked.

--- a/cmd/gossamer/account.go
+++ b/cmd/gossamer/account.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/utils"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // accountAction executes the action for the "account" subcommand

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -643,6 +643,8 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 	cfg.MaxPeers = tomlCfg.MaxPeers
 	cfg.PersistentPeers = tomlCfg.PersistentPeers
 	cfg.DiscoveryInterval = time.Second * time.Duration(tomlCfg.DiscoveryInterval)
+	cfg.NodeKey = tomlCfg.NodeKey
+	cfg.ListenAddress = tomlCfg.ListenAddress
 
 	// check --port flag and update node configuration
 	if port := ctx.Uint(PortFlag.Name); port != 0 {
@@ -687,6 +689,11 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 	// check --node-key flag and update node configuration
 	if nodekey := ctx.String(NodeKeyFlag.Name); nodekey != "" {
 		cfg.NodeKey = nodekey
+	}
+
+	// checx --listen-addr flag and update node configuration
+	if listenAddress := ctx.String(ListenAddressFlag.Name); listenAddress != "" {
+		cfg.ListenAddress = listenAddress
 	}
 
 	if len(cfg.PersistentPeers) == 0 {

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -657,10 +657,10 @@ func setDotCoreConfig(ctx *cli.Context, tomlCfg ctoml.CoreConfig, cfg *dot.CoreC
 // setDotNetworkConfig sets dot.NetworkConfig using flag values from the cli context
 func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot.NetworkConfig) error {
 	if listenAddress := ctx.String(ListenAddressFlag.Name); listenAddress != "" {
+		// check if default port (cfg.Port value) has been changed by toml config or cli flag
 		if (tomlCfg.Port != cfg.Port) || (ctx.Uint(PortFlag.Name) != 0) {
 			return fmt.Errorf("can not set both port and listen address")
 		}
-		cfg.ListenAddress = listenAddress
 	}
 
 	cfg.Port = tomlCfg.Port
@@ -682,7 +682,7 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 
 	// check --bootnodes flag and update node configuration
 	if bootnodes := ctx.String(BootnodesFlag.Name); bootnodes != "" {
-		cfg.Bootnodes = strings.Split(ctx.String(BootnodesFlag.Name), ",")
+		cfg.Bootnodes = strings.Split(bootnodes, ",")
 	}
 
 	// format bootnodes

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -595,6 +595,11 @@ func setDotAccountConfig(ctx *cli.Context, tomlCfg ctoml.AccountConfig, cfg *dot
 
 // setDotCoreConfig sets dot.CoreConfig using flag values from the cli context
 func setDotCoreConfig(ctx *cli.Context, tomlCfg ctoml.CoreConfig, cfg *dot.CoreConfig) {
+	if validator := ctx.Bool(ValidatorFlag.Name); validator {
+		tomlCfg.Roles = 4
+		tomlCfg.BabeAuthority = true
+		tomlCfg.GrandpaAuthority = true
+	}
 	cfg.Roles = common.Roles(tomlCfg.Roles)
 	cfg.BabeAuthority = common.Roles(tomlCfg.Roles) == common.AuthorityRole
 	cfg.GrandpaAuthority = common.Roles(tomlCfg.Roles) == common.AuthorityRole
@@ -778,6 +783,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 
 	// check --rpc-unsafe-external flag value
 	if externalUnsafe := ctx.Bool(RPCUnsafeExternalFlag.Name); externalUnsafe {
+		cfg.Enabled = true
 		cfg.Unsafe = true
 		cfg.UnsafeExternal = true
 	}
@@ -789,6 +795,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 
 	// check --ws-unsafe-external flag value
 	if wsExternalUnsafe := ctx.Bool(WSUnsafeExternalFlag.Name); wsExternalUnsafe {
+		cfg.WS = true
 		cfg.WSUnsafe = true
 		cfg.WSUnsafeExternal = true
 	}
@@ -806,7 +813,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 	// check --rpcmods flag and update node configuration
 	if modules := ctx.String(RPCModulesFlag.Name); modules != "" {
 		if modules == "unsafe" {
-			cfg.Modules = []string{"system", "author", "state", "rpc", "grandpa", "offchain", "childstate",
+			cfg.Modules = []string{"system", "author", "chain", "state", "rpc", "grandpa", "offchain", "childstate",
 				"syncstate", "payment"}
 		} else {
 			cfg.Modules = strings.Split(ctx.String(RPCModulesFlag.Name), ",")

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -6,11 +6,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/ChainSafe/gossamer/dot"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ChainSafe/gossamer/dot"
 	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/state/pruner"

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -456,7 +456,7 @@ func setDotGlobalConfigFromToml(tomlCfg *ctoml.Config, cfg *dot.GlobalConfig) {
 // setDotGlobalConfigFromFlags sets dot.GlobalConfig using flag values from the cli context
 func setDotGlobalConfigFromFlags(ctx *cli.Context, cfg *dot.GlobalConfig) error {
 	// check --basepath flag and update node configuration
-	if basepath := ctx.GlobalString(BasePathFlag.Name); basepath != "" {
+	if basepath := ctx.GlobalString(strings.Split(BasePathFlag.Name, ",")[0]); basepath != "" {
 		cfg.BasePath = basepath
 	}
 
@@ -668,7 +668,7 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 	}
 
 	// check --nomdns flag and update node configuration
-	if nomdns := ctx.GlobalBool(NoMDNSFlag.Name); nomdns {
+	if nomdns := ctx.GlobalBool(strings.Split(NoMDNSFlag.Name, ",")[0]); nomdns {
 		cfg.NoMDNS = true
 	}
 

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -6,13 +6,11 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/ChainSafe/gossamer/dot"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/ChainSafe/gossamer/chain/dev"
-	"github.com/ChainSafe/gossamer/chain/gssmr"
-	"github.com/ChainSafe/gossamer/dot"
 	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/dot/state"
 	"github.com/ChainSafe/gossamer/dot/state/pruner"
@@ -782,16 +780,12 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 		cfg.WSPort = uint32(wsport)
 	}
 
-	if WS := ctx.Bool(WSFlag.Name); WS || cfg.WS {
-		cfg.WS = true
-	} else if ctx.IsSet(WSFlag.Name) && !WS {
-		cfg.WS = false
 	wsFlagIsSet := ctx.IsSet(WSFlag.Name)
 
 	// if ws flag is set then set its value otherwise keep
 	// cfg.WS as it is
 	if wsFlagIsSet {
-		cfg.WS = ctx.GlobalBool(WSFlag.Name)
+		cfg.WS = ctx.Bool(WSFlag.Name)
 	}
 
 	if wsExternal := ctx.Bool(WSExternalFlag.Name); wsExternal {

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -682,6 +682,11 @@ func setDotNetworkConfig(ctx *cli.Context, tomlCfg ctoml.NetworkConfig, cfg *dot
 		cfg.PublicDNS = pubdns
 	}
 
+	// check --node-key flag and update node configuration
+	if nodekey := ctx.GlobalString(NodeKeyFlag.Name); nodekey != "" {
+		cfg.NodeKey = nodekey
+	}
+
 	if len(cfg.PersistentPeers) == 0 {
 		cfg.PersistentPeers = []string(nil)
 	}

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -757,7 +757,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 	}
 
 	// check --rpcport flag and update node configuration
-	if port := ctx.GlobalUint(RPCPortFlag.Name); port != 0 {
+	if port := ctx.GlobalUint(strings.Split(RPCPortFlag.Name, ",")[0]); port != 0 {
 		cfg.Port = uint32(port)
 	}
 
@@ -771,7 +771,7 @@ func setDotRPCConfig(ctx *cli.Context, tomlCfg ctoml.RPCConfig, cfg *dot.RPCConf
 		cfg.Modules = strings.Split(ctx.GlobalString(RPCModulesFlag.Name), ",")
 	}
 
-	if wsport := ctx.GlobalUint(WSPortFlag.Name); wsport != 0 {
+	if wsport := ctx.GlobalUint(strings.Split(WSPortFlag.Name, ",")[0]); wsport != 0 {
 		cfg.WSPort = uint32(wsport)
 	}
 

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -114,13 +114,7 @@ func TestInitConfigFromFlags(t *testing.T) {
 // TestGlobalConfigFromFlags tests createDotGlobalConfig using relevant global flags
 func TestGlobalConfigFromFlags(t *testing.T) {
 	t.Parallel()
-	defaultGlobalConfig := dot.GlobalConfig{
-		Name:           "carpet-drill-8904",
-		ID:             "gssmr",
-		BasePath:       "~/.gossamer/gssmr",
-		LogLvl:         log.Info,
-		MetricsAddress: "localhost:9876",
-	}
+	defaultGlobalConfig := dot.PolkadotConfig().Global
 
 	testcases := map[string]struct {
 		args     []string
@@ -402,7 +396,6 @@ func TestCoreConfigFromFlags(t *testing.T) {
 func TestNetworkConfigFromFlags(t *testing.T) {
 	t.Parallel()
 	westendDevConfig := dot.WestendDevConfig()
-	testCfg, _ := newTestConfigWithFile(t, westendDevConfig)
 
 	testcases := map[string]struct {
 		args     []string
@@ -411,100 +404,70 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		"Test_gossamer_--port": {
 			[]string{"app", "--port", "1234"},
 			dot.NetworkConfig{
-				Port:              1234,
-				DiscoveryInterval: testCfg.DiscoveryInterval,
-				MinPeers:          testCfg.MinPeers,
-				MaxPeers:          testCfg.MaxPeers,
+				Port: 1234,
 			},
 		},
 		"Test_gossamer_--bootnodes": {
 			[]string{"app", "--bootnodes", "peer1,peer2"},
 			dot.NetworkConfig{
-				Port:              testCfg.Port,
-				Bootnodes:         []string{"peer1", "peer2"},
-				DiscoveryInterval: testCfg.DiscoveryInterval,
-				MinPeers:          testCfg.MinPeers,
-				MaxPeers:          testCfg.MaxPeers,
+				Port:      westendDevConfig.Network.Port,
+				Bootnodes: []string{"peer1", "peer2"},
 			},
 		},
 		"Test_gossamer_--protocol": {
 			[]string{"app", "--protocol", "/gossamer/test/0"},
 			dot.NetworkConfig{
-				Port:              testCfg.Port,
-				ProtocolID:        "/gossamer/test/0",
-				DiscoveryInterval: testCfg.DiscoveryInterval,
-				MinPeers:          testCfg.MinPeers,
-				MaxPeers:          testCfg.MaxPeers,
+				Port:       westendDevConfig.Network.Port,
+				ProtocolID: "/gossamer/test/0",
 			},
 		},
 		"Test_gossamer_--nobootstrap": {
 			[]string{"app", "--nobootstrap"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				NoBootstrap:       true,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				Port:        westendDevConfig.Network.Port,
+				NoBootstrap: true,
 			},
 		},
 		"Test_gossamer_--nomdns": {
 			[]string{"app", "--nomdns"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				NoMDNS:            true,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				Port:   westendDevConfig.Network.Port,
+				NoMDNS: true,
 			},
 		},
 		"Test_gossamer_--no-mdns": {
 			[]string{"app", "--no-mdns"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				NoMDNS:            true,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				Port:   westendDevConfig.Network.Port,
+				NoMDNS: true,
 			},
 		},
 		"Test_gossamer_--pubip": {
 			[]string{"app", "--pubip", "10.0.5.2"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
-				PublicIP:          "10.0.5.2",
+				Port:     westendDevConfig.Network.Port,
+				PublicIP: "10.0.5.2",
 			},
 		},
 		"Test_gossamer_--pubdns": {
 			[]string{"app", "--pubdns", "alice"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
-				PublicDNS:         "alice",
+				Port:      westendDevConfig.Network.Port,
+				PublicDNS: "alice",
 			},
 		},
 		"Test_gossamer_--node-key": {
 			[]string{"app", "--node-key", "testkey"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
-				NodeKey:           "testkey",
+				Port:    westendDevConfig.Network.Port,
+				NodeKey: "testkey",
 			},
 		},
 		"Test_gossamer_--listen-addr": {
 			[]string{"app", "--listen-addr", "/ip4/0.0.0.0/tcp/1234/ws"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
-				ListenAddress:     "/ip4/0.0.0.0/tcp/1234/ws",
+				Port:          westendDevConfig.Network.Port,
+				ListenAddress: "/ip4/0.0.0.0/tcp/1234/ws",
 			},
 		},
 	}
@@ -530,7 +493,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 // TestRPCConfigFromFlags tests createDotRPCConfig using relevant rpc flags
 func TestRPCConfigFromFlags(t *testing.T) {
 	polkadotConfig := dot.PolkadotConfig()
-	testCfg, testCfgFile := newTestConfigWithFile(t, polkadotConfig)
+	testCfg, _ := newTestConfigWithFile(t, polkadotConfig)
 
 	testApp := cli.NewApp()
 	testApp.Flags = StartupFlags
@@ -543,20 +506,20 @@ func TestRPCConfigFromFlags(t *testing.T) {
 			[]string{"", "--rpc"},
 			dot.RPCConfig{
 				Enabled: true,
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpc_false": {
 			[]string{""},
 			dot.RPCConfig{
 				Enabled: false,
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpc-external": {
@@ -564,10 +527,10 @@ func TestRPCConfigFromFlags(t *testing.T) {
 			dot.RPCConfig{
 				Enabled:  true,
 				External: true,
-				Port:     defaultCfg.Port,
-				Host:     defaultCfg.Host,
-				Modules:  defaultCfg.Modules,
-				WSPort:   defaultCfg.WSPort,
+				Port:     testCfg.RPC.Port,
+				Host:     testCfg.RPC.Host,
+				Modules:  testCfg.RPC.Modules,
+				WSPort:   testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpc-external_false": {
@@ -575,93 +538,93 @@ func TestRPCConfigFromFlags(t *testing.T) {
 			dot.RPCConfig{
 				Enabled:  true,
 				External: false,
-				Port:     defaultCfg.Port,
-				Host:     defaultCfg.Host,
-				Modules:  defaultCfg.Modules,
-				WSPort:   defaultCfg.WSPort,
+				Port:     testCfg.RPC.Port,
+				Host:     testCfg.RPC.Host,
+				Modules:  testCfg.RPC.Modules,
+				WSPort:   testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpchost": {
 			[]string{"", "--rpchost", "testhost"},
 			dot.RPCConfig{
-				Port:    defaultCfg.Port,
+				Port:    testCfg.RPC.Port,
 				Host:    "testhost",
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpcport": {
 			[]string{"", "--rpcport", "5678"},
 			dot.RPCConfig{
 				Port:    5678,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpc-port": {
 			[]string{"", "--rpc-port", "5678"},
 			dot.RPCConfig{
 				Port:    5678,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--rpcsmods": {
 			[]string{"", "--rpcmods", "mod1,mod2"},
 			dot.RPCConfig{
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
 				Modules: []string{"mod1", "mod2"},
-				WSPort:  defaultCfg.WSPort,
+				WSPort:  testCfg.RPC.WSPort,
 			},
 		},
 		"Test_gossamer_--wsport": {
 			[]string{"", "--wsport", "7070"},
 			dot.RPCConfig{
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
 				WSPort:  7070,
 			},
 		},
 		"Test_gossamer_--ws-port": {
 			[]string{"", "--ws-port", "7071"},
 			dot.RPCConfig{
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
 				WSPort:  7071,
 			},
 		},
 		"Test_gossamer_--ws": {
 			[]string{"config", "--ws"},
 			dot.RPCConfig{
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 				WS:      true,
 			},
 		},
 		"Test_gossamer_--ws_false": {
 			[]string{""},
 			dot.RPCConfig{
-				Port:    defaultCfg.Port,
-				Host:    defaultCfg.Host,
-				Modules: defaultCfg.Modules,
-				WSPort:  defaultCfg.WSPort,
+				Port:    testCfg.RPC.Port,
+				Host:    testCfg.RPC.Host,
+				Modules: testCfg.RPC.Modules,
+				WSPort:  testCfg.RPC.WSPort,
 				WS:      false,
 			},
 		},
 		"Test_gossamer_--ws-external": {
 			[]string{"", "--ws-external"},
 			dot.RPCConfig{
-				Port:       defaultCfg.Port,
-				Host:       defaultCfg.Host,
-				Modules:    defaultCfg.Modules,
-				WSPort:     defaultCfg.WSPort,
+				Port:       testCfg.RPC.Port,
+				Host:       testCfg.RPC.Host,
+				Modules:    testCfg.RPC.Modules,
+				WSPort:     testCfg.RPC.WSPort,
 				WS:         true,
 				WSExternal: true,
 			},
@@ -669,10 +632,10 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		"Test_gossamer_--ws-external_false": {
 			[]string{""},
 			dot.RPCConfig{
-				Port:       defaultCfg.Port,
-				Host:       defaultCfg.Host,
-				Modules:    defaultCfg.Modules,
-				WSPort:     defaultCfg.WSPort,
+				Port:       testCfg.RPC.Port,
+				Host:       testCfg.RPC.Host,
+				Modules:    testCfg.RPC.Modules,
+				WSPort:     testCfg.RPC.WSPort,
 				WSExternal: false,
 			},
 		},

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -403,7 +403,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 		args     []string
 		expected dot.NetworkConfig
 	}{
-		"Test gossamer --port": {
+		"Test_gossamer_--port": {
 			[]string{"app", "--port", "1234"},
 			dot.NetworkConfig{
 				Port:              1234,
@@ -412,7 +412,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 			},
 		},
-		"Test gossamer --bootnodes": {
+		"Test_gossamer_--bootnodes": {
 			[]string{"app", "--bootnodes", "peer1,peer2"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -422,7 +422,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 			},
 		},
-		"Test gossamer --protocol": {
+		"Test_gossamer_--protocol": {
 			[]string{"app", "--protocol", "/gossamer/test/0"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -432,7 +432,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 			},
 		},
-		"Test gossamer --nobootstrap": {
+		"Test_gossamer_--nobootstrap": {
 			[]string{"app", "--nobootstrap"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -442,7 +442,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 			},
 		},
-		"Test gossamer --nomdns": {
+		"Test_gossamer_--nomdns": {
 			[]string{"app", "--nomdns"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -452,7 +452,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 			},
 		},
-		"Test gossamer --no-mdns": {
+		"Test_gossamer_--no-mdns": {
 			[]string{"app", "--no-mdns"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -462,7 +462,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 			},
 		},
-		"Test gossamer --pubip": {
+		"Test_gossamer_--pubip": {
 			[]string{"app", "--pubip", "10.0.5.2"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -472,7 +472,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				PublicIP:          "10.0.5.2",
 			},
 		},
-		"Test gossamer --pubdns": {
+		"Test_gossamer_--pubdns": {
 			[]string{"app", "--pubdns", "alice"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -482,7 +482,7 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				PublicDNS:         "alice",
 			},
 		},
-		"Test gossamer --node-key": {
+		"Test_gossamer_--node-key": {
 			[]string{"app", "--node-key", "testkey"},
 			dot.NetworkConfig{
 				Port:              defaultNetworkCfg.Port,
@@ -520,7 +520,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		args     []string
 		expected dot.RPCConfig
 	}{
-		"Test gossamer --rpc": {
+		"Test_gossamer_--rpc": {
 			[]string{"", "--rpc"},
 			dot.RPCConfig{
 				Enabled: true,
@@ -530,7 +530,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpc false": {
+		"Test_gossamer_--rpc_false": {
 			[]string{""},
 			dot.RPCConfig{
 				Enabled: false,
@@ -540,7 +540,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpc-external": {
+		"Test_gossamer_--rpc-external": {
 			[]string{"", "--rpc-external"},
 			dot.RPCConfig{
 				Enabled:  true,
@@ -551,7 +551,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:   defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpc-external false": {
+		"Test_gossamer_--rpc-external_false": {
 			[]string{"", "--rpc"},
 			dot.RPCConfig{
 				Enabled:  true,
@@ -562,7 +562,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:   defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpchost": {
+		"Test_gossamer_--rpchost": {
 			[]string{"", "--rpchost", "testhost"},
 			dot.RPCConfig{
 				Port:    defaultCfg.Port,
@@ -571,7 +571,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpcport": {
+		"Test_gossamer_--rpcport": {
 			[]string{"", "--rpcport", "5678"},
 			dot.RPCConfig{
 				Port:    5678,
@@ -580,7 +580,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpc-port": {
+		"Test_gossamer_--rpc-port": {
 			[]string{"", "--rpc-port", "5678"},
 			dot.RPCConfig{
 				Port:    5678,
@@ -589,7 +589,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --rpcsmods": {
+		"Test_gossamer_--rpcsmods": {
 			[]string{"", "--rpcmods", "mod1,mod2"},
 			dot.RPCConfig{
 				Port:    defaultCfg.Port,
@@ -598,7 +598,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  defaultCfg.WSPort,
 			},
 		},
-		"Test gossamer --wsport": {
+		"Test_gossamer_--wsport": {
 			[]string{"", "--wsport", "7070"},
 			dot.RPCConfig{
 				Port:    defaultCfg.Port,
@@ -607,7 +607,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  7070,
 			},
 		},
-		"Test gossamer --ws-port": {
+		"Test_gossamer_--ws-port": {
 			[]string{"", "--ws-port", "7071"},
 			dot.RPCConfig{
 				Port:    defaultCfg.Port,
@@ -616,7 +616,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSPort:  7071,
 			},
 		},
-		"Test gossamer --ws": {
+		"Test_gossamer_--ws": {
 			[]string{"config", "--ws"},
 			dot.RPCConfig{
 				Port:    defaultCfg.Port,
@@ -626,7 +626,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WS:      true,
 			},
 		},
-		"Test gossamer --ws false": {
+		"Test_gossamer_--ws_false": {
 			[]string{""},
 			dot.RPCConfig{
 				Port:    defaultCfg.Port,
@@ -636,7 +636,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WS:      false,
 			},
 		},
-		"Test gossamer --ws-external": {
+		"Test_gossamer_--ws-external": {
 			[]string{"", "--ws-external"},
 			dot.RPCConfig{
 				Port:       defaultCfg.Port,
@@ -647,7 +647,7 @@ func TestRPCConfigFromFlags(t *testing.T) {
 				WSExternal: true,
 			},
 		},
-		"Test gossamer --ws-external false": {
+		"Test_gossamer_--ws-external_false": {
 			[]string{""},
 			dot.RPCConfig{
 				Port:       defaultCfg.Port,

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // TestConfigFromChainFlag tests createDotConfig using the --chain flag
@@ -115,9 +115,6 @@ func TestInitConfigFromFlags(t *testing.T) {
 func TestGlobalConfigFromFlags(t *testing.T) {
 	polkadotConfig := dot.PolkadotConfig()
 	testCfg, testCfgFile := newTestConfigWithFile(t, polkadotConfig)
-
-	testApp := cli.NewApp()
-	testApp.Flags = RootFlags
 
 	testcases := map[string]struct {
 		args     []string
@@ -230,8 +227,12 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 	}
 
 	for key, c := range testcases {
-		c := c // bypass scopelint false positive
+		c := c
 		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+			testApp := cli.NewApp()
+			testApp.Writer = io.Discard
+			testApp.Flags = RootFlags
 			testApp.Action = func(ctx *cli.Context) error {
 				cfg, err := createDotConfig(ctx)
 				require.NoError(t, err)
@@ -396,9 +397,6 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 	westendDevConfig := dot.WestendDevConfig()
 	testCfg, testCfgFile := newTestConfigWithFile(t, westendDevConfig)
 
-	testApp := cli.NewApp()
-	testApp.Flags = StartupFlags
-
 	testcases := map[string]struct {
 		args     []string
 		expected dot.NetworkConfig
@@ -495,8 +493,12 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 	}
 
 	for key, c := range testcases {
-		c := c // bypass scopelint false positive
+		c := c
 		t.Run(key, func(t *testing.T) {
+			t.Parallel()
+			testApp := cli.NewApp()
+			testApp.Writer = io.Discard
+			testApp.Flags = StartupFlags
 			testApp.Action = func(ctx *cli.Context) error {
 				cfg, err := createDotConfig(ctx)
 				require.NoError(t, err)

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -123,7 +123,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		args     []string
 		expected dot.GlobalConfig
 	}{
-		"Test gossamer default": {
+		"Test_gossamer_default": {
 			[]string{"app", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
@@ -133,7 +133,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: defaultGlobalConfig.MetricsAddress,
 			},
 		},
-		"Test kusama --chain": {
+		"Test_kusama_--chain": {
 			[]string{"app", "--chain", "kusama", "--name", dot.KusamaConfig().Global.Name},
 			dot.GlobalConfig{
 				Name:           dot.KusamaConfig().Global.Name,
@@ -144,7 +144,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: defaultGlobalConfig.MetricsAddress,
 			},
 		},
-		"Test gossamer --name": {
+		"Test_gossamer_--name": {
 			[]string{"app", "--name", "test_name"},
 			dot.GlobalConfig{
 				Name:           "test_name",
@@ -155,7 +155,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: defaultGlobalConfig.MetricsAddress,
 			},
 		},
-		"Test gossamer --basepath": {
+		"Test_gossamer_--basepath": {
 			[]string{"app", "--basepath", "test_basepath", "--name", "testname"},
 			dot.GlobalConfig{
 				Name:           "testname",
@@ -166,7 +166,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: defaultGlobalConfig.MetricsAddress,
 			},
 		},
-		"Test gossamer --base-path": {
+		"Test_gossamer_--base-path": {
 			[]string{"app", "--base-path", "test_basepath", "--name", "testname"},
 			dot.GlobalConfig{
 				Name:           "testname",
@@ -177,7 +177,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: defaultGlobalConfig.MetricsAddress,
 			},
 		},
-		"Test gossamer --publish-metrics": {
+		"Test_gossamer_--publish-metrics": {
 			[]string{"app", "--publish-metrics", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
@@ -188,7 +188,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: defaultGlobalConfig.MetricsAddress,
 			},
 		},
-		"Test gossamer --metrics-address": {
+		"Test_gossamer_--metrics-address": {
 			[]string{"app", "--metrics-address", ":9871", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
@@ -199,7 +199,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				MetricsAddress: ":9871",
 			},
 		},
-		"Test gossamer --no-telemetry": {
+		"Test_gossamer_--no-telemetry": {
 			[]string{"app", "--no-telemetry", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
@@ -211,7 +211,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 				NoTelemetry:    true,
 			},
 		},
-		"Test gossamer --telemetry-url": {
+		"Test_gossamer_--telemetry-url": {
 			[]string{"config", "--telemetry-url", "ws://localhost:8001/submit 0", "--telemetry-url",
 				"ws://foo/bar 0", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -124,7 +124,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 		expected dot.GlobalConfig
 	}{
 		"Test gossamer default": {
-			[]string{"app"},
+			[]string{"app", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
 				ID:             defaultGlobalConfig.ID,

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -12,10 +12,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/ChainSafe/gossamer/chain/dev"
-	"github.com/ChainSafe/gossamer/chain/gssmr"
+	"github.com/ChainSafe/gossamer/chain/kusama"
+	"github.com/ChainSafe/gossamer/chain/polkadot"
 	"github.com/ChainSafe/gossamer/dot"
 	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/dot/state"
@@ -24,6 +23,7 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/genesis"
 	"github.com/ChainSafe/gossamer/lib/runtime"
+	"github.com/ChainSafe/gossamer/lib/runtime/wasmer"
 	"github.com/ChainSafe/gossamer/lib/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -401,14 +401,8 @@ func TestCoreConfigFromFlags(t *testing.T) {
 // TestNetworkConfigFromFlags tests createDotNetworkConfig using relevant network flags
 func TestNetworkConfigFromFlags(t *testing.T) {
 	t.Parallel()
-	defaultNetworkCfg := dot.NetworkConfig{
-		Port:              7001,
-		MinPeers:          1,
-		MaxPeers:          50,
-		DiscoveryInterval: 10 * time.Second,
-	}
 	westendDevConfig := dot.WestendDevConfig()
-	testCfg, testCfgFile := newTestConfigWithFile(t, westendDevConfig)
+	testCfg, _ := newTestConfigWithFile(t, westendDevConfig)
 
 	testcases := map[string]struct {
 		args     []string
@@ -418,29 +412,29 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 			[]string{"app", "--port", "1234"},
 			dot.NetworkConfig{
 				Port:              1234,
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				DiscoveryInterval: testCfg.DiscoveryInterval,
+				MinPeers:          testCfg.MinPeers,
+				MaxPeers:          testCfg.MaxPeers,
 			},
 		},
 		"Test_gossamer_--bootnodes": {
 			[]string{"app", "--bootnodes", "peer1,peer2"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
+				Port:              testCfg.Port,
 				Bootnodes:         []string{"peer1", "peer2"},
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				DiscoveryInterval: testCfg.DiscoveryInterval,
+				MinPeers:          testCfg.MinPeers,
+				MaxPeers:          testCfg.MaxPeers,
 			},
 		},
 		"Test_gossamer_--protocol": {
 			[]string{"app", "--protocol", "/gossamer/test/0"},
 			dot.NetworkConfig{
-				Port:              defaultNetworkCfg.Port,
+				Port:              testCfg.Port,
 				ProtocolID:        "/gossamer/test/0",
-				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
-				MinPeers:          defaultNetworkCfg.MinPeers,
-				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				DiscoveryInterval: testCfg.DiscoveryInterval,
+				MinPeers:          testCfg.MinPeers,
+				MaxPeers:          testCfg.MaxPeers,
 			},
 		},
 		"Test_gossamer_--nobootstrap": {

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -113,8 +113,14 @@ func TestInitConfigFromFlags(t *testing.T) {
 
 // TestGlobalConfigFromFlags tests createDotGlobalConfig using relevant global flags
 func TestGlobalConfigFromFlags(t *testing.T) {
-	polkadotConfig := dot.PolkadotConfig()
-	testCfg, testCfgFile := newTestConfigWithFile(t, polkadotConfig)
+	t.Parallel()
+	defaultGlobalConfig := dot.GlobalConfig{
+		Name:           "carpet-drill-8904",
+		ID:             "gssmr",
+		BasePath:       "~/.gossamer/gssmr",
+		LogLvl:         log.Info,
+		MetricsAddress: "localhost:9876",
+	}
 
 	testcases := map[string]struct {
 		args     []string
@@ -394,6 +400,13 @@ func TestCoreConfigFromFlags(t *testing.T) {
 
 // TestNetworkConfigFromFlags tests createDotNetworkConfig using relevant network flags
 func TestNetworkConfigFromFlags(t *testing.T) {
+	t.Parallel()
+	defaultNetworkCfg := dot.NetworkConfig{
+		Port:              7001,
+		MinPeers:          1,
+		MaxPeers:          50,
+		DiscoveryInterval: 10 * time.Second,
+	}
 	westendDevConfig := dot.WestendDevConfig()
 	testCfg, testCfgFile := newTestConfigWithFile(t, westendDevConfig)
 
@@ -488,6 +501,16 @@ func TestNetworkConfigFromFlags(t *testing.T) {
 				MinPeers:          defaultNetworkCfg.MinPeers,
 				MaxPeers:          defaultNetworkCfg.MaxPeers,
 				NodeKey:           "testkey",
+			},
+		},
+		"Test_gossamer_--listen-addr": {
+			[]string{"app", "--listen-addr", "/ip4/0.0.0.0/tcp/1234/ws"},
+			dot.NetworkConfig{
+				Port:              defaultNetworkCfg.Port,
+				DiscoveryInterval: defaultNetworkCfg.DiscoveryInterval,
+				MinPeers:          defaultNetworkCfg.MinPeers,
+				MaxPeers:          defaultNetworkCfg.MaxPeers,
+				ListenAddress:     "/ip4/0.0.0.0/tcp/1234/ws",
 			},
 		},
 	}

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -178,7 +178,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			},
 		},
 		"Test gossamer --publish-metrics": {
-			[]string{"app", "--publish-metrics"},
+			[]string{"app", "--publish-metrics", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
 				ID:             defaultGlobalConfig.ID,
@@ -189,7 +189,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			},
 		},
 		"Test gossamer --metrics-address": {
-			[]string{"app", "--metrics-address", ":9871"},
+			[]string{"app", "--metrics-address", ":9871", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
 				ID:             defaultGlobalConfig.ID,
@@ -200,7 +200,7 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			},
 		},
 		"Test gossamer --no-telemetry": {
-			[]string{"app", "--no-telemetry"},
+			[]string{"app", "--no-telemetry", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
 				ID:             defaultGlobalConfig.ID,
@@ -212,7 +212,8 @@ func TestGlobalConfigFromFlags(t *testing.T) {
 			},
 		},
 		"Test gossamer --telemetry-url": {
-			[]string{"config", "--telemetry-url", "ws://localhost:8001/submit 0", "--telemetry-url", "ws://foo/bar 0"},
+			[]string{"config", "--telemetry-url", "ws://localhost:8001/submit 0", "--telemetry-url",
+				"ws://foo/bar 0", "--name", defaultGlobalConfig.Name},
 			dot.GlobalConfig{
 				Name:           defaultGlobalConfig.Name,
 				ID:             defaultGlobalConfig.ID,

--- a/cmd/gossamer/config_test.go
+++ b/cmd/gossamer/config_test.go
@@ -648,7 +648,6 @@ func TestRPCConfigFromFlags(t *testing.T) {
 		},
 		"Test gossamer --ws-external false": {
 			[]string{""},
-			//[]interface{}{testCfgFile, false},
 			dot.RPCConfig{
 				Port:       defaultCfg.Port,
 				Host:       defaultCfg.Host,

--- a/cmd/gossamer/export.go
+++ b/cmd/gossamer/export.go
@@ -12,13 +12,13 @@ import (
 	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/lib/utils"
 
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // exportAction is the action for the "export" subcommand
 func exportAction(ctx *cli.Context) error {
 	// use --config value as export destination
-	config := ctx.GlobalString(ConfigFlag.Name)
+	config := ctx.String(ConfigFlag.Name)
 
 	// check if --config value is set
 	if config == "" {

--- a/cmd/gossamer/export_test.go
+++ b/cmd/gossamer/export_test.go
@@ -12,7 +12,7 @@ import (
 	ctoml "github.com/ChainSafe/gossamer/dot/config/toml"
 	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // TestExportCommand test "gossamer export --config"
@@ -162,7 +162,7 @@ func TestExportCommand(t *testing.T) {
 			err = exportAction(ctx)
 			require.NoError(t, err)
 
-			config := ctx.GlobalString(ConfigFlag.Name)
+			config := ctx.String(ConfigFlag.Name)
 
 			cfg := new(ctoml.Config)
 			err = loadConfig(cfg, config)

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -231,6 +231,11 @@ var (
 		Name:  "pubdns",
 		Usage: "Overrides public DNS used for peer to peer networking",
 	}
+	// NodeKeyFlag uses the supplied hex-encoded Ed25519 secret key seed for libp2p networking
+	NodeKeyFlag = cli.StringFlag{
+		Name:  "node-key",
+		Usage: "Overrides the secret Ed25519 key to use for libp2p",
+	}
 )
 
 // RPC service configuration flags
@@ -407,6 +412,7 @@ var (
 		NoMDNSFlag,
 		PublicIPFlag,
 		PublicDNSFlag,
+		NodeKeyFlag,
 
 		// rpc flags
 		RPCEnabledFlag,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -267,7 +267,7 @@ var (
 	}
 	// RPCPortFlag HTTP-RPC server listening port
 	RPCPortFlag = cli.IntFlag{
-		Name:  "rpcport",
+		Name:  "rpcport,rpc-port", // rpc-port is argument used by polkadot node
 		Usage: "HTTP-RPC server listening port",
 	}
 	// RPCModulesFlag API modules to enable via HTTP-RPC
@@ -277,7 +277,7 @@ var (
 	}
 	// WSPortFlag WebSocket server listening port
 	WSPortFlag = cli.IntFlag{
-		Name:  "wsport",
+		Name:  "wsport,ws-port", // ws-port is argument used by polkadot node
 		Usage: "Websockets server listening port",
 	}
 	// WSFlag Enable the websockets server

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -239,6 +239,11 @@ var (
 		Name:  "node-key",
 		Usage: "Overrides the secret Ed25519 key to use for libp2p",
 	}
+	// ListenAddressFlag uses the supplied multiaddress string as the address to listen on
+	ListenAddressFlag = cli.StringFlag{
+		Name:  "listen-addr",
+		Usage: "Listen on this multiaddress",
+	}
 )
 
 // RPC service configuration flags
@@ -418,6 +423,7 @@ var (
 		&PublicIPFlag,
 		&PublicDNSFlag,
 		&NodeKeyFlag,
+		&ListenAddressFlag,
 
 		// rpc flags
 		&RPCEnabledFlag,

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -4,7 +4,8 @@
 package main
 
 import (
-	"github.com/urfave/cli"
+	"github.com/ChainSafe/gossamer/chain/dev"
+	"github.com/urfave/cli/v2"
 )
 
 // Node flags
@@ -99,8 +100,9 @@ var (
 	}
 	// BasePathFlag data directory for node
 	BasePathFlag = cli.StringFlag{
-		Name:  "base-path,basepath", // base-path is argument used by polkadot node
-		Usage: "Data directory for the node",
+		Name:    "basepath",
+		Aliases: []string{"base-bath"}, // base-path is argument used by polkadot node
+		Usage:   "Data directory for the node",
 	}
 	PprofServerFlag = cli.BoolFlag{
 		Name:  "pprofserver",
@@ -218,8 +220,9 @@ var (
 	}
 	// NoMDNSFlag Disables network mDNS
 	NoMDNSFlag = cli.BoolFlag{
-		Name:  "nomdns,no-mdns", // no-mdns is argument used by polkadot node
-		Usage: "Disables network mDNS discovery",
+		Name:    "nomdns",
+		Aliases: []string{"no-mdns"}, // no-mdns is argument used by polkadot node
+		Usage:   "Disables network mDNS discovery",
 	}
 	// PublicIPFlag uses the supplied IP for broadcasting
 	PublicIPFlag = cli.StringFlag{
@@ -267,8 +270,9 @@ var (
 	}
 	// RPCPortFlag HTTP-RPC server listening port
 	RPCPortFlag = cli.IntFlag{
-		Name:  "rpcport,rpc-port", // rpc-port is argument used by polkadot node
-		Usage: "HTTP-RPC server listening port",
+		Name:    "rpcport",
+		Aliases: []string{"rpc-port"}, // rpc-port is argument used by polkadot node
+		Usage:   "HTTP-RPC server listening port",
 	}
 	// RPCModulesFlag API modules to enable via HTTP-RPC
 	RPCModulesFlag = cli.StringFlag{
@@ -277,8 +281,9 @@ var (
 	}
 	// WSPortFlag WebSocket server listening port
 	WSPortFlag = cli.IntFlag{
-		Name:  "wsport,ws-port", // ws-port is argument used by polkadot node
-		Usage: "Websockets server listening port",
+		Name:    "wsport",
+		Aliases: []string{"ws-port"}, // ws-port is argument used by polkadot node
+		Usage:   "Websockets server listening port",
 	}
 	// WSFlag Enable the websockets server
 	WSFlag = cli.BoolFlag{
@@ -376,121 +381,121 @@ var (
 var (
 	// GlobalFlags are flags that are valid for use with the root command and all subcommands
 	GlobalFlags = []cli.Flag{
-		LogFlag,
-		LogCoreLevelFlag,
-		LogDigestLevelFlag,
-		LogSyncLevelFlag,
-		LogNetworkLevelFlag,
-		LogRPCLevelFlag,
-		LogStateLevelFlag,
-		LogRuntimeLevelFlag,
-		LogBabeLevelFlag,
-		LogGrandpaLevelFlag,
-		NameFlag,
-		ChainFlag,
-		ConfigFlag,
-		BasePathFlag,
-		PprofServerFlag,
-		PprofAddressFlag,
-		PprofBlockRateFlag,
-		PprofMutexRateFlag,
-		RewindFlag,
+		&LogFlag,
+		&LogCoreLevelFlag,
+		&LogDigestLevelFlag,
+		&LogSyncLevelFlag,
+		&LogNetworkLevelFlag,
+		&LogRPCLevelFlag,
+		&LogStateLevelFlag,
+		&LogRuntimeLevelFlag,
+		&LogBabeLevelFlag,
+		&LogGrandpaLevelFlag,
+		&NameFlag,
+		&ChainFlag,
+		&ConfigFlag,
+		&BasePathFlag,
+		&PprofServerFlag,
+		&PprofAddressFlag,
+		&PprofBlockRateFlag,
+		&PprofMutexRateFlag,
+		&RewindFlag,
 	}
 
 	// StartupFlags are flags that are valid for use with the root command and the export subcommand
 	StartupFlags = []cli.Flag{
 		// keystore flags
-		KeyFlag,
-		UnlockFlag,
+		&KeyFlag,
+		&UnlockFlag,
 
 		// network flags
-		PortFlag,
-		BootnodesFlag,
-		ProtocolFlag,
-		RolesFlag,
-		NoBootstrapFlag,
-		NoMDNSFlag,
-		PublicIPFlag,
-		PublicDNSFlag,
-		NodeKeyFlag,
+		&PortFlag,
+		&BootnodesFlag,
+		&ProtocolFlag,
+		&RolesFlag,
+		&NoBootstrapFlag,
+		&NoMDNSFlag,
+		&PublicIPFlag,
+		&PublicDNSFlag,
+		&NodeKeyFlag,
 
 		// rpc flags
-		RPCEnabledFlag,
-		RPCExternalFlag,
-		RPCUnsafeEnabledFlag,
-		RPCUnsafeExternalFlag,
-		RPCHostFlag,
-		RPCPortFlag,
-		RPCModulesFlag,
-		WSFlag,
-		WSExternalFlag,
-		WSUnsafeEnabledFlag,
-		WSUnsafeExternalFlag,
-		WSPortFlag,
+		&RPCEnabledFlag,
+		&RPCExternalFlag,
+		&RPCUnsafeEnabledFlag,
+		&RPCUnsafeExternalFlag,
+		&RPCHostFlag,
+		&RPCPortFlag,
+		&RPCModulesFlag,
+		&WSFlag,
+		&WSExternalFlag,
+		&WSUnsafeEnabledFlag,
+		&WSUnsafeExternalFlag,
+		&WSPortFlag,
 
 		// metrics flag
-		PublishMetricsFlag,
-		MetricsAddressFlag,
+		&PublishMetricsFlag,
+		&MetricsAddressFlag,
 
 		// telemetry flags
-		NoTelemetryFlag,
-		TelemetryURLFlag,
+		&NoTelemetryFlag,
+		&TelemetryURLFlag,
 
 		// BABE flags
-		BABELeadFlag,
+		&BABELeadFlag,
 	}
 )
 
 // local flag sets for the root gossamer command and all subcommands
 var (
 	// RootFlags are the flags that are valid for use with the root gossamer command
-	RootFlags = append(append(GlobalFlags, StartupFlags...), GenesisFlag)
+	RootFlags = append(append(GlobalFlags, StartupFlags...), &GenesisFlag)
 
 	// InitFlags are flags that are valid for use with the init subcommand
 	InitFlags = append([]cli.Flag{
-		ForceFlag,
-		GenesisFlag,
-		PruningFlag,
-		RetainBlockNumberFlag,
+		&ForceFlag,
+		&GenesisFlag,
+		&PruningFlag,
+		&RetainBlockNumberFlag,
 	}, GlobalFlags...)
 
 	BuildSpecFlags = append([]cli.Flag{
-		RawFlag,
-		GenesisSpecFlag,
-		OutputSpecFlag,
+		&RawFlag,
+		&GenesisSpecFlag,
+		&OutputSpecFlag,
 	}, GlobalFlags...)
 
 	// ExportFlags are the flags that are valid for use with the export subcommand
 	ExportFlags = append([]cli.Flag{
-		ForceFlag,
-		GenesisFlag,
+		&ForceFlag,
+		&GenesisFlag,
 	}, append(GlobalFlags, StartupFlags...)...)
 
 	// AccountFlags are flags that are valid for use with the account subcommand
 	AccountFlags = append([]cli.Flag{
-		GenerateFlag,
-		PasswordFlag,
-		ImportFlag,
-		ImportRawFlag,
-		ListFlag,
-		Ed25519Flag,
-		Sr25519Flag,
-		Secp256k1Flag,
+		&GenerateFlag,
+		&PasswordFlag,
+		&ImportFlag,
+		&ImportRawFlag,
+		&ListFlag,
+		&Ed25519Flag,
+		&Sr25519Flag,
+		&Secp256k1Flag,
 	}, GlobalFlags...)
 
 	ImportStateFlags = []cli.Flag{
-		BasePathFlag,
-		ChainFlag,
-		ConfigFlag,
-		StateFlag,
-		HeaderFlag,
-		FirstSlotFlag,
+		&BasePathFlag,
+		&ChainFlag,
+		&ConfigFlag,
+		&StateFlag,
+		&HeaderFlag,
+		&FirstSlotFlag,
 	}
 
 	PruningFlags = []cli.Flag{
-		ChainFlag,
-		ConfigFlag,
-		RetainBlockNumberFlag,
+		&ChainFlag,
+		&ConfigFlag,
+		&RetainBlockNumberFlag,
 	}
 )
 
@@ -507,14 +512,14 @@ func FixFlagOrder(f func(ctx *cli.Context) error) func(*cli.Context) error {
 		for _, flagName := range ctx.FlagNames() {
 
 			// check if flag is set as global or local flag
-			if ctx.GlobalIsSet(flagName) {
+			if ctx.IsSet(flagName) {
 				// log global flag if log equals trace
 				if ctx.String(LogFlag.Name) == trace {
 					logger.Trace("[cmd] global flag set with name: " + flagName)
 				}
 			} else if ctx.IsSet(flagName) {
 				// check if global flag using set as global flag
-				err := ctx.GlobalSet(flagName, ctx.String(flagName))
+				err := ctx.Set(flagName, ctx.String(flagName))
 				if err == nil {
 					// log fixed global flag if log equals trace
 					if ctx.String(LogFlag.Name) == trace {

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -101,7 +101,7 @@ var (
 	// BasePathFlag data directory for node
 	BasePathFlag = cli.StringFlag{
 		Name:    "basepath",
-		Aliases: []string{"base-bath"}, // base-path is argument used by polkadot node
+		Aliases: []string{"base-path"}, // base-path is argument used by polkadot node
 		Usage:   "Data directory for the node",
 	}
 	PprofServerFlag = cli.BoolFlag{

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"github.com/ChainSafe/gossamer/chain/dev"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -218,7 +218,7 @@ var (
 	}
 	// NoMDNSFlag Disables network mDNS
 	NoMDNSFlag = cli.BoolFlag{
-		Name:  "nomdns",
+		Name:  "nomdns,no-mdns",
 		Usage: "Disables network mDNS discovery",
 	}
 	// PublicIPFlag uses the supplied IP for broadcasting

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -99,7 +99,7 @@ var (
 	}
 	// BasePathFlag data directory for node
 	BasePathFlag = cli.StringFlag{
-		Name:  "basepath",
+		Name:  "base-path,basepath", // base-path is argument used by polkadot node
 		Usage: "Data directory for the node",
 	}
 	PprofServerFlag = cli.BoolFlag{
@@ -218,7 +218,7 @@ var (
 	}
 	// NoMDNSFlag Disables network mDNS
 	NoMDNSFlag = cli.BoolFlag{
-		Name:  "nomdns,no-mdns",
+		Name:  "nomdns,no-mdns", // no-mdns is argument used by polkadot node
 		Usage: "Disables network mDNS discovery",
 	}
 	// PublicIPFlag uses the supplied IP for broadcasting

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -124,14 +124,16 @@ var (
 
 	// PublishMetricsFlag publishes node metrics to prometheus.
 	PublishMetricsFlag = cli.BoolFlag{
-		Name:  "publish-metrics",
-		Usage: "Publish node metrics",
+		Name:    "publish-metrics",
+		Aliases: []string{"prometheus-external"}, // prometheus-external is argument used by polkadot node
+		Usage:   "Publish node metrics",
 	}
 
 	// MetricsAddressFlag sets the metric server listening address
 	MetricsAddressFlag = cli.StringFlag{
-		Name:  "metrics-address",
-		Usage: "Set the metric server listening address",
+		Name:    "metrics-address",
+		Aliases: []string{"prometheus-port"},
+		Usage:   "Set the metric server listening address",
 	}
 
 	// NoTelemetryFlag stops publishing telemetry to default defined in genesis.json
@@ -264,8 +266,9 @@ var (
 	}
 	// RPCExternalFlag Enable the external HTTP-RPC
 	RPCUnsafeExternalFlag = cli.BoolFlag{
-		Name:  "rpc-unsafe-external",
-		Usage: "Enable external HTTP-RPC connections to unsafe procedures",
+		Name:    "rpc-unsafe-external",
+		Aliases: []string{"unsafe-rpc-external"}, // unsafe-rpc-external is argument used by polkadot node
+		Usage:   "Enable external HTTP-RPC connections to unsafe procedures",
 	}
 	// RPCHostFlag HTTP-RPC server listening hostname
 	RPCHostFlag = cli.StringFlag{
@@ -280,8 +283,9 @@ var (
 	}
 	// RPCModulesFlag API modules to enable via HTTP-RPC
 	RPCModulesFlag = cli.StringFlag{
-		Name:  "rpcmods",
-		Usage: "API modules to enable via HTTP-RPC, comma separated list",
+		Name:    "rpcmods",
+		Aliases: []string{"rpc-methods"}, // rpc-methods is argument used by polkadot node
+		Usage:   "API modules to enable via HTTP-RPC, comma separated list",
 	}
 	// WSPortFlag WebSocket server listening port
 	WSPortFlag = cli.IntFlag{
@@ -306,8 +310,14 @@ var (
 	}
 	// WSExternalFlag Enable external websocket connections
 	WSUnsafeExternalFlag = cli.BoolFlag{
-		Name:  "ws-unsafe-external",
-		Usage: "Enable external access to websocket unsafe calls",
+		Name:    "ws-unsafe-external",
+		Aliases: []string{"unsafe-ws-external"}, // unsafe-ws-external is argument used by polkadot node
+		Usage:   "Enable external access to websocket unsafe calls",
+	}
+	// RPCCorsFlag dummy flag provided to conform to polkadot flags
+	RPCCorsFlag = cli.StringFlag{
+		Name:  "rpc-cors",
+		Usage: "dummy place holder to conform with polkadot cli flags",
 	}
 )
 
@@ -379,6 +389,9 @@ var (
 		Name:  "babe-lead",
 		Usage: `specify whether node should build block 1 of the network. only used when starting a new network`,
 	}
+	ValidatorFlag = cli.BoolFlag{
+		Name: "validator", // TODO(ed) implement
+	}
 )
 
 // flag sets that are shared by multiple commands
@@ -437,6 +450,7 @@ var (
 		&WSUnsafeEnabledFlag,
 		&WSUnsafeExternalFlag,
 		&WSPortFlag,
+		&RPCCorsFlag,
 
 		// metrics flag
 		&PublishMetricsFlag,
@@ -448,6 +462,7 @@ var (
 
 		// BABE flags
 		&BABELeadFlag,
+		&ValidatorFlag,
 	}
 )
 

--- a/cmd/gossamer/flags_test.go
+++ b/cmd/gossamer/flags_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/dot"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // TestFixFlagOrder tests the FixFlagOrder method

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -208,7 +208,7 @@ func importRuntimeAction(ctx *cli.Context) error {
 func gossamerAction(ctx *cli.Context) error {
 	// check for unknown command arguments
 	if arguments := ctx.Args(); arguments.Len() > 0 {
-		return fmt.Errorf("%d extra unknown command line arguments", arguments.Len())
+		return fmt.Errorf("%d extra unknown command line argument: %v", arguments.Len(), arguments.Slice())
 	}
 
 	// setup gossamer logger

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/lib/utils"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 
 	_ "github.com/breml/rootcerts"
 )
@@ -133,16 +133,16 @@ func init() {
 	app.Copyright = "Copyright 2019 ChainSafe Systems Authors"
 	app.Name = "gossamer"
 	app.Usage = "Official gossamer command-line interface"
-	app.Author = "ChainSafe Systems 2019"
+	app.Authors = []*cli.Author{{Name: "ChainSafe Systems"}}
 	app.Version = "0.3.2"
-	app.Commands = []cli.Command{
-		exportCommand,
-		initCommand,
-		accountCommand,
-		buildSpecCommand,
-		importRuntimeCommand,
-		importStateCommand,
-		pruningCommand,
+	app.Commands = []*cli.Command{
+		&exportCommand,
+		&initCommand,
+		&accountCommand,
+		&buildSpecCommand,
+		&importRuntimeCommand,
+		&importStateCommand,
+		&pruningCommand,
 	}
 	app.Flags = RootFlags
 }
@@ -186,12 +186,12 @@ func importStateAction(ctx *cli.Context) error {
 // importRuntimeAction generates a genesis file given a .wasm runtime binary.
 func importRuntimeAction(ctx *cli.Context) error {
 	arguments := ctx.Args()
-	if len(arguments) != 2 {
+	if arguments.Len() != 2 {
 		return fmt.Errorf("please provide a wasm file and the genesis spec file")
 	}
 
-	fp := arguments[0]
-	genesisChainSpec := arguments[1]
+	fp := arguments.Get(0)
+	genesisChainSpec := arguments.Get(1)
 
 	out, err := createGenesisWithRuntime(fp, genesisChainSpec)
 	if err != nil {
@@ -207,8 +207,8 @@ func importRuntimeAction(ctx *cli.Context) error {
 // then creates and starts the node and node services
 func gossamerAction(ctx *cli.Context) error {
 	// check for unknown command arguments
-	if arguments := ctx.Args(); len(arguments) > 0 {
-		return fmt.Errorf("failed to read command argument: %q", arguments[0])
+	if arguments := ctx.Args(); arguments.Len() > 0 {
+		return fmt.Errorf("failed to read command argument: %q", arguments.Get(0))
 	}
 
 	// setup gossamer logger
@@ -442,7 +442,7 @@ func pruneState(ctx *cli.Context) error {
 	inputDBPath := filepath.Join(tomlCfg.Global.BasePath, "db")
 
 	const uint32Max = ^uint32(0)
-	flagValue := ctx.GlobalUint64(RetainBlockNumberFlag.Name)
+	flagValue := ctx.Uint64(RetainBlockNumberFlag.Name)
 
 	if uint64(uint32Max) < flagValue {
 		return fmt.Errorf("retain blocks value overflows uint32 boundaries, must be less than or equal to: %d", uint32Max)

--- a/cmd/gossamer/main.go
+++ b/cmd/gossamer/main.go
@@ -208,7 +208,7 @@ func importRuntimeAction(ctx *cli.Context) error {
 func gossamerAction(ctx *cli.Context) error {
 	// check for unknown command arguments
 	if arguments := ctx.Args(); arguments.Len() > 0 {
-		return fmt.Errorf("failed to read command argument: %q", arguments.Get(0))
+		return fmt.Errorf("%d extra unknown command line arguments", arguments.Len())
 	}
 
 	// setup gossamer logger

--- a/cmd/gossamer/main_test.go
+++ b/cmd/gossamer/main_test.go
@@ -215,7 +215,7 @@ func TestInvalidCommand(t *testing.T) {
 	gossamer.ExpectExit()
 
 	expectedMessages := []string{
-		"failed to read command argument: \"potato\"",
+		"1 extra unknown command line argument: [potato]\n",
 	}
 
 	for _, m := range expectedMessages {

--- a/cmd/gossamer/utils.go
+++ b/cmd/gossamer/utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ChainSafe/gossamer/dot"
 	"github.com/ChainSafe/gossamer/internal/log"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 	terminal "golang.org/x/term"
 )
 

--- a/cmd/gossamer/utils_test.go
+++ b/cmd/gossamer/utils_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 // newTestContext creates a cli context for a test given a set of flags and values

--- a/dot/config.go
+++ b/dot/config.go
@@ -103,6 +103,7 @@ type NetworkConfig struct {
 	DiscoveryInterval time.Duration
 	PublicIP          string
 	PublicDNS         string
+	NodeKey           string
 }
 
 // CoreConfig is to marshal/unmarshal toml core config vars

--- a/dot/config.go
+++ b/dot/config.go
@@ -104,6 +104,7 @@ type NetworkConfig struct {
 	PublicIP          string
 	PublicDNS         string
 	NodeKey           string
+	ListenAddress     string
 }
 
 // CoreConfig is to marshal/unmarshal toml core config vars

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -64,6 +64,8 @@ type NetworkConfig struct {
 	DiscoveryInterval int      `toml:"discovery-interval,omitempty"`
 	PublicIP          string   `toml:"public-ip,omitempty"`
 	PublicDNS         string   `toml:"public-dns,omitempty"`
+	NodeKey           string   `toml:"node-key,omitempty"`
+	ListenAddress     string   `toml:"listen-addr,omitempty"`
 }
 
 // CoreConfig is to marshal/unmarshal toml core config vars

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -84,6 +84,8 @@ type Config struct {
 	NoBootstrap bool
 	// NoMDNS disables MDNS discovery
 	NoMDNS bool
+	// ListenAddress multiaddress to listen on
+	ListenAddress string
 
 	MinPeers int
 	MaxPeers int

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	// privateKey the private key for the network p2p identity
 	privateKey crypto.PrivKey
 
-	//NodeKey is the private hex encoded Ed25519 key to build the p2p identity
+	// NodeKey is the private hex encoded Ed25519 key to build the p2p identity
 	NodeKey string
 
 	// telemetryInterval how often to send telemetry metrics
@@ -179,6 +179,7 @@ func (c *Config) buildIdentity() error {
 		c.privateKey = privateKey
 		return nil
 	}
+
 	if c.RandSeed == 0 {
 
 		// attempt to load existing key

--- a/dot/network/config.go
+++ b/dot/network/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	NoBootstrap bool
 	// NoMDNS disables MDNS discovery
 	NoMDNS bool
-	// ListenAddress multiaddress to listen on
+	// ListenAddress is the multiaddress to listen on
 	ListenAddress string
 
 	MinPeers int
@@ -95,11 +95,11 @@ type Config struct {
 	// PersistentPeers is a list of multiaddrs which the node should remain connected to
 	PersistentPeers []string
 
-	// privateKey the private key for the network p2p identity
-	privateKey crypto.PrivKey
-
 	// NodeKey is the private hex encoded Ed25519 key to build the p2p identity
 	NodeKey string
+
+	// privateKey the private key for the network p2p identity
+	privateKey crypto.PrivKey
 
 	// telemetryInterval how often to send telemetry metrics
 	telemetryInterval time.Duration

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -82,7 +82,11 @@ type host struct {
 
 func newHost(ctx context.Context, cfg *Config) (*host, error) {
 	// create multiaddress (without p2p identity)
-	addr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.Port))
+	addrString := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.Port)
+	if cfg.ListenAddress != "" {
+		addrString = cfg.ListenAddress
+	}
+	addr, err := ma.NewMultiaddr(addrString)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -91,6 +92,15 @@ func newHost(ctx context.Context, cfg *Config) (*host, error) {
 		return nil, err
 	}
 
+	portString, err := addr.ValueForProtocol(ma.P_TCP)
+	if err != nil {
+		return nil, err
+	}
+
+	port, err := strconv.ParseUint(portString, 10, 64)
+	if err != nil {
+		return nil, err
+	}
 	var externalAddr ma.Multiaddr
 
 	switch {
@@ -100,13 +110,13 @@ func newHost(ctx context.Context, cfg *Config) (*host, error) {
 			return nil, fmt.Errorf("invalid public ip: %s", cfg.PublicIP)
 		}
 		logger.Debugf("using config PublicIP: %s", ip)
-		externalAddr, err = ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, cfg.Port))
+		externalAddr, err = ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port))
 		if err != nil {
 			return nil, err
 		}
 	case strings.TrimSpace(cfg.PublicDNS) != "":
 		logger.Debugf("using config PublicDNS: %s", cfg.PublicDNS)
-		externalAddr, err = ma.NewMultiaddr(fmt.Sprintf("/dns/%s/tcp/%d", cfg.PublicDNS, cfg.Port))
+		externalAddr, err = ma.NewMultiaddr(fmt.Sprintf("/dns/%s/tcp/%d", cfg.PublicDNS, port))
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +126,7 @@ func newHost(ctx context.Context, cfg *Config) (*host, error) {
 			logger.Errorf("failed to get public IP error: %v", err)
 		} else {
 			logger.Debugf("got public IP address %s", ip)
-			externalAddr, err = ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, cfg.Port))
+			externalAddr, err = ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ip, port))
 			if err != nil {
 				return nil, err
 			}

--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -82,11 +82,11 @@ type host struct {
 
 func newHost(ctx context.Context, cfg *Config) (*host, error) {
 	// create multiaddress (without p2p identity)
-	addrString := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.Port)
+	listenAddress := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", cfg.Port)
 	if cfg.ListenAddress != "" {
-		addrString = cfg.ListenAddress
+		listenAddress = cfg.ListenAddress
 	}
-	addr, err := ma.NewMultiaddr(addrString)
+	addr, err := ma.NewMultiaddr(listenAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -87,6 +87,12 @@ var (
 		Name:      "outbound_total",
 		Help:      "total number of outbound streams",
 	})
+	// TODO(ed), find better way to handle this, to actually override the default process_start_time_seconds metric
+	runningGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "substrate",
+		Name:      "process_start_time_seconds",
+		Help:      "gossamer process start time seconds",
+	})
 )
 
 type (
@@ -352,6 +358,7 @@ func (s *Service) updateMetrics() {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
+			runningGauge.Set(1.5)
 			peerCountGauge.Set(float64(s.host.peerCount()))
 			connectionsGauge.Set(float64(len(s.host.p2pHost.Network().Conns())))
 			nodeLatencyGauge.Set(float64(

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -87,12 +87,6 @@ var (
 		Name:      "outbound_total",
 		Help:      "total number of outbound streams",
 	})
-	// TODO(ed), find better way to handle this, to actually override the default process_start_time_seconds metric
-	runningGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "substrate",
-		Name:      "process_start_time_seconds",
-		Help:      "gossamer process start time seconds",
-	})
 )
 
 type (
@@ -358,7 +352,6 @@ func (s *Service) updateMetrics() {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
-			runningGauge.Set(1.5)
 			peerCountGauge.Set(float64(s.host.peerCount()))
 			connectionsGauge.Set(float64(len(s.host.p2pHost.Network().Conns())))
 			nodeLatencyGauge.Set(float64(

--- a/dot/services.go
+++ b/dot/services.go
@@ -308,6 +308,7 @@ func (nodeBuilder) createNetworkService(cfg *Config, stateSrvc *state.Service,
 		PublicDNS:         cfg.Network.PublicDNS,
 		Metrics:           metrics.NewIntervalConfig(cfg.Global.PublishMetrics),
 		NodeKey:           cfg.Network.NodeKey,
+		ListenAddress:     cfg.Network.ListenAddress,
 	}
 
 	networkSrvc, err := network.NewService(&networkConfig)

--- a/dot/services.go
+++ b/dot/services.go
@@ -307,6 +307,7 @@ func (nodeBuilder) createNetworkService(cfg *Config, stateSrvc *state.Service,
 		Telemetry:         telemetryMailer,
 		PublicDNS:         cfg.Network.PublicDNS,
 		Metrics:           metrics.NewIntervalConfig(cfg.Global.PublishMetrics),
+		NodeKey:           cfg.Network.NodeKey,
 	}
 
 	networkSrvc, err := network.NewService(&networkConfig)

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/qdm12/gotree v0.2.0
 	github.com/stretchr/testify v1.8.2
-	github.com/urfave/cli v1.22.12
+	github.com/urfave/cli/v2 v2.10.2
 	github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec
 	github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9
 	golang.org/x/crypto v0.7.0
@@ -164,6 +164,7 @@ require (
 	github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce // indirect
 	github.com/vedhavyas/go-subkey v1.0.3 // indirect
 	github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.3.0
 	github.com/qdm12/gotree v0.2.0
 	github.com/stretchr/testify v1.8.2
-	github.com/urfave/cli/v2 v2.10.2
+	github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa
 	github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec
 	github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9
 	golang.org/x/crypto v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -842,7 +842,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.sum
+++ b/go.sum
@@ -602,9 +602,9 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/urfave/cli v1.22.12 h1:igJgVw1JdKH+trcLWLeLwZjU9fEfPesQ+9/e4MQ44S8=
-github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/urfave/cli/v2 v2.10.2 h1:x3p8awjp/2arX+Nl/G2040AZpOCHS/eMJJ1/a+mye4Y=
+github.com/urfave/cli/v2 v2.10.2/go.mod h1:f8iq5LtQ/bLxafbdBSLPPNsgaW0l/2fYYEHhAyPlwvo=
 github.com/vedhavyas/go-subkey v1.0.3 h1:iKR33BB/akKmcR2PMlXPBeeODjWLM90EL98OrOGs8CA=
 github.com/vedhavyas/go-subkey v1.0.3/go.mod h1:CloUaFQSSTdWnINfBRFjVMkWXZANW+nd8+TI5jYcl6Y=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
@@ -617,6 +617,9 @@ github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9 h1:Y1/FEOpaCpD21WxrmfeIYCFPuVPRCY2XZTWzTNHGw30=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
+github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,6 @@ dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/ChainSafe/chaindb v0.1.5-0.20220708005902-df45dbc8e840 h1:qdwel/UNcN1PmrzZG4iTf8/cKAVCas+/RdXq/5NOxps=
 github.com/ChainSafe/chaindb v0.1.5-0.20220708005902-df45dbc8e840/go.mod h1:P01m9E6xj6Mps1rtf7SurEX9oOcy1jYEyccZQAEw9+4=
 github.com/ChainSafe/go-schnorrkel v1.0.1-0.20220711122024-027d287d27bf h1:S195ZBRu20VgXC1i5nHTR6b4BbTQaMCDuq6tzFQN5zU=
@@ -603,8 +602,8 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/urfave/cli/v2 v2.10.2 h1:x3p8awjp/2arX+Nl/G2040AZpOCHS/eMJJ1/a+mye4Y=
-github.com/urfave/cli/v2 v2.10.2/go.mod h1:f8iq5LtQ/bLxafbdBSLPPNsgaW0l/2fYYEHhAyPlwvo=
+github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bCzK15ozrqo2sZxkh0FHynJZOTVoV6Q=
+github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/vedhavyas/go-subkey v1.0.3 h1:iKR33BB/akKmcR2PMlXPBeeODjWLM90EL98OrOGs8CA=
 github.com/vedhavyas/go-subkey v1.0.3/go.mod h1:CloUaFQSSTdWnINfBRFjVMkWXZANW+nd8+TI5jYcl6Y=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
@@ -619,7 +618,6 @@ github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
-github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
## Changes
This PR contains changes to make gossamer more congruent with polkadot CLI commands in order to enable gossamer to work with paritytech zombienet testing framework.  
- Add CLI flag `no-mdns` to alias `nomdns`.
- Add CLI flag `base-path` to alias `basepath`
- Add CLI flag `rpc-port` to alias `rpcport`
- Add CLI flag `ws-port` to alias `wsport`
- Implement new CLI flag `node-key` which overrides the secret Ed25519 key to use for libp2p
- Add unit tests for new flags

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/cmd/gossamer -run ^TestGlobalConfigFromFlags$ -v
go test github.com/ChainSafe/gossamer/cmd/gossamer -run ^TestNetworkConfigFromFlags$ -v
 go test github.com/ChainSafe/gossamer/cmd/gossamer -run ^TestRPCConfigFromFlags$ -v

```

## Issues
Work done researching issue #2843 
<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
