### PR TITLE
fix(docs): Fixing link to polkadot runtime fundamentals to the right one

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -118,7 +118,7 @@ Anyone can become a part-time contributor and help out on gossamer. Contribution
 -   Follow up on open PRs
     -   Have an estimated timeframe to completion and let the core contributors know if a PR will take longer than expected
 
-We do not expect all part-time contributors to be experts on all the latest Polkadot documentation, but all contributors should at least be familiarized with the fundamentals of the [Polkadot Runtime Specification](https://research.web3.foundation/en/latest/_static/pdfview/viewer.html?file=../pdf/polkadot_re_spec.pdf).
+We do not expect all part-time contributors to be experts on all the latest Polkadot documentation, but all contributors should at least be familiarized with the fundamentals of The <a href="https://spec.polkadot.network/id-polkadot-protocol" target="_blank">Polkadot Runtime Specification.</a>
 
 ### Core Contributors
 


### PR DESCRIPTION
## Changes

Changing `Polkadot Runtime Specification` hiperlink  and adding a target so that it opens a new tab with the link instead of refreshing your active one
Current one is not working and it's refreshing the current tab instead of opening a new tab with the link

## Tests


Click`Polkadot Runtime Specification` hiperlink and see if the link is not broken and it's opening a new tab instead of refreshing the page.
The hiperlink should open a new tab with [this page ](https://spec.polkadot.network/id-polkadot-protocol)

## Issues

No active issues related to this one.

## Primary Reviewer

@jimjbrettj 
