### PR TITLE
fix(lib/babe): `TestCalculateThreshold` failing locally

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,6 +22,10 @@ jobs:
     timeout-minutes: 60
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
+      - name: uname -a
+        run: |
+          uname -a
+
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
         with:

--- a/lib/babe/crypto.go
+++ b/lib/babe/crypto.go
@@ -163,11 +163,14 @@ func CalculateThreshold(C1, C2 uint64, numAuths int) (*scale.Uint128, error) {
 
 	// 1 << 128
 	shift := new(big.Int).Lsh(big.NewInt(1), 128)
+	fmt.Printf("=====> shift %d\n", len(shift.Bytes()))
+
 	numer := new(big.Int).Mul(shift, pRat.Num())
 	denom := pRat.Denom()
 
 	// (1 << 128) * (1 - (1-c)^(w_k/sum(w_i)))
 	thresholdBig := new(big.Int).Div(numer, denom)
+	fmt.Printf("=====> thresholdBig %d\n", len(thresholdBig.Bytes()))
 
 	// special case where threshold is maximum
 	if thresholdBig.Cmp(shift) == 0 {
@@ -177,6 +180,8 @@ func CalculateThreshold(C1, C2 uint64, numAuths int) (*scale.Uint128, error) {
 	if len(thresholdBig.Bytes()) > 16 {
 		return nil, errors.New("threshold must be under or equal to 16 bytes")
 	}
+
+	fmt.Printf("=====> value %d\n", thresholdBig)
 
 	return scale.NewUint128(thresholdBig)
 }

--- a/lib/babe/crypto_test.go
+++ b/lib/babe/crypto_test.go
@@ -32,7 +32,7 @@ func TestCalculateThreshold(t *testing.T) {
 				C2:       2,
 				numAuths: 3,
 			},
-			exp: &scale.Uint128{Upper: 0x34d00ad6148e1800, Lower: 0x0},
+			exp: &scale.Uint128{Upper: 0x34d00ad6148e2000, Lower: 0x0},
 		},
 		{
 			name: "0_value_input",


### PR DESCRIPTION
## Changes

- `TestCalculateThreshold` failed locally due to a difference of 1 byte



## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -timeout 10m -run ^TestCalculateThreshold$ github.com/ChainSafe/gossamer/lib/babe --tags=integration -v
```

## Issues

N/A

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kanishkatn @jimjbrettj @dimartiro 
