### PR TITLE
fix(lib/trie): `ClearFromChild` should update parent trie

### DIFF
--- a/lib/runtime/wazero/imports.go
+++ b/lib/runtime/wazero/imports.go
@@ -363,7 +363,7 @@ func ext_crypto_secp256k1_ecdsa_recover_version_1(ctx context.Context, m api.Mod
 	return ret
 }
 
-func ext_crypto_secp256k1_ecdsa_recover_version_2(ctx context.Context, m api.Module, sig uint32, msg uint32) uint64 {
+func ext_crypto_secp256k1_ecdsa_recover_version_2(ctx context.Context, m api.Module, sig, msg uint32) uint64 {
 	return ext_crypto_secp256k1_ecdsa_recover_version_1(ctx, m, sig, msg)
 }
 
@@ -1172,17 +1172,17 @@ func ext_default_child_storage_next_key_version_1(
 
 	keyToChild := read(m, childStorageKey)
 	keyBytes := read(m, key)
-	child, err := storage.GetChildNextKey(keyToChild, keyBytes)
+	childNextKey, err := storage.GetChildNextKey(keyToChild, keyBytes)
 	if err != nil {
 		logger.Errorf("failed to get child's next key: %s", err)
-		return 0
+		return mustWrite(m, rtCtx.Allocator, noneEncoded)
 	}
 
-	ret, err := write(m, rtCtx.Allocator, scale.MustMarshal(&child))
-	if err != nil {
-		panic(err)
+	if childNextKey == nil {
+		return mustWrite(m, rtCtx.Allocator, noneEncoded)
 	}
-	return ret
+
+	return mustWrite(m, rtCtx.Allocator, scale.MustMarshal(&childNextKey))
 }
 
 func ext_default_child_storage_root_version_1(

--- a/lib/runtime/wazero/imports_test.go
+++ b/lib/runtime/wazero/imports_test.go
@@ -920,9 +920,10 @@ func Test_ext_default_child_storage_clear_version_1(t *testing.T) {
 	_, err = inst.Exec("rtm_ext_default_child_storage_clear_version_1", append(encChildKey, encKey...))
 	require.NoError(t, err)
 
-	val, err = inst.Context.Storage.GetChildStorage(testChildKey, testKey)
-	require.NoError(t, err)
-	require.Nil(t, val)
+	_, err = inst.Context.Storage.GetChildStorage(testChildKey, testKey)
+	require.ErrorIs(t, err, trie.ErrChildTrieDoesNotExist)
+	require.EqualError(t, err, "child trie does not exist at key "+
+		"0x3a6368696c645f73746f726167653a64656661756c743a6368696c644b6579")
 }
 
 func Test_ext_default_child_storage_clear_prefix_version_1(t *testing.T) {

--- a/lib/runtime/wazero/imports_test.go
+++ b/lib/runtime/wazero/imports_test.go
@@ -1040,8 +1040,6 @@ func Test_ext_default_child_storage_get_version_1(t *testing.T) {
 }
 
 func Test_ext_default_child_storage_next_key_version_1(t *testing.T) {
-	inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
-
 	testKeyValuePair := []struct {
 		key   []byte
 		value []byte
@@ -1050,30 +1048,73 @@ func Test_ext_default_child_storage_next_key_version_1(t *testing.T) {
 		{[]byte("key"), []byte("value2")},
 	}
 
-	key := testKeyValuePair[0].key
+	testcases := map[string]struct {
+		setupInstance func(t *testing.T) *Instance
+		expected      *[]byte
+	}{
+		"next_key_exists": {
+			setupInstance: func(t *testing.T) *Instance {
+				inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
 
-	err := inst.Context.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
-	require.NoError(t, err)
+				err := inst.Context.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+				require.NoError(t, err)
 
-	for _, kv := range testKeyValuePair {
-		err = inst.Context.Storage.SetChildStorage(testChildKey, kv.key, kv.value)
-		require.NoError(t, err)
+				for _, kv := range testKeyValuePair {
+					err = inst.Context.Storage.SetChildStorage(testChildKey, kv.key, kv.value)
+					require.NoError(t, err)
+				}
+
+				return inst
+			},
+			expected: &testKeyValuePair[1].key,
+		},
+		"child_tree_not_exists": {
+			setupInstance: func(t *testing.T) *Instance {
+				return NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
+			},
+			expected: nil,
+		},
+		"with_only_one_key": {
+			setupInstance: func(t *testing.T) *Instance {
+				inst := NewTestInstance(t, runtime.HOST_API_TEST_RUNTIME)
+
+				err := inst.Context.Storage.SetChild(testChildKey, trie.NewEmptyTrie())
+				require.NoError(t, err)
+
+				kv := testKeyValuePair[0]
+				err = inst.Context.Storage.SetChildStorage(testChildKey, kv.key, kv.value)
+				require.NoError(t, err)
+
+				return inst
+			},
+			expected: nil,
+		},
 	}
 
-	encChildKey, err := scale.Marshal(testChildKey)
-	require.NoError(t, err)
+	for tname, tt := range testcases {
+		tt := tt
 
-	encKey, err := scale.Marshal(key)
-	require.NoError(t, err)
+		t.Run(tname, func(t *testing.T) {
+			key := testKeyValuePair[0].key
 
-	ret, err := inst.Exec("rtm_ext_default_child_storage_next_key_version_1", append(encChildKey, encKey...))
-	require.NoError(t, err)
+			encChildKey, err := scale.Marshal(testChildKey)
+			require.NoError(t, err)
 
-	var read *[]byte
-	err = scale.Unmarshal(ret, &read)
-	require.NoError(t, err)
-	require.NotNil(t, read)
-	require.Equal(t, testKeyValuePair[1].key, *read)
+			encKey, err := scale.Marshal(key)
+			require.NoError(t, err)
+
+			inst := tt.setupInstance(t)
+			ret, err := inst.Exec("rtm_ext_default_child_storage_next_key_version_1", append(encChildKey, encKey...))
+			require.NoError(t, err)
+
+			var read *[]byte
+			err = scale.Unmarshal(ret, &read)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, read)
+		})
+	}
+
 }
 
 func Test_ext_default_child_storage_root_version_1(t *testing.T) {

--- a/lib/trie/child_storage.go
+++ b/lib/trie/child_storage.go
@@ -111,8 +111,14 @@ func (t *Trie) ClearFromChild(keyToChild, key []byte) error {
 	if err != nil {
 		return err
 	}
+
 	if child == nil {
 		return fmt.Errorf("%w at key 0x%x%x", ErrChildTrieDoesNotExist, ChildStorageKeyPrefix, keyToChild)
+	}
+
+	origChildHash, err := child.Hash()
+	if err != nil {
+		return err
 	}
 
 	err = child.Delete(key)
@@ -120,5 +126,10 @@ func (t *Trie) ClearFromChild(keyToChild, key []byte) error {
 		return fmt.Errorf("deleting from child trie located at key 0x%x: %w", keyToChild, err)
 	}
 
-	return nil
+	delete(t.childTries, origChildHash)
+	if child.root == nil {
+		return t.DeleteChild(keyToChild)
+	}
+
+	return t.SetChild(keyToChild, child)
 }

--- a/lib/trie/child_storage_test.go
+++ b/lib/trie/child_storage_test.go
@@ -5,8 +5,11 @@ package trie
 
 import (
 	"bytes"
+	"encoding/binary"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPutAndGetChild(t *testing.T) {
@@ -70,4 +73,36 @@ func TestPutAndGetFromChild(t *testing.T) {
 	if !bytes.Equal(valueRes, testValue) {
 		t.Fatalf("Fail: got %x expected %x", valueRes, testValue)
 	}
+}
+
+func TestChildTrieHashAfterClear(t *testing.T) {
+	trieThatHoldsAChildTrie := NewEmptyTrie()
+	originalEmptyHash := trieThatHoldsAChildTrie.MustHash()
+
+	keyToChild := []byte("crowdloan")
+	keyInChild := []byte("account-alice")
+	contributed := uint64(1000)
+	contributedWith := make([]byte, 8)
+	binary.BigEndian.PutUint64(contributedWith, contributed)
+
+	err := trieThatHoldsAChildTrie.PutIntoChild(keyToChild, keyInChild, contributedWith)
+	require.NoError(t, err)
+
+	// the parent trie hash SHOULT NOT BE EQUAL to the original
+	// empty hash since it contains a value
+	require.NotEqual(t, originalEmptyHash, trieThatHoldsAChildTrie.MustHash())
+
+	// ensure the value is inside the child trie
+	valueStored, err := trieThatHoldsAChildTrie.GetFromChild(keyToChild, keyInChild)
+	require.NoError(t, err)
+	require.Equal(t, contributed, binary.BigEndian.Uint64(valueStored))
+
+	// clear child trie key value
+	err = trieThatHoldsAChildTrie.ClearFromChild(keyToChild, keyInChild)
+	require.NoError(t, err)
+
+	// the parent trie hash SHOULD BE EQUAL to the original
+	// empty hash since now it does not have any other value in it
+	require.Equal(t, originalEmptyHash, trieThatHoldsAChildTrie.MustHash())
+
 }


### PR DESCRIPTION
## Changes

- This PR fixes the issue `Storage root must match that calculated` described at https://github.com/ChainSafe/gossamer/issues/3478
- Full description https://hackmd.io/@-8f0KkDaSXGl-AgsJkF8Jg/rJy08gWya

## Tests

<!-- Detail how to run relevant tests to the changes -->

```
go test -run ^TestChildTrieHashAfterClear$ github.com/ChainSafe/gossamer/lib/trie --tags=integration -v
```
## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/3478

## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@dimartiro 
