### PR TITLE
fix(babe): Add support for versioned NextConfigData decoding

### DIFF
--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -201,17 +201,26 @@ func (h *Handler) handleBabeConsensusDigest(digest scale.VaryingDataType, header
 	case types.BABEOnDisabled:
 		return nil
 
-	case types.NextConfigData:
-		currEpoch, err := h.epochState.GetEpochForBlock(header)
+	case types.VersionedNextConfigData:
+		nextVersionedConfigData := digestValue.(types.VersionedNextConfigData)
+		nextConfigDataVersion, err := nextVersionedConfigData.Value()
 		if err != nil {
-			return fmt.Errorf("cannot get epoch for block %d (%s): %w",
-				header.Number, headerHash, err)
+			return fmt.Errorf("getting digest value: %w", err)
 		}
 
-		nextEpoch := currEpoch + 1
-		h.epochState.StoreBABENextConfigData(nextEpoch, headerHash, val)
-		h.logger.Debugf("stored BABENextConfigData data: %v for hash: %s to epoch: %d", digest, headerHash, nextEpoch)
-		return nil
+		switch nextConfigData := nextConfigDataVersion.(type) {
+		case types.NextConfigDataV1:
+			currEpoch, err := h.epochState.GetEpochForBlock(header)
+			if err != nil {
+				return fmt.Errorf("cannot get epoch for block %d (%s): %w", header.Number, headerHash, err)
+			}
+			nextEpoch := currEpoch + 1
+			h.epochState.StoreBABENextConfigData(nextEpoch, headerHash, nextConfigData)
+			h.logger.Debugf("stored BABENextConfigData data: %v for hash: %s to epoch: %d", digest, headerHash, nextEpoch)
+			return nil
+		default:
+			return fmt.Errorf("next config data version not supported: %T", nextConfigDataVersion)
+		}
 	}
 
 	return errors.New("invalid consensus digest data")

--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -202,8 +202,7 @@ func (h *Handler) handleBabeConsensusDigest(digest scale.VaryingDataType, header
 		return nil
 
 	case types.VersionedNextConfigData:
-		nextVersionedConfigData := digestValue.(types.VersionedNextConfigData)
-		nextConfigDataVersion, err := nextVersionedConfigData.Value()
+		nextConfigDataVersion, err := val.Value()
 		if err != nil {
 			return fmt.Errorf("getting digest value: %w", err)
 		}

--- a/dot/digest/digest.go
+++ b/dot/digest/digest.go
@@ -189,7 +189,7 @@ func (h *Handler) handleBabeConsensusDigest(digest scale.VaryingDataType, header
 	case types.NextEpochData:
 		currEpoch, err := h.epochState.GetEpochForBlock(header)
 		if err != nil {
-			return fmt.Errorf("cannot get epoch for block %d (%s): %w",
+			return fmt.Errorf("getting epoch for block %d (%s): %w",
 				header.Number, headerHash, err)
 		}
 
@@ -212,7 +212,7 @@ func (h *Handler) handleBabeConsensusDigest(digest scale.VaryingDataType, header
 		case types.NextConfigDataV1:
 			currEpoch, err := h.epochState.GetEpochForBlock(header)
 			if err != nil {
-				return fmt.Errorf("cannot get epoch for block %d (%s): %w", header.Number, headerHash, err)
+				return fmt.Errorf("getting epoch for block %d (%s): %w", header.Number, headerHash, err)
 			}
 			nextEpoch := currEpoch + 1
 			h.epochState.StoreBABENextConfigData(nextEpoch, headerHash, nextConfigData)

--- a/dot/digest/digest_integration_test.go
+++ b/dot/digest/digest_integration_test.go
@@ -387,10 +387,10 @@ func TestHandler_HandleNextConfigData(t *testing.T) {
 		SecondarySlots: 1,
 	}
 
-	VersionedNextConfigData := types.NewVersionedNextConfigData()
-	VersionedNextConfigData.Set(nextConfigData)
+	versionedNextConfigData := types.NewVersionedNextConfigData()
+	versionedNextConfigData.Set(nextConfigData)
 
-	err := digest.Set(VersionedNextConfigData)
+	err := digest.Set(versionedNextConfigData)
 	require.NoError(t, err)
 
 	data, err := scale.Marshal(digest)

--- a/dot/digest/digest_integration_test.go
+++ b/dot/digest/digest_integration_test.go
@@ -381,13 +381,16 @@ func TestHandler_HandleNextEpochData(t *testing.T) {
 
 func TestHandler_HandleNextConfigData(t *testing.T) {
 	var digest = types.NewBabeConsensusDigest()
-	nextConfigData := types.NextConfigData{
+	nextConfigData := types.NextConfigDataV1{
 		C1:             1,
 		C2:             8,
 		SecondarySlots: 1,
 	}
 
-	err := digest.Set(nextConfigData)
+	VersionedNextConfigData := types.NewVersionedNextConfigData()
+	VersionedNextConfigData.Set(nextConfigData)
+
+	err := digest.Set(VersionedNextConfigData)
 	require.NoError(t, err)
 
 	data, err := scale.Marshal(digest)
@@ -428,12 +431,20 @@ func TestHandler_HandleNextConfigData(t *testing.T) {
 
 	digestValue, err := digest.Value()
 	require.NoError(t, err)
-	act, ok := digestValue.(types.NextConfigData)
+	nextVersionedConfigData, ok := digestValue.(types.VersionedNextConfigData)
+	if !ok {
+		t.Fatal()
+	}
+
+	decodedNextConfigData, err := nextVersionedConfigData.Value()
+	require.NoError(t, err)
+
+	decodedNextConfigDataV1, ok := decodedNextConfigData.(types.NextConfigDataV1)
 	if !ok {
 		t.Fatal()
 	}
 
 	stored, err := handler.epochState.(*state.EpochState).GetConfigData(targetEpoch, nil)
 	require.NoError(t, err)
-	require.Equal(t, act.ToConfigData(), stored)
+	require.Equal(t, decodedNextConfigDataV1.ToConfigData(), stored)
 }

--- a/dot/digest/interfaces.go
+++ b/dot/digest/interfaces.go
@@ -23,7 +23,7 @@ type BlockState interface {
 type EpochState interface {
 	GetEpochForBlock(header *types.Header) (uint64, error)
 	StoreBABENextEpochData(epoch uint64, hash common.Hash, nextEpochData types.NextEpochData)
-	StoreBABENextConfigData(epoch uint64, hash common.Hash, nextEpochData types.NextConfigData)
+	StoreBABENextConfigData(epoch uint64, hash common.Hash, nextEpochData types.NextConfigDataV1)
 	FinalizeBABENextEpochData(finalizedHeader *types.Header) error
 	FinalizeBABENextConfigData(finalizedHeader *types.Header) error
 }

--- a/dot/digest/mock_epoch_state_test.go
+++ b/dot/digest/mock_epoch_state_test.go
@@ -79,7 +79,7 @@ func (mr *MockEpochStateMockRecorder) GetEpochForBlock(arg0 interface{}) *gomock
 }
 
 // StoreBABENextConfigData mocks base method.
-func (m *MockEpochState) StoreBABENextConfigData(arg0 uint64, arg1 common.Hash, arg2 types.NextConfigData) {
+func (m *MockEpochState) StoreBABENextConfigData(arg0 uint64, arg1 common.Hash, arg2 types.NextConfigDataV1) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StoreBABENextConfigData", arg0, arg1, arg2)
 }

--- a/dot/state/epoch_test.go
+++ b/dot/state/epoch_test.go
@@ -446,7 +446,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 
 	tests := map[string]struct {
 		finalizedHeader      *types.Header
-		inMemoryEpoch        []inMemoryBABEData[types.NextConfigData]
+		inMemoryEpoch        []inMemoryBABEData[types.NextConfigDataV1]
 		finalizedEpoch       uint64
 		expectErr            error
 		shouldRemainInMemory int
@@ -455,7 +455,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 			shouldRemainInMemory: 1,
 			finalizedEpoch:       2,
 			finalizedHeader:      finalizedHeader,
-			inMemoryEpoch: []inMemoryBABEData[types.NextConfigData]{
+			inMemoryEpoch: []inMemoryBABEData[types.NextConfigDataV1]{
 				{
 					epoch: 1,
 					hashes: []common.Hash{
@@ -463,7 +463,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 						common.MustHexToHash("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"),
 						common.MustHexToHash("0xc0096358534ec8d21d01d34b836eed476a1c343f8724fa2153dc0725ad797a90"),
 					},
-					nextData: []types.NextConfigData{
+					nextData: []types.NextConfigDataV1{
 						{
 							C1:             1,
 							C2:             2,
@@ -488,7 +488,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 						common.MustHexToHash("0xd380bee22de487a707cbda65dd9d4e2188f736908c42cf390c8919d4f7fc547c"),
 						finalizedHeaderHash,
 					},
-					nextData: []types.NextConfigData{
+					nextData: []types.NextConfigDataV1{
 						{
 							C1:             1,
 							C2:             2,
@@ -511,7 +511,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 					hashes: []common.Hash{
 						common.MustHexToHash("0xab5c9230a7dde8bb90a6728ba4a0165423294dac14336b1443f865b796ff682c"),
 					},
-					nextData: []types.NextConfigData{
+					nextData: []types.NextConfigDataV1{
 						{
 							C1:             1,
 							C2:             2,
@@ -526,7 +526,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 			finalizedEpoch:       2,
 			finalizedHeader:      finalizedHeader, // finalize when the hash does not exist
 			expectErr:            errHashNotPersisted,
-			inMemoryEpoch: []inMemoryBABEData[types.NextConfigData]{
+			inMemoryEpoch: []inMemoryBABEData[types.NextConfigDataV1]{
 				{
 					epoch: 2,
 					hashes: []common.Hash{
@@ -534,7 +534,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 						common.MustHexToHash("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"),
 						common.MustHexToHash("0xc0096358534ec8d21d01d34b836eed476a1c343f8724fa2153dc0725ad797a90"),
 					},
-					nextData: []types.NextConfigData{
+					nextData: []types.NextConfigDataV1{
 						{
 							C1:             1,
 							C2:             2,
@@ -558,7 +558,7 @@ func TestStoreAndFinalizeBabeNextConfigData(t *testing.T) {
 			shouldRemainInMemory: 0,
 			finalizedEpoch:       1, // try to finalize an epoch that does not exist
 			finalizedHeader:      finalizedHeader,
-			inMemoryEpoch:        []inMemoryBABEData[types.NextConfigData]{},
+			inMemoryEpoch:        []inMemoryBABEData[types.NextConfigDataV1]{},
 		},
 	}
 

--- a/dot/types/consensus_digest_test.go
+++ b/dot/types/consensus_digest_test.go
@@ -46,3 +46,26 @@ func TestBabeEncodeAndDecode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, d, dec)
 }
+
+func TestBabeDecodeVersionedNextConfigData(t *testing.T) {
+	// Block #5608275 NextConfigData digest
+	enc := common.MustHexToBytes("0x03010100000000000000040000000000000002")
+
+	var dec = NewBabeConsensusDigest()
+	err := scale.Unmarshal(enc, &dec)
+	require.NoError(t, err)
+
+	decValue, err := dec.Value()
+	require.NoError(t, err)
+
+	nextVersionedConfigData := decValue.(VersionedNextConfigData)
+
+	nextConfigData, err := nextVersionedConfigData.Value()
+	require.NoError(t, err)
+
+	nextConfigDataV1 := nextConfigData.(NextConfigDataV1)
+
+	require.GreaterOrEqual(t, 1, int(nextConfigDataV1.C1))
+	require.GreaterOrEqual(t, 4, int(nextConfigDataV1.C2))
+	require.GreaterOrEqual(t, 2, int(nextConfigDataV1.SecondarySlots))
+}

--- a/lib/babe/verify_integration_test.go
+++ b/lib/babe/verify_integration_test.go
@@ -544,7 +544,7 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 	aliceBlockNextEpoch := types.NextEpochData{
 		Authorities: authorities[3:],
 	}
-	aliceBlockNextConfigData := types.NextConfigData{
+	aliceBlockNextConfigData := types.NextConfigDataV1{
 		C1:             9,
 		C2:             10,
 		SecondarySlots: 1,
@@ -555,7 +555,7 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 	bobBlockNextEpoch := types.NextEpochData{
 		Authorities: authorities[6:],
 	}
-	bobBlockNextConfigData := types.NextConfigData{
+	bobBlockNextConfigData := types.NextConfigDataV1{
 		C1:             3,
 		C2:             8,
 		SecondarySlots: 1,
@@ -672,7 +672,7 @@ func TestVerifyForkBlocksWithRespectiveEpochData(t *testing.T) {
 // blocks that contains different consensus messages digests
 func issueConsensusDigestsBlockFromGenesis(t *testing.T, genesisHeader *types.Header,
 	kp *sr25519.Keypair, stateService *state.Service,
-	nextEpoch types.NextEpochData, nextConfig types.NextConfigData) *types.Header {
+	nextEpoch types.NextEpochData, nextConfig types.NextConfigDataV1) *types.Header {
 	t.Helper()
 
 	output, proof, err := kp.VrfSign(makeTranscript(Randomness{}, uint64(0), 0))
@@ -691,7 +691,11 @@ func issueConsensusDigestsBlockFromGenesis(t *testing.T, genesisHeader *types.He
 	require.NoError(t, babeConsensusDigestNextEpoch.Set(nextEpoch))
 
 	babeConsensusDigestNextConfigData := types.NewBabeConsensusDigest()
-	require.NoError(t, babeConsensusDigestNextConfigData.Set(nextConfig))
+
+	versionedNextConfigData := types.NewVersionedNextConfigData()
+	versionedNextConfigData.Set(nextConfig)
+
+	require.NoError(t, babeConsensusDigestNextConfigData.Set(versionedNextConfigData))
 
 	nextEpochData, err := scale.Marshal(babeConsensusDigestNextEpoch)
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->

Adds support for NextConfigData versioning following the [substrate implementation](https://github.com/paritytech/substrate/blob/7d6084b5774ee13d0b33810c2830aa5a8506cbae/primitives/consensus/babe/src/digests.rs#L143C1-L152)

- Created `VersionedNextConfigData` to support different `NextConfigData` versions 
- Renamed the old `NextConfigData` as `NextConfigDataV1`

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make test
```
Since I modified a current structure used in different tests 

## Issues

<!-- Write the issue number(s), for example: #123 -->

Closes #3236 

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20 @EclesioMeloJunior 
