### PR TITLE
chore(dot/parachain/overseer): fix `TestHandleBlockEvents` the flaky test

### DIFF
--- a/dot/parachain/overseer/overseer.go
+++ b/dot/parachain/overseer/overseer.go
@@ -232,10 +232,6 @@ func (o *Overseer) Stop() error {
 	// close the errorChan to unblock any listeners on the errChan
 	close(o.errChan)
 
-	for _, sub := range o.subsystems {
-		close(sub)
-	}
-
 	// wait for subsystems to stop
 	// TODO: determine reasonable timeout duration for production, currently this is just for testing
 	timedOut := waitTimeout(&o.wg, 500*time.Millisecond)

--- a/dot/parachain/overseer/overseer_test.go
+++ b/dot/parachain/overseer/overseer_test.go
@@ -92,36 +92,10 @@ func TestHandleBlockEvents(t *testing.T) {
 		for {
 			select {
 			case msg := <-overseerToSubSystem1:
-				if msg == nil {
-					continue
-				}
-
-				_, ok := msg.(parachaintypes.BlockFinalizedSignal)
-				if ok {
-					finalizedCounter.Add(1)
-				}
-
-				_, ok = msg.(parachaintypes.ActiveLeavesUpdateSignal)
-				if ok {
-					importedCounter.Add(1)
-				}
-
+				incrementCounters(t, msg, &finalizedCounter, &importedCounter)
 			case msg := <-overseerToSubSystem2:
-				if msg == nil {
-					continue
-				}
-
-				_, ok := msg.(parachaintypes.BlockFinalizedSignal)
-				if ok {
-					finalizedCounter.Add(1)
-				}
-
-				_, ok = msg.(parachaintypes.ActiveLeavesUpdateSignal)
-				if ok {
-					importedCounter.Add(1)
-				}
+				incrementCounters(t, msg, &finalizedCounter, &importedCounter)
 			}
-
 		}
 	}()
 
@@ -137,4 +111,19 @@ func TestHandleBlockEvents(t *testing.T) {
 
 	require.Equal(t, int32(2), finalizedCounter.Load())
 	require.Equal(t, int32(2), importedCounter.Load())
+}
+
+func incrementCounters(t *testing.T, msg any, finalizedCounter *atomic.Int32, importedCounter *atomic.Int32) {
+	t.Helper()
+
+	if msg == nil {
+		return
+	}
+
+	switch msg.(type) {
+	case parachaintypes.BlockFinalizedSignal:
+		finalizedCounter.Add(1)
+	case parachaintypes.ActiveLeavesUpdateSignal:
+		importedCounter.Add(1)
+	}
 }

--- a/dot/parachain/overseer/overseer_test.go
+++ b/dot/parachain/overseer/overseer_test.go
@@ -105,7 +105,7 @@ func TestHandleBlockEvents(t *testing.T) {
 				if ok {
 					importedCounter.Add(1)
 				}
-				
+
 			case msg := <-overseerToSubSystem2:
 				if msg == nil {
 					continue

--- a/dot/parachain/overseer/overseer_test.go
+++ b/dot/parachain/overseer/overseer_test.go
@@ -105,6 +105,7 @@ func TestHandleBlockEvents(t *testing.T) {
 				if ok {
 					importedCounter.Add(1)
 				}
+				
 			case msg := <-overseerToSubSystem2:
 				if msg == nil {
 					continue


### PR DESCRIPTION
## Changes
![overseer](https://github.com/ChainSafe/gossamer/assets/40173579/3ddeb210-360e-4e40-99e6-ce387a5ce5c7)

- If we close overseerToSub1, subsystem2 could still send a message for subsystem1 via subsystemToOverseer, and it will be panic.
- we can close overseerToSubsystem channels only if the subsystemToOverseer channel is closed.

IMO, we should not close either of them.
That is why I removed the code to close overseerToSubsystem channels.

Used a `waitGroup` in the test to wait till we received all the messages in mocked subsystems before we called the stop function of overseer. 




## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
closes #3717
## Primary Reviewer

<!-- Tag a code owner to review your PR -->

@kishansagathiya @EclesioMeloJunior 
