### PR TITLE
refactor(cli): Remove babe-lead flag

### DIFF
--- a/chain/westend-local/config-alice.toml
+++ b/chain/westend-local/config-alice.toml
@@ -25,7 +25,6 @@ unlock = ""
 roles = 4
 babe-authority = true
 grandpa-authority = true
-babe-lead = true
 
 [network]
 port = 7001

--- a/cmd/gossamer/config.go
+++ b/cmd/gossamer/config.go
@@ -605,11 +605,6 @@ func setDotCoreConfig(ctx *cli.Context, tomlCfg ctoml.CoreConfig, cfg *dot.CoreC
 	cfg.GrandpaAuthority = common.Roles(tomlCfg.Roles) == common.AuthorityRole
 	cfg.GrandpaInterval = time.Second * time.Duration(tomlCfg.GrandpaInterval)
 
-	cfg.BABELead = tomlCfg.BABELead
-	if ctx.IsSet(BABELeadFlag.Name) {
-		cfg.BABELead = ctx.Bool(BABELeadFlag.Name)
-	}
-
 	// check --roles flag and update node configuration
 	if roles := ctx.String(RolesFlag.Name); roles != "" {
 		// convert string to byte

--- a/cmd/gossamer/flags.go
+++ b/cmd/gossamer/flags.go
@@ -385,10 +385,6 @@ var (
 
 // BABE flags
 var (
-	BABELeadFlag = cli.BoolFlag{
-		Name:  "babe-lead",
-		Usage: `specify whether node should build block 1 of the network. only used when starting a new network`,
-	}
 	ValidatorFlag = cli.BoolFlag{
 		Name: "validator", // TODO(ed) implement
 	}
@@ -461,7 +457,6 @@ var (
 		&TelemetryURLFlag,
 
 		// BABE flags
-		&BABELeadFlag,
 		&ValidatorFlag,
 	}
 )

--- a/devnet/README.md
+++ b/devnet/README.md
@@ -43,7 +43,7 @@ export $DD_API_KEY=YourKey
 
 There are four Docker files used in the devnet.  
 
-- `alice.Dockerfile` is the lead node and is initiated with the `babe-lead` flag to build the first block.  
+- `alice.Dockerfile` is the lead node.  
 - `bob.Dockerfile` is used for both `bob` and `charlie` and shares the same genesis as alice docker file.
 - `substrate_alice.Dockerfile` is the alice node initiated with explicit node key to keep a deterministic peer id (the same used by gossamer alice node)
 - `substrate_bob.Dockerfile` is used for `bob` and `charlie` and shares the same genesis as alice docker file.

--- a/devnet/alice.Dockerfile
+++ b/devnet/alice.Dockerfile
@@ -35,6 +35,6 @@ RUN go run cmd/update-dd-agent-confd/main.go -n=${METRICS_NAMESPACE} -t=key:alic
 
 WORKDIR /gossamer
 
-ENTRYPOINT service datadog-agent start && gossamer --key=alice --babe-lead --publish-metrics  --metrics-address=":9876" --rpc --rpc-external=true --pubdns=alice --port 7001
+ENTRYPOINT service datadog-agent start && gossamer --key=alice --publish-metrics  --metrics-address=":9876" --rpc --rpc-external=true --pubdns=alice --port 7001
 
 EXPOSE 7001/tcp 8545/tcp 8546/tcp 8540/tcp 9876/tcp 6060/tcp

--- a/dot/config.go
+++ b/dot/config.go
@@ -111,7 +111,6 @@ type NetworkConfig struct {
 type CoreConfig struct {
 	Roles            common.Roles
 	BabeAuthority    bool
-	BABELead         bool
 	GrandpaAuthority bool
 	WasmInterpreter  string
 	GrandpaInterval  time.Duration

--- a/dot/config/toml/config.go
+++ b/dot/config/toml/config.go
@@ -77,7 +77,6 @@ type CoreConfig struct {
 	EpochLength      uint64 `toml:"epoch-length,omitempty"`
 	WasmInterpreter  string `toml:"wasm-interpreter,omitempty"`
 	GrandpaInterval  uint32 `toml:"grandpa-interval,omitempty"`
-	BABELead         bool   `toml:"babe-lead,omitempty"`
 }
 
 // StateConfig contains the configuration for the state.

--- a/dot/services.go
+++ b/dot/services.go
@@ -214,7 +214,6 @@ func (nodeBuilder) createBABEServiceWithBuilder(cfg *Config, st *state.Service, 
 		BlockImportHandler: cs,
 		Authority:          cfg.Core.BabeAuthority,
 		IsDev:              cfg.Global.ID == "dev",
-		Lead:               cfg.Core.BABELead,
 		Telemetry:          telemetryMailer,
 	}
 

--- a/dot/utils_test.go
+++ b/dot/utils_test.go
@@ -120,7 +120,6 @@ func TestNewTestConfig(t *testing.T) {
 				Core: CoreConfig{
 					Roles:            4,
 					BabeAuthority:    true,
-					BABELead:         false,
 					GrandpaAuthority: true,
 					WasmInterpreter:  "wasmer",
 					GrandpaInterval:  1000000000,

--- a/lib/babe/babe.go
+++ b/lib/babe/babe.go
@@ -23,14 +23,10 @@ var logger = log.NewFromGlobal(log.AddContext("pkg", "babe"))
 
 // Service contains the VRF keys for the validator, as well as BABE configuation data
 type Service struct {
-	ctx       context.Context
-	cancel    context.CancelFunc
-	authority bool
-	dev       bool
-	// lead is used when setting up a new network from genesis.
-	// the "lead" node is the node that is designated to build block 1, after which the rest of the nodes
-	// will sync block 1 and determine the first slot of the network based on it
-	lead         bool
+	ctx          context.Context
+	cancel       context.CancelFunc
+	authority    bool
+	dev          bool
 	constants    constants
 	epochHandler *epochHandler
 
@@ -64,7 +60,6 @@ type ServiceConfig struct {
 	AuthData           []types.Authority
 	IsDev              bool
 	Authority          bool
-	Lead               bool
 	Telemetry          Telemetry
 }
 
@@ -112,7 +107,6 @@ func (Builder) NewServiceIFace(cfg *ServiceConfig) (service *Service, err error)
 		authority:          cfg.Authority,
 		dev:                cfg.IsDev,
 		blockImportHandler: cfg.BlockImportHandler,
-		lead:               cfg.Lead,
 		constants: constants{
 			slotDuration: slotDuration,
 			epochLength:  epochLength,
@@ -160,7 +154,6 @@ func NewService(cfg *ServiceConfig) (*Service, error) {
 		authority:          cfg.Authority,
 		dev:                cfg.IsDev,
 		blockImportHandler: cfg.BlockImportHandler,
-		lead:               cfg.Lead,
 		constants: constants{
 			slotDuration: slotDuration,
 			epochLength:  epochLength,

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -41,7 +41,6 @@ func TestService_ProducesBlocks(t *testing.T) {
 		Return(nil).MinTimes(2)
 	cfg := ServiceConfig{
 		Authority:          true,
-		Lead:               true,
 		BlockImportHandler: blockImportHandler,
 	}
 
@@ -90,9 +89,7 @@ func TestService_GetAuthorityIndex(t *testing.T) {
 }
 
 func TestStartAndStop(t *testing.T) {
-	cfg := ServiceConfig{
-		Lead: true,
-	}
+	cfg := ServiceConfig{}
 	gen, genTrie, genHeader := newWestendLocalGenesisWithTrieAndHeader(t)
 	bs := createTestService(t, cfg, gen, genTrie, genHeader, nil)
 	err := bs.Start()
@@ -102,9 +99,7 @@ func TestStartAndStop(t *testing.T) {
 }
 
 func TestService_PauseAndResume(t *testing.T) {
-	cfg := ServiceConfig{
-		Lead: true,
-	}
+	cfg := ServiceConfig{}
 	genesis, genesisTrie, genesisHeader := newWestendLocalGenesisWithTrieAndHeader(t)
 	babeService := createTestService(t, cfg, genesis, genesisTrie, genesisHeader, nil)
 	err := babeService.Start()
@@ -136,7 +131,6 @@ func TestService_PauseAndResume(t *testing.T) {
 func TestService_HandleSlotWithLaggingSlot(t *testing.T) {
 	cfg := ServiceConfig{
 		Authority: true,
-		Lead:      true,
 	}
 
 	genesis, genesisTrie, genesisHeader := newWestendDevGenesisWithTrieAndHeader(t)

--- a/lib/babe/errors.go
+++ b/lib/babe/errors.go
@@ -65,8 +65,6 @@ var (
 
 	errNilParentHeader            = errors.New("parent header is nil")
 	errInvalidResult              = errors.New("invalid error value")
-	errFirstBlockTimeout          = errors.New("timed out waiting for first block")
-	errChannelClosed              = errors.New("block notifier channel was closed")
 	errOverPrimarySlotThreshold   = errors.New("cannot claim slot, over primary threshold")
 	errNotOurTurnToPropose        = errors.New("cannot claim slot, not our turn to propose a block")
 	errMissingDigestItems         = errors.New("block header is missing digest items")

--- a/tests/polkadotjs_test/start_polkadotjs_test.go
+++ b/tests/polkadotjs_test/start_polkadotjs_test.go
@@ -47,7 +47,6 @@ func TestStartGossamerAndPolkadotAPI(t *testing.T) {
 
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = libutils.GetWestendLocalRawGenesisPath(t)
-	tomlConfig.Core.BABELead = true
 	tomlConfig.RPC.WS = true
 	tomlConfig.RPC.Unsafe = true
 	tomlConfig.RPC.WSUnsafe = true

--- a/tests/rpc/rpc_02-author_test.go
+++ b/tests/rpc/rpc_02-author_test.go
@@ -29,7 +29,6 @@ func TestAuthorSubmitExtrinsic(t *testing.T) {
 	tomlConfig := config.Default()
 	tomlConfig.Account.Key = "alice"
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -100,7 +99,6 @@ func TestAuthorRPC(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)

--- a/tests/rpc/rpc_03-chain_test.go
+++ b/tests/rpc/rpc_03-chain_test.go
@@ -33,7 +33,6 @@ func TestChainRPC(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -138,7 +137,6 @@ func TestChainSubscriptionRPC(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	tomlConfig.RPC.WS = true // WS port is set in the node.New constructor
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tests/rpc/rpc_04-offchain_test.go
+++ b/tests/rpc/rpc_04-offchain_test.go
@@ -17,7 +17,6 @@ func TestOffchainRPC(t *testing.T) { //nolint:tparallel
 
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
-	tomlConfig.Core.BABELead = true
 	tomlConfig.Init.Genesis = genesisPath
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tests/rpc/rpc_05-state_test.go
+++ b/tests/rpc/rpc_05-state_test.go
@@ -22,7 +22,6 @@ func TestStateRPCResponseValidation(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)
@@ -165,7 +164,6 @@ func TestStateRPCAPI(t *testing.T) {
 	genesisPath := libutils.GetWestendLocalRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)
@@ -367,7 +365,6 @@ func TestStateRPCAPI(t *testing.T) {
 func TestRPCStructParamUnmarshal(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
-	tomlConfig.Core.BABELead = true
 	tomlConfig.Init.Genesis = genesisPath
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/tests/rpc/rpc_06-engine_test.go
+++ b/tests/rpc/rpc_06-engine_test.go
@@ -18,7 +18,6 @@ func TestEngineRPC(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)

--- a/tests/rpc/rpc_07-payment_test.go
+++ b/tests/rpc/rpc_07-payment_test.go
@@ -18,7 +18,6 @@ func TestPaymentRPC(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)

--- a/tests/rpc/rpc_08-contracts_test.go
+++ b/tests/rpc/rpc_08-contracts_test.go
@@ -18,7 +18,6 @@ func TestContractsRPC(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)

--- a/tests/rpc/rpc_09-babe_test.go
+++ b/tests/rpc/rpc_09-babe_test.go
@@ -18,7 +18,6 @@ func TestBabeRPC(t *testing.T) { //nolint:tparallel
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
 	tomlConfig.Init.Genesis = genesisPath
-	tomlConfig.Core.BABELead = true
 	node := node.New(t, tomlConfig)
 	ctx, cancel := context.WithCancel(context.Background())
 	node.InitAndStartTest(ctx, t, cancel)

--- a/tests/stress/grandpa_test.go
+++ b/tests/stress/grandpa_test.go
@@ -20,7 +20,6 @@ import (
 func TestStress_Grandpa_OneAuthority(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	tomlConfig := config.Default()
-	tomlConfig.Core.BABELead = true
 	tomlConfig.Init.Genesis = genesisPath
 	n := node.New(t, tomlConfig)
 

--- a/tests/stress/stress_test.go
+++ b/tests/stress/stress_test.go
@@ -106,7 +106,6 @@ func TestSync_SingleBlockProducer(t *testing.T) {
 
 	configNoGrandpa := config.NoGrandpa()
 	configNoGrandpa.Init.Genesis = genesisPath
-	configNoGrandpa.Core.BABELead = true
 	configNoGrandpa.Account.Key = "alice"
 	babeLeadNode := node.New(t, configNoGrandpa, node.SetIndex(numNodes-1))
 
@@ -212,7 +211,6 @@ func TestSync_SingleSyncingNode(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	blockProducingConfig := config.Default()
 	blockProducingConfig.Init.Genesis = genesisPath
-	blockProducingConfig.Core.BABELead = true
 	alice := node.New(t, blockProducingConfig, node.SetIndex(0))
 
 	alice.InitAndStartTest(ctx, t, cancel)
@@ -252,7 +250,6 @@ func TestSync_Bench(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	configNoGrandpa := config.NoGrandpa()
 	configNoGrandpa.Init.Genesis = genesisPath
-	configNoGrandpa.Core.BABELead = true
 
 	alice := node.New(t, configNoGrandpa, node.SetIndex(0))
 
@@ -284,7 +281,6 @@ func TestSync_Bench(t *testing.T) {
 	// start syncing node
 	configNoAuthority := config.NotAuthority()
 	configNoAuthority.Init.Genesis = genesisPath
-	configNoAuthority.Core.BABELead = true
 	bob := node.New(t, configNoAuthority, node.SetIndex(1))
 
 	bob.InitAndStartTest(ctx, t, cancel)
@@ -362,7 +358,6 @@ func TestSync_Restart(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	blockProducingConfig := config.Default()
 	blockProducingConfig.Init.Genesis = genesisPath
-	blockProducingConfig.Core.BABELead = true
 	producingNode := node.New(t, blockProducingConfig, node.SetIndex(numNodes-1))
 
 	err := producingNode.Init(mainCtx)
@@ -456,7 +451,6 @@ func TestSync_SubmitExtrinsic(t *testing.T) {
 	genesisPath := libutils.GetWestendDevRawGenesisPath(t)
 	configNoGrandpa := config.NoGrandpa()
 	configNoGrandpa.Init.Genesis = genesisPath
-	configNoGrandpa.Core.BABELead = true
 	producingNode := node.New(t, configNoGrandpa, node.SetIndex(0))
 	producingNode.InitAndStartTest(ctx, t, cancel)
 
@@ -628,7 +622,6 @@ func Test_SubmitAndWatchExtrinsic(t *testing.T) {
 	tomlConfig := config.NoGrandpa()
 	tomlConfig.Init.Genesis = genesisPath
 	tomlConfig.RPC.WS = true
-	tomlConfig.Core.BABELead = true
 	producingNode := node.New(t, tomlConfig, node.SetIndex(0))
 	ctx, cancel := context.WithCancel(context.Background())
 	producingNode.InitAndStartTest(ctx, t, cancel)

--- a/tests/utils/config/config.go
+++ b/tests/utils/config/config.go
@@ -36,7 +36,6 @@ func NoBabe() (cfg toml.Config) {
 func NoGrandpa() (cfg toml.Config) {
 	cfg = Default()
 	cfg.Core.GrandpaAuthority = false
-	cfg.Core.BABELead = true
 	cfg.Core.GrandpaInterval = 1
 	return cfg
 }

--- a/tests/utils/node/node_test.go
+++ b/tests/utils/node/node_test.go
@@ -18,7 +18,6 @@ func Test_Node_InitAndStartTest(t *testing.T) {
 	t.Cleanup(cancel)
 
 	tomlConfig := config.Default()
-	tomlConfig.Core.BABELead = true
 
 	n := New(t, tomlConfig)
 

--- a/tests/utils/node/nodes.go
+++ b/tests/utils/node/nodes.go
@@ -18,14 +18,12 @@ type Nodes []Node
 
 // MakeNodes creates `num` nodes using the `tomlConfig`
 // as a base config for each node. It overrides some of configuration:
-// - the first node is always the BABE lead (overrides the toml configuration)
 // - the index of each node is incremented per node (overrides the SetIndex option, if set)
 func MakeNodes(t *testing.T, num int, tomlConfig toml.Config,
 	options ...Option) (nodes Nodes) {
 	nodes = make(Nodes, num)
 	for i := range nodes {
 		options = append(options, SetIndex(i))
-		tomlConfig.Core.BABELead = i == 0
 		nodes[i] = New(t, tomlConfig, options...)
 	}
 	return nodes


### PR DESCRIPTION
## Changes

- Removes babe-lead flag that prevents a node to create blocks until it receive the first one

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make tests
```

- manual tests running nodes locally checking that all nodes are producing blocks using the same canonical chain
- also tested using zombienet

## Issues

<!-- Write the issue number(s), for example: #123 -->
#3184 

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
