### PR TITLE
chore(keyring): Fix naming when using default keyring values

### DIFF
--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -468,11 +468,11 @@ func TestAuthorModule_HasKey_Integration(t *testing.T) {
 func TestAuthorModule_HasSessionKeys_Integration(t *testing.T) {
 	t.Parallel()
 
-	const granSeed = "0xabf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115"
-	const granPubK = "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"
+	const aliceGrandpaSeed = "0xabf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115"
+	const aliceGrandpaPublicKey = "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"
 
-	const sr25519Seed = "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"
-	const sr25519AlicePubkey = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+	const sr25519AliceSeed = "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"
+	const sr25519AlicePublicKey = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
 
 	insertSessionKeys := []struct {
 		ktype      []string
@@ -480,13 +480,13 @@ func TestAuthorModule_HasSessionKeys_Integration(t *testing.T) {
 	}{
 		{
 			ktype: []string{"gran"},
-			seed:  granSeed,
-			pubk:  granPubK,
+			seed:  aliceGrandpaSeed,
+			pubk:  aliceGrandpaPublicKey,
 		},
 		{
 			ktype: []string{"babe", "imon", "para", "asgn", "audi"},
-			seed:  sr25519Seed,
-			pubk:  sr25519AlicePubkey,
+			seed:  sr25519AliceSeed,
+			pubk:  sr25519AlicePublicKey,
 		},
 	}
 

--- a/dot/rpc/modules/author_integration_test.go
+++ b/dot/rpc/modules/author_integration_test.go
@@ -472,7 +472,7 @@ func TestAuthorModule_HasSessionKeys_Integration(t *testing.T) {
 	const granPubK = "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"
 
 	const sr25519Seed = "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a"
-	const sr25519Pubk = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+	const sr25519AlicePubkey = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
 
 	insertSessionKeys := []struct {
 		ktype      []string
@@ -486,7 +486,7 @@ func TestAuthorModule_HasSessionKeys_Integration(t *testing.T) {
 		{
 			ktype: []string{"babe", "imon", "para", "asgn", "audi"},
 			seed:  sr25519Seed,
-			pubk:  sr25519Pubk,
+			pubk:  sr25519AlicePubkey,
 		},
 	}
 

--- a/lib/crypto/ed25519/ed25519_test.go
+++ b/lib/crypto/ed25519/ed25519_test.go
@@ -162,18 +162,18 @@ func TestVerifySignature(t *testing.T) {
 
 func TestPublicKeyFromPrivate(t *testing.T) {
 	// subkey inspect //Alice --scheme ed25519
-	priv := common.MustHexToBytes("0xabf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115")
-	pub := common.MustHexToBytes("0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee")
+	alicePrivateKey := common.MustHexToBytes("0xabf8e5bdbe30c65656c0a3cbd181ff8a56294a69dfedd27982aace4a76909115")
+	alicePublicKey := common.MustHexToBytes("0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee")
 
-	sk, err := NewPrivateKey(append(priv, pub...))
+	sk, err := NewPrivateKey(append(alicePrivateKey, alicePublicKey...))
 	require.NoError(t, err)
 	pk, err := sk.Public()
 	require.NoError(t, err)
-	require.Equal(t, pub, pk.(*PublicKey).Encode())
+	require.Equal(t, alicePublicKey, pk.(*PublicKey).Encode())
 
-	kp, err := NewKeypairFromSeed(priv)
+	kp, err := NewKeypairFromSeed(alicePrivateKey)
 	require.NoError(t, err)
-	require.Equal(t, pub, kp.public.Encode())
+	require.Equal(t, alicePublicKey, kp.public.Encode())
 
 	addr := crypto.PublicKeyToAddress(kp.Public())
 	require.Equal(t, "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu", string(addr))

--- a/tests/polkadotjs_test/test.js
+++ b/tests/polkadotjs_test/test.js
@@ -66,9 +66,9 @@ async function main() {
     const aliceKey = keyring.addFromUri('//Alice',  { name: 'Alice default' });
     console.log(`${aliceKey.meta.name}: has address ${aliceKey.address} with publicKey [${aliceKey.publicKey}]`);
 
-    const ADDR_Bob = '0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22';
+    const ADDR_Charlie = '0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22';
 
-    const transfer = await api.tx.balances.transfer(ADDR_Bob, 12345)
+    const transfer = await api.tx.balances.transfer(ADDR_Charlie, 12345)
         .signAndSend(aliceKey);
 
     console.log(`hxHash ${transfer}`);

--- a/tests/polkadotjs_test/test_transaction.js
+++ b/tests/polkadotjs_test/test_transaction.js
@@ -22,9 +22,6 @@ async function main() {
     const bobKey = keyring.addFromUri('//Bob', {name: 'Bob default'});
     console.log(`${bobKey.meta.name}: has address ${bobKey.address} with publicKey [${bobKey.publicKey}], ${toHexString(bobKey.publicKey)}`);
 
-    const ADDR_Bob = '0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22';
-    // bob 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
-
     const transfer = await api.tx.balances.transfer(bobKey.address, 12345).signAndSend(aliceKey);
     console.log(`transaction hash: ${transfer}`);
 }


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- We were mixin up bob and charlie in our tests, so I fixed naming when using default keyring values
- Got rid of using the hardcoded values and used the keyring to retrieve the keys when possible
- Cleaned up TestBuildAndApplyExtrinsic to avoid using hardcoded values and have better naming

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./lib/babe --tags=integration
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kishansagathiya 
