### PR TITLE
chore(lib/babe): ensure babe goroutines exits after calling `Stop`

### DIFF
--- a/dot/rpc/interfaces.go
+++ b/dot/rpc/interfaces.go
@@ -66,8 +66,8 @@ type NetworkAPI interface {
 
 // BlockProducerAPI is the interface for BlockProducer methods
 type BlockProducerAPI interface {
-	Pause() error
-	Resume() error
+	Pause()
+	Resume()
 	EpochLength() uint64
 	SlotDuration() uint64
 }

--- a/dot/rpc/modules/api.go
+++ b/dot/rpc/modules/api.go
@@ -64,8 +64,8 @@ type NetworkAPI interface {
 
 // BlockProducerAPI is the interface for BlockProducer methods
 type BlockProducerAPI interface {
-	Pause() error
-	Resume() error
+	Pause()
+	Resume()
 	EpochLength() uint64
 	SlotDuration() uint64
 }

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -42,10 +42,10 @@ func (m *DevModule) Control(r *http.Request, req *[]string, res *string) error {
 
 		switch reqA[1] {
 		case "stop":
-			err = m.blockProducerAPI.Pause()
+			m.blockProducerAPI.Pause()
 			*res = blockProducerStoppedMsg
 		case "start":
-			err = m.blockProducerAPI.Resume()
+			m.blockProducerAPI.Resume()
 			*res = blockProducerStartedMsg
 		}
 

--- a/dot/rpc/modules/dev.go
+++ b/dot/rpc/modules/dev.go
@@ -31,7 +31,7 @@ func NewDevModule(bp BlockProducerAPI, net NetworkAPI) *DevModule {
 }
 
 // Control to send start and stop messages to services
-func (m *DevModule) Control(r *http.Request, req *[]string, res *string) error {
+func (m *DevModule) Control(_ *http.Request, req *[]string, res *string) error {
 	reqA := *req
 	var err error
 	switch reqA[0] {
@@ -63,14 +63,14 @@ func (m *DevModule) Control(r *http.Request, req *[]string, res *string) error {
 }
 
 // SlotDuration Dev RPC to return slot duration
-func (m *DevModule) SlotDuration(r *http.Request, req *EmptyRequest, res *string) error {
+func (m *DevModule) SlotDuration(_ *http.Request, _ *EmptyRequest, res *string) error {
 	var err error
 	*res = uint64ToHex(m.blockProducerAPI.SlotDuration())
 	return err
 }
 
 // EpochLength Dev RPC to return epoch length
-func (m *DevModule) EpochLength(r *http.Request, req *EmptyRequest, res *string) error {
+func (m *DevModule) EpochLength(_ *http.Request, _ *EmptyRequest, res *string) error {
 	var err error
 	*res = uint64ToHex(m.blockProducerAPI.EpochLength())
 	return err

--- a/dot/rpc/modules/dev_test.go
+++ b/dot/rpc/modules/dev_test.go
@@ -160,15 +160,11 @@ func TestDevModule_Control(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockBlockProducerAPI := mocks.NewMockBlockProducerAPI(ctrl)
-	mockErrorBlockProducerAPI := mocks.NewMockBlockProducerAPI(ctrl)
 	mockNetworkAPI := mocks.NewMockNetworkAPI(ctrl)
 	mockErrorNetworkAPI := mocks.NewMockNetworkAPI(ctrl)
 
-	mockErrorBlockProducerAPI.EXPECT().Pause().Return(errors.New("babe pause error"))
-	mockBlockProducerAPI.EXPECT().Pause().Return(nil)
-
-	mockErrorBlockProducerAPI.EXPECT().Resume().Return(errors.New("babe resume error"))
-	mockBlockProducerAPI.EXPECT().Resume().Return(nil)
+	mockBlockProducerAPI.EXPECT().Pause()
+	mockBlockProducerAPI.EXPECT().Resume()
 
 	mockErrorNetworkAPI.EXPECT().Stop().Return(errors.New("network stop error"))
 	mockNetworkAPI.EXPECT().Stop().Return(nil)
@@ -203,18 +199,6 @@ func TestDevModule_Control(t *testing.T) {
 			expErr: errors.New("not a block producer"),
 		},
 		{
-			name: "Babe_Stop_Error",
-			fields: fields{
-				mockNetworkAPI,
-				mockErrorBlockProducerAPI,
-			},
-			args: args{
-				req: &[]string{"babe", "stop"},
-			},
-			exp:    "babe service stopped",
-			expErr: errors.New("babe pause error"),
-		},
-		{
 			name: "Babe_Stop_OK",
 			fields: fields{
 				mockNetworkAPI,
@@ -224,18 +208,6 @@ func TestDevModule_Control(t *testing.T) {
 				req: &[]string{"babe", "stop"},
 			},
 			exp: "babe service stopped",
-		},
-		{
-			name: "Babe_Start_Error",
-			fields: fields{
-				mockNetworkAPI,
-				mockErrorBlockProducerAPI,
-			},
-			args: args{
-				req: &[]string{"babe", "start"},
-			},
-			exp:    "babe service started",
-			expErr: errors.New("babe resume error"),
 		},
 		{
 			name: "Babe_Start_OK",

--- a/dot/rpc/modules/mocks/mocks.go
+++ b/dot/rpc/modules/mocks/mocks.go
@@ -619,11 +619,9 @@ func (mr *MockBlockProducerAPIMockRecorder) EpochLength() *gomock.Call {
 }
 
 // Pause mocks base method.
-func (m *MockBlockProducerAPI) Pause() error {
+func (m *MockBlockProducerAPI) Pause() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Pause")
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Pause")
 }
 
 // Pause indicates an expected call of Pause.
@@ -633,11 +631,9 @@ func (mr *MockBlockProducerAPIMockRecorder) Pause() *gomock.Call {
 }
 
 // Resume mocks base method.
-func (m *MockBlockProducerAPI) Resume() error {
+func (m *MockBlockProducerAPI) Resume() {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resume")
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "Resume")
 }
 
 // Resume indicates an expected call of Resume.

--- a/dot/services.go
+++ b/dot/services.go
@@ -39,8 +39,8 @@ import (
 
 // BlockProducer to produce blocks
 type BlockProducer interface {
-	Pause() error
-	Resume() error
+	Pause()
+	Resume()
 	EpochLength() uint64
 	SlotDuration() uint64
 }

--- a/lib/babe/babe_integration_test.go
+++ b/lib/babe/babe_integration_test.go
@@ -6,6 +6,7 @@
 package babe
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -106,24 +107,17 @@ func TestService_PauseAndResume(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(time.Second)
 
-	go func() {
-		_ = babeService.Pause()
-	}()
+	wg := sync.WaitGroup{}
+	wg.Add(4)
 
-	go func() {
-		_ = babeService.Pause()
-	}()
+	babeService.Pause()
+	_, ok := <-babeService.pauseCh
+	require.False(t, ok)
 
-	go func() {
-		err := babeService.Resume()
-		require.NoError(t, err)
-	}()
+	_, ok = <-babeService.doneCh
+	require.False(t, ok)
 
-	go func() {
-		err := babeService.Resume()
-		require.NoError(t, err)
-	}()
-
+	babeService.Resume()
 	err = babeService.Stop()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Changes

- Methods dont't return error
- Test `TestService_PauseAndResume` rewrite without goroutines
- Introduce `doneCh` that releases only when babe engines goroutine is finished
- Unblocks https://github.com/ChainSafe/gossamer/pull/3434

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer/lib/babe
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@edwardmack 
