### PR TITLE
chore(lint): use crypto/rand instead of math/rand

### DIFF
--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	mrand "math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -62,9 +63,13 @@ func stringsToAddrInfos(peers []string) ([]peer.AddrInfo, error) {
 // generateKey generates an ed25519 private key and writes it to the data directory
 // If the seed is zero, we use real cryptographic randomness. Otherwise, we use a
 // deterministic randomness source to make keys the same across multiple runs.
-// TODO : See if I can remove crand
 func generateKey(seed int64, fp string) (crypto.PrivKey, error) {
-	r := crand.Reader
+	var r io.Reader
+	if seed == 0 {
+		r = crand.Reader
+	} else {
+		r = mrand.New(mrand.NewSource(seed)) //nolint:gosec
+	}
 	key, _, err := crypto.GenerateEd25519Key(r)
 	if err != nil {
 		return nil, err

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	mrand "math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -63,13 +62,9 @@ func stringsToAddrInfos(peers []string) ([]peer.AddrInfo, error) {
 // generateKey generates an ed25519 private key and writes it to the data directory
 // If the seed is zero, we use real cryptographic randomness. Otherwise, we use a
 // deterministic randomness source to make keys the same across multiple runs.
+// TODO : See if I can remove crand
 func generateKey(seed int64, fp string) (crypto.PrivKey, error) {
-	var r io.Reader
-	if seed == 0 {
-		r = crand.Reader
-	} else {
-		r = mrand.New(mrand.NewSource(seed)) //nolint:gosec
-	}
+	r := crand.Reader
 	key, _, err := crypto.GenerateEd25519Key(r)
 	if err != nil {
 		return nil, err

--- a/dot/state/base_test.go
+++ b/dot/state/base_test.go
@@ -17,9 +17,8 @@ func TestTrie_StoreAndLoadFromDB(t *testing.T) {
 	db := NewInMemoryDB(t)
 	tt := trie.NewEmptyTrie()
 
-	generator := newGenerator()
 	const size = 500
-	kv := generateKeyValues(t, generator, size)
+	kv := generateKeyValues(t, size)
 
 	for keyString, value := range kv {
 		key := []byte(keyString)

--- a/dot/state/helpers_test.go
+++ b/dot/state/helpers_test.go
@@ -4,9 +4,9 @@
 package state
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	"math/big"
 	"testing"
-	"time"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -26,34 +26,25 @@ func newTriesEmpty() *Tries {
 	}
 }
 
-// newGenerator creates a new PRNG seeded with the
-// unix nanoseconds value of the current time.
-func newGenerator() (prng *rand.Rand) {
-	seed := time.Now().UnixNano()
-	source := rand.NewSource(seed)
-	return rand.New(source) //skipcq: GSC-G404
-}
-
-func generateKeyValues(tb testing.TB, generator *rand.Rand, size int) (kv map[string][]byte) {
+func generateKeyValues(tb testing.TB, size int) (kv map[string][]byte) {
 	tb.Helper()
 
 	kv = make(map[string][]byte, size)
 
 	const maxKeySize, maxValueSize = 510, 128
 	for i := 0; i < size; i++ {
-		populateKeyValueMap(tb, kv, generator, maxKeySize, maxValueSize)
+		populateKeyValueMap(tb, kv, maxKeySize, maxValueSize)
 	}
 
 	return kv
 }
 
-func populateKeyValueMap(tb testing.TB, kv map[string][]byte,
-	generator *rand.Rand, maxKeySize, maxValueSize int) {
+func populateKeyValueMap(tb testing.TB, kv map[string][]byte, maxKeySize, maxValueSize int) {
 	tb.Helper()
 
 	for {
 		const minKeySize = 2
-		key := generateRandBytesMinMax(tb, minKeySize, maxKeySize, generator)
+		key := generateRandBytesMinMax(tb, minKeySize, maxKeySize)
 
 		keyString := string(key)
 
@@ -64,7 +55,7 @@ func populateKeyValueMap(tb testing.TB, kv map[string][]byte,
 		}
 
 		const minValueSize = 0
-		value := generateRandBytesMinMax(tb, minValueSize, maxValueSize, generator)
+		value := generateRandBytesMinMax(tb, minValueSize, maxValueSize)
 
 		kv[keyString] = value
 
@@ -72,19 +63,18 @@ func populateKeyValueMap(tb testing.TB, kv map[string][]byte,
 	}
 }
 
-func generateRandBytesMinMax(tb testing.TB, minSize, maxSize int,
-	generator *rand.Rand) (b []byte) {
+func generateRandBytesMinMax(tb testing.TB, minSize, maxSize int) (b []byte) {
 	tb.Helper()
-	size := minSize +
-		generator.Intn(maxSize-minSize)
-	return generateRandBytes(tb, size, generator)
+	randN, err := crand.Int(crand.Reader, big.NewInt(int64(maxSize-minSize)))
+	require.NoError(tb, err)
+	size := minSize + int(randN.Int64())
+	return generateRandBytes(tb, size)
 }
 
-func generateRandBytes(tb testing.TB, size int,
-	generator *rand.Rand) (b []byte) {
+func generateRandBytes(tb testing.TB, size int) (b []byte) {
 	tb.Helper()
 	b = make([]byte, size)
-	_, err := generator.Read(b)
+	_, err := crand.Read(b)
 	require.NoError(tb, err)
 	return b
 }

--- a/dot/state/transaction_test.go
+++ b/dot/state/transaction_test.go
@@ -4,10 +4,10 @@
 package state
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	"math/big"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
@@ -87,16 +87,19 @@ func TestTransactionState_NotifierChannels(t *testing.T) {
 	// number of "ready" status updates
 	var readyCount int
 
-	rand.Seed(time.Now().UnixNano())
-
 	// In practice, one won't see ready and future in this order. This is merely
 	// meant to check that notifier channels work as expected.
-	expectedFutureCount := rand.Intn(10) + 10
-	expectedReadyCount := rand.Intn(5) + 5
+	randN, err := crand.Int(crand.Reader, big.NewInt(10))
+	require.NoError(t, err)
+	expectedFutureCount := randN.Int64()
+
+	randN, err = crand.Int(crand.Reader, big.NewInt(10))
+	require.NoError(t, err)
+	expectedReadyCount := randN.Int64()
 
 	dummyTransactions := make([]*transaction.ValidTransaction, expectedFutureCount)
 
-	for i := 0; i < expectedFutureCount; i++ {
+	for i := 0; i < int(expectedFutureCount); i++ {
 		dummyTransactions[i] = &transaction.ValidTransaction{
 			Extrinsic: ext,
 			Validity:  transaction.NewValidity(0, [][]byte{{}}, [][]byte{{}}, 0, false),
@@ -105,7 +108,7 @@ func TestTransactionState_NotifierChannels(t *testing.T) {
 		ts.AddToPool(dummyTransactions[i])
 	}
 
-	for i := 0; i < expectedReadyCount; i++ {
+	for i := 0; i < int(expectedReadyCount); i++ {
 		ts.Push(dummyTransactions[i])
 	}
 

--- a/dot/state/transaction_test.go
+++ b/dot/state/transaction_test.go
@@ -91,15 +91,15 @@ func TestTransactionState_NotifierChannels(t *testing.T) {
 	// meant to check that notifier channels work as expected.
 	randN, err := crand.Int(crand.Reader, big.NewInt(10))
 	require.NoError(t, err)
-	expectedFutureCount := randN.Int64()
+	expectedFutureCount := int(randN.Int64()) + 10
 
-	randN, err = crand.Int(crand.Reader, big.NewInt(10))
+	randN, err = crand.Int(crand.Reader, big.NewInt(5))
 	require.NoError(t, err)
-	expectedReadyCount := randN.Int64()
+	expectedReadyCount := int(randN.Int64()) + 5
 
 	dummyTransactions := make([]*transaction.ValidTransaction, expectedFutureCount)
 
-	for i := 0; i < int(expectedFutureCount); i++ {
+	for i := 0; i < expectedFutureCount; i++ {
 		dummyTransactions[i] = &transaction.ValidTransaction{
 			Extrinsic: ext,
 			Validity:  transaction.NewValidity(0, [][]byte{{}}, [][]byte{{}}, 0, false),
@@ -108,7 +108,7 @@ func TestTransactionState_NotifierChannels(t *testing.T) {
 		ts.AddToPool(dummyTransactions[i])
 	}
 
-	for i := 0; i < int(expectedReadyCount); i++ {
+	for i := 0; i < expectedReadyCount; i++ {
 		ts.Push(dummyTransactions[i])
 	}
 

--- a/lib/blocktree/blocktree_test.go
+++ b/lib/blocktree/blocktree_test.go
@@ -5,8 +5,9 @@ package blocktree
 
 import (
 	"bytes"
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"testing"
 	"time"
 
@@ -60,7 +61,6 @@ func createTestBlockTree(t *testing.T, header *types.Header, number uint) (*Bloc
 
 	// branch tree randomly
 	var branches []testBranch
-	r := rand.New(rand.NewSource(time.Now().UnixNano())) //skipcq: GSC-G404
 
 	at := int64(0)
 
@@ -78,7 +78,10 @@ func createTestBlockTree(t *testing.T, header *types.Header, number uint) (*Bloc
 
 		previousHash = hash
 
-		isBranch := r.Intn(2)
+		randN, err := crand.Int(crand.Reader, big.NewInt(2))
+		require.NoError(t, err)
+		isBranch := randN.Uint64()
+
 		if isBranch == 1 {
 			branches = append(branches, testBranch{
 				hash:        hash,
@@ -87,7 +90,9 @@ func createTestBlockTree(t *testing.T, header *types.Header, number uint) (*Bloc
 			})
 		}
 
-		at += int64(r.Intn(8))
+		randN, err = crand.Int(crand.Reader, big.NewInt(8))
+		require.NoError(t, err)
+		at += randN.Int64()
 	}
 
 	// create tree branches
@@ -108,8 +113,10 @@ func createTestBlockTree(t *testing.T, header *types.Header, number uint) (*Bloc
 			require.NoError(t, err)
 
 			previousHash = hash
-			at += int64(r.Intn(8))
 
+			randN, err := crand.Int(crand.Reader, big.NewInt(8))
+			require.NoError(t, err)
+			at += randN.Int64()
 		}
 	}
 

--- a/lib/grandpa/round_integration_test.go
+++ b/lib/grandpa/round_integration_test.go
@@ -7,8 +7,9 @@ package grandpa
 
 import (
 	"context"
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -41,7 +42,10 @@ func TestGrandpa_DifferentChains(t *testing.T) {
 		gs = setupGrandpa(t, kr.Keys[i])
 		gss[i] = gs
 
-		r := uint(rand.Intn(2)) // 0 or 1
+		randN, err := crand.Int(crand.Reader, big.NewInt(int64(2)))
+		require.NoError(t, err)
+		r := uint(randN.Uint64()) // 0 or 1
+
 		state.AddBlocksToState(t, gs.blockState.(*state.BlockState), 4+r, false)
 		pv, err := gs.determinePreVote()
 		require.NoError(t, err)
@@ -118,12 +122,14 @@ func TestPlayGrandpaRound(t *testing.T) {
 			},
 			defineBlockTree: func(t *testing.T, blockState BlockState, neighbourServices []*Service) {
 				const diff = 5
-				rand := uint(rand.Intn(diff))
+				randN, err := crand.Int(crand.Reader, big.NewInt(int64(diff)))
+				require.NoError(t, err)
+				r := uint(randN.Uint64())
 
 				const withBranches = false
 				const baseLength = 4
 				headers, _ := state.AddBlocksToState(t, blockState.(*state.BlockState),
-					baseLength+rand, withBranches)
+					baseLength+r, withBranches)
 
 				// sync the created blocks with the neighbour services
 				// letting them know about those blocks

--- a/lib/trie/proof/helpers_test.go
+++ b/lib/trie/proof/helpers_test.go
@@ -5,7 +5,7 @@ package proof
 
 import (
 	"bytes"
-	"math/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/internal/trie/node"
@@ -63,9 +63,8 @@ func concatBytes(slices [][]byte) (concatenated []byte) {
 // deterministic unit tests.
 func generateBytes(t *testing.T, length uint) (bytes []byte) {
 	t.Helper()
-	generator := rand.New(rand.NewSource(0)) //skipcq: GSC-G404
 	bytes = make([]byte, length)
-	_, err := generator.Read(bytes)
+	_, err := crand.Read(bytes)
 	require.NoError(t, err)
 	return bytes
 }

--- a/lib/trie/proof/verify_test.go
+++ b/lib/trie/proof/verify_test.go
@@ -21,10 +21,11 @@ func Test_Verify(t *testing.T) {
 		StorageValue: []byte{1},
 	}
 
+	randomBytes := generateBytes(t, 40)
 	// leafB is a leaf encoding to more than 32 bytes
 	leafB := node.Node{
 		PartialKey:   []byte{2},
-		StorageValue: generateBytes(t, 40),
+		StorageValue: randomBytes,
 	}
 	assertLongEncoding(t, leafB)
 
@@ -65,7 +66,7 @@ func Test_Verify(t *testing.T) {
 			errWrapped: ErrKeyNotFoundInProofTrie,
 			errMessage: "key not found in proof trie: " +
 				"0x0101 in proof trie for root hash " +
-				"0xec4bb0acfcf778ae8746d3ac3325fc73c3d9b376eb5f8d638dbf5eb462f5e703",
+				common.BytesToHex(blake2bNode(t, branch)),
 		},
 		"key_found_with_nil_search_value": {
 			encodedProofNodes: [][]byte{
@@ -97,7 +98,7 @@ func Test_Verify(t *testing.T) {
 			},
 			rootHash: blake2bNode(t, branch),
 			keyLE:    []byte{0x34, 0x32}, // large hash-referenced leaf of branch
-			value:    generateBytes(t, 40),
+			value:    randomBytes,
 		},
 	}
 

--- a/lib/trie/proof/verify_test.go
+++ b/lib/trie/proof/verify_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ChainSafe/gossamer/internal/trie/node"
+	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -564,8 +565,8 @@ func Test_loadProof(t *testing.T) {
 			},
 			errWrapped: node.ErrVariantUnknown,
 			errMessage: "decoding child node for hash digest " +
-				"0x6888b9403129c11350c6054b46875292c0ffedcfd581e66b79bdf350b775ebf2: " +
-				"decoding header: decoding header byte: node variant is unknown: " +
+				common.BytesToHex(blake2bNode(t, leafLarge)) +
+				": decoding header: decoding header byte: node variant is unknown: " +
 				"for header byte 00000001",
 		},
 	}

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -5,8 +5,9 @@ package rpc
 
 import (
 	"context"
+	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"testing"
 	"time"
 
@@ -330,7 +331,10 @@ func callAndSubscribeWebsocket(ctx context.Context, t *testing.T,
 	defer connection.Close() // in case of failed required assertion
 
 	const maxid = 100000 // otherwise it becomes a float64
-	id := rand.Intn(maxid)
+	randN, err := crand.Int(crand.Reader, big.NewInt(int64(maxid)))
+	require.NoError(t, err)
+	id := randN.Int64()
+
 	messageData := fmt.Sprintf(`{
     "jsonrpc": "2.0",
     "method": %q,

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -5,9 +5,10 @@ package stress
 
 import (
 	"context"
+	crand "crypto/rand"
 	"fmt"
 	"math/big"
-	"math/rand"
+
 	"os"
 	"path/filepath"
 	"strings"
@@ -405,7 +406,9 @@ func TestSync_Restart(t *testing.T) {
 		for {
 			select {
 			case <-time.After(time.Second * 10):
-				idx := rand.Intn(numNodes)
+				randN, err := crand.Int(crand.Reader, big.NewInt(int64(numNodes)))
+				require.NoError(t, err)
+				idx := randN.Int64()
 
 				// Stop node
 				nodeCancels[idx]()


### PR DESCRIPTION
## Changes
`make lint` and deepsource both keep on complaining about how we should use crypto/rand package instead of math/rand.

Considering that `make lint` and deepsource both are compulsary checks in our CI, I require this fix to merge my existing PRs.
<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make lint
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@jimjbrettj  
