### PR TITLE
feat(dot/network): introduce libp2p resource manager + prometheus metrics

### DIFF
--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -26,7 +26,10 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoreds"
+	rm "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	rmObs "github.com/libp2p/go-libp2p/p2p/host/resource-manager/obs"
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func newPrivateIPFilters() (privateIPs *ma.Filters, err error) {
@@ -178,8 +181,27 @@ func newHost(ctx context.Context, cfg *Config) (*host, error) {
 		return nil, fmt.Errorf("failed to create peerstore: %w", err)
 	}
 
+	limiter := rm.NewFixedLimiter(rm.DefaultLimits.AutoScale())
+	var managerOptions []rm.Option
+
+	if cfg.Metrics.Publish {
+		rmObs.MustRegisterWith(prometheus.DefaultRegisterer)
+		reporter, err := rmObs.NewStatsTraceReporter()
+		if err != nil {
+			return nil, fmt.Errorf("while creating resource manager stats trace reporter: %w", err)
+		}
+
+		managerOptions = append(managerOptions, rm.WithTraceReporter(reporter))
+	}
+
+	manager, err := rm.NewResourceManager(limiter, managerOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("while creating the resource manager: %w", err)
+	}
+
 	// set libp2p host options
 	opts := []libp2p.Option{
+		libp2p.ResourceManager(manager),
 		libp2p.ListenAddrs(addr),
 		libp2p.DisableRelay(),
 		libp2p.Identity(cfg.privateKey),


### PR DESCRIPTION
## Changes

- Introduce libp2p resource manager + Prometheus metrics to the `network` pkg

A little explanation of this library [go-libp2p/resource-manager](https://github.com/libp2p/go-libp2p/tree/master/p2p/host/resource-manager)
> The Resource Manager doesn't prioritize resource requests at all, it simply checks if the resource being requested is currently below the defined limits and returns an error if the limit is reached. It has no notion of honest vs bad peers.
## Tests

- Running gossamer with libp2p resource manager + exposing the metrics through Prometheus. It is possible to see the number of streams in use per protocol:

![image](https://github.com/ChainSafe/gossamer/assets/17255488/b2a4f829-27dc-4343-b306-bfe9ec597b63)

## Issues

- N/A

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
