### PR TITLE
feat(dot/rpc): implement RPC method state_queryStorageAt

### DIFF
--- a/dot/rpc/modules/state_test.go
+++ b/dot/rpc/modules/state_test.go
@@ -936,11 +936,11 @@ func TestStateModuleQueryStorage(t *testing.T) {
 				storageAPIBuilder: func(ctrl *gomock.Controller) StorageAPI {
 					mockStorageAPI := NewMockStorageAPI(ctrl)
 					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{1}, []byte{1, 2, 4}).
-						Return([]byte{}, nil)
-					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{1, 2, 4}).
 						Return([]byte{1, 1, 1}, nil)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{1, 2, 4}).
+						Return([]byte(nil), nil)
 					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{3}, []byte{1, 2, 4}).
-						Return([]byte{2, 2, 2}, nil)
+						Return([]byte{}, nil)
 					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{4}, []byte{1, 2, 4}).
 						Return([]byte{3, 3, 3}, nil)
 					return mockStorageAPI
@@ -968,19 +968,19 @@ func TestStateModuleQueryStorage(t *testing.T) {
 				{
 					Block: &common.Hash{1},
 					Changes: [][2]*string{
-						{stringPtr("0x010204"), nil},
+						makeChange("0x010204", "0x010101"),
 					},
 				},
 				{
 					Block: &common.Hash{2},
 					Changes: [][2]*string{
-						makeChange("0x010204", "0x010101"),
+						{stringPtr("0x010204"), nil},
 					},
 				},
 				{
 					Block: &common.Hash{3},
 					Changes: [][2]*string{
-						makeChange("0x010204", "0x020202"),
+						makeChange("0x010204", "0x"),
 					},
 				},
 				{
@@ -1126,6 +1126,142 @@ func TestStateModuleQueryStorage(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.exp, res)
+		})
+	}
+}
+func TestStateModuleQueryStorageAt(t *testing.T) {
+	t.Parallel()
+	errTest := errors.New("test error")
+
+	type fields struct {
+		storageAPIBuilder func(ctrl *gomock.Controller) *MockStorageAPI
+		blockAPIBuilder   func(ctrl *gomock.Controller) *MockBlockAPI
+	}
+
+	tests := map[string]struct {
+		fields           fields
+		request          *StateStorageQueryAtRequest
+		expectedError    error
+		expectedResponse []StorageChangeSetResponse
+	}{
+		"missing_start_block": {
+			fields: fields{
+				storageAPIBuilder: func(ctrl *gomock.Controller) *MockStorageAPI {
+					mockStorageAPI := NewMockStorageAPI(ctrl)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{1, 2, 3}).
+						Return([]byte{1, 1, 1}, nil)
+					return mockStorageAPI
+				},
+				blockAPIBuilder: func(ctrl *gomock.Controller) *MockBlockAPI {
+					mockBlockAPI := NewMockBlockAPI(ctrl)
+					mockBlockAPI.EXPECT().BestBlockHash().Return(common.Hash{2})
+					return mockBlockAPI
+				}},
+			request: &StateStorageQueryAtRequest{
+				Keys: []string{"0x010203"},
+			},
+			expectedResponse: []StorageChangeSetResponse{
+				{
+					Block: &common.Hash{2},
+					Changes: [][2]*string{
+						makeChange("0x010203", "0x010101"),
+					},
+				},
+			},
+		},
+		"start_block_not_found_error": {
+			fields: fields{
+				storageAPIBuilder: func(ctrl *gomock.Controller) *MockStorageAPI {
+					mockStorageAPI := NewMockStorageAPI(ctrl)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{1}, []byte{1, 2, 3}).Return(nil, errTest)
+					return mockStorageAPI
+				},
+				blockAPIBuilder: func(ctrl *gomock.Controller) *MockBlockAPI {
+					return NewMockBlockAPI(ctrl)
+				}},
+			request: &StateStorageQueryAtRequest{
+				Keys: []string{"0x010203"},
+				At:   common.Hash{1},
+			},
+			expectedResponse: []StorageChangeSetResponse{},
+			expectedError:    errors.New("getting value by block hash: test error"),
+		},
+		"start_block/multi_keys": {
+			fields: fields{
+				storageAPIBuilder: func(ctrl *gomock.Controller) *MockStorageAPI {
+					mockStorageAPI := NewMockStorageAPI(ctrl)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{8, 8, 8}).
+						Return([]byte{8, 8, 8, 8}, nil)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{1, 2, 4}).
+						Return([]byte{}, nil)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{9, 9, 9}).
+						Return([]byte(nil), nil)
+					return mockStorageAPI
+				},
+				blockAPIBuilder: func(ctrl *gomock.Controller) *MockBlockAPI {
+					return NewMockBlockAPI(ctrl)
+				}},
+			request: &StateStorageQueryAtRequest{
+				Keys: []string{"0x080808", "0x010204", "0x090909"},
+				At:   common.Hash{2},
+			},
+			expectedResponse: []StorageChangeSetResponse{
+				{
+					Block: &common.Hash{2},
+					Changes: [][2]*string{
+						makeChange("0x080808", "0x08080808"),
+						makeChange("0x010204", "0x"),
+						{stringPtr("0x090909"), nil},
+					},
+				},
+			},
+		},
+		"missing_start_block/multi_keys": {
+			fields: fields{
+				storageAPIBuilder: func(ctrl *gomock.Controller) *MockStorageAPI {
+					mockStorageAPI := NewMockStorageAPI(ctrl)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{1, 2, 4}).
+						Return([]byte{1, 1, 1}, nil)
+					mockStorageAPI.EXPECT().GetStorageByBlockHash(&common.Hash{2}, []byte{9, 9, 9}).
+						Return([]byte{9, 9, 9, 9}, nil)
+					return mockStorageAPI
+				},
+				blockAPIBuilder: func(ctrl *gomock.Controller) *MockBlockAPI {
+					mockBlockAPI := NewMockBlockAPI(ctrl)
+					mockBlockAPI.EXPECT().BestBlockHash().Return(common.Hash{2})
+					return mockBlockAPI
+				}},
+			request: &StateStorageQueryAtRequest{
+				Keys: []string{"0x010204", "0x090909"},
+			},
+			expectedResponse: []StorageChangeSetResponse{
+				{
+					Block: &common.Hash{2},
+					Changes: [][2]*string{
+						makeChange("0x010204", "0x010101"),
+						makeChange("0x090909", "0x09090909"),
+					},
+				},
+			},
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			sm := &StateModule{
+				storageAPI: tt.fields.storageAPIBuilder(ctrl),
+				blockAPI:   tt.fields.blockAPIBuilder(ctrl),
+			}
+			response := []StorageChangeSetResponse{}
+			err := sm.QueryStorageAt(nil, tt.request, &response)
+			if tt.expectedError != nil {
+				assert.EqualError(t, err, tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedResponse, response)
 		})
 	}
 }


### PR DESCRIPTION
## Changes
NOTE: This PR replaces PR #3185, which has been replaced because that PR contained code merged from other branches not related to this implementation.  This PR contains all changes related to implementing state_queryStorageAt

- Implement code for RPC method `state_queryStorageAt` which returns storage values for given keys at best block or given block hash if `at` parameter is used.
- This fixes error `rpc: can't find method "state.QueryStorageAt"` that occurs when using polkadot.js/api methods in `api.query` package.


## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/rpc/modules -run ^TestStateModuleQueryStorageAt$ -v
```

## Issues

closes: #3182 

## Primary Reviewer


@timwu20
