### PR TITLE
ci: cancel previous workflow runs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,11 @@ jobs:
   linting:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -14,6 +14,11 @@ jobs:
   copyright-check:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -8,6 +8,11 @@ jobs:
   update:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3

--- a/.github/workflows/docker-grandpa.yml
+++ b/.github/workflows/docker-grandpa.yml
@@ -22,6 +22,11 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: docker/build-push-action@v4
         with:
           load: true

--- a/.github/workflows/docker-js.yml
+++ b/.github/workflows/docker-js.yml
@@ -22,6 +22,11 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: docker/build-push-action@v4
         with:
           load: true

--- a/.github/workflows/docker-rpc.yml
+++ b/.github/workflows/docker-rpc.yml
@@ -22,6 +22,11 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: docker/build-push-action@v4
         with:
           load: true

--- a/.github/workflows/docker-stress.yml
+++ b/.github/workflows/docker-stress.yml
@@ -22,6 +22,11 @@ jobs:
     env:
       DOCKER_BUILDKIT: "1"
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: docker/build-push-action@v4
         with:
           load: true

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,11 @@ jobs:
     timeout-minutes: 30
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,6 +37,11 @@ jobs:
           ]
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -13,6 +13,11 @@ jobs:
   mocks-check:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,11 @@ jobs:
     timeout-minutes: 60
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action
+        with:
+          all_but_latest: true
+
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19


### PR DESCRIPTION
## Changes

cancel stale ci workflows to prevent a buildup of a long queue

## Primary Reviewer

@timwu20
