### PR TITLE
Runtime context to zero sized struct

### DIFF
--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -30,11 +30,11 @@ import (
 // Name represents the name of the interpreter
 const Name = "wazero"
 
-type contextKey string
+type runtimeContextKeyType struct{}
 
-const runtimeContextKey = contextKey("runtime.Context")
+var runtimeContextKey = runtimeContextKeyType{}
 
-var _ runtime.Instance = &Instance{}
+var _ runtime.Instance = (*Instance)(nil)
 
 type wazeroMeta struct {
 	config      wazero.RuntimeConfig


### PR DESCRIPTION
## Changes

Changes the Runtime's context key from string to empty struct. Saves on memory and saves on CPU cycles by avoiding copies 

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@
