### PR TITLE
chore: only initialize if it is not initialized

### DIFF
--- a/dot/node.go
+++ b/dot/node.go
@@ -258,7 +258,7 @@ func newNode(config *cfg.Config,
 		return nil, fmt.Errorf("checking if node is initialised: %w", err)
 	}
 
-	if isInitialised {
+	if !isInitialised {
 		err := builder.initNode(config)
 		if err != nil {
 			return nil, fmt.Errorf("cannot initialise node: %w", err)

--- a/dot/node_integration_test.go
+++ b/dot/node_integration_test.go
@@ -88,7 +88,7 @@ func TestNewNode(t *testing.T) {
 	mockServiceRegistry.EXPECT().RegisterService(gomock.Any()).Times(8)
 
 	m := NewMocknodeBuilderIface(ctrl)
-	m.EXPECT().isNodeInitialised(initConfig.BasePath).Return(false, nil)
+	m.EXPECT().isNodeInitialised(initConfig.BasePath).Return(true, nil)
 	m.EXPECT().createStateService(initConfig).DoAndReturn(func(config *cfg.Config) (*state.Service, error) {
 		stateSrvc := state.NewService(stateConfig)
 		// create genesis from configuration file


### PR DESCRIPTION
## Changes

`builder.isNodeInitialised` returns a boolean after checking if the base path is there with important files, meaning that the node is already initialized. However, Gossamer re-initialize the node if `isInitialized == true` which is not the intended behavior

## Tests

N/A

## Issues

N/A

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@dimartiro  
