### PR TITLE
chore(babe): fix skipped integration tests and remove unneeded test helper

### DIFF
--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -211,13 +211,13 @@ func TestService_HandleSlotWithSameSlot(t *testing.T) {
 	const authorityIndex = 0
 
 	bestBlockHash := babeService.blockState.BestBlockHash()
-	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
+	runtime, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
 	require.NoError(t, err)
 
-	slot := getSlot(t, rt, time.Unix(6, 0))
+	slot := getSlot(t, runtime, time.Unix(6, 0))
 	preRuntimeDigest, err := claimSlot(testEpochIndex, slot.number, epochData, babeService.keypair)
 	require.NoError(t, err)
 
@@ -229,7 +229,7 @@ func TestService_HandleSlotWithSameSlot(t *testing.T) {
 		preRuntimeDigest,
 	)
 
-	block, err := builder.buildBlock(&genesisHeader, slot, rt)
+	block, err := builder.buildBlock(&genesisHeader, slot, runtime)
 	require.NoError(t, err)
 
 	// Create new non authority service

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -6,7 +6,6 @@
 package babe
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -197,81 +196,6 @@ func TestService_HandleSlotWithLaggingSlot(t *testing.T) {
 		duration: babeService.constants.slotDuration * time.Millisecond,
 		number:   bestBlockSlotNum - 1,
 	}
-	err = babeService.handleSlot(
-		babeService.epochHandler.epochNumber,
-		slot,
-		babeService.epochHandler.epochData.authorityIndex,
-		preRuntimeDigest)
-
-	require.ErrorIs(t, err, errLaggingSlot)
-}
-
-func TestService_HandleSlotWithLaggingSlotBelow(t *testing.T) {
-	cfg := ServiceConfig{
-		Authority: true,
-		Lead:      true,
-	}
-
-	genesis, genesisTrie, genesisHeader := newWestendDevGenesisWithTrieAndHeader(t)
-	babeService := createTestService(t, cfg, genesis, genesisTrie, genesisHeader, nil)
-
-	err := babeService.Start()
-	require.NoError(t, err)
-	defer func() {
-		err = babeService.Stop()
-		require.NoError(t, err)
-	}()
-
-	parentHash := babeService.blockState.GenesisHash()
-	bestBlockHash := babeService.blockState.BestBlockHash()
-	rt, err := babeService.blockState.GetRuntime(bestBlockHash)
-	require.NoError(t, err)
-
-	bestBlockHeader, err := babeService.blockState.GetHeader(bestBlockHash)
-	require.NoError(t, err)
-
-	epochData, err := babeService.initiateEpoch(testEpochIndex)
-	require.NoError(t, err)
-
-	timestamp := time.Unix(6, 0)
-	slot := getSlot(t, rt, timestamp)
-	ext := runtime.NewTestExtrinsic(t, rt, parentHash, parentHash, 0, signature.TestKeyringPairAlice,
-		"System.remark", []byte{0xab, 0xcd})
-	block := createTestBlockWithSlot(t, babeService, bestBlockHeader, [][]byte{common.MustHexToBytes(ext)},
-		testEpochIndex, epochData, slot)
-
-	err = babeService.blockState.AddBlock(block)
-	require.NoError(t, err)
-	time.Sleep(babeService.constants.slotDuration)
-
-	header, err := babeService.blockState.BestBlockHeader()
-	require.NoError(t, err)
-
-	bestBlockSlotNum, err := babeService.blockState.GetSlotForBlock(header.Hash())
-	require.NoError(t, err)
-
-	fmt.Println(bestBlockSlotNum)
-
-	//slotnum := uint64(1)
-	slot = Slot{
-		start:    time.Now(),
-		duration: babeService.constants.slotDuration * time.Millisecond,
-		number:   bestBlockSlotNum,
-	}
-	preRuntimeDigest, err := types.NewBabePrimaryPreDigest(
-		0, slot.number,
-		[sr25519.VRFOutputLength]byte{},
-		[sr25519.VRFProofLength]byte{},
-	).ToPreRuntimeDigest()
-
-	require.NoError(t, err)
-
-	//slot = Slot{
-	//	start:    time.Now(),
-	//	duration: babeService.constants.slotDuration * time.Millisecond,
-	//	number:   bestBlockSlotNum,
-	//}
-	slot = getSlot(t, rt, time.Now())
 	err = babeService.handleSlot(
 		babeService.epochHandler.epochNumber,
 		slot,

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -342,13 +342,9 @@ func TestVerificationManager_VerifyBlock_InvalidBlockAuthority(t *testing.T) {
 		Randomness:         [32]byte{},
 		SecondarySlots:     0,
 	}
-	serviceConfig := ServiceConfig{
-		Keypair: keyring.Bob().(*sr25519.Keypair),
-	}
-
 	genesisBob, genesisTrieBob, genesisHeaderBob := newWestendDevGenesisWithTrieAndHeader(t)
-	babeServiceBob := createTestService(t, serviceConfig, genesisBob, genesisTrieBob, genesisHeaderBob, babeConfig)
-	vm := NewVerificationManager(babeServiceBob.blockState, babeServiceBob.epochState)
+	babeServiceBob := createTestService(t, ServiceConfig{}, genesisBob, genesisTrieBob, genesisHeaderBob, babeConfig)
+	verificationManager := NewVerificationManager(babeServiceBob.blockState, babeServiceBob.epochState)
 
 	bestBlockHash := babeService.blockState.BestBlockHash()
 	runtime, err := babeService.blockState.GetRuntime(bestBlockHash)
@@ -360,7 +356,7 @@ func TestVerificationManager_VerifyBlock_InvalidBlockAuthority(t *testing.T) {
 	slot := getSlot(t, runtime, time.Now())
 	block := createTestBlockWithSlot(t, babeServiceBob, &genesisHeader, [][]byte{}, testEpochIndex, epochData, slot)
 
-	err = vm.VerifyBlock(&block.Header)
+	err = verificationManager.VerifyBlock(&block.Header)
 	require.Equal(t, ErrInvalidBlockProducerIndex, errors.Unwrap(err))
 }
 

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -25,49 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestVerificationManager(t *testing.T, genCfg *types.BabeConfiguration) *VerificationManager {
-	testDatadirPath := t.TempDir()
-
-	ctrl := gomock.NewController(t)
-	telemetryMock := NewMockTelemetry(ctrl)
-	telemetryMock.EXPECT().SendMessage(gomock.Any()).AnyTimes()
-
-	config := state.Config{
-		Path:      testDatadirPath,
-		LogLevel:  log.Info,
-		Telemetry: telemetryMock,
-	}
-
-	dbSrv := state.NewService(config)
-	dbSrv.UseMemDB()
-
-	genesis, genesisTrie, genesisHeader := newWestendDevGenesisWithTrieAndHeader(t)
-	err := dbSrv.Initialise(&genesis, &genesisHeader, &genesisTrie)
-	require.NoError(t, err)
-
-	err = dbSrv.Start()
-	require.NoError(t, err)
-
-	if genCfg == nil {
-		genCfg = &types.BabeConfiguration{
-			SlotDuration:       2000,
-			EpochLength:        200,
-			C1:                 1,
-			C2:                 4,
-			GenesisAuthorities: []types.AuthorityRaw{},
-			Randomness:         [32]byte{},
-			SecondarySlots:     0,
-		}
-	}
-
-	dbSrv.Epoch, err = state.NewEpochStateFromGenesis(dbSrv.DB(), dbSrv.Block, genCfg)
-	require.NoError(t, err)
-
-	logger.Patch(log.SetLevel(defaultTestLogLvl))
-
-	return NewVerificationManager(dbSrv.Block, dbSrv.Epoch)
-}
-
 func TestVerificationManager_OnDisabled_InvalidIndex(t *testing.T) {
 	genesis, genesisTrie, genesisHeader := newWestendDevGenesisWithTrieAndHeader(t)
 	babeService := createTestService(t, ServiceConfig{}, genesis, genesisTrie, genesisHeader, nil)
@@ -372,30 +329,36 @@ func TestVerificationManager_VerifyBlock_InvalidBlockOverThreshold(t *testing.T)
 }
 
 func TestVerificationManager_VerifyBlock_InvalidBlockAuthority(t *testing.T) {
-	serviceConfig := ServiceConfig{
-		Authority: true,
-	}
 	genesis, genesisTrie, genesisHeader := newWestendDevGenesisWithTrieAndHeader(t)
-	babeService := createTestService(t, serviceConfig, genesis, genesisTrie, genesisHeader, nil)
+	babeService := createTestService(t, ServiceConfig{}, genesis, genesisTrie, genesisHeader, nil)
+
+	// Create service with no authorities
+	babeConfig := &types.BabeConfiguration{
+		SlotDuration:       6000,
+		EpochLength:        600,
+		C1:                 1,
+		C2:                 1,
+		GenesisAuthorities: nil,
+		Randomness:         [32]byte{},
+		SecondarySlots:     0,
+	}
+	serviceConfig := ServiceConfig{
+		Keypair: keyring.Bob().(*sr25519.Keypair),
+	}
+
+	genesisBob, genesisTrieBob, genesisHeaderBob := newWestendDevGenesisWithTrieAndHeader(t)
+	babeServiceBob := createTestService(t, serviceConfig, genesisBob, genesisTrieBob, genesisHeaderBob, babeConfig)
+	vm := NewVerificationManager(babeServiceBob.blockState, babeServiceBob.epochState)
 
 	bestBlockHash := babeService.blockState.BestBlockHash()
 	runtime, err := babeService.blockState.GetRuntime(bestBlockHash)
 	require.NoError(t, err)
 
-	cfg, err := runtime.BabeConfiguration()
-	require.NoError(t, err)
-
-	cfg.C1 = 1
-	cfg.C2 = 1
-	cfg.GenesisAuthorities = []types.AuthorityRaw{}
-
-	vm := newTestVerificationManager(t, cfg)
-
 	epochData, err := babeService.initiateEpoch(testEpochIndex)
 	require.NoError(t, err)
 
 	slot := getSlot(t, runtime, time.Now())
-	block := createTestBlockWithSlot(t, babeService, &genesisHeader, [][]byte{}, testEpochIndex, epochData, slot)
+	block := createTestBlockWithSlot(t, babeServiceBob, &genesisHeader, [][]byte{}, testEpochIndex, epochData, slot)
 
 	err = vm.VerifyBlock(&block.Header)
 	require.Equal(t, ErrInvalidBlockProducerIndex, errors.Unwrap(err))


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Fixed TestService_HandleSlotWithSameSlot and rewrote TestService_HandleSlotWithLaggingSlot
- Removed newVerificationManagerHelper as it was not necessary

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./lib/babe --tags=integration
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
#3060

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@EclesioMeloJunior 
