### PR TITLE
fix(tests/rpc): place `GreaterOrEqual` arguments in the correct order at `chain_subscribeNewHeads` test

### DIFF
--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -162,7 +162,7 @@ func TestChainSubscriptionRPC(t *testing.T) { //nolint:tparallel
 			result := getResultMapFromParams(t, params)
 
 			number := getResultNumber(t, result)
-			assert.GreaterOrEqual(t, uint(i+1), number)
+			assert.GreaterOrEqual(t, number, uint(i+1))
 
 			assertResult32BHex(t, result, "parentHash")
 			assertResult32BHex(t, result, "stateRoot")


### PR DESCRIPTION
## Changes

- The following test `TestChainSubscriptionRPC/chain_subscribeNewHeads` was supposed to not be flaky due to this PR https://github.com/ChainSafe/gossamer/pull/3092, however, it seems to keep the unstable behavior.
- After a quick investigation the test method `GreaterOrEqual` expects the first argument be greater or equal the second and in the PR https://github.com/ChainSafe/gossamer/pull/3092 I just replace the method name without changing the argument order 😢 

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
MODE=rpc go test -timeout 10m -run ^TestChainSubscriptionRPC$ github.com/ChainSafe/gossamer/tests/rpc --tags=integration -v
```

## Issues

N/A

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
