### PR TITLE
fix test to pass on all OSs

### DIFF
--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -58,5 +59,5 @@ func TestKeystoreDir(t *testing.T) {
 	keystoreDir, err := KeystoreDir(testDir)
 	require.NoError(t, err)
 
-	assert.Equal(t, testDir+"/keystore", keystoreDir)
+	assert.Equal(t, filepath.Join(testDir, "keystore"), keystoreDir)
 }


### PR DESCRIPTION
## Changes

Fixes utils test that was creating a path manually instead of relying on Go `filepath` package to do it based on OS.

## Tests

On a mac and a windows machine:

```sh
go test -timeout 30s -run ^TestKeystoreDir$ github.com/ChainSafe/gossamer/lib/utils
```

## Issues

Fixes #3367

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@timwu20
