### PR TITLE
fix(lib/trie): create an empty child trie if not found

### DIFF
--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -455,17 +455,22 @@ func TestStateModule_GetKeysPaged(t *testing.T) {
 			params: StateStorageKeyRequest{
 				Qty:   10,
 				Block: nil,
-			}, expected: []string{"0x3a6b657931", "0x3a6b657932"}},
+			}, expected: []string{
+				"0x3a6368696c645f73746f726167653a64656661756c743a3a6368696c6431",
+				"0x3a6b657931", "0x3a6b657932"}},
 		{name: "allKeysTestBlockHash",
 			params: StateStorageKeyRequest{
 				Qty:   10,
 				Block: stateRootHash,
-			}, expected: []string{"0x3a6b657931", "0x3a6b657932"}},
+			}, expected: []string{
+				"0x3a6368696c645f73746f726167653a64656661756c743a3a6368696c6431",
+				"0x3a6b657931", "0x3a6b657932"}},
 		{name: "prefixMatchAll",
 			params: StateStorageKeyRequest{
 				Prefix: "0x3a6b6579",
 				Qty:    10,
-			}, expected: []string{"0x3a6b657931", "0x3a6b657932"}},
+			}, expected: []string{
+				"0x3a6b657931", "0x3a6b657932"}},
 		{name: "prefixMatchOne",
 			params: StateStorageKeyRequest{
 				Prefix: "0x3a6b657931",
@@ -479,7 +484,7 @@ func TestStateModule_GetKeysPaged(t *testing.T) {
 		{name: "qtyOne",
 			params: StateStorageKeyRequest{
 				Qty: 1,
-			}, expected: []string{"0x3a6b657931"}},
+			}, expected: []string{"0x3a6368696c645f73746f726167653a64656661756c743a3a6368696c6431"}},
 		{name: "afterKey",
 			params: StateStorageKeyRequest{
 				Qty:      10,

--- a/dot/rpc/modules/state_integration_test.go
+++ b/dot/rpc/modules/state_integration_test.go
@@ -127,7 +127,8 @@ func TestStateModule_GetPairs(t *testing.T) {
 				"0x8f733acc98dff0e6527f97e2a87e4834cd8b2e601f56fb003084e9d43183d7ff"},
 			[]string{hexEncode(":key1"), hexEncode("value1")},
 			[]string{hexEncode(":key2"), hexEncode("value2")}}},
-		{params: []string{hexEncode(":key1"), hash.String()}, expected: []interface{}{[]string{hexEncode(":key1"), hexEncode("value1")}}},
+		{params: []string{hexEncode(":key1"), hash.String()},
+			expected: []interface{}{[]string{hexEncode(":key1"), hexEncode("value1")}}},
 		{params: []string{"", randomHash.String()}, errMsg: "pebble: not found"},
 	}
 

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -8,8 +8,8 @@ const (
 	// This wasm is generated using https://github.com/ChainSafe/polkadot-spec.
 	HOST_API_TEST_RUNTIME     = "hostapi_runtime"
 	HOST_API_TEST_RUNTIME_FP  = "hostapi_runtime.compact.wasm"
-	HOST_API_TEST_RUNTIME_URL = "https://github.com/ChainSafe/polkadot-spec/blob/" +
-		"b50f72fd57c563da7183e7768d348933e80c3106/test/runtimes/hostapi/hostapi_runtime.compact.wasm?raw=true"
+	HOST_API_TEST_RUNTIME_URL = "https://github.com/ChainSafe/polkadot-spec/raw/master/test/" +
+		"runtimes/hostapi/hostapi_runtime.compact.wasm"
 
 	// v0.9.29 polkadot
 	POLKADOT_RUNTIME_v0929     = "polkadot_runtime-v929"

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -8,8 +8,9 @@ const (
 	// This wasm is generated using https://github.com/ChainSafe/polkadot-spec.
 	HOST_API_TEST_RUNTIME     = "hostapi_runtime"
 	HOST_API_TEST_RUNTIME_FP  = "hostapi_runtime.compact.wasm"
-	HOST_API_TEST_RUNTIME_URL = "https://github.com/ChainSafe/polkadot-spec/raw/master/test/" +
-		"runtimes/hostapi/hostapi_runtime.compact.wasm"
+	HOST_API_TEST_RUNTIME_URL = "https://github.com/ChainSafe/polkadot-spec/tree" +
+		"/b50f72fd57c563da7183e7768d348933e80c3106" +
+		"/test/runtimes/hostapi/hostapi_runtime.compact.wasm"
 
 	// v0.9.29 polkadot
 	POLKADOT_RUNTIME_v0929     = "polkadot_runtime-v929"

--- a/lib/runtime/constants.go
+++ b/lib/runtime/constants.go
@@ -8,9 +8,8 @@ const (
 	// This wasm is generated using https://github.com/ChainSafe/polkadot-spec.
 	HOST_API_TEST_RUNTIME     = "hostapi_runtime"
 	HOST_API_TEST_RUNTIME_FP  = "hostapi_runtime.compact.wasm"
-	HOST_API_TEST_RUNTIME_URL = "https://github.com/ChainSafe/polkadot-spec/tree" +
-		"/b50f72fd57c563da7183e7768d348933e80c3106" +
-		"/test/runtimes/hostapi/hostapi_runtime.compact.wasm"
+	HOST_API_TEST_RUNTIME_URL = "https://github.com/ChainSafe/polkadot-spec/blob/" +
+		"b50f72fd57c563da7183e7768d348933e80c3106/test/runtimes/hostapi/hostapi_runtime.compact.wasm?raw=true"
 
 	// v0.9.29 polkadot
 	POLKADOT_RUNTIME_v0929     = "polkadot_runtime-v929"

--- a/lib/runtime/wazero/imports_test.go
+++ b/lib/runtime/wazero/imports_test.go
@@ -887,8 +887,7 @@ func Test_ext_default_child_storage_set_version_1(t *testing.T) {
 			anotherValue := []byte("some_acc_address_2")
 			insertKeyAndValue(t, inst, exampleChildKey, anotherKey, anotherValue)
 
-			// should be possible to retrive the first address and the new inserted one
-
+			// should be possible to retrieve the first address and the new inserted one
 			acc1 := getValueFromChildStorage(t, inst, exampleChildKey, exampleKey)
 			require.Equal(t, &exampleValue, acc1)
 

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -53,19 +53,13 @@ func (t *Trie) GetChild(keyToChild []byte) (*Trie, error) {
 
 // PutIntoChild puts a key-value pair into the child trie located in the main trie at key :child_storage:[keyToChild]
 func (t *Trie) PutIntoChild(keyToChild, key, value []byte) error {
-	var freshNewTrie bool
-
 	child, err := t.GetChild(keyToChild)
 	if err != nil {
 		if errors.Is(err, ErrChildTrieDoesNotExist) {
-			freshNewTrie = true
+			child = NewEmptyTrie()
 		} else {
 			return fmt.Errorf("getting child: %w", err)
 		}
-	}
-
-	if freshNewTrie {
-		child = NewEmptyTrie()
 	}
 
 	origChildHash, err := child.Hash()


### PR DESCRIPTION
## Changes

- When the runtime tries to set a key/value in the child trie and it does not exist then it was failing with
```
child trie does not exist at key 0x...
```
- After the fix, if the child trie does not exist Gossamer creates a fresh new empty trie, insert key and value and persists it in the root trie

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -timeout 10m -run ^Test_ext_default_child_storage_set_version_1$ github.com/ChainSafe/gossamer/lib/runtime/wazero --tags=integration -v
```

## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/3458
- Related https://github.com/ChainSafe/gossamer/issues/3409

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kanishkatn
@dimartiro
