### PR TITLE
chore(internal/mdns): disable `mdns` package default logging

### DIFF
--- a/internal/mdns/mdns.go
+++ b/internal/mdns/mdns.go
@@ -29,7 +29,6 @@ type Service struct {
 	serviceTag string
 
 	logger                  Logger
-	disableInnerMDNSLogging bool
 
 	notifee Notifee
 
@@ -60,7 +59,6 @@ func NewService(p2pHost IDNetworker, serviceTag string,
 		notifee:                 notifee,
 		logger:                  logger,
 		pollPeriod:              time.Minute,
-		disableInnerMDNSLogging: true,
 	}
 }
 
@@ -80,7 +78,7 @@ func (s *Service) Start() (err error) {
 	hostIDPretty := hostID.Pretty()
 	txt := []string{hostIDPretty}
 
-	mdns.DisableLogging = s.disableInnerMDNSLogging
+	mdns.DisableLogging = true
 	mdnsService, err := mdns.NewMDNSService(hostIDPretty, s.serviceTag, "", "", int(port), ips, txt)
 	if err != nil {
 		return fmt.Errorf("creating mDNS service: %w", err)

--- a/internal/mdns/mdns.go
+++ b/internal/mdns/mdns.go
@@ -27,10 +27,8 @@ type Service struct {
 	// Dependencies and configuration injected
 	p2pHost    IDNetworker
 	serviceTag string
-
-	logger                  Logger
-
-	notifee Notifee
+	logger     Logger
+	notifee    Notifee
 
 	// Constant fields
 	pollPeriod time.Duration
@@ -54,11 +52,11 @@ func NewService(p2pHost IDNetworker, serviceTag string,
 	}
 
 	return &Service{
-		p2pHost:                 p2pHost,
-		serviceTag:              serviceTag,
-		notifee:                 notifee,
-		logger:                  logger,
-		pollPeriod:              time.Minute,
+		p2pHost:    p2pHost,
+		serviceTag: serviceTag,
+		notifee:    notifee,
+		logger:     logger,
+		pollPeriod: time.Minute,
 	}
 }
 

--- a/internal/mdns/mdns.go
+++ b/internal/mdns/mdns.go
@@ -27,8 +27,11 @@ type Service struct {
 	// Dependencies and configuration injected
 	p2pHost    IDNetworker
 	serviceTag string
-	logger     Logger
-	notifee    Notifee
+
+	logger                  Logger
+	disableInnerMDNSLogging bool
+
+	notifee Notifee
 
 	// Constant fields
 	pollPeriod time.Duration
@@ -52,11 +55,12 @@ func NewService(p2pHost IDNetworker, serviceTag string,
 	}
 
 	return &Service{
-		p2pHost:    p2pHost,
-		serviceTag: serviceTag,
-		notifee:    notifee,
-		logger:     logger,
-		pollPeriod: time.Minute,
+		p2pHost:                 p2pHost,
+		serviceTag:              serviceTag,
+		notifee:                 notifee,
+		logger:                  logger,
+		pollPeriod:              time.Minute,
+		disableInnerMDNSLogging: true,
 	}
 }
 
@@ -75,6 +79,8 @@ func (s *Service) Start() (err error) {
 
 	hostIDPretty := hostID.Pretty()
 	txt := []string{hostIDPretty}
+
+	mdns.DisableLogging = s.disableInnerMDNSLogging
 	mdnsService, err := mdns.NewMDNSService(hostIDPretty, s.serviceTag, "", "", int(port), ips, txt)
 	if err != nil {
 		return fmt.Errorf("creating mDNS service: %w", err)


### PR DESCRIPTION
## Changes

- After this commit: https://github.com/whyrusleeping/mdns/commit/90e1930071ab6e5dc4388b54210152256ba07d37 is possible to disable the default logging in the `whyrusleeping/mdns` library we use

## Tests

<!-- Detail how to run relevant tests to the changes -->

- Run a Gossamer node using the `westend` chain config and then you should not see these logs:

```
2023/02/22 15:43:16 [ERR] mdns: Failed to read packet: read udp4 0.0.0.0:63685: use of closed network connection
2023/02/22 15:43:16 [ERR] mdns: Failed to read packet: read udp4 0.0.0.0:5353: use of closed network connection
2023/02/22 15:43:16 [ERR] mdns: Failed to read packet: read udp6 [::]:60744: use of closed network connection
```
## Issues

- Closes #3124

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
