### PR TITLE
chore(dot/digest): fix `TestHandler_GrandpaForcedChange` by initializing runtimes mapping

### DIFF
--- a/dot/digest/digest_integration_test.go
+++ b/dot/digest/digest_integration_test.go
@@ -58,10 +58,16 @@ func TestHandler_GrandpaScheduledChange(t *testing.T) {
 	handler.Start()
 	defer handler.Stop()
 
+	blockState := handler.blockState.(*state.BlockState)
+
 	// create 4 blocks and finalize only blocks 0, 1, 2
 	headers, _ := state.AddBlocksToState(t, handler.blockState.(*state.BlockState), 4, false)
+	for _, h := range headers {
+		blockState.StoreRuntime(h.Hash(), nil)
+	}
+
 	for i, h := range headers[:3] {
-		err := handler.blockState.(*state.BlockState).SetFinalisedHash(h.Hash(), uint64(i), 0)
+		err := blockState.SetFinalisedHash(h.Hash(), uint64(i), 0)
 		require.NoError(t, err)
 	}
 

--- a/dot/rpc/modules/chain_integration_test.go
+++ b/dot/rpc/modules/chain_integration_test.go
@@ -327,6 +327,7 @@ func TestChainGetFinalizedHeadByRound(t *testing.T) {
 	require.NoError(t, err)
 
 	testhash := header.Hash()
+	state.Block.StoreRuntime(testhash, nil)
 	err = state.Block.SetFinalisedHash(testhash, 77, 1)
 	require.NoError(t, err)
 

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -83,6 +83,7 @@ func TestBlockState_SetFinalisedHash(t *testing.T) {
 	}
 
 	testhash := header.Hash()
+	bs.StoreRuntime(testhash, nil)
 	err = bs.db.Put(headerKey(testhash), []byte{})
 	require.NoError(t, err)
 

--- a/dot/state/block_finalisation_test.go
+++ b/dot/state/block_finalisation_test.go
@@ -144,6 +144,7 @@ func TestSetFinalisedHash_setFirstSlotOnFinalisation(t *testing.T) {
 		Body:   types.Body{},
 	})
 	require.NoError(t, err)
+	bs.StoreRuntime(header2.Hash(), nil)
 
 	err = bs.SetFinalisedHash(header2.Hash(), 1, 1)
 	require.NoError(t, err)

--- a/dot/state/block_notify_test.go
+++ b/dot/state/block_notify_test.go
@@ -49,8 +49,8 @@ func TestFinalizedChannel(t *testing.T) {
 	defer bs.FreeFinalisedNotifierChannel(ch)
 
 	chain, _ := AddBlocksToState(t, bs, 3, false)
-
 	for _, b := range chain {
+		bs.StoreRuntime(b.Hash(), nil)
 		bs.SetFinalisedHash(b.Hash(), 1, 0)
 	}
 
@@ -106,6 +106,9 @@ func TestFinalizedChannel_Multi(t *testing.T) {
 	}
 
 	chain, _ := AddBlocksToState(t, bs, 1, false)
+	for _, header := range chain {
+		bs.StoreRuntime(header.Hash(), nil)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(num)

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -302,6 +302,7 @@ func TestGetAllDescendants(t *testing.T) {
 	}
 	err = bs.AddBlockWithArrivalTime(block2, time.Now())
 	require.NoError(t, err)
+	bs.StoreRuntime(block2.Header.Hash(), nil)
 
 	err = bs.SetFinalisedHash(block2.Header.Hash(), 1, 1)
 	require.NoError(t, err)
@@ -446,7 +447,10 @@ func TestAddBlock_BlockNumberToHash(t *testing.T) {
 
 func TestFinalization_DeleteBlock(t *testing.T) {
 	bs := newTestBlockState(t, newTriesEmpty())
-	AddBlocksToState(t, bs, 5, false)
+	chain, _ := AddBlocksToState(t, bs, 5, false)
+	for _, header := range chain {
+		bs.StoreRuntime(header.Hash(), nil)
+	}
 
 	btBefore := bs.bt.DeepCopy()
 	before := bs.bt.GetAllBlocks()
@@ -701,6 +705,8 @@ func TestNumberIsFinalised(t *testing.T) {
 		Header: header2,
 		Body:   types.Body{},
 	})
+	bs.StoreRuntime(header2.Hash(), nil)
+
 	require.NoError(t, err)
 	err = bs.SetFinalisedHash(header2.Hash(), 1, 1)
 	require.NoError(t, err)
@@ -1032,6 +1038,7 @@ func TestRange(t *testing.T) {
 				}
 
 				err := blockState.AddBlock(block)
+				blockState.StoreRuntime(block.Header.Hash(), nil)
 				require.NoError(t, err)
 
 				hashesCreated = append(hashesCreated, currentHeader.Hash())

--- a/dot/state/service_integration_test.go
+++ b/dot/state/service_integration_test.go
@@ -146,9 +146,10 @@ func TestService_BlockTree(t *testing.T) {
 
 	// add blocks to state
 	AddBlocksToState(t, stateA.Block, 10, false)
-	head := stateA.Block.BestBlockHash()
+	bestBlockHash := stateA.Block.BestBlockHash()
+	stateA.Block.StoreRuntime(bestBlockHash, nil)
 
-	err = stateA.Block.SetFinalisedHash(head, 1, 1)
+	err = stateA.Block.SetFinalisedHash(bestBlockHash, 1, 1)
 	require.NoError(t, err)
 
 	err = stateA.Stop()
@@ -294,6 +295,7 @@ func TestService_PruneStorage(t *testing.T) {
 	}
 
 	// finalise a block
+	serv.Block.StoreRuntime(toFinalize, nil)
 	serv.Block.SetFinalisedHash(toFinalize, 0, 0)
 
 	time.Sleep(1 * time.Second)
@@ -337,8 +339,9 @@ func TestService_Rewind(t *testing.T) {
 	require.NoError(t, err)
 
 	AddBlocksToState(t, serv.Block, 12, false)
-	head := serv.Block.BestBlockHash()
-	err = serv.Block.SetFinalisedHash(head, 0, 0)
+	bestBlockHash := serv.Block.BestBlockHash()
+	serv.Block.StoreRuntime(bestBlockHash, nil)
+	err = serv.Block.SetFinalisedHash(bestBlockHash, 0, 0)
 	require.NoError(t, err)
 
 	err = serv.Rewind(6)

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -640,6 +640,7 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 			fmt.Sprint(forkBobLastHeader.Number),
 		),
 	)
+	stateService.Block.StoreRuntime(forkBobLastHeader.Hash(), nil)
 	err = stateService.Block.SetFinalisedHash(forkBobLastHeader.Hash(), 1, 1)
 	require.NoError(t, err)
 

--- a/lib/grandpa/message_handler_integration_test.go
+++ b/lib/grandpa/message_handler_integration_test.go
@@ -476,6 +476,7 @@ func TestMessageHandler_CatchUpRequest_WithResponse(t *testing.T) {
 	err = st.Block.AddBlock(block)
 	require.NoError(t, err)
 
+	gs.blockState.(*state.BlockState).StoreRuntime(testGenesisHeader.Hash(), nil)
 	err = gs.blockState.SetFinalisedHash(testGenesisHeader.Hash(), round, setID)
 	require.NoError(t, err)
 	err = gs.blockState.(*state.BlockState).SetHeader(&block.Header)
@@ -997,6 +998,7 @@ func TestMessageHandler_VerifyBlockJustification_ErrFinalisedBlockMismatch(t *te
 	round := uint64(1)
 	number := uint32(1)
 
+	st.Block.StoreRuntime(block.Header.Hash(), nil)
 	err = st.Block.SetFinalisedHash(block.Header.Hash(), round, setID)
 	require.NoError(t, err)
 

--- a/lib/grandpa/message_integration_test.go
+++ b/lib/grandpa/message_integration_test.go
@@ -180,6 +180,7 @@ func TestNewCatchUpResponse(t *testing.T) {
 	err = st.Block.AddBlock(block)
 	require.NoError(t, err)
 
+	st.Block.StoreRuntime(hash, nil)
 	err = gs.blockState.SetFinalisedHash(hash, round, setID)
 	require.NoError(t, err)
 	err = gs.blockState.(*state.BlockState).SetHeader(testHeader)


### PR DESCRIPTION
## Changes

- The test `TestHandler_GrandpaForcedChange` was not initializing/storing any runtime in the `blocktree.runtimes` field, so when the function `onFinalisation` is called it panics since there is no entry for the given block hash

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -timeout 10m -run ^TestHandler_GrandpaScheduledChange$ github.com/ChainSafe/gossamer/dot/digest --tags=integration -v
```

## Issues

N/A

## Primary Reviewer

@qdm12 
