### PR TITLE
feat(lib/runtime): remove runtime type reflection in host module function definitions

### DIFF
--- a/lib/runtime/wazero/imports.go
+++ b/lib/runtime/wazero/imports.go
@@ -90,7 +90,7 @@ func mustWrite(m api.Module, allocator runtime.Allocator, data []byte) (pointerS
 	return pointerSize
 }
 
-func ext_logging_log_version_1(ctx context.Context, m api.Module, level int32, targetData, msgData uint64) {
+func ext_logging_log_version_1(_ context.Context, m api.Module, level int32, targetData, msgData uint64) {
 	target := string(read(m, targetData))
 	msg := string(read(m, msgData))
 

--- a/lib/runtime/wazero/imports.go
+++ b/lib/runtime/wazero/imports.go
@@ -781,7 +781,7 @@ func ext_crypto_start_batch_verify_version_1(ctx context.Context, m api.Module) 
 	// beginBatchVerify(context)
 }
 
-func ext_crypto_finish_batch_verify_version_1(ctx context.Context, m api.Module) uint32 {
+func ext_crypto_finish_batch_verify_version_1(_ context.Context) uint32 {
 	// TODO: fix and re-enable signature verification (#1405)
 	// return finishBatchVerify(context)
 	return 1
@@ -956,16 +956,16 @@ func ext_trie_blake2_256_verify_proof_version_2(
 	return 1
 }
 
-func ext_misc_print_hex_version_1(ctx context.Context, m api.Module, dataSpan uint64) {
+func ext_misc_print_hex_version_1(_ context.Context, m api.Module, dataSpan uint64) {
 	data := read(m, dataSpan)
 	logger.Debugf("data: 0x%x", data)
 }
 
-func ext_misc_print_num_version_1(ctx context.Context, m api.Module, data uint64) {
+func ext_misc_print_num_version_1(_ context.Context, _ api.Module, data uint64) {
 	logger.Debugf("num: %d", int64(data))
 }
 
-func ext_misc_print_utf8_version_1(ctx context.Context, m api.Module, dataSpan uint64) {
+func ext_misc_print_utf8_version_1(_ context.Context, m api.Module, dataSpan uint64) {
 	data := read(m, dataSpan)
 	logger.Debug("utf8: " + string(data))
 }
@@ -1259,7 +1259,7 @@ func ext_default_child_storage_root_version_1(
 
 //export ext_default_child_storage_root_version_2
 func ext_default_child_storage_root_version_2(ctx context.Context, m api.Module, childStorageKey uint64,
-	version uint32) (ptrSize uint64) { //skipcq: RVV-B0012
+	_ uint32) (ptrSize uint64) { //skipcq: RVV-B0012
 	rtCtx := ctx.Value(runtimeContextKey).(*runtime.Context)
 	if rtCtx == nil {
 		panic("nil runtime context")
@@ -1878,7 +1878,7 @@ func ext_offchain_sleep_until_version_1(_ context.Context, _ api.Module, deadlin
 }
 
 func ext_offchain_http_request_start_version_1(
-	ctx context.Context, m api.Module, methodSpan, uriSpan, metaSpan uint64) (pointerSize uint64) { //skipcq: RVV-B0012
+	ctx context.Context, m api.Module, methodSpan, uriSpan, _ uint64) (pointerSize uint64) { //skipcq: RVV-B0012
 	rtCtx := ctx.Value(runtimeContextKey).(*runtime.Context)
 	if rtCtx == nil {
 		panic("nil runtime context")
@@ -2044,7 +2044,7 @@ func ext_storage_append_version_1(ctx context.Context, m api.Module, keySpan, va
 
 // Always returns `None`. This function exists for compatibility reasons.
 func ext_storage_changes_root_version_1(
-	ctx context.Context, m api.Module, parentHashSpan uint64) uint64 { //skipcq: RVV-B0012
+	ctx context.Context, m api.Module, _ uint64) uint64 { //skipcq: RVV-B0012
 	rtCtx := ctx.Value(runtimeContextKey).(*runtime.Context)
 	if rtCtx == nil {
 		panic("nil runtime context")

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -289,8 +289,8 @@ func newRuntime(ctx context.Context,
 		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_num_version_1").
 		NewFunctionBuilder().
-		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
-			ext_misc_print_utf8_version_1(ctx, nil, stack[0])
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_misc_print_utf8_version_1(ctx, m, stack[0])
 		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_utf8_version_1").
 		NewFunctionBuilder().

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -478,7 +478,7 @@ func newRuntime(ctx context.Context,
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_offchain_http_request_add_header_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2])
-		}), []api.ValueType{i32, i64, i64}, []api.ValueType{i32}).
+		}), []api.ValueType{i32, i64, i64}, []api.ValueType{i64}).
 		Export("ext_offchain_http_request_add_header_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -119,7 +119,9 @@ func newRuntime(ctx context.Context,
 		// values from newer kusama/polkadot runtimes
 		ExportMemory("memory", 23).
 		NewFunctionBuilder().
-		WithFunc(ext_logging_log_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_logging_log_version_1(ctx, m, api.DecodeI32(stack[0]), stack[1], stack[2])
+		}), []api.ValueType{i32, i64, i64}, []api.ValueType{}).
 		Export("ext_logging_log_version_1").
 		NewFunctionBuilder().
 		WithFunc(func() int32 {
@@ -237,10 +239,14 @@ func newRuntime(ctx context.Context,
 		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_sr25519_verify_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_start_batch_verify_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_crypto_start_batch_verify_version_1(ctx, m)
+		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_crypto_start_batch_verify_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_finish_batch_verify_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_finish_batch_verify_version_1(ctx, m))
+		}), []api.ValueType{}, []api.ValueType{i32}).
 		Export("ext_crypto_finish_batch_verify_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
@@ -425,34 +431,54 @@ func newRuntime(ctx context.Context,
 		}), []api.ValueType{}, []api.ValueType{i32}).
 		Export("ext_offchain_is_validator_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_local_storage_compare_and_set_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_offchain_local_storage_compare_and_set_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3]))
+		}), []api.ValueType{i32, i64, i64, i64}, []api.ValueType{i32}).
 		Export("ext_offchain_local_storage_compare_and_set_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_local_storage_get_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_offchain_local_storage_get_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1])
+		}), []api.ValueType{i32, i64}, []api.ValueType{i64}).
 		Export("ext_offchain_local_storage_get_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_local_storage_set_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_offchain_local_storage_set_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2])
+		}), []api.ValueType{i32, i64, i64}, []api.ValueType{}).
 		Export("ext_offchain_local_storage_set_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_network_state_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_offchain_network_state_version_1(ctx, m)
+		}), []api.ValueType{}, []api.ValueType{i64}).
 		Export("ext_offchain_network_state_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_random_seed_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_offchain_random_seed_version_1(ctx, m))
+		}), []api.ValueType{}, []api.ValueType{i32}).
 		Export("ext_offchain_random_seed_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_submit_transaction_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_offchain_submit_transaction_version_1(ctx, m, stack[0])
+		}), []api.ValueType{i64}, []api.ValueType{i64}).
 		Export("ext_offchain_submit_transaction_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_timestamp_version_1).
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			stack[0] = ext_offchain_timestamp_version_1(ctx, nil)
+		}), []api.ValueType{}, []api.ValueType{i64}).
 		Export("ext_offchain_timestamp_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_sleep_until_version_1).
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_offchain_sleep_until_version_1(ctx, nil, stack[0])
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_offchain_sleep_until_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_http_request_start_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_offchain_http_request_start_version_1(ctx, m, stack[0], stack[1], stack[2])
+		}), []api.ValueType{i64, i64, i64}, []api.ValueType{i64}).
 		Export("ext_offchain_http_request_start_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_http_request_add_header_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_offchain_http_request_add_header_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2])
+		}), []api.ValueType{i32, i64, i64}, []api.ValueType{i32}).
 		Export("ext_offchain_http_request_add_header_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -165,46 +165,88 @@ func newRuntime(ctx context.Context,
 		}).
 		Export("ext_sandbox_memory_teardown_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_ed25519_generate_version_1).
+		// WithFunc(ext_crypto_ed25519_generate_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_ed25519_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ed25519_generate_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_ed25519_public_keys_version_1).
+		// WithFunc(ext_crypto_ed25519_public_keys_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_ed25519_public_keys_version_1(ctx, m, api.DecodeU32(stack[0]))
+		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_ed25519_public_keys_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_ed25519_sign_version_1).
+		// WithFunc(ext_crypto_ed25519_sign_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_ed25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_ed25519_sign_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_ed25519_verify_version_1).
+		// WithFunc(ext_crypto_ed25519_verify_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_ed25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ed25519_verify_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_secp256k1_ecdsa_recover_version_1).
+		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_secp256k1_ecdsa_recover_version_2).
+		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_ecdsa_verify_version_2).
+		// WithFunc(ext_crypto_ecdsa_verify_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_ecdsa_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ecdsa_verify_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_secp256k1_ecdsa_recover_compressed_version_1).
+		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_compressed_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_secp256k1_ecdsa_recover_compressed_version_2).
+		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_compressed_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_sr25519_generate_version_1).
+		// WithFunc(ext_crypto_sr25519_generate_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_sr25519_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_sr25519_generate_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_sr25519_public_keys_version_1).
+		// WithFunc(ext_crypto_sr25519_public_keys_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_sr25519_public_keys_version_1(ctx, m, api.DecodeU32(stack[0]))
+		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_sr25519_public_keys_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_sr25519_sign_version_1).
+		// WithFunc(ext_crypto_sr25519_sign_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_crypto_sr25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_sr25519_sign_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_sr25519_verify_version_1).
+		// WithFunc(ext_crypto_sr25519_verify_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_sr25519_verify_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_sr25519_verify_version_2).
+		// WithFunc(ext_crypto_sr25519_verify_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_sr25519_verify_version_2").
 		NewFunctionBuilder().
 		WithFunc(ext_crypto_start_batch_verify_version_1).
@@ -213,112 +255,222 @@ func newRuntime(ctx context.Context,
 		WithFunc(ext_crypto_finish_batch_verify_version_1).
 		Export("ext_crypto_finish_batch_verify_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_trie_blake2_256_root_version_1).
+		// WithFunc(ext_trie_blake2_256_root_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_trie_blake2_256_root_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_root_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_trie_blake2_256_root_version_2).
+		// WithFunc(ext_trie_blake2_256_root_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_trie_blake2_256_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_root_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_trie_blake2_256_ordered_root_version_1).
+		// WithFunc(ext_trie_blake2_256_ordered_root_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_ordered_root_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_trie_blake2_256_ordered_root_version_2).
+		// WithFunc(ext_trie_blake2_256_ordered_root_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_ordered_root_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_trie_blake2_256_verify_proof_version_1).
+		// WithFunc(ext_trie_blake2_256_verify_proof_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_verify_proof_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_trie_blake2_256_verify_proof_version_2).
+		// WithFunc(ext_trie_blake2_256_verify_proof_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3], api.DecodeU32(stack[4])))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_misc_print_hex_version_1).
+		// WithFunc(ext_misc_print_hex_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_misc_print_hex_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_misc_print_hex_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_misc_print_num_version_1).
+		// WithFunc(ext_misc_print_num_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_misc_print_num_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_misc_print_num_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_misc_print_utf8_version_1).
+		// WithFunc(ext_misc_print_utf8_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_misc_print_utf8_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_misc_print_utf8_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_misc_runtime_version_version_1).
+		// WithFunc(ext_misc_runtime_version_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_misc_runtime_version_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_misc_runtime_version_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_set_version_1).
+		// WithFunc(ext_default_child_storage_set_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(
+			ctx context.Context, m api.Module, stack []uint64) {
+			ext_default_child_storage_set_version_1(ctx, m, stack[0], stack[1], stack[2])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_set_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_read_version_1).
+		// WithFunc(ext_default_child_storage_read_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(
+			ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_read_version_1(ctx, m, stack[0], stack[1], stack[2], api.DecodeU32(stack[3]))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_read_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_clear_version_1).
+		// WithFunc(ext_default_child_storage_clear_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_default_child_storage_clear_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_clear_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_clear_prefix_version_1).
+		// WithFunc(ext_default_child_storage_clear_prefix_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_default_child_storage_clear_prefix_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_clear_prefix_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_clear_prefix_version_2).
+		// WithFunc(ext_default_child_storage_clear_prefix_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_clear_prefix_version_2(ctx, m, stack[0], stack[1], stack[2])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_clear_prefix_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_exists_version_1).
+		// WithFunc(ext_default_child_storage_exists_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_default_child_storage_exists_version_1(ctx, m, stack[0], stack[1]))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_default_child_storage_exists_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_get_version_1).
+		// WithFunc(ext_default_child_storage_get_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_get_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_get_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_next_key_version_1).
+		// WithFunc(ext_default_child_storage_next_key_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_next_key_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_next_key_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_root_version_1).
+		// WithFunc(ext_default_child_storage_root_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_root_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_root_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_root_version_2).
+		// WithFunc(ext_default_child_storage_root_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1]))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_root_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_storage_kill_version_1).
+		// WithFunc(ext_default_child_storage_storage_kill_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_default_child_storage_storage_kill_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_storage_kill_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_storage_kill_version_2).
+		// WithFunc(ext_default_child_storage_storage_kill_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_default_child_storage_storage_kill_version_2(ctx, m, stack[0], stack[1]))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_default_child_storage_storage_kill_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_default_child_storage_storage_kill_version_3).
+		// WithFunc(ext_default_child_storage_storage_kill_version_3).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_default_child_storage_storage_kill_version_3(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_storage_kill_version_3").
 		NewFunctionBuilder().
-		WithFunc(ext_allocator_free_version_1).
+		// WithFunc(ext_allocator_free_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_allocator_free_version_1(ctx, m, api.DecodeU32(stack[0]))
+		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{}).
 		Export("ext_allocator_free_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_allocator_malloc_version_1).
+		// WithFunc(ext_allocator_malloc_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_allocator_malloc_version_1(ctx, m, api.DecodeU32(stack[0])))
+		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_allocator_malloc_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_blake2_128_version_1).
+		// WithFunc(ext_hashing_blake2_128_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_blake2_128_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_blake2_128_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_blake2_256_version_1).
+		// WithFunc(ext_hashing_blake2_256_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_blake2_256_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_blake2_256_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_keccak_256_version_1).
+		// WithFunc(ext_hashing_keccak_256_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_keccak_256_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_keccak_256_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_sha2_256_version_1).
+		// WithFunc(ext_hashing_sha2_256_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_sha2_256_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_sha2_256_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_twox_256_version_1).
+		// WithFunc(ext_hashing_twox_256_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_twox_256_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_twox_256_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_twox_128_version_1).
+		// WithFunc(ext_hashing_twox_128_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_twox_128_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_twox_128_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_hashing_twox_64_version_1).
+		// WithFunc(ext_hashing_twox_64_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_hashing_twox_64_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_twox_64_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_index_set_version_1).
+		// WithFunc(ext_offchain_index_set_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_offchain_index_set_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_offchain_index_set_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_index_clear_version_1).
+		// WithFunc(ext_offchain_index_clear_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_offchain_index_clear_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_offchain_index_clear_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_local_storage_clear_version_1).
+		// WithFunc(ext_offchain_local_storage_clear_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_offchain_local_storage_clear_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1])
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_offchain_local_storage_clear_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_offchain_is_validator_version_1).
+		// WithFunc(ext_offchain_is_validator_version_1).
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_offchain_is_validator_version_1(ctx, nil))
+		}), []api.ValueType{}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_offchain_is_validator_version_1").
 		NewFunctionBuilder().
 		WithFunc(ext_offchain_local_storage_compare_and_set_version_1).
@@ -351,52 +503,100 @@ func newRuntime(ctx context.Context,
 		WithFunc(ext_offchain_http_request_add_header_version_1).
 		Export("ext_offchain_http_request_add_header_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_append_version_1).
+		// WithFunc(ext_storage_append_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_storage_append_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_append_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_changes_root_version_1).
+		// WithFunc(ext_storage_changes_root_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_changes_root_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_changes_root_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_clear_version_1).
+		// WithFunc(ext_storage_clear_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_storage_clear_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_clear_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_clear_prefix_version_1).
+		// WithFunc(ext_storage_clear_prefix_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_storage_clear_prefix_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_clear_prefix_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_clear_prefix_version_2).
+		// WithFunc(ext_storage_clear_prefix_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_clear_prefix_version_2(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_clear_prefix_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_exists_version_1).
+		// WithFunc(ext_storage_exists_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_storage_exists_version_1(ctx, m, stack[0]))
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_storage_exists_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_get_version_1).
+		// WithFunc(ext_storage_get_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_get_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_get_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_next_key_version_1).
+		// WithFunc(ext_storage_next_key_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_next_key_version_1(ctx, m, stack[0])
+		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_next_key_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_read_version_1).
+		// WithFunc(ext_storage_read_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_read_version_1(ctx, m, stack[0], stack[1], api.DecodeU32(stack[2]))
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_read_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_root_version_1).
+		// WithFunc(ext_storage_root_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_root_version_1(ctx, m)
+		}), []api.ValueType{}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_root_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_root_version_2).
+		// WithFunc(ext_storage_root_version_2).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = ext_storage_root_version_2(ctx, m, api.DecodeU32(stack[0]))
+		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_root_version_2").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_set_version_1).
+		// WithFunc(ext_storage_set_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			ext_storage_set_version_1(ctx, m, stack[0], stack[1])
+		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_set_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_start_transaction_version_1).
+		// WithFunc(ext_storage_start_transaction_version_1).
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_storage_start_transaction_version_1(ctx, nil)
+		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_storage_start_transaction_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_rollback_transaction_version_1).
+		// WithFunc(ext_storage_rollback_transaction_version_1).
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_storage_rollback_transaction_version_1(ctx, nil)
+		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_storage_rollback_transaction_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_storage_commit_transaction_version_1).
+		// WithFunc(ext_storage_commit_transaction_version_1).
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_storage_commit_transaction_version_1(ctx, nil)
+		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_storage_commit_transaction_version_1").
 		NewFunctionBuilder().
-		WithFunc(ext_crypto_ecdsa_generate_version_1).
+		// WithFunc(ext_crypto_ecdsa_generate_version_1).
+		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
+			stack[0] = api.EncodeU32(ext_crypto_ecdsa_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
+		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ecdsa_generate_version_1").
 		Compile(ctx)
 

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -113,6 +113,8 @@ func newRuntime(ctx context.Context,
 ) (api.Module, wazero.Runtime, wazero.CompiledModule, error) {
 	rt := wazero.NewRuntimeWithConfig(ctx, config)
 
+	const i32, i64 = api.ValueTypeI32, api.ValueTypeI64
+
 	hostCompiledModule, err := rt.NewHostModuleBuilder("env").
 		// values from newer kusama/polkadot runtimes
 		ExportMemory("memory", 23).
@@ -167,72 +169,72 @@ func newRuntime(ctx context.Context,
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ed25519_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64}, []api.ValueType{i32}).
 		Export("ext_crypto_ed25519_generate_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_ed25519_public_keys_version_1(ctx, m, api.DecodeU32(stack[0]))
-		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32}, []api.ValueType{i64}).
 		Export("ext_crypto_ed25519_public_keys_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_ed25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32, i32, i64}, []api.ValueType{i64}).
 		Export("ext_crypto_ed25519_sign_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ed25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_ed25519_verify_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ecdsa_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_ecdsa_verify_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_sr25519_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64}, []api.ValueType{i32}).
 		Export("ext_crypto_sr25519_generate_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_sr25519_public_keys_version_1(ctx, m, api.DecodeU32(stack[0]))
-		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32}, []api.ValueType{i64}).
 		Export("ext_crypto_sr25519_public_keys_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_sr25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32, i32, i64}, []api.ValueType{i64}).
 		Export("ext_crypto_sr25519_sign_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_sr25519_verify_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_sr25519_verify_version_2").
 		NewFunctionBuilder().
 		WithFunc(ext_crypto_start_batch_verify_version_1).
@@ -243,184 +245,184 @@ func newRuntime(ctx context.Context,
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_root_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_root_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64, i32}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_root_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_ordered_root_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64, i32}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_ordered_root_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64, i64, i64}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_verify_proof_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3], api.DecodeU32(stack[4])))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64, i64, i64, i32}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_misc_print_hex_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_hex_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_misc_print_num_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_num_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_misc_print_utf8_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_utf8_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_misc_runtime_version_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64}, []api.ValueType{i64}).
 		Export("ext_misc_runtime_version_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(
 			ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_set_version_1(ctx, m, stack[0], stack[1], stack[2])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64, i64, i64}, []api.ValueType{}).
 		Export("ext_default_child_storage_set_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(
 			ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_read_version_1(ctx, m, stack[0], stack[1], stack[2], api.DecodeU32(stack[3]))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64, i64, i32}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_read_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_clear_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{}).
 		Export("ext_default_child_storage_clear_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_clear_prefix_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{}).
 		Export("ext_default_child_storage_clear_prefix_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_clear_prefix_version_2(ctx, m, stack[0], stack[1], stack[2])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64, i64}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_clear_prefix_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_default_child_storage_exists_version_1(ctx, m, stack[0], stack[1]))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{i32}).
 		Export("ext_default_child_storage_exists_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_get_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_get_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_next_key_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_next_key_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_root_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_root_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1]))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i32}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_root_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_storage_kill_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_default_child_storage_storage_kill_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_default_child_storage_storage_kill_version_2(ctx, m, stack[0], stack[1]))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{i32}).
 		Export("ext_default_child_storage_storage_kill_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_storage_kill_version_3(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_storage_kill_version_3").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_allocator_free_version_1(ctx, m, api.DecodeU32(stack[0]))
-		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{}).
+		}), []api.ValueType{i32}, []api.ValueType{}).
 		Export("ext_allocator_free_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_allocator_malloc_version_1(ctx, m, api.DecodeU32(stack[0])))
-		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32}, []api.ValueType{i32}).
 		Export("ext_allocator_malloc_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_blake2_128_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_blake2_128_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_blake2_256_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_blake2_256_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_keccak_256_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_keccak_256_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_sha2_256_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_sha2_256_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_twox_256_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_twox_256_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_twox_128_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_twox_128_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_twox_64_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_hashing_twox_64_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_offchain_index_set_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{}).
 		Export("ext_offchain_index_set_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_offchain_index_clear_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_offchain_index_clear_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_offchain_local_storage_clear_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1])
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i32, i64}, []api.ValueType{}).
 		Export("ext_offchain_local_storage_clear_version_1").
 		NewFunctionBuilder().
 		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_offchain_is_validator_version_1(ctx, nil))
-		}), []api.ValueType{}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{}, []api.ValueType{i32}).
 		Export("ext_offchain_is_validator_version_1").
 		NewFunctionBuilder().
 		WithFunc(ext_offchain_local_storage_compare_and_set_version_1).
@@ -455,62 +457,62 @@ func newRuntime(ctx context.Context,
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_append_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{}).
 		Export("ext_storage_append_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_changes_root_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64}, []api.ValueType{i64}).
 		Export("ext_storage_changes_root_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_clear_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_storage_clear_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_clear_prefix_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_storage_clear_prefix_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_clear_prefix_version_2(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{i64}).
 		Export("ext_storage_clear_prefix_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_storage_exists_version_1(ctx, m, stack[0]))
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i64}, []api.ValueType{i32}).
 		Export("ext_storage_exists_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_get_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64}, []api.ValueType{i64}).
 		Export("ext_storage_get_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_next_key_version_1(ctx, m, stack[0])
-		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64}, []api.ValueType{i64}).
 		Export("ext_storage_next_key_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_read_version_1(ctx, m, stack[0], stack[1], api.DecodeU32(stack[2]))
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i64, i64, i32}, []api.ValueType{i64}).
 		Export("ext_storage_read_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_root_version_1(ctx, m)
-		}), []api.ValueType{}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{}, []api.ValueType{i64}).
 		Export("ext_storage_root_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_root_version_2(ctx, m, api.DecodeU32(stack[0]))
-		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
+		}), []api.ValueType{i32}, []api.ValueType{i64}).
 		Export("ext_storage_root_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_set_version_1(ctx, m, stack[0], stack[1])
-		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
+		}), []api.ValueType{i64, i64}, []api.ValueType{}).
 		Export("ext_storage_set_version_1").
 		NewFunctionBuilder().
 		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
@@ -530,7 +532,7 @@ func newRuntime(ctx context.Context,
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ecdsa_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
-		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
+		}), []api.ValueType{i32, i64}, []api.ValueType{i32}).
 		Export("ext_crypto_ecdsa_generate_version_1").
 		Compile(ctx)
 

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -245,7 +245,7 @@ func newRuntime(ctx context.Context,
 		Export("ext_crypto_start_batch_verify_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_crypto_finish_batch_verify_version_1(ctx, m))
+			stack[0] = api.EncodeU32(ext_crypto_finish_batch_verify_version_1(ctx))
 		}), []api.ValueType{}, []api.ValueType{i32}).
 		Export("ext_crypto_finish_batch_verify_version_1").
 		NewFunctionBuilder().
@@ -279,18 +279,18 @@ func newRuntime(ctx context.Context,
 		}), []api.ValueType{i32, i64, i64, i64, i32}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().
-		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			ext_misc_print_hex_version_1(ctx, m, stack[0])
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_misc_print_hex_version_1(ctx, nil, stack[0])
 		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_hex_version_1").
 		NewFunctionBuilder().
-		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			ext_misc_print_num_version_1(ctx, m, stack[0])
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_misc_print_num_version_1(ctx, nil, stack[0])
 		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_num_version_1").
 		NewFunctionBuilder().
-		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			ext_misc_print_utf8_version_1(ctx, m, stack[0])
+		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
+			ext_misc_print_utf8_version_1(ctx, nil, stack[0])
 		}), []api.ValueType{i64}, []api.ValueType{}).
 		Export("ext_misc_print_utf8_version_1").
 		NewFunctionBuilder().

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -165,85 +165,71 @@ func newRuntime(ctx context.Context,
 		}).
 		Export("ext_sandbox_memory_teardown_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_ed25519_generate_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ed25519_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ed25519_generate_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_ed25519_public_keys_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_ed25519_public_keys_version_1(ctx, m, api.DecodeU32(stack[0]))
 		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_ed25519_public_keys_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_ed25519_sign_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_ed25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_ed25519_sign_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_ed25519_verify_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ed25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ed25519_verify_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_ecdsa_verify_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ecdsa_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_ecdsa_verify_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_compressed_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_secp256k1_ecdsa_recover_compressed_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_sr25519_generate_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_sr25519_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_sr25519_generate_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_sr25519_public_keys_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_sr25519_public_keys_version_1(ctx, m, api.DecodeU32(stack[0]))
 		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_sr25519_public_keys_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_sr25519_sign_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_crypto_sr25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_crypto_sr25519_sign_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_sr25519_verify_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_crypto_sr25519_verify_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_sr25519_verify_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
@@ -255,219 +241,183 @@ func newRuntime(ctx context.Context,
 		WithFunc(ext_crypto_finish_batch_verify_version_1).
 		Export("ext_crypto_finish_batch_verify_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_trie_blake2_256_root_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_root_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_root_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_trie_blake2_256_root_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_root_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_trie_blake2_256_ordered_root_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_ordered_root_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_trie_blake2_256_ordered_root_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_ordered_root_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_trie_blake2_256_verify_proof_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_verify_proof_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_trie_blake2_256_verify_proof_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3], api.DecodeU32(stack[4])))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_misc_print_hex_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_misc_print_hex_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_misc_print_hex_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_misc_print_num_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_misc_print_num_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_misc_print_num_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_misc_print_utf8_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_misc_print_utf8_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_misc_print_utf8_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_misc_runtime_version_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_misc_runtime_version_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_misc_runtime_version_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_set_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(
 			ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_set_version_1(ctx, m, stack[0], stack[1], stack[2])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_set_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_read_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(
 			ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_read_version_1(ctx, m, stack[0], stack[1], stack[2], api.DecodeU32(stack[3]))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_read_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_clear_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_clear_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_clear_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_clear_prefix_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_clear_prefix_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_clear_prefix_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_clear_prefix_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_clear_prefix_version_2(ctx, m, stack[0], stack[1], stack[2])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_clear_prefix_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_exists_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_default_child_storage_exists_version_1(ctx, m, stack[0], stack[1]))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_default_child_storage_exists_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_get_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_get_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_get_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_next_key_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_next_key_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_next_key_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_root_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_root_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_root_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_root_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1]))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_root_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_storage_kill_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_default_child_storage_storage_kill_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_default_child_storage_storage_kill_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_storage_kill_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_default_child_storage_storage_kill_version_2(ctx, m, stack[0], stack[1]))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_default_child_storage_storage_kill_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_default_child_storage_storage_kill_version_3).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_default_child_storage_storage_kill_version_3(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_default_child_storage_storage_kill_version_3").
 		NewFunctionBuilder().
-		// WithFunc(ext_allocator_free_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_allocator_free_version_1(ctx, m, api.DecodeU32(stack[0]))
 		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{}).
 		Export("ext_allocator_free_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_allocator_malloc_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_allocator_malloc_version_1(ctx, m, api.DecodeU32(stack[0])))
 		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_allocator_malloc_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_blake2_128_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_blake2_128_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_blake2_128_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_blake2_256_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_blake2_256_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_blake2_256_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_keccak_256_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_keccak_256_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_keccak_256_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_sha2_256_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_sha2_256_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_sha2_256_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_twox_256_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_twox_256_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_twox_256_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_twox_128_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_twox_128_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_twox_128_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_hashing_twox_64_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_hashing_twox_64_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_hashing_twox_64_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_offchain_index_set_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_offchain_index_set_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_offchain_index_set_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_offchain_index_clear_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_offchain_index_clear_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_offchain_index_clear_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_offchain_local_storage_clear_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_offchain_local_storage_clear_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1])
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_offchain_local_storage_clear_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_offchain_is_validator_version_1).
 		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_offchain_is_validator_version_1(ctx, nil))
 		}), []api.ValueType{}, []api.ValueType{api.ValueTypeI32}).
@@ -503,97 +453,81 @@ func newRuntime(ctx context.Context,
 		WithFunc(ext_offchain_http_request_add_header_version_1).
 		Export("ext_offchain_http_request_add_header_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_append_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_append_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_append_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_changes_root_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_changes_root_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_changes_root_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_clear_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_clear_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_clear_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_clear_prefix_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_clear_prefix_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_clear_prefix_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_clear_prefix_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_clear_prefix_version_2(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_clear_prefix_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_exists_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_storage_exists_version_1(ctx, m, stack[0]))
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).
 		Export("ext_storage_exists_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_get_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_get_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_get_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_next_key_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_next_key_version_1(ctx, m, stack[0])
 		}), []api.ValueType{api.ValueTypeI64}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_next_key_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_read_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_read_version_1(ctx, m, stack[0], stack[1], api.DecodeU32(stack[2]))
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64, api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_read_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_root_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_root_version_1(ctx, m)
 		}), []api.ValueType{}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_root_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_root_version_2).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = ext_storage_root_version_2(ctx, m, api.DecodeU32(stack[0]))
 		}), []api.ValueType{api.ValueTypeI32}, []api.ValueType{api.ValueTypeI64}).
 		Export("ext_storage_root_version_2").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_set_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			ext_storage_set_version_1(ctx, m, stack[0], stack[1])
 		}), []api.ValueType{api.ValueTypeI64, api.ValueTypeI64}, []api.ValueType{}).
 		Export("ext_storage_set_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_start_transaction_version_1).
 		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
 			ext_storage_start_transaction_version_1(ctx, nil)
 		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_storage_start_transaction_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_rollback_transaction_version_1).
 		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
 			ext_storage_rollback_transaction_version_1(ctx, nil)
 		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_storage_rollback_transaction_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_storage_commit_transaction_version_1).
 		WithGoFunction(api.GoFunc(func(ctx context.Context, stack []uint64) {
 			ext_storage_commit_transaction_version_1(ctx, nil)
 		}), []api.ValueType{}, []api.ValueType{}).
 		Export("ext_storage_commit_transaction_version_1").
 		NewFunctionBuilder().
-		// WithFunc(ext_crypto_ecdsa_generate_version_1).
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
 			stack[0] = api.EncodeU32(ext_crypto_ecdsa_generate_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1]))
 		}), []api.ValueType{api.ValueTypeI32, api.ValueTypeI64}, []api.ValueType{api.ValueTypeI32}).

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -180,37 +180,67 @@ func newRuntime(ctx context.Context,
 		Export("ext_crypto_ed25519_public_keys_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_crypto_ed25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
+			stack[0] = ext_crypto_ed25519_sign_version_1(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				api.DecodeU32(stack[1]),
+				stack[2],
+			)
 		}), []api.ValueType{i32, i32, i64}, []api.ValueType{i64}).
 		Export("ext_crypto_ed25519_sign_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_crypto_ed25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+			stack[0] = api.EncodeU32(
+				ext_crypto_ed25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])),
+			)
 		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_ed25519_verify_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_1(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				api.DecodeU32(stack[1]),
+			)
 		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_version_2(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				api.DecodeU32(stack[1]),
+			)
 		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_crypto_ecdsa_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+			stack[0] = api.EncodeU32(
+				ext_crypto_ecdsa_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])),
+			)
 		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_ecdsa_verify_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_1(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				api.DecodeU32(stack[1]),
+			)
 		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]))
+			stack[0] = ext_crypto_secp256k1_ecdsa_recover_compressed_version_2(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				api.DecodeU32(stack[1]),
+			)
 		}), []api.ValueType{i32, i32}, []api.ValueType{i64}).
 		Export("ext_crypto_secp256k1_ecdsa_recover_compressed_version_2").
 		NewFunctionBuilder().
@@ -225,17 +255,27 @@ func newRuntime(ctx context.Context,
 		Export("ext_crypto_sr25519_public_keys_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_crypto_sr25519_sign_version_1(ctx, m, api.DecodeU32(stack[0]), api.DecodeU32(stack[1]), stack[2])
+			stack[0] = ext_crypto_sr25519_sign_version_1(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				api.DecodeU32(stack[1]),
+				stack[2],
+			)
 		}), []api.ValueType{i32, i32, i64}, []api.ValueType{i64}).
 		Export("ext_crypto_sr25519_sign_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+			stack[0] = api.EncodeU32(
+				ext_crypto_sr25519_verify_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])),
+			)
 		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_sr25519_verify_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_crypto_sr25519_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])))
+			stack[0] = api.EncodeU32(
+				ext_crypto_sr25519_verify_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], api.DecodeU32(stack[2])),
+			)
 		}), []api.ValueType{i32, i64, i32}, []api.ValueType{i32}).
 		Export("ext_crypto_sr25519_verify_version_2").
 		NewFunctionBuilder().
@@ -265,17 +305,38 @@ func newRuntime(ctx context.Context,
 		Export("ext_trie_blake2_256_ordered_root_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_trie_blake2_256_ordered_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])))
+			stack[0] = api.EncodeU32(
+				ext_trie_blake2_256_ordered_root_version_2(ctx, m, stack[0], api.DecodeU32(stack[1])),
+			)
 		}), []api.ValueType{i64, i32}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_ordered_root_version_2").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3]))
+			stack[0] = api.EncodeU32(
+				ext_trie_blake2_256_verify_proof_version_1(
+					ctx,
+					m,
+					api.DecodeU32(stack[0]),
+					stack[1],
+					stack[2],
+					stack[3],
+				),
+			)
 		}), []api.ValueType{i32, i64, i64, i64}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_verify_proof_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_trie_blake2_256_verify_proof_version_2(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3], api.DecodeU32(stack[4])))
+			stack[0] = api.EncodeU32(
+				ext_trie_blake2_256_verify_proof_version_2(
+					ctx,
+					m,
+					api.DecodeU32(stack[0]),
+					stack[1],
+					stack[2],
+					stack[3],
+					api.DecodeU32(stack[4]),
+				),
+			)
 		}), []api.ValueType{i32, i64, i64, i64, i32}, []api.ValueType{i32}).
 		Export("ext_trie_blake2_256_verify_proof_version_2").
 		NewFunctionBuilder().
@@ -307,7 +368,14 @@ func newRuntime(ctx context.Context,
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(
 			ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_default_child_storage_read_version_1(ctx, m, stack[0], stack[1], stack[2], api.DecodeU32(stack[3]))
+			stack[0] = ext_default_child_storage_read_version_1(
+				ctx,
+				m,
+				stack[0],
+				stack[1],
+				stack[2],
+				api.DecodeU32(stack[3]),
+			)
 		}), []api.ValueType{i64, i64, i64, i32}, []api.ValueType{i64}).
 		Export("ext_default_child_storage_read_version_1").
 		NewFunctionBuilder().
@@ -432,7 +500,16 @@ func newRuntime(ctx context.Context,
 		Export("ext_offchain_is_validator_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = api.EncodeU32(ext_offchain_local_storage_compare_and_set_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2], stack[3]))
+			stack[0] = api.EncodeU32(
+				ext_offchain_local_storage_compare_and_set_version_1(
+					ctx,
+					m,
+					api.DecodeU32(stack[0]),
+					stack[1],
+					stack[2],
+					stack[3],
+				),
+			)
 		}), []api.ValueType{i32, i64, i64, i64}, []api.ValueType{i32}).
 		Export("ext_offchain_local_storage_compare_and_set_version_1").
 		NewFunctionBuilder().
@@ -477,7 +554,13 @@ func newRuntime(ctx context.Context,
 		Export("ext_offchain_http_request_start_version_1").
 		NewFunctionBuilder().
 		WithGoModuleFunction(api.GoModuleFunc(func(ctx context.Context, m api.Module, stack []uint64) {
-			stack[0] = ext_offchain_http_request_add_header_version_1(ctx, m, api.DecodeU32(stack[0]), stack[1], stack[2])
+			stack[0] = ext_offchain_http_request_add_header_version_1(
+				ctx,
+				m,
+				api.DecodeU32(stack[0]),
+				stack[1],
+				stack[2],
+			)
 		}), []api.ValueType{i32, i64, i64}, []api.ValueType{i64}).
 		Export("ext_offchain_http_request_add_header_version_1").
 		NewFunctionBuilder().


### PR DESCRIPTION
## Changes
By avoiding the function type reflection of host methods at runtime in the Runtime, we can gain around 2x speedup (according to @EclesioMeloJunior 's microbenchmarks).

The downside to this is we lose some compile time type guarantees and also maintainability goes down a little. 
<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/3959

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@
