### PR TITLE
fix(lib/runtime): update `MaxPossibleAllocation` to `2^25`

### DIFF
--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -20,7 +20,7 @@ const DefaultHeapBase = uint32(1469576)
 const alignment uint32 = 8
 
 // HeadsQty 22
-const HeadsQty = 22
+const HeadsQty = 23
 
 // MaxPossibleAllocation 2^25 bytes, 32 MiB
 const MaxPossibleAllocation = (1 << 25)

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -22,7 +22,7 @@ const alignment uint32 = 8
 // HeadsQty 22
 const HeadsQty = 22
 
-// MaxPossibleAllocation 2^24 bytes
+// MaxPossibleAllocation 2^25 bytes, 32 MiB
 const MaxPossibleAllocation = (1 << 25)
 
 // FreeingBumpHeapAllocator struct

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -23,7 +23,7 @@ const alignment uint32 = 8
 const HeadsQty = 22
 
 // MaxPossibleAllocation 2^24 bytes
-const MaxPossibleAllocation = (1 << 24)
+const MaxPossibleAllocation = (1 << 25)
 
 // FreeingBumpHeapAllocator struct
 type FreeingBumpHeapAllocator struct {

--- a/lib/runtime/allocator.go
+++ b/lib/runtime/allocator.go
@@ -19,7 +19,7 @@ const DefaultHeapBase = uint32(1469576)
 // The pointers need to be aligned to 8 bytes
 const alignment uint32 = 8
 
-// HeadsQty 22
+// HeadsQty 23
 const HeadsQty = 23
 
 // MaxPossibleAllocation 2^25 bytes, 32 MiB

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -90,7 +90,7 @@ var allocateFreeTest = []testSet{
 			totalSize: 40}},
 	{test: &freeTest{ptr: 24}, // address of second allocation
 		state: allocatorState{bumper: 40,
-			heads:     [22]uint32{0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			totalSize: 16}},
 }
 
@@ -108,7 +108,7 @@ var allocateDeallocateReallocateWithOffset = []testSet{
 			totalSize: 40}},
 	{test: &freeTest{ptr: 40}, // address of second allocation
 		state: allocatorState{bumper: 40,
-			heads:     [22]uint32{0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{0, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ptrOffset: 16,
 			totalSize: 16}},
 	{test: &allocateTest{size: 9},
@@ -141,18 +141,18 @@ var allocateShouldBuildFreeList = []testSet{
 	// free second allocation
 	{test: &freeTest{ptr: 24}, // address of second allocation
 		state: allocatorState{bumper: 48,
-			heads:     [22]uint32{16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			totalSize: 16}},
 	// free third allocation
 	{test: &freeTest{ptr: 40}, // address of third allocation
 		state: allocatorState{bumper: 48,
-			heads:     [22]uint32{32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			totalSize: 0}},
 	// allocate 8 bytes
 	{test: &allocateTest{size: 8},
 		output: uint32(40),
 		state: allocatorState{bumper: 48,
-			heads:     [22]uint32{16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			totalSize: 16}},
 }
 
@@ -200,7 +200,7 @@ var heapShouldBeZeroAfterFreeWithOffsetFiveTimes = []testSet{
 	// second free
 	{test: &freeTest{ptr: 104},
 		state: allocatorState{bumper: 144,
-			heads:     [22]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ptrOffset: 24,
 			totalSize: 0}},
 	// third alloc
@@ -212,7 +212,7 @@ var heapShouldBeZeroAfterFreeWithOffsetFiveTimes = []testSet{
 	// third free
 	{test: &freeTest{ptr: 104},
 		state: allocatorState{bumper: 144,
-			heads:     [22]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ptrOffset: 24,
 			totalSize: 0}},
 	// forth alloc
@@ -224,7 +224,7 @@ var heapShouldBeZeroAfterFreeWithOffsetFiveTimes = []testSet{
 	// forth free
 	{test: &freeTest{ptr: 104},
 		state: allocatorState{bumper: 144,
-			heads:     [22]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ptrOffset: 24,
 			totalSize: 0}},
 	// fifth alloc
@@ -236,7 +236,7 @@ var heapShouldBeZeroAfterFreeWithOffsetFiveTimes = []testSet{
 	// fifth free
 	{test: &freeTest{ptr: 104},
 		state: allocatorState{bumper: 144,
-			heads:     [22]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			heads:     [HeadsQty]uint32{0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ptrOffset: 24,
 			totalSize: 0}},
 }

--- a/lib/runtime/allocator_test.go
+++ b/lib/runtime/allocator_test.go
@@ -484,7 +484,7 @@ func TestShouldGetItemFromIndex(t *testing.T) {
 // that that getItemSizeFromIndex method gets expected item size from index
 // max index position
 func TestShouldGetMaxFromIndex(t *testing.T) {
-	index := uint(21)
+	index := uint(HeadsQty - 1)
 	itemSize := getItemSizeFromIndex(index)
 	if itemSize != MaxPossibleAllocation {
 		t.Errorf("item_size should be %d, got item_size: %d", MaxPossibleAllocation, itemSize)


### PR DESCRIPTION
## Changes

- This changes increases the amount of possible allocations from `2 ^ 24` to `2 ^ 25` as it is defined in substrate `primitives/core` 

```rs
pub const MAX_POSSIBLE_ALLOCATION: u32 = 33554432; // 2^25 bytes, 32 MiB
```
ref: https://github.com/paritytech/substrate/blob/2ca66197161b3b5c4e2aafdb7238f3c5af84a0e8/primitives/core/src/lib.rs#L400

- Also increase the `HeadsQty` to 23 as it is in substrate implementation

https://github.com/paritytech/substrate/blob/2ca66197161b3b5c4e2aafdb7238f3c5af84a0e8/client/allocator/src/freeing_bump.rs#L288C1-L288C1

This fixes the following error while syncing

![image](https://github.com/ChainSafe/gossamer/assets/17255488/c60bab96-3934-4e75-b029-7dbabe2a38c1)


## Tests

<!-- Detail how to run relevant tests to the changes -->

N/A

## Issues

N/A

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@dimartiro 
