### PR TITLE
feat(dot/parachian): Get committed candidate receipt from statement table for the given candidate hash

### DIFF
--- a/dot/parachain/backing/active_leaves_update.go
+++ b/dot/parachain/backing/active_leaves_update.go
@@ -366,8 +366,8 @@ func constructPerRelayParentState(
 		validators: validators,
 	}
 
-	tableConfig := Config{
-		AllowMultipleSeconded: mode.IsEnabled,
+	tableConfig := tableConfig{
+		allowMultipleSeconded: mode.IsEnabled,
 	}
 
 	newPerRelayParentState := perRelayParentState{

--- a/dot/parachain/backing/candidate_backing.go
+++ b/dot/parachain/backing/candidate_backing.go
@@ -306,7 +306,7 @@ func (cb *CandidateBacking) handleStatementMessage(
 	var attesting attestingData
 	switch statementVDT := statementVDT.(type) {
 	case parachaintypes.Seconded:
-		commitedCandidateReceipt, err := rpState.table2.getCandidate(summary.Candidate)
+		commitedCandidateReceipt, err := rpState.table.getCandidate(summary.Candidate)
 		if err != nil {
 			return fmt.Errorf("getting candidate: %w", err)
 		}

--- a/dot/parachain/backing/candidate_backing.go
+++ b/dot/parachain/backing/candidate_backing.go
@@ -306,7 +306,7 @@ func (cb *CandidateBacking) handleStatementMessage(
 	var attesting attestingData
 	switch statementVDT := statementVDT.(type) {
 	case parachaintypes.Seconded:
-		commitedCandidateReceipt, err := rpState.table.getCandidate(summary.Candidate)
+		commitedCandidateReceipt, err := rpState.table2.getCandidate(summary.Candidate)
 		if err != nil {
 			return fmt.Errorf("getting candidate: %w", err)
 		}

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -1194,7 +1194,7 @@ func TestHandleStatementMessage(t *testing.T) {
 				mockTable.EXPECT().getCandidate(
 					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
 				).Return(&dummyCCR, nil)
-				
+
 				return map[common.Hash]*perRelayParentState{
 					relayParent: {
 						table:      mockTable,

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -1148,6 +1148,12 @@ func TestHandleStatementMessage(t *testing.T) {
 					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
 					gomock.AssignableToTypeOf(new(TableContext)),
 				).Return(new(AttestedCandidate), nil)
+				mockTable.EXPECT().getCandidate(
+					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
+				).Return(
+					new(parachaintypes.CommittedCandidateReceipt),
+					errors.New("could not get candidate from table"),
+				)
 
 				return map[common.Hash]*perRelayParentState{
 					relayParent: {
@@ -1164,7 +1170,7 @@ func TestHandleStatementMessage(t *testing.T) {
 				}
 			},
 			signedStatementWithPVD: secondedSignedFullStatementWithPVD(t, statementVDTSeconded),
-			err:                    errCandidateDataNotFound.Error(),
+			err:                    "could not get candidate from table",
 		},
 		{
 			description: "statementVDT_set_to_seconded_and_successfully_get_candidate_from_table",
@@ -1185,15 +1191,13 @@ func TestHandleStatementMessage(t *testing.T) {
 					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
 					gomock.AssignableToTypeOf(new(TableContext)),
 				).Return(new(AttestedCandidate), nil)
-
+				mockTable.EXPECT().getCandidate(
+					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
+				).Return(&dummyCCR, nil)
+				
 				return map[common.Hash]*perRelayParentState{
 					relayParent: {
-						table: mockTable,
-						table2: Table2{
-							candidateVotes: map[parachaintypes.CandidateHash]candidateData{
-								candidateHash: {candidate: dummyCCR},
-							},
-						},
+						table:      mockTable,
 						assignment: paraIDPtr4,
 						backed: map[parachaintypes.CandidateHash]bool{
 							candidateHash: true,

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -1151,7 +1151,7 @@ func TestHandleStatementMessage(t *testing.T) {
 				mockTable.EXPECT().getCandidate(
 					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
 				).Return(
-					new(parachaintypes.CommittedCandidateReceipt),
+					parachaintypes.CommittedCandidateReceipt{},
 					errors.New("could not get candidate from table"),
 				)
 
@@ -1193,7 +1193,7 @@ func TestHandleStatementMessage(t *testing.T) {
 				).Return(new(AttestedCandidate), nil)
 				mockTable.EXPECT().getCandidate(
 					gomock.AssignableToTypeOf(parachaintypes.CandidateHash{}),
-				).Return(&dummyCCR, nil)
+				).Return(dummyCCR, nil)
 
 				return map[common.Hash]*perRelayParentState{
 					relayParent: {

--- a/dot/parachain/backing/mocks_test.go
+++ b/dot/parachain/backing/mocks_test.go
@@ -70,10 +70,10 @@ func (mr *MockTableMockRecorder) drainMisbehaviors() *gomock.Call {
 }
 
 // getCandidate mocks base method.
-func (m *MockTable) getCandidate(arg0 parachaintypes.CandidateHash) (*parachaintypes.CommittedCandidateReceipt, error) {
+func (m *MockTable) getCandidate(arg0 parachaintypes.CandidateHash) (parachaintypes.CommittedCandidateReceipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getCandidate", arg0)
-	ret0, _ := ret[0].(*parachaintypes.CommittedCandidateReceipt)
+	ret0, _ := ret[0].(parachaintypes.CommittedCandidateReceipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/backing/per_relay_parent_state.go
+++ b/dot/parachain/backing/per_relay_parent_state.go
@@ -25,7 +25,8 @@ type perRelayParentState struct {
 	// The `ParaId` assigned to the local validator at this relay parent.
 	assignment *parachaintypes.ParaID
 	// The table of candidates and statements under this relay-parent.
-	table Table
+	table  Table
+	table2 Table2
 	// The table context, including groups.
 	tableContext TableContext
 	// Data needed for retrying in case of `ValidatedCandidateCommand::AttestNoPoV`.
@@ -226,7 +227,7 @@ func attestedToBackedCandidate(
 	// the order of bits set in the bitfield, which is not necessarily
 	// the order of the `validity_votes` we got from the table.
 	for positionInGroup, validatorIndex := range group {
-		for _, validityVote := range attested.ValidityVotes {
+		for _, validityVote := range attested.ValidityAttestations {
 			if validityVote.ValidatorIndex == validatorIndex {
 				validatorIndices[positionInGroup] = true
 				validityAttestations = append(validityAttestations, validityVote.ValidityAttestation)

--- a/dot/parachain/backing/per_relay_parent_state.go
+++ b/dot/parachain/backing/per_relay_parent_state.go
@@ -25,8 +25,7 @@ type perRelayParentState struct {
 	// The `ParaId` assigned to the local validator at this relay parent.
 	assignment *parachaintypes.ParaID
 	// The table of candidates and statements under this relay-parent.
-	table  Table
-	table2 Table2
+	table Table
 	// The table context, including groups.
 	tableContext TableContext
 	// Data needed for retrying in case of `ValidatedCandidateCommand::AttestNoPoV`.

--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -10,22 +10,17 @@ import (
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
 )
 
-/*
-------------------------------------------
-*** Statement table implementation notes:
-------------------------------------------
-
-added table2 field of type Table2 in perRelayParentState, which is implementation of statement table.
-
-table field of type Table needs to be removed after implementing the methods in Table2.
-
-rename Table2 to Table after implementing the methods in Table2.
-
-
-=> At the end check for all the types in this file, if they should be exported or not.
-*/
-
 var errCandidateDataNotFound = errors.New("candidate data not found")
+
+// statementTable implements the Table interface.
+type statementTable struct {
+	authorityData  map[parachaintypes.ValidatorIndex]authorityData
+	candidateVotes map[parachaintypes.CandidateHash]candidateData
+	config         tableConfig
+
+	// TODO: Implement this
+	// detected_misbehaviour: HashMap<Ctx::AuthorityId, Vec<MisbehaviorFor<Ctx>>>,
+}
 
 type authorityData []proposal
 
@@ -54,28 +49,10 @@ const (
 	valid
 )
 
-// Table configuration.
-type tableConfig struct {
-	// When this is true, the table will allow multiple seconded candidates
-	// per authority. This flag means that higher-level code is responsible for
-	// bounding the number of candidates.
-	allowMultipleSeconded bool
-}
-
-// after finishing implementing statement table, we can remove Table interface,
-// and rename StatementTable to Table
-type StatementTable struct {
-	// TODO: types of fields needs to be identified as we implement the methods
-
-	authorityData map[parachaintypes.ValidatorIndex]authorityData
-	// detected_misbehaviour: HashMap<Ctx::AuthorityId, Vec<MisbehaviorFor<Ctx>>>,
-	candidateVotes map[parachaintypes.CandidateHash]candidateData
-	config         tableConfig
-}
-
-func (t StatementTable) getCandidate(candidateHash parachaintypes.CandidateHash,
+// getCandidate returns the commited candidate receipt for the given candidate hash.
+func (table *statementTable) getCandidate(candidateHash parachaintypes.CandidateHash,
 ) (parachaintypes.CommittedCandidateReceipt, error) {
-	data, ok := t.candidateVotes[candidateHash]
+	data, ok := table.candidateVotes[candidateHash]
 	if !ok {
 		return parachaintypes.CommittedCandidateReceipt{},
 			fmt.Errorf("%w for candidate-hash: %s", errCandidateDataNotFound, candidateHash)
@@ -83,17 +60,20 @@ func (t StatementTable) getCandidate(candidateHash parachaintypes.CandidateHash,
 	return data.candidate, nil
 }
 
-func (StatementTable) importStatement(ctx *TableContext, statement parachaintypes.SignedFullStatementWithPVD,
+func (statementTable) importStatement(ctx *TableContext, statement parachaintypes.SignedFullStatementWithPVD,
 ) (*Summary, error) {
+	// TODO: Implement this method
 	return nil, nil
 }
 
-func (StatementTable) attestedCandidate(candidateHash parachaintypes.CandidateHash, ctx *TableContext,
+func (statementTable) attestedCandidate(candidateHash parachaintypes.CandidateHash, ctx *TableContext,
 ) (*AttestedCandidate, error) {
+	// TODO: Implement this method
 	return nil, nil
 }
 
-func (StatementTable) drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport {
+func (statementTable) drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport {
+	// TODO: Implement this method
 	return nil
 }
 
@@ -133,4 +113,12 @@ type AttestedCandidate struct {
 type validityAttestation struct {
 	ValidatorIndex      parachaintypes.ValidatorIndex      `scale:"1"`
 	ValidityAttestation parachaintypes.ValidityAttestation `scale:"2"`
+}
+
+// Table configuration.
+type tableConfig struct {
+	// When this is true, the table will allow multiple seconded candidates
+	// per authority. This flag means that higher-level code is responsible for
+	// bounding the number of candidates.
+	allowMultipleSeconded bool
 }

--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -63,8 +63,8 @@ type tableConfig struct {
 }
 
 // after finishing implementing statement table, we can remove Table interface,
-// and rename Table2 to Table
-type Table2 struct {
+// and rename StatementTable to Table
+type StatementTable struct {
 	// TODO: types of fields needs to be identified as we implement the methods
 
 	authorityData map[parachaintypes.ValidatorIndex]authorityData
@@ -73,7 +73,7 @@ type Table2 struct {
 	config         tableConfig
 }
 
-func (t *Table2) getCandidate(candidateHash parachaintypes.CandidateHash,
+func (t StatementTable) getCandidate(candidateHash parachaintypes.CandidateHash,
 ) (parachaintypes.CommittedCandidateReceipt, error) {
 	data, ok := t.candidateVotes[candidateHash]
 	if !ok {
@@ -83,7 +83,22 @@ func (t *Table2) getCandidate(candidateHash parachaintypes.CandidateHash,
 	return data.candidate, nil
 }
 
+func (StatementTable) importStatement(ctx *TableContext, statement parachaintypes.SignedFullStatementWithPVD,
+) (*Summary, error) {
+	return nil, nil
+}
+
+func (StatementTable) attestedCandidate(candidateHash parachaintypes.CandidateHash, ctx *TableContext,
+) (*AttestedCandidate, error) {
+	return nil, nil
+}
+
+func (StatementTable) drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport {
+	return nil
+}
+
 type Table interface {
+	getCandidate(parachaintypes.CandidateHash) (parachaintypes.CommittedCandidateReceipt, error)
 	importStatement(*TableContext, parachaintypes.SignedFullStatementWithPVD) (*Summary, error)
 	attestedCandidate(parachaintypes.CandidateHash, *TableContext) (*AttestedCandidate, error)
 	drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport

--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -10,10 +10,10 @@ import (
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
 )
 
-var errCandidateDataNotFound = errors.New("candidate data not found")
+var errCandidateDataNotFound = errors.New("candidate data not found") //nolint:unused
 
 // statementTable implements the Table interface.
-type statementTable struct {
+type statementTable struct { //nolint:unused
 	authorityData  map[parachaintypes.ValidatorIndex]authorityData
 	candidateVotes map[parachaintypes.CandidateHash]candidateData
 	config         tableConfig
@@ -22,35 +22,35 @@ type statementTable struct {
 	// detected_misbehaviour: HashMap<Ctx::AuthorityId, Vec<MisbehaviorFor<Ctx>>>,
 }
 
-type authorityData []proposal
+type authorityData []proposal //nolint:unused
 
-type proposal struct {
+type proposal struct { //nolint:unused
 	candidateHash parachaintypes.CandidateHash
 	signature     parachaintypes.Signature
 }
 
-type candidateData struct {
+type candidateData struct { //nolint:unused
 	groupID       parachaintypes.ParaID
 	candidate     parachaintypes.CommittedCandidateReceipt
 	validityVotes map[parachaintypes.ValidatorIndex]validityVoteWithSign
 }
 
-type validityVoteWithSign struct {
+type validityVoteWithSign struct { //nolint:unused
 	validityVote validityVote
 	signature    parachaintypes.Signature
 }
 
-type validityVote byte
+type validityVote byte //nolint:unused
 
 const (
 	// Implicit validity vote.
-	issued validityVote = iota
+	issued validityVote = iota //nolint:unused
 	// Direct validity vote.
-	valid
+	valid //nolint:unused
 )
 
-// getCandidate returns the commited candidate receipt for the given candidate hash.
-func (table *statementTable) getCandidate(candidateHash parachaintypes.CandidateHash,
+// getCandidate returns the committed candidate receipt for the given candidate hash.
+func (table *statementTable) getCandidate(candidateHash parachaintypes.CandidateHash, //nolint:unused
 ) (parachaintypes.CommittedCandidateReceipt, error) {
 	data, ok := table.candidateVotes[candidateHash]
 	if !ok {
@@ -60,19 +60,20 @@ func (table *statementTable) getCandidate(candidateHash parachaintypes.Candidate
 	return data.candidate, nil
 }
 
-func (statementTable) importStatement(ctx *TableContext, statement parachaintypes.SignedFullStatementWithPVD,
+func (statementTable) importStatement( //nolint:unused
+	ctx *TableContext, statement parachaintypes.SignedFullStatementWithPVD,
 ) (*Summary, error) {
 	// TODO: Implement this method
 	return nil, nil
 }
 
-func (statementTable) attestedCandidate(candidateHash parachaintypes.CandidateHash, ctx *TableContext,
+func (statementTable) attestedCandidate(candidateHash parachaintypes.CandidateHash, ctx *TableContext, //nolint:unused
 ) (*AttestedCandidate, error) {
 	// TODO: Implement this method
 	return nil, nil
 }
 
-func (statementTable) drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport {
+func (statementTable) drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport { //nolint:unused
 	// TODO: Implement this method
 	return nil
 }
@@ -109,7 +110,7 @@ type AttestedCandidate struct {
 	ValidityAttestations []validityAttestation `scale:"3"`
 }
 
-// validityAttestation represents a vote on the validity of a candidate by a validator.
+// validityAttestation represents a validity attestation for a candidate.
 type validityAttestation struct {
 	ValidatorIndex      parachaintypes.ValidatorIndex      `scale:"1"`
 	ValidityAttestation parachaintypes.ValidityAttestation `scale:"2"`

--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -3,16 +3,93 @@
 
 package backing
 
-import parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+import (
+	"errors"
+	"fmt"
+
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+)
+
+/*
+------------------------------------------
+*** Statement table implementation notes:
+------------------------------------------
+
+added table2 field of type Table2 in perRelayParentState, which is implementation of statement table.
+
+table field of type Table needs to be removed after implementing the methods in Table2.
+
+rename Table2 to Table after implementing the methods in Table2.
+
+
+=> At the end check for all the types in this file, if they should be exported or not.
+*/
+
+var errCandidateDataNotFound = errors.New("candidate data not found")
+
+type authorityData []proposal
+
+type proposal struct {
+	candidateHash parachaintypes.CandidateHash
+	signature     parachaintypes.Signature
+}
+
+type candidateData struct {
+	groupID       parachaintypes.ParaID
+	candidate     parachaintypes.CommittedCandidateReceipt
+	validityVotes map[parachaintypes.ValidatorIndex]validityVoteWithSign
+}
+
+type validityVoteWithSign struct {
+	validityVote validityVote
+	signature    parachaintypes.Signature
+}
+
+type validityVote byte
+
+const (
+	// Implicit validity vote.
+	issued validityVote = iota
+	// Direct validity vote.
+	valid
+)
+
+// Table configuration.
+type tableConfig struct {
+	// When this is true, the table will allow multiple seconded candidates
+	// per authority. This flag means that higher-level code is responsible for
+	// bounding the number of candidates.
+	allowMultipleSeconded bool
+}
+
+// after finishing inplementing statement table, we can remove Table interface,
+// and rename Table2 to Table
+type Table2 struct {
+	// TODO: types of fields needs to be identified as we implement the methods
+
+	authorityData map[parachaintypes.ValidatorIndex]authorityData
+	// detected_misbehavior: HashMap<Ctx::AuthorityId, Vec<MisbehaviorFor<Ctx>>>,
+	candidateVotes map[parachaintypes.CandidateHash]candidateData
+	config         tableConfig
+}
+
+func (t *Table2) getCandidate(candidateHash parachaintypes.CandidateHash,
+) (parachaintypes.CommittedCandidateReceipt, error) {
+	data, ok := t.candidateVotes[candidateHash]
+	if !ok {
+		return parachaintypes.CommittedCandidateReceipt{},
+			fmt.Errorf("%w for candidate-hash: %s", errCandidateDataNotFound, candidateHash)
+	}
+	return data.candidate, nil
+}
 
 type Table interface {
-	getCandidate(parachaintypes.CandidateHash) (*parachaintypes.CommittedCandidateReceipt, error)
 	importStatement(*TableContext, parachaintypes.SignedFullStatementWithPVD) (*Summary, error)
 	attestedCandidate(parachaintypes.CandidateHash, *TableContext) (*AttestedCandidate, error)
 	drainMisbehaviors() []parachaintypes.ProvisionableDataMisbehaviorReport
 }
 
-func newTable(Config) Table {
+func newTable(tableConfig) Table {
 	// TODO: Implement this function
 	return nil
 }
@@ -30,23 +107,15 @@ type Summary struct {
 // AttestedCandidate represents an attested-to candidate.
 type AttestedCandidate struct {
 	// The group ID that the candidate is in.
-	GroupID parachaintypes.ParaID
+	GroupID parachaintypes.ParaID `scale:"1"`
 	// The candidate data.
-	Candidate parachaintypes.CommittedCandidateReceipt
+	Candidate parachaintypes.CommittedCandidateReceipt `scale:"2"`
 	// Validity attestations.
-	ValidityVotes []validityVote
+	ValidityAttestations []validityAttestation `scale:"3"`
 }
 
-// validityVote represents a vote on the validity of a candidate by a validator.
-type validityVote struct {
-	ValidatorIndex      parachaintypes.ValidatorIndex
-	ValidityAttestation parachaintypes.ValidityAttestation
-}
-
-// Table configuration.
-type Config struct {
-	// When this is true, the table will allow multiple seconded candidates
-	// per authority. This flag means that higher-level code is responsible for
-	// bounding the number of candidates.
-	AllowMultipleSeconded bool
+// validityAttestation represents a vote on the validity of a candidate by a validator.
+type validityAttestation struct {
+	ValidatorIndex      parachaintypes.ValidatorIndex      `scale:"1"`
+	ValidityAttestation parachaintypes.ValidityAttestation `scale:"2"`
 }

--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -62,13 +62,13 @@ type tableConfig struct {
 	allowMultipleSeconded bool
 }
 
-// after finishing inplementing statement table, we can remove Table interface,
+// after finishing implementing statement table, we can remove Table interface,
 // and rename Table2 to Table
 type Table2 struct {
 	// TODO: types of fields needs to be identified as we implement the methods
 
 	authorityData map[parachaintypes.ValidatorIndex]authorityData
-	// detected_misbehavior: HashMap<Ctx::AuthorityId, Vec<MisbehaviorFor<Ctx>>>,
+	// detected_misbehaviour: HashMap<Ctx::AuthorityId, Vec<MisbehaviorFor<Ctx>>>,
 	candidateVotes map[parachaintypes.CandidateHash]candidateData
 	config         tableConfig
 }


### PR DESCRIPTION
## Description

- The statement table stores messages other authorities(parachain validators) issue about candidates(parachain blocks).

- These messages create a proposal submitted to a BFT(Byzantine Fault Tolerance) consensus process.

- Proposals are formed of sets of candidates which have the requisite number of validity and availability votes.

- Each parachain is associated with a committee of authorities, who issue statements indicating whether the candidate is valid or invalid. Once a threshold of the committee has signed validity statements, the candidate may be marked includable.

## Changes

<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
#3471 

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@
