### PR TITLE
fix(dot/network): remove `maxReads` limitation to read stream

### DIFF
--- a/dot/network/errors.go
+++ b/dot/network/errors.go
@@ -16,4 +16,6 @@ var (
 	errInvalidStartingBlockType      = errors.New("invalid StartingBlock in messsage")
 	errInboundHanshakeExists         = errors.New("an inbound handshake already exists for given peer")
 	errInvalidRole                   = errors.New("invalid role")
+	ErrFailedToReadEntireMessage     = errors.New("failed to read entire message")
+	ErrUnexpectedLenght              = errors.New("unexpected length")
 )

--- a/dot/network/service.go
+++ b/dot/network/service.go
@@ -39,8 +39,7 @@ const (
 )
 
 var (
-	logger   = log.NewFromGlobal(log.AddContext("pkg", "network"))
-	maxReads = 256
+	logger = log.NewFromGlobal(log.AddContext("pkg", "network"))
 
 	peerCountGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "gossamer_network_node",

--- a/dot/network/utils.go
+++ b/dot/network/utils.go
@@ -217,7 +217,7 @@ func readStream(stream libp2pnetwork.Stream, bufPointer *[]byte, maxSize uint64)
 	}
 
 	tot = 0
-	for i := 0; i < maxReads; i++ {
+	for {
 		n, err := stream.Read(buf[tot:])
 		if err != nil {
 			return n + tot, err
@@ -226,6 +226,10 @@ func readStream(stream libp2pnetwork.Stream, bufPointer *[]byte, maxSize uint64)
 		tot += n
 		if tot == int(length) {
 			break
+		}
+
+		if tot > int(length) {
+			return tot, fmt.Errorf("%w, expected %d bytes, read %d", ErrUnexpectedLenght, length, tot)
 		}
 	}
 


### PR DESCRIPTION
## Changes

- Remove the `maxReads` limitation to read stream responses
- The `readStream` function has the information on the total size of the response so we only stop reading the stream once we reach the total length instead of using a `maxReads` that was leading to a wrong read of bigger stream responses

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/3286

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kanishkatn 
