### PR TITLE
feat(dot/parachain/backing): Implement a function to get PoV from validator

### DIFF
--- a/dot/parachain/backing/candidate_backing.go
+++ b/dot/parachain/backing/candidate_backing.go
@@ -353,9 +353,3 @@ func (cb *CandidateBacking) handleStatementMessage(
 		attesting,
 	)
 }
-
-func getPovFromValidator() parachaintypes.PoV {
-	// TODO: Implement this #3545
-	// https://github.com/paritytech/polkadot-sdk/blob/7ca0d65f19497ac1c3c7ad6315f1a0acb2ca32f8/polkadot/node/core/backing/src/lib.rs#L1744 //nolint:lll
-	return parachaintypes.PoV{}
-}

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -535,8 +535,9 @@ func TestKickOffValidationWork(t *testing.T) {
 	candidateHash := parachaintypes.CandidateHash{Value: hash}
 
 	testCases := []struct {
-		description string
-		rpState     perRelayParentState
+		description     string
+		rpState         perRelayParentState
+		processChannels func(chan any, chan relayParentAndCommand)
 	}{
 		{
 			description: "already_issued_statement_for_candidate",
@@ -545,6 +546,7 @@ func TestKickOffValidationWork(t *testing.T) {
 					candidateHash: true,
 				},
 			},
+			processChannels: func(chan any, chan relayParentAndCommand) {},
 		},
 		{
 			description: "not_issued_statement_but_waiting_for_validation",
@@ -553,6 +555,21 @@ func TestKickOffValidationWork(t *testing.T) {
 				awaitingValidation: map[parachaintypes.CandidateHash]bool{
 					candidateHash: true,
 				},
+			},
+			processChannels: func(subSystemToOverseer chan any, cmdCh chan relayParentAndCommand) {
+				for {
+					select {
+					case data := <-subSystemToOverseer:
+						val, ok := data.(parachaintypes.AvailabilityDistributionMessageFetchPoV)
+						if !ok {
+							t.Errorf("invalid overseer message type: %T\n", data)
+						}
+						val.PovCh <- parachaintypes.OverseerFuncRes[parachaintypes.PoV]{
+							Err: parachaintypes.ErrFetchPoV,
+						}
+					case <-cmdCh:
+					}
+				}
 			},
 		},
 	}
@@ -565,6 +582,8 @@ func TestKickOffValidationWork(t *testing.T) {
 			subSystemToOverseer := make(chan any)
 			chRelayParentAndCommand := make(chan relayParentAndCommand)
 			pvd := parachaintypes.PersistedValidationData{}
+
+			go c.processChannels(subSystemToOverseer, chRelayParentAndCommand)
 
 			err := c.rpState.kickOffValidationWork(subSystemToOverseer, chRelayParentAndCommand, pvd, attesting)
 			require.NoError(t, err)

--- a/dot/parachain/types/errors.go
+++ b/dot/parachain/types/errors.go
@@ -1,0 +1,8 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package parachaintypes
+
+import "errors"
+
+var ErrFetchPoV = errors.New("failed to fetch PoV")

--- a/dot/parachain/types/overseer_message.go
+++ b/dot/parachain/types/overseer_message.go
@@ -214,3 +214,22 @@ type ValidationResult struct {
 	PersistedValidationData PersistedValidationData
 	Err                     error
 }
+
+// AvailabilityDistributionMessageFetchPoV represents a message instructing
+// availability distribution to fetch a remote Proof of Validity (PoV).
+type AvailabilityDistributionMessageFetchPoV struct {
+	RelayParent common.Hash
+	// FromValidator is the validator to fetch the PoV from.
+	FromValidator ValidatorIndex
+	// ParaID is the ID of the parachain that produced this PoV.
+	// This field is only used to provide more context when logging errors
+	// from the AvailabilityDistribution subsystem.
+	ParaID ParaID
+	// CandidateHash is the candidate hash to fetch the PoV for.
+	CandidateHash CandidateHash
+	// PovHash is the expected hash of the PoV; a PoV not matching this hash will be rejected.
+	PovHash common.Hash
+	// PovCh is the channel for receiving the result of this fetch.
+	// The channel will be closed if the fetching fails for some reason.
+	PovCh chan OverseerFuncRes[PoV]
+}


### PR DESCRIPTION
## Changes
I have implemented a function to fetch a proof of validity (PoV) from the validator.

When we receive a `Valid` statement for a para candidate block from other parachain validators, 
we validate that candidate block, and for that, we need proof of validity, which we try to fetch from other parachain validators.

Reference: https://github.com/paritytech/polkadot-sdk/blob/7ca0d65f19497ac1c3c7ad6315f1a0acb2ca32f8/polkadot/node/core/backing/src/lib.rs#L642-L665

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
closes #3545

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@kishansagathiya @EclesioMeloJunior 
