### PR TITLE
fix(ci): Fix staging metrics collection

### DIFF
--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -7,6 +7,7 @@ ARG DD_API_KEY
 ENV chain=${chain}
 ENV basepath=${basepath}
 ENV DD_API_KEY=${DD_API_KEY}
+ENV DD_HOSTNAME=${chain}-host
 
 RUN ["sh", "-c", "DD_AGENT_MAJOR_VERSION=7 DD_INSTALL_ONLY=true DD_API_KEY=${DD_API_KEY} DD_SITE=\"datadoghq.com\" bash -c \"$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script.sh)\""]
 
@@ -19,5 +20,5 @@ RUN go get ./...
 RUN go install -trimpath github.com/ChainSafe/gossamer/cmd/gossamer
 
 RUN ["sh", "-c", "gossamer init --chain=${chain}"]
-ENTRYPOINT ["sh", "-c", "service datadog-agent start && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]
+ENTRYPOINT ["sh", "-c", "service datadog-agent start gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]
 EXPOSE 7001 8546 8540 9876 6060

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -20,5 +20,5 @@ RUN go get ./...
 RUN go install -trimpath github.com/ChainSafe/gossamer/cmd/gossamer
 
 RUN ["sh", "-c", "gossamer init --chain=${chain}"]
-ENTRYPOINT ["sh", "-c", "service datadog-agent start gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]
+ENTRYPOINT ["sh", "-c", "service datadog-agent start && gossamer --chain=${chain} --basepath=${basepath}/${chain} --publish-metrics --metrics-address=\":9876\" --pprofserver --pprofaddress=\":6060\""]
 EXPOSE 7001 8546 8540 9876 6060


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- set `DD_HOSTNAME` env variable
- datadog fails in ECS environment with latest version of datadog-agent

## Tests

<!-- Detail how to run relevant tests to the changes -->
- push to staging workflow and ensure staging nodes start

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@jimjbrettj 
