### PR TITLE
fix(storage): Improve get nextkey performance when we have txs

### DIFF
--- a/lib/runtime/storage/storagediff.go
+++ b/lib/runtime/storage/storagediff.go
@@ -298,11 +298,9 @@ func (cs *storageDiff) applyToTrie(t trie.Trie) {
 }
 
 func (cs *storageDiff) insertSortedKey(key string) {
-	pos := sort.Search(len(cs.sortedKeys), func(i int) bool {
-		return cs.sortedKeys[i] >= key
-	})
+	pos, found := slices.BinarySearch(cs.sortedKeys, key)
 
-	if pos < len(cs.sortedKeys) && cs.sortedKeys[pos] == key {
+	if found {
 		return // key already exists
 	}
 
@@ -312,11 +310,9 @@ func (cs *storageDiff) insertSortedKey(key string) {
 }
 
 func (cs *storageDiff) removeSortedKey(key string) {
-	pos := sort.Search(len(cs.sortedKeys), func(i int) bool {
-		return cs.sortedKeys[i] >= key
-	})
+	pos, found := slices.BinarySearch(cs.sortedKeys, key)
 
-	if pos < len(cs.sortedKeys) && cs.sortedKeys[pos] == key {
+	if found {
 		cs.sortedKeys = append(cs.sortedKeys[:pos], cs.sortedKeys[pos+1:]...)
 	}
 }

--- a/lib/runtime/storage/storagediff.go
+++ b/lib/runtime/storage/storagediff.go
@@ -24,6 +24,7 @@ import (
 type storageDiff struct {
 	upserts        map[string][]byte
 	deletes        map[string]bool
+	sortedKeys     []string
 	childChangeSet map[string]*storageDiff
 }
 
@@ -66,6 +67,7 @@ func (cs *storageDiff) upsert(key string, value []byte) {
 	}
 
 	cs.upserts[key] = value
+	cs.insertSortedKey(key)
 }
 
 // delete marks a key for deletion and removes it from upserts and
@@ -78,6 +80,7 @@ func (cs *storageDiff) delete(key string) {
 	delete(cs.childChangeSet, key)
 	delete(cs.upserts, key)
 	cs.deletes[key] = true
+	cs.removeSortedKey(key)
 }
 
 // deleteChildLimit deletes lexicographical sorted keys from a child trie with
@@ -198,6 +201,7 @@ func (cs *storageDiff) upsertChild(keyToChild, key string, value []byte) {
 
 	childChanges.upserts[key] = value
 	cs.childChangeSet[keyToChild] = childChanges
+	childChanges.insertSortedKey(key)
 }
 
 // deleteFromChild marks a key for deletion within a specific child trie.
@@ -213,6 +217,7 @@ func (cs *storageDiff) deleteFromChild(keyToChild, key string) {
 
 	childChanges.delete(key)
 	cs.childChangeSet[keyToChild] = childChanges
+	childChanges.removeSortedKey(key)
 }
 
 // snapshot creates a deep copy of the current change set, including all upserts,
@@ -231,6 +236,7 @@ func (cs *storageDiff) snapshot() *storageDiff {
 		upserts:        maps.Clone(cs.upserts),
 		deletes:        maps.Clone(cs.deletes),
 		childChangeSet: childChangeSetCopy,
+		sortedKeys:     slices.Clone(cs.sortedKeys),
 	}
 }
 
@@ -288,5 +294,29 @@ func (cs *storageDiff) applyToTrie(t trie.Trie) {
 			}
 		}
 
+	}
+}
+
+func (cs *storageDiff) insertSortedKey(key string) {
+	pos := sort.Search(len(cs.sortedKeys), func(i int) bool {
+		return cs.sortedKeys[i] >= key
+	})
+
+	if pos < len(cs.sortedKeys) && cs.sortedKeys[pos] == key {
+		return // key already exists
+	}
+
+	cs.sortedKeys = append(cs.sortedKeys, "")
+	copy(cs.sortedKeys[pos+1:], cs.sortedKeys[pos:])
+	cs.sortedKeys[pos] = key
+}
+
+func (cs *storageDiff) removeSortedKey(key string) {
+	pos := sort.Search(len(cs.sortedKeys), func(i int) bool {
+		return cs.sortedKeys[i] >= key
+	})
+
+	if pos < len(cs.sortedKeys) && cs.sortedKeys[pos] == key {
+		cs.sortedKeys = append(cs.sortedKeys[:pos], cs.sortedKeys[pos+1:]...)
 	}
 }

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -374,11 +374,11 @@ func (t *TrieState) DeleteChildLimit(key []byte, limit *[]byte) (
 	childTrieEntries := child.Entries()
 	qtyEntries := uint32(len(childTrieEntries))
 	if limit == nil {
-		err = t.DeleteChild(key)
+		err = t.state.DeleteChild(key)
 		if err != nil {
 			return 0, false, fmt.Errorf("deleting child trie: %w", err)
 		}
-
+		delete(t.childSortedKeys, string(key))
 		return qtyEntries, true, nil
 	}
 	limitUint := binary.LittleEndian.Uint32(*limit)


### PR DESCRIPTION
## Changes

Improve `TrieState` `NextKey` performance by keeping the keys sorted in memory

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make test
```

## Issues

<!-- Write the issue number(s), for example: #123 -->

closes: https://github.com/ChainSafe/gossamer/issues/3958

## Benchmarks

| Case | time / op | bytes / op | allocs / op |
|--------|--------:|--------:|--------:|
| old implementation | 920289771 ns/op | 993969728 B/op | 11610410 allocs/op |
| new implementation | 1270280 ns/op | 208029 B/op | 12002 allocs/op | 

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@jimjbrettj 
