### PR TITLE
fix(tests): Export unimplemented runtime fuctions

### DIFF
--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -208,7 +208,7 @@ func NewInstance(code []byte, cfg Config) (instance *Instance, err error) {
 		Export("ext_trie_blake2_256_root_version_1").
 		NewFunctionBuilder().
 		WithFunc(func(a int64, v int32) int32 {
-			panic("unimplemented")
+			panic("ext_trie_blake2_256_root_version_2 unimplemented")
 		}).
 		Export("ext_trie_blake2_256_root_version_2").
 		NewFunctionBuilder().
@@ -222,7 +222,7 @@ func NewInstance(code []byte, cfg Config) (instance *Instance, err error) {
 		Export("ext_trie_blake2_256_verify_proof_version_1").
 		NewFunctionBuilder().
 		WithFunc(func(a int32, b int64, c int64, d int64, v int32) int32 {
-			panic("unimplemented")
+			panic("ext_trie_blake2_256_verify_proof_version_2 unimplemented")
 		}).
 		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -207,6 +207,11 @@ func NewInstance(code []byte, cfg Config) (instance *Instance, err error) {
 		WithFunc(ext_trie_blake2_256_root_version_1).
 		Export("ext_trie_blake2_256_root_version_1").
 		NewFunctionBuilder().
+		WithFunc(func(a int64, v int32) int32 {
+			panic("unimplemented")
+		}).
+		Export("ext_trie_blake2_256_root_version_2").
+		NewFunctionBuilder().
 		WithFunc(ext_trie_blake2_256_ordered_root_version_1).
 		Export("ext_trie_blake2_256_ordered_root_version_1").
 		NewFunctionBuilder().
@@ -215,6 +220,11 @@ func NewInstance(code []byte, cfg Config) (instance *Instance, err error) {
 		NewFunctionBuilder().
 		WithFunc(ext_trie_blake2_256_verify_proof_version_1).
 		Export("ext_trie_blake2_256_verify_proof_version_1").
+		NewFunctionBuilder().
+		WithFunc(func(a int32, b int64, c int64, d int64, v int32) int32 {
+			panic("unimplemented")
+		}).
+		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().
 		WithFunc(ext_misc_print_hex_version_1).
 		Export("ext_misc_print_hex_version_1").


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->

Our current implementation fails if we don't export all runtime functions declared in polkadot runtime.
I made this change to add new exported functions and fix failing tests [due our last runtime changes](https://github.com/ChainSafe/polkadot-spec/pull/17) used for tests

This will be fixed with the right implementation after merging #3428 (only for the same functions)

We can discuss what to do to prevent issues in case a new function is added in polkadot runtime and we don't have it exported


## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make test
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@EclesioMeloJunior 
