### PR TITLE
parachain/disputes: add participation queue for dispute-coordinator

### DIFF
--- a/dot/parachain/dispute/queue_test.go
+++ b/dot/parachain/dispute/queue_test.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	parachain "github.com/ChainSafe/gossamer/dot/parachain/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/parachain"
 	"github.com/google/btree"
 	"github.com/stretchr/testify/require"
 )

--- a/dot/parachain/dispute/queue_test.go
+++ b/dot/parachain/dispute/queue_test.go
@@ -59,6 +59,7 @@ func runTests(t *testing.T, tests []test, queue Queue) {
 				err := queue.Queue(tt.comparator, tt.request, tt.priority)
 				if tt.mustError {
 					require.Error(t, err)
+					require.Equal(t, err, tt.expected)
 					return
 				}
 				require.NoError(t, err)
@@ -326,6 +327,7 @@ func TestQueue_OverflowPriority(t *testing.T) {
 			request:    dummyParticipationRequest(),
 			priority:   ParticipationPriorityHigh,
 			mustError:  true,
+			expected:   errorPriorityQueueFull,
 		},
 	}
 
@@ -372,6 +374,7 @@ func TestQueue_OverflowBestEffort(t *testing.T) {
 			request:    dummyParticipationRequest(),
 			priority:   ParticipationPriorityBestEffort,
 			mustError:  true,
+			expected:   errorBestEffortQueueFull,
 		},
 	}
 

--- a/dot/parachain/dispute/queue_test.go
+++ b/dot/parachain/dispute/queue_test.go
@@ -7,14 +7,14 @@ import (
 
 	parachain "github.com/ChainSafe/gossamer/dot/parachain/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/google/btree"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/btree"
 )
 
 func newTestQueue(size int) *QueueHandler {
 	return &QueueHandler{
-		bestEffort:        btree.New(size / 2),
-		priority:          btree.New(size / 2),
+		bestEffort:        btree.New(participationItemComparator),
+		priority:          btree.New(participationItemComparator),
 		bestEffortMaxSize: size,
 		priorityMaxSize:   size,
 	}

--- a/dot/parachain/dispute/queue_test.go
+++ b/dot/parachain/dispute/queue_test.go
@@ -1,0 +1,589 @@
+package dispute
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/parachain"
+	"github.com/google/btree"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestQueue(size int) *QueueHandler {
+	return &QueueHandler{
+		bestEffort:        btree.New(size / 2),
+		priority:          btree.New(size / 2),
+		bestEffortMaxSize: size,
+		priorityMaxSize:   size,
+	}
+}
+
+func newComparator(blockNumber, order uint32) CandidateComparator {
+	candidateHash := make([]byte, 4)
+	binary.LittleEndian.PutUint32(candidateHash, order)
+
+	return CandidateComparator{
+		relayParentBlockNumber: &blockNumber,
+		candidateHash:          common.NewHash(candidateHash),
+	}
+}
+
+func dummyParticipationRequest() *ParticipationRequest {
+	return &ParticipationRequest{
+		candidateHash:    [32]byte{},
+		candidateReceipt: parachain.CandidateReceipt{},
+		session:          1,
+	}
+}
+
+type test struct {
+	name string
+	// operation one of "queue", "dequeue", "prioritise", "pop_priority", "pop_best_effort",
+	// "len_priority", "len_best_effort"
+	operation  string
+	comparator CandidateComparator
+	request    *ParticipationRequest
+	priority   ParticipationPriority
+	expected   any
+	mustError  bool
+}
+
+func runTests(t *testing.T, tests []test, queue Queue) {
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.operation {
+			case "queue":
+				err := queue.Queue(tt.comparator, tt.request, tt.priority)
+				if tt.mustError {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			case "dequeue":
+				item := queue.Dequeue()
+				require.Equal(t, tt.expected, item)
+			case "prioritise":
+				err := queue.PrioritiseIfPresent(tt.comparator)
+				if tt.mustError {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+			case "pop_priority":
+				item := queue.PopPriority()
+				require.Equal(t, tt.expected, item)
+			case "pop_best_effort":
+				item := queue.PopBestEffort()
+				require.Equal(t, tt.expected, item)
+			case "len_priority":
+				require.Equal(t, tt.expected, queue.Len(ParticipationPriorityHigh))
+			case "len_best_effort":
+				require.Equal(t, tt.expected, queue.Len(ParticipationPriorityBestEffort))
+			default:
+				t.Fatalf("unknown operation %s", tt.operation)
+			}
+		})
+	}
+}
+
+// TestQueue_CompareRelayParentBlock tests the following:
+// - queueing 3 requests into priority queue with different relay parent block numbers
+// - queueing 1 request with the best effort priority
+// - dequeue must return the request with the lowest relay parent block number from the priority queue
+func TestQueue_CompareRelayParentBlock(t *testing.T) {
+	tests := []test{
+		{
+			name:       "block 1",
+			operation:  "queue",
+			comparator: newComparator(1, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 2",
+			operation:  "queue",
+			comparator: newComparator(2, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 3",
+			operation:  "queue",
+			comparator: newComparator(3, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1 - best effort",
+			operation:  "queue",
+			comparator: newComparator(1, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:      "dequeue",
+			operation: "dequeue",
+			expected: &ParticipationItem{
+				comparator: newComparator(1, 1),
+				request:    dummyParticipationRequest(),
+			},
+		},
+	}
+
+	runTests(t, tests, newTestQueue(10))
+}
+
+// TestQueue_CompareCandidateHash tests the following:
+// - queueing 3 requests with same relay parent block number into priority queue with different candidate hashes
+// - queueing 1 request with the best effort priority
+// - dequeue must return the request with the lowest candidate hash from the priority queue
+func TestQueue_CompareCandidateHash(t *testing.T) {
+	tests := []test{
+		{
+			name:       "block 1",
+			operation:  "queue",
+			comparator: newComparator(1, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1 - 2",
+			operation:  "queue",
+			comparator: newComparator(1, 2),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:      "dequeue",
+			operation: "dequeue",
+			expected: &ParticipationItem{
+				comparator: newComparator(1, 1),
+				request:    dummyParticipationRequest(),
+			},
+		},
+	}
+
+	runTests(t, tests, newTestQueue(10))
+}
+
+// TestQueue_EndToEnd tests the following:
+// - queueing 3 requests into priority queue
+// - queueing 3 requests into best effort queue
+// - popping the best effort queue
+// - popping the priority queue
+// - prioritising a request in the best effort queue
+func TestQueue_EndToEnd(t *testing.T) {
+	tests := []test{
+		{
+			name:       "block 1, order 1",
+			operation:  "queue",
+			comparator: newComparator(1, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 2, order 1",
+			operation:  "queue",
+			comparator: newComparator(2, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 3, order 1",
+			operation:  "queue",
+			comparator: newComparator(3, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1, order 2 - best effort",
+			operation:  "queue",
+			comparator: newComparator(1, 2),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:       "block 2, order 2 - best effort",
+			operation:  "queue",
+			comparator: newComparator(2, 2),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:       "block 3, order 2 - best effort",
+			operation:  "queue",
+			comparator: newComparator(3, 2),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:      "priority length",
+			operation: "len_priority",
+			expected:  3,
+		},
+		{
+			name:      "best effort length",
+			operation: "len_best_effort",
+			expected:  3,
+		},
+		{
+			name:      "pop priority",
+			operation: "pop_priority",
+			expected: &ParticipationItem{
+				comparator: newComparator(1, 1),
+				request:    dummyParticipationRequest(),
+			},
+		},
+		{
+			name:      "pop best effort",
+			operation: "pop_best_effort",
+			expected: &ParticipationItem{
+				comparator: newComparator(1, 2),
+				request:    dummyParticipationRequest(),
+			},
+		},
+		{
+			name:      "priority length",
+			operation: "len_priority",
+			expected:  2,
+		},
+		{
+			name:      "best effort length",
+			operation: "len_best_effort",
+			expected:  2,
+		},
+		{
+			name:       "prioritise best effort",
+			operation:  "prioritise",
+			comparator: newComparator(2, 2),
+		},
+		{
+			name:      "priority length",
+			operation: "len_priority",
+			expected:  3,
+		},
+		{
+			name:      "dequeue",
+			operation: "dequeue",
+			expected: &ParticipationItem{
+				comparator: newComparator(2, 1),
+				request:    dummyParticipationRequest(),
+			},
+		},
+		{
+			name:      "dequeue",
+			operation: "dequeue",
+			expected: &ParticipationItem{
+				comparator: newComparator(2, 2),
+				request:    dummyParticipationRequest(),
+			},
+		},
+	}
+
+	runTests(t, tests, newTestQueue(10))
+}
+
+// TestQueue_OverflowPriority tests the following:
+// - queueing 5 requests into priority queue with the max length of 4
+// - the 5th request must return an error
+func TestQueue_OverflowPriority(t *testing.T) {
+	tests := []test{
+		{
+			name:       "block 1",
+			operation:  "queue",
+			comparator: newComparator(1, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1 - 2",
+			operation:  "queue",
+			comparator: newComparator(1, 2),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1 - 3",
+			operation:  "queue",
+			comparator: newComparator(1, 3),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1 - 4",
+			operation:  "queue",
+			comparator: newComparator(1, 4),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+		},
+		{
+			name:       "block 1 - 5",
+			operation:  "queue",
+			comparator: newComparator(1, 5),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityHigh,
+			mustError:  true,
+		},
+	}
+
+	runTests(t, tests, newTestQueue(4))
+}
+
+// TestQueue_OverflowBestEffort tests the following:
+// - queueing 5 requests into the best effort queue with the max length of 4
+// - the 5th request must return an error
+func TestQueue_OverflowBestEffort(t *testing.T) {
+	tests := []test{
+		{
+			name:       "block 1",
+			operation:  "queue",
+			comparator: newComparator(1, 1),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:       "block 1 - 2",
+			operation:  "queue",
+			comparator: newComparator(1, 2),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:       "block 1 - 3",
+			operation:  "queue",
+			comparator: newComparator(1, 3),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:       "block 1 - 4",
+			operation:  "queue",
+			comparator: newComparator(1, 4),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+		},
+		{
+			name:       "block 1 - 5",
+			operation:  "queue",
+			comparator: newComparator(1, 5),
+			request:    dummyParticipationRequest(),
+			priority:   ParticipationPriorityBestEffort,
+			mustError:  true,
+		},
+	}
+
+	runTests(t, tests, newTestQueue(4))
+}
+
+// TestQueueConcurrency_Dequeue tests the following:
+// - concurrent queueing of 1000 requests
+// - concurrent dequeue of 1000 requests
+func TestQueueConcurrency_Dequeue(t *testing.T) {
+	q := NewQueue()
+	numberOfOperations := 1000
+
+	wg := sync.WaitGroup{}
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		block := uint32(i)
+		go func() {
+			defer wg.Done()
+
+			err := q.Queue(newComparator(block, 1), dummyParticipationRequest(), ParticipationPriorityHigh)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, numberOfOperations, q.Len(ParticipationPriorityHigh))
+
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		go func() {
+			defer wg.Done()
+			q.Dequeue()
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 0, q.Len(ParticipationPriorityHigh))
+}
+
+// TestQueueConcurrency_Prioritise tests the following:
+// - concurrent queueing of 1000 requests into the best effort queue
+// - concurrent prioritise of 1000 requests
+func TestQueueConcurrency_Prioritise(t *testing.T) {
+	q := NewQueue()
+	numberOfOperations := 100
+
+	wg := sync.WaitGroup{}
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		block := uint32(i)
+		go func() {
+			defer wg.Done()
+
+			err := q.Queue(newComparator(block, 1), dummyParticipationRequest(), ParticipationPriorityBestEffort)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, numberOfOperations, q.Len(ParticipationPriorityBestEffort))
+
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		block := uint32(i)
+		go func() {
+			defer wg.Done()
+			err := q.PrioritiseIfPresent(newComparator(block, 1))
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, numberOfOperations, q.Len(ParticipationPriorityHigh))
+	require.Equal(t, 0, q.Len(ParticipationPriorityBestEffort))
+}
+
+// TestQueueConcurrency_PopBestEffort tests the following:
+// - concurrent queueing of 1000 requests into the best effort queue
+// - concurrent pop of 1000 requests from the best effort queue
+func TestQueueConcurrency_PopBestEffort(t *testing.T) {
+	q := NewQueue()
+	numberOfOperations := 100
+
+	wg := sync.WaitGroup{}
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		block := uint32(i)
+		go func() {
+			defer wg.Done()
+
+			err := q.Queue(newComparator(block, 1), dummyParticipationRequest(), ParticipationPriorityBestEffort)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, numberOfOperations, q.Len(ParticipationPriorityBestEffort))
+
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		go func() {
+			defer wg.Done()
+			item := q.PopBestEffort()
+			require.NotNil(t, item)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 0, q.Len(ParticipationPriorityBestEffort))
+}
+
+// TestQueueConcurrency_PopPriority tests the following:
+// - concurrent queueing of 1000 requests into the high priority queue
+// - concurrent pop of 1000 requests from the high priority queue
+func TestQueueConcurrency_PopPriority(t *testing.T) {
+	q := NewQueue()
+	numberOfOperations := 100
+
+	wg := sync.WaitGroup{}
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		block := uint32(i)
+		go func() {
+			defer wg.Done()
+
+			err := q.Queue(newComparator(block, 1), dummyParticipationRequest(), ParticipationPriorityHigh)
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, numberOfOperations, q.Len(ParticipationPriorityHigh))
+
+	wg.Add(numberOfOperations)
+	for i := 0; i < numberOfOperations; i++ {
+		go func() {
+			defer wg.Done()
+			item := q.PopPriority()
+			require.NotNil(t, item)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, 0, q.Len(ParticipationPriorityHigh))
+}
+
+func BenchmarkQueue_Queue(b *testing.B) {
+	q := newTestQueue(priorityQueueSize)
+
+	for i := 0; i < priorityQueueSize; i++ {
+		err := q.Queue(newComparator(uint32(i), 1), dummyParticipationRequest(), ParticipationPriorityHigh)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkQueue_Dequeue(b *testing.B) {
+	q := NewQueue()
+
+	for i := 0; i < bestEffortQueueSize; i++ {
+		err := q.Queue(newComparator(uint32(i), 1), dummyParticipationRequest(), ParticipationPriorityBestEffort)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < bestEffortQueueSize; i++ {
+		item := q.Dequeue()
+		require.NotNil(b, item)
+	}
+}
+
+func BenchmarkQueue_PopPriority(b *testing.B) {
+	q := NewQueue()
+
+	for i := 0; i < priorityQueueSize; i++ {
+		err := q.Queue(newComparator(uint32(i), 1), dummyParticipationRequest(), ParticipationPriorityHigh)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < priorityQueueSize; i++ {
+		item := q.PopPriority()
+		require.NotNil(b, item)
+	}
+}
+
+func BenchmarkQueue_PopBestEffort(b *testing.B) {
+	q := NewQueue()
+
+	for i := 0; i < bestEffortQueueSize; i++ {
+		err := q.Queue(newComparator(uint32(i), 1), dummyParticipationRequest(), ParticipationPriorityBestEffort)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < bestEffortQueueSize; i++ {
+		item := q.PopBestEffort()
+		require.NotNil(b, item)
+	}
+}
+
+func BenchmarkQueue_PrioritiseIfPresent(b *testing.B) {
+	q := NewQueue()
+
+	for i := 0; i < bestEffortQueueSize; i++ {
+		err := q.Queue(newComparator(uint32(i), 1), dummyParticipationRequest(), ParticipationPriorityBestEffort)
+		require.NoError(b, err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < priorityQueueSize; i++ {
+		err := q.PrioritiseIfPresent(newComparator(uint32(i), 1))
+		require.NoError(b, err)
+	}
+}

--- a/dot/parachain/dispute/queue_test.go
+++ b/dot/parachain/dispute/queue_test.go
@@ -8,13 +8,12 @@ import (
 	parachain "github.com/ChainSafe/gossamer/dot/parachain/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/stretchr/testify/require"
-	"github.com/tidwall/btree"
 )
 
 func newTestQueue(size int) *QueueHandler {
 	return &QueueHandler{
-		bestEffort:        btree.New(participationItemComparator),
-		priority:          btree.New(participationItemComparator),
+		bestEffort:        newSyncedBTree(participationItemComparator),
+		priority:          newSyncedBTree(participationItemComparator),
 		bestEffortMaxSize: size,
 		priorityMaxSize:   size,
 	}

--- a/dot/parachain/dispute/queues.go
+++ b/dot/parachain/dispute/queues.go
@@ -1,0 +1,230 @@
+package dispute
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/parachain"
+
+	"github.com/google/btree"
+	"github.com/pkg/errors"
+)
+
+// This file contains the types and methods for the queues used by the dispute coordinator
+// The implementation is based on parity's participation queue
+// Read more here: https://paritytech.github.io/polkadot/book/node/disputes/dispute-coordinator.html
+// https://github.com/paritytech/polkadot/blob/master/node/core/dispute-coordinator/src/participation/queues/mod.rs
+// It uses btree. Find it here: https://github.com/google/btree
+
+// TODO: Parity's implementation captures metrics for the queue. We should do the same.
+// However, I will not be implementing it right away. It will be picked up as a single task for the
+// entire dispute module https://github.com/ChainSafe/gossamer/issues/3313.
+
+// CandidateComparator comparator for ordering of disputes for candidate.
+type CandidateComparator struct {
+	relayParentBlockNumber *uint32
+	candidateHash          common.Hash
+}
+
+// ParticipationRequest a dispute participation request
+type ParticipationRequest struct {
+	candidateHash    common.Hash
+	candidateReceipt parachain.CandidateReceipt
+	session          parachain.SessionIndex
+	//TODO: requestTimer for metrics
+}
+
+// ParticipationItem implements btree.Item
+type ParticipationItem struct {
+	comparator CandidateComparator
+	request    *ParticipationRequest
+}
+
+// Less returns true if the current item is less than the other item
+// it uses the CandidateComparator to determine the order
+func (q ParticipationItem) Less(than btree.Item) bool {
+	other := than.(*ParticipationItem)
+
+	if q.comparator.relayParentBlockNumber == nil && other.comparator.relayParentBlockNumber == nil {
+		return bytes.Compare(q.comparator.candidateHash[:], other.comparator.candidateHash[:]) < 0
+	}
+
+	if other.comparator.relayParentBlockNumber == nil {
+		return false
+	}
+
+	if q.comparator.relayParentBlockNumber == nil {
+		return true
+	}
+
+	if isEqual := *q.comparator.relayParentBlockNumber == *other.comparator.relayParentBlockNumber; isEqual {
+		return bytes.Compare(q.comparator.candidateHash[:], other.comparator.candidateHash[:]) < 0
+	}
+
+	return *q.comparator.relayParentBlockNumber < *other.comparator.relayParentBlockNumber
+}
+
+func newParticipationItem(comparator CandidateComparator, request *ParticipationRequest) *ParticipationItem {
+	return &ParticipationItem{
+		comparator: comparator,
+		request:    request,
+	}
+}
+
+// ParticipationPriority the priority of a participation request
+type ParticipationPriority int
+
+const (
+	// ParticipationPriorityBestEffort is the lowest priority
+	ParticipationPriorityBestEffort ParticipationPriority = iota
+	// ParticipationPriorityHigh is the highest priority
+	ParticipationPriorityHigh
+)
+
+// IsPriority returns true if the priority is high
+func (p ParticipationPriority) IsPriority() bool {
+	return p == ParticipationPriorityHigh
+}
+
+var (
+	// errorBestEffortQueueFull is returned when the best effort queue is full and the request could not be processed
+	errorBestEffortQueueFull = errors.New("best effort queue is full")
+	// errorPriorityQueueFull is returned when the priority queue is full and the request could not be processed
+	errorPriorityQueueFull = errors.New("priority queue is full")
+)
+
+// Queue the dispute participation queue
+type Queue interface {
+	// Queue adds a new participation request to the queue
+	Queue(comparator CandidateComparator, request *ParticipationRequest, priority ParticipationPriority) error
+
+	// Dequeue gets the next best request for dispute participation if any.
+	Dequeue() *ParticipationItem
+
+	// PrioritiseIfPresent moves a participation request from the best effort queue to the priority queue
+	PrioritiseIfPresent(comparator CandidateComparator) error
+
+	// PopBestEffort removes the next participation request from the best effort queue
+	PopBestEffort() *ParticipationItem
+
+	// PopPriority removes the next participation request from the priority queue
+	PopPriority() *ParticipationItem
+
+	// Len returns the number of items in the specified queue
+	Len(queueType ParticipationPriority) int
+}
+
+// QueueHandler implements Queue
+// It uses two btree's to store the requests. One for best effort and one for priority.
+// The queues store participationItem's.
+// The btree is ordered by the CandidateComparator of participationItem.
+type QueueHandler struct {
+	bestEffort *btree.BTree
+	priority   *btree.BTree
+
+	bestEffortLock sync.Mutex
+	priorityLock   sync.Mutex
+
+	bestEffortMaxSize int
+	priorityMaxSize   int
+
+	//TODO: add metrics
+}
+
+const (
+	// bestEffortQueueSize is the maximum size of the best effort queue
+	bestEffortQueueSize = 100
+	// priorityQueueSize is the maximum size of the priority queue
+	priorityQueueSize = 20000
+)
+
+func (q *QueueHandler) Queue(
+	comparator CandidateComparator,
+	request *ParticipationRequest,
+	priority ParticipationPriority,
+) error {
+	if priority.IsPriority() {
+		if q.priority.Len() >= q.priorityMaxSize {
+			return errorPriorityQueueFull
+		}
+
+		q.priorityLock.Lock()
+		q.priority.ReplaceOrInsert(newParticipationItem(comparator, request))
+		q.priorityLock.Unlock()
+	} else {
+		if q.bestEffort.Len() >= q.bestEffortMaxSize {
+			return errorBestEffortQueueFull
+		}
+
+		q.bestEffortLock.Lock()
+		q.bestEffort.ReplaceOrInsert(newParticipationItem(comparator, request))
+		q.bestEffortLock.Unlock()
+	}
+
+	return nil
+}
+
+func (q *QueueHandler) Dequeue() *ParticipationItem {
+	if item := q.PopPriority(); item != nil {
+		return item
+	}
+
+	return q.PopBestEffort()
+}
+
+func (q *QueueHandler) PrioritiseIfPresent(comparator CandidateComparator) error {
+	if q.priority.Len() >= priorityQueueSize {
+		return errorPriorityQueueFull
+	}
+
+	q.bestEffortLock.Lock()
+	// We remove the item from the best effort queue and add it to the priority queue if it exists
+	if item := q.bestEffort.Delete(newParticipationItem(comparator, nil)); item != nil {
+		q.priorityLock.Lock()
+		q.priority.ReplaceOrInsert(item)
+		q.priorityLock.Unlock()
+	}
+	q.bestEffortLock.Unlock()
+
+	return nil
+}
+
+func (q *QueueHandler) PopBestEffort() *ParticipationItem {
+	q.bestEffortLock.Lock()
+	defer q.bestEffortLock.Unlock()
+	if item := q.bestEffort.DeleteMin(); item != nil {
+		return item.(*ParticipationItem)
+	}
+
+	return nil
+}
+
+func (q *QueueHandler) PopPriority() *ParticipationItem {
+	q.priorityLock.Lock()
+	defer q.priorityLock.Unlock()
+	if item := q.priority.DeleteMin(); item != nil {
+		return item.(*ParticipationItem)
+	}
+
+	return nil
+}
+
+func (q *QueueHandler) Len(queueType ParticipationPriority) int {
+	if queueType.IsPriority() {
+		return q.priority.Len()
+	}
+
+	return q.bestEffort.Len()
+}
+
+var _ Queue = &QueueHandler{}
+
+func NewQueue() *QueueHandler {
+	return &QueueHandler{
+		bestEffort:        btree.New(bestEffortQueueSize / 2),
+		priority:          btree.New(priorityQueueSize / 2),
+		bestEffortMaxSize: bestEffortQueueSize,
+		priorityMaxSize:   priorityQueueSize,
+	}
+}

--- a/dot/parachain/dispute/queues.go
+++ b/dot/parachain/dispute/queues.go
@@ -145,7 +145,7 @@ func (q *QueueHandler) Queue(
 	priority ParticipationPriority,
 ) error {
 	if priority.IsPriority() {
-		if q.priority.Len() >= q.priorityMaxSize {
+		if q.Len(ParticipationPriorityHigh) >= q.priorityMaxSize {
 			return errorPriorityQueueFull
 		}
 
@@ -153,7 +153,7 @@ func (q *QueueHandler) Queue(
 		q.priority.ReplaceOrInsert(newParticipationItem(comparator, request))
 		q.priorityLock.Unlock()
 	} else {
-		if q.bestEffort.Len() >= q.bestEffortMaxSize {
+		if q.Len(ParticipationPriorityBestEffort) >= q.bestEffortMaxSize {
 			return errorBestEffortQueueFull
 		}
 
@@ -174,7 +174,7 @@ func (q *QueueHandler) Dequeue() *ParticipationItem {
 }
 
 func (q *QueueHandler) PrioritiseIfPresent(comparator CandidateComparator) error {
-	if q.priority.Len() >= priorityQueueSize {
+	if q.Len(ParticipationPriorityHigh) >= priorityQueueSize {
 		return errorPriorityQueueFull
 	}
 

--- a/dot/parachain/dispute/queues.go
+++ b/dot/parachain/dispute/queues.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	parachain "github.com/ChainSafe/gossamer/dot/parachain/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 
-	"github.com/pkg/errors"
 	"github.com/tidwall/btree"
 )
 
@@ -20,6 +21,13 @@ import (
 // TODO: Parity's implementation captures metrics for the queue. We should do the same.
 // However, I will not be implementing it right away. It will be picked up as a single task for the
 // entire dispute module https://github.com/ChainSafe/gossamer/issues/3313.
+
+var (
+	// errorBestEffortQueueFull is returned when the best effort queue is full and the request could not be processed
+	errorBestEffortQueueFull = errors.New("best effort queue is full")
+	// errorPriorityQueueFull is returned when the priority queue is full and the request could not be processed
+	errorPriorityQueueFull = errors.New("priority queue is full")
+)
 
 // CandidateComparator comparator for ordering of disputes for candidate.
 type CandidateComparator struct {
@@ -84,13 +92,6 @@ const (
 func (p ParticipationPriority) IsPriority() bool {
 	return p == ParticipationPriorityHigh
 }
-
-var (
-	// errorBestEffortQueueFull is returned when the best effort queue is full and the request could not be processed
-	errorBestEffortQueueFull = errors.New("best effort queue is full")
-	// errorPriorityQueueFull is returned when the priority queue is full and the request could not be processed
-	errorPriorityQueueFull = errors.New("priority queue is full")
-)
 
 // Queue the dispute participation queue
 type Queue interface {

--- a/dot/parachain/dispute/queues.go
+++ b/dot/parachain/dispute/queues.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"sync"
 
+	parachain "github.com/ChainSafe/gossamer/dot/parachain/types"
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/parachain"
 
 	"github.com/google/btree"
 	"github.com/pkg/errors"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/fatih/color v1.15.0
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/golang/mock v1.6.0
+	github.com/google/btree v1.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
@@ -32,6 +33,7 @@ require (
 	github.com/minio/sha256-simd v1.0.1
 	github.com/multiformats/go-multiaddr v0.10.1
 	github.com/nanobox-io/golang-scribble v0.0.0-20190309225732-aa3e7c118975
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
 	github.com/qdm12/gotree v0.2.0
@@ -150,7 +152,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/phuslu/iploc v1.0.20230201 // indirect
 	github.com/pierrec/xxHash v0.1.5 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tetratelabs/wazero v1.1.0
+	github.com/tidwall/btree v1.6.0
 	github.com/wasmerio/go-ext-wasm v0.3.2-0.20200326095750-0a32be6068ec
 	github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9
 	golang.org/x/crypto v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,7 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb h1:PBC98N2aIaM3XXiurYmW7fx4GZkL8feAMVq7nEjURHk=
 github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v23.1.21+incompatible h1:bUqzx/MXCDxuS0hRJL2EfjyZL3uQrPbMocUa8zGqsTA=
 github.com/google/flatbuffers v23.1.21+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=

--- a/go.sum
+++ b/go.sum
@@ -702,6 +702,8 @@ github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
+github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tklauser/go-sysconf v0.3.5 h1:uu3Xl4nkLzQfXNsWn15rPc/HQCJKObbt1dKJeWp3vU4=
 github.com/tklauser/go-sysconf v0.3.5/go.mod h1:MkWzOF4RMCshBAMXuhXJs64Rte09mITnppBXY/rYEFI=
 github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=


### PR DESCRIPTION
## Changes
- Implements the queues needed for dispute participation

read the note on `queue.go` for more details.

## Issues

#3302 

## Primary Reviewer

@kishansagathiya 
