### PR TITLE
feat(internal/client/state-db) `StateDB` type which incorporates non-canonical overlays and pruning

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ jobs:
   integration-tests:
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         packages:
           [

--- a/internal/client/state-db/statedb.go
+++ b/internal/client/state-db/statedb.go
@@ -19,7 +19,7 @@ var (
 	pruningModeConstrained  = []byte("constrained")
 )
 
-// Database value type.
+// DBValue is the database value type.
 type DBValue []byte
 
 // Hash is interface for the Block hash and node key types.
@@ -27,41 +27,42 @@ type Hash interface {
 	comparable
 }
 
+// HashDBValue is a helper struct which contains Hash and DBValue.
 type HashDBValue[H any] struct {
 	Hash H
 	DBValue
 }
 
-// Backend database interface for metadata. Read-only.
+// MetaDB is the backend database interface for metadata. Read-only.
 type MetaDB interface {
 	// Get meta value, such as the journal.
 	GetMeta(key []byte) (*DBValue, error)
 }
 
-// Backend database interface. Read-only.
+// NodeDB is the backend database interface. Read-only.
 type NodeDB[Key comparable] interface {
 	// Get state trie node.
 	Get(key Key) (*DBValue, error)
 }
 
 var (
-	// Trying to canonicalize invalid block.
+	// ErrInvalidBlock is trying to canonicalize invalid block.
 	ErrInvalidBlock = errors.New("trying to canonicalize invalid block")
-	// Trying to insert block with invalid number.
+	// ErrInvalidBlockNumber is trying to insert block with invalid number.
 	ErrInvalidBlockNumber = errors.New("trying to insert block with invalid number")
-	// Trying to insert block with unknown parent.
+	// ErrInvalidParent is trying to insert block with unknown parent.
 	ErrInvalidParent = errors.New("trying to insert block with unknown parent")
-	// Invalid pruning mode specified. Contains expected mode.
+	// ErrIncompatiblePruningModes is an invalid pruning mode specified. Contains expected mode.
 	ErrIncompatiblePruningModes = errors.New("incompatible pruning modes")
-	// Trying to insert existing block.
+	// ErrBlockAlreadyExists is trying to insert existing block.
 	ErrBlockAlreadyExists = errors.New("block already exists")
-	// Trying to get a block record from db while it is not commit to db yet
+	// ErrBlockUnavailable is trying to get a block record from db while it is not commit to db yet
 	ErrBlockUnavailable = errors.New("trying to get a block record from db while it is not commit to db yet")
-	// Invalid metadata
+	// ErrMetadata is invalid metadata
 	ErrMetadata = errors.New("Invalid metadata:")
 )
 
-// A set of state node changes.
+// ChangeSet is a set of state node changes.
 type ChangeSet[H any] struct {
 	// Inserted nodes.
 	Inserted []HashDBValue[H]
@@ -69,7 +70,7 @@ type ChangeSet[H any] struct {
 	Deleted []H
 }
 
-// A set of changes to the backing database.
+// CommitSet is a set of changes to the backing database.
 type CommitSet[H Hash] struct {
 	// State node changes.
 	Data ChangeSet[H]
@@ -77,7 +78,7 @@ type CommitSet[H Hash] struct {
 	Meta ChangeSet[[]byte]
 }
 
-// Pruning constraints. If none are specified pruning is
+// Constraints are the pruning constraints. If none are specified pruning is
 type Constraints struct {
 	// Maximum blocks. Defaults to 0 when unspecified, effectively keeping only non-canonical
 	// states.

--- a/internal/client/state-db/statedb.go
+++ b/internal/client/state-db/statedb.go
@@ -667,7 +667,7 @@ func fetchStoredPruningMode(db MetaDB) (PruningMode, error) {
 		return nil, err
 	}
 	if val == nil {
-		return nil, fmt.Errorf("unable to retrieve stored value for PRUNING_MODE")
+		return nil, nil //nolint: nilnil
 	}
 	mode := NewPruningModeFromID(*val)
 	if mode != nil {

--- a/internal/client/state-db/statedb.go
+++ b/internal/client/state-db/statedb.go
@@ -3,46 +3,30 @@
 
 package statedb
 
-// State database maintenance. Handles canonicalization and pruning in the database.
-//
-// # Canonicalization.
-// Canonicalization window tracks a tree of blocks identified by header hash. The in-memory
-// overlay allows to get any trie node that was inserted in any of the blocks within the window.
-// The overlay is journaled to the backing database and rebuilt on startup.
-// There's a limit of 32 blocks that may have the same block number in the canonicalization window.
-//
-// Canonicalization function selects one root from the top of the tree and discards all other roots
-// and their subtrees. Upon canonicalization all trie nodes that were inserted in the block are
-// added to the backing DB and block tracking is moved to the pruning window, where no forks are
-// allowed.
-//
-// # Canonicalization vs Finality
-// Database engine uses a notion of canonicality, rather then finality. A canonical block may not
-// be yet finalized from the perspective of the consensus engine, but it still can't be reverted in
-// the database. Most of the time during normal operation last canonical block is the same as last
-// finalized. However if finality stall for a long duration for some reason, there's only a certain
-// number of blocks that can fit in the non-canonical overlay, so canonicalization of an
-// unfinalized block may be forced.
-//
-// # Pruning.
-// See `RefWindow` for pruning algorithm details. `StateDb` prunes on each canonicalization until
-// pruning constraints are satisfied.
-
 import (
 	"errors"
+	"fmt"
+	"log"
+	"sync"
 
 	"github.com/ChainSafe/gossamer/pkg/scale"
+)
+
+var (
+	pruningMode             = []byte("mode")
+	pruningModeArchive      = []byte("archive")
+	pruningModeArchiveCanon = []byte("archive_canonical")
+	pruningModeConstrained  = []byte("constrained")
 )
 
 // Database value type.
 type DBValue []byte
 
-// Basic set of requirements for the Block hash and node key types.
+// Hash is interface for the Block hash and node key types.
 type Hash interface {
 	comparable
 }
 
-// HashDBValue is a helper struct which contains Hash and DBValue.
 type HashDBValue[H any] struct {
 	Hash H
 	DBValue
@@ -93,8 +77,589 @@ type CommitSet[H Hash] struct {
 	Meta ChangeSet[[]byte]
 }
 
+// Pruning constraints. If none are specified pruning is
+type Constraints struct {
+	// Maximum blocks. Defaults to 0 when unspecified, effectively keeping only non-canonical
+	// states.
+	MaxBlocks *uint32
+}
+
+// Pruning mode.
+type PruningMode interface {
+	IsArchive() bool
+	ID() []byte
+}
+type PruningModes interface {
+	PruningModeConstrained | PruningModeArchiveAll | PruningModeArchiveCanonical
+}
+
+func NewPruningModeFromID(id []byte) PruningMode {
+	switch string(id) {
+	case string(pruningModeArchive):
+		return PruningModeArchiveAll{}
+	case string(pruningModeArchiveCanon):
+		return PruningModeArchiveCanonical{}
+	case string(pruningModeConstrained):
+		defaultBlocks := defaultMaxBlockConstraint
+		return PruningModeConstrained{MaxBlocks: &defaultBlocks}
+	default:
+		return nil
+	}
+}
+
+// Maintain a pruning window.
+type PruningModeConstrained Constraints
+
+func (pmc PruningModeConstrained) IsArchive() bool {
+	return false
+}
+func (pmc PruningModeConstrained) ID() []byte {
+	return []byte("constrained")
+}
+
+// No pruning. Canonicalization is a no-op.
+type PruningModeArchiveAll struct{}
+
+func (pmaa PruningModeArchiveAll) IsArchive() bool {
+	return true
+}
+func (pmaa PruningModeArchiveAll) ID() []byte {
+	return []byte("archive")
+}
+
+// Canonicalization discards non-canonical nodes. All the canonical nodes are kept in the DB.
+type PruningModeArchiveCanonical struct{}
+
+func (pmac PruningModeArchiveCanonical) IsArchive() bool {
+	return true
+}
+func (pmac PruningModeArchiveCanonical) ID() []byte {
+	return []byte("archive_canonical")
+}
+
 func toMetaKey(suffix []byte, data any) []byte {
 	key := scale.MustMarshal(data)
 	key = append(key, suffix...)
 	return key
+}
+
+// Status information about the last canonicalized block.
+type LastCanonicalized any
+type LastCanonicalizedValues interface {
+	LastCanonicalizedNone | LastCanonicalizedBlock | LastCanonicalizedNotCanonicalizing
+}
+
+// Not yet have canonicalized any block.
+type LastCanonicalizedNone struct{}
+
+// The given block number is the last canonicalized block.
+type LastCanonicalizedBlock uint64
+
+// No canonicalization is happening (pruning mode is archive all).
+type LastCanonicalizedNotCanonicalizing struct{}
+
+type StateDBSync[BlockHash Hash, Key Hash] struct {
+	mode         PruningMode
+	nonCanonical NonCanonicalOverlay[BlockHash, Key]
+	pruning      *pruningWindow[BlockHash, Key]
+	pinned       map[BlockHash]uint32
+}
+
+func NewStateDBSync[BlockHash Hash, Key Hash](
+	mode PruningMode,
+	db MetaDB,
+) (StateDBSync[BlockHash, Key], error) {
+	nonCanonical, err := NewNonCanonicalOverlay[BlockHash, Key](db)
+	if err != nil {
+		return StateDBSync[BlockHash, Key]{}, err
+	}
+	var pruning *pruningWindow[BlockHash, Key]
+	switch mode := mode.(type) {
+	case PruningModeConstrained:
+		rw, err := newPruningWindow[BlockHash, Key](db, *mode.MaxBlocks)
+		if err != nil {
+			return StateDBSync[BlockHash, Key]{}, err
+		}
+		pruning = &rw
+	}
+	return StateDBSync[BlockHash, Key]{
+		mode:         mode,
+		nonCanonical: nonCanonical,
+		pruning:      pruning,
+		pinned:       make(map[BlockHash]uint32),
+	}, nil
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) insertBlock(
+	hash BlockHash,
+	number uint64,
+	parentHash BlockHash,
+	changeset ChangeSet[Key],
+) (CommitSet[Key], error) {
+	switch sdbs.mode.(type) {
+	case PruningModeArchiveAll:
+		changeset.Deleted = nil
+		return CommitSet[Key]{
+			Data: changeset,
+		}, nil
+	default:
+		return sdbs.nonCanonical.Insert(hash, number, parentHash, changeset)
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) canonicalizeBlock(hash BlockHash) (CommitSet[Key], error) {
+	// NOTE: it is important that the change to `LAST_CANONICAL` (emit from
+	// `non_canonical.canonicalize`) and the insert of the new pruning journal (emit from
+	// `pruning.note_canonical`) are collected into the same `CommitSet` and are committed to
+	// the database atomically to keep their consistency when restarting the node
+	commit := CommitSet[Key]{}
+	if _, ok := sdbs.mode.(PruningModeArchiveAll); ok {
+		return commit, nil
+	}
+	number, err := sdbs.nonCanonical.Canonicalize(hash, &commit)
+	if err != nil {
+		return CommitSet[Key]{}, err
+	}
+	if _, ok := sdbs.mode.(PruningModeArchiveCanonical); ok {
+		commit.Data.Deleted = nil
+	}
+	if sdbs.pruning != nil {
+		err := sdbs.pruning.NoteCanonical(hash, number, &commit)
+		if err != nil {
+			return CommitSet[Key]{}, err
+		}
+	}
+	err = sdbs.prune(&commit)
+	if err != nil {
+		return CommitSet[Key]{}, err
+	}
+	return commit, nil
+}
+
+// Returns the block number of the last canonicalized block.
+func (sdbs *StateDBSync[BlockHash, Key]) lastCanonicalized() LastCanonicalized {
+	switch sdbs.mode.(type) {
+	case PruningModeArchiveAll:
+		return LastCanonicalizedNotCanonicalizing{}
+	default:
+		num := sdbs.nonCanonical.LastCanonicalizedBlockNumber()
+		if num == nil {
+			return LastCanonicalizedNone{}
+		}
+		return LastCanonicalizedBlock(*num)
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) isPruned(hash BlockHash, number uint64) IsPruned {
+	switch sdbs.mode.(type) {
+	case PruningModeArchiveAll:
+		return IsPrunedNotPruned
+	case PruningModeArchiveCanonical, PruningModeConstrained:
+		var cond bool
+		num := sdbs.nonCanonical.LastCanonicalizedBlockNumber()
+		if num != nil {
+			cond = number > *num
+		} else {
+			cond = true
+		}
+		if cond {
+			if sdbs.nonCanonical.HaveBlock(hash) {
+				return IsPrunedNotPruned
+			}
+			return IsPrunedPruned
+		}
+
+		if sdbs.pruning != nil {
+			switch sdbs.pruning.HaveBlock(hash, number) {
+			case haveBlockNo:
+				return IsPrunedPruned
+			case haveBlockYes:
+				return IsPrunedNotPruned
+				// case haveBlockMaybe:
+				// 	return IsPrunedMaybePruned
+			}
+		}
+		// We don't know for sure.
+		return IsPrunedMaybePruned
+	default:
+		panic("wtf?")
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) prune(commit *CommitSet[Key]) error {
+	if constraints, ok := sdbs.mode.(PruningModeConstrained); ok {
+		for {
+			var maxBlocks uint64
+			if constraints.MaxBlocks != nil {
+				maxBlocks = uint64(*constraints.MaxBlocks)
+			}
+			if sdbs.pruning.WindowSize() <= maxBlocks {
+				break
+			}
+
+			hash, err := sdbs.pruning.NextHash()
+			if err != nil {
+				if errors.Is(err, ErrBlockUnavailable) {
+					// the block record is temporary unavailable, break and try next time
+					break
+				}
+				return err
+			}
+			if hash != nil {
+				_, ok := sdbs.pinned[*hash]
+				if ok {
+					break
+				}
+			}
+			err = sdbs.pruning.PruneOne(commit)
+			// this branch should not reach as previous `next_hash` don't return error
+			// keeping it for robustness
+			if err != nil {
+				if errors.Is(err, ErrBlockUnavailable) {
+					break
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Revert all non-canonical blocks with the best block number.
+// Returns a database commit or `None` if not possible.
+// For archive an empty commit set is returned.
+func (sdbs *StateDBSync[BlockHash, Key]) revertOne() *CommitSet[Key] {
+	switch sdbs.mode.(type) {
+	case PruningModeArchiveAll:
+		return &CommitSet[Key]{}
+	case PruningModeArchiveCanonical, PruningModeConstrained:
+		return sdbs.nonCanonical.RevertOne()
+	default:
+		panic("wtf?")
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) remove(hash BlockHash) *CommitSet[Key] {
+	switch sdbs.mode.(type) {
+	case PruningModeArchiveAll:
+		return &CommitSet[Key]{}
+	case PruningModeArchiveCanonical, PruningModeConstrained:
+		return sdbs.nonCanonical.Remove(hash)
+	default:
+		panic("wtf?")
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) pin(hash BlockHash, number uint64, hint func() bool) error {
+	switch sdbs.mode.(type) {
+	case PruningModeArchiveAll:
+		return nil
+	case PruningModeArchiveCanonical, PruningModeConstrained:
+		var haveBlock bool
+		left := sdbs.nonCanonical.HaveBlock(hash)
+		var right bool
+		if sdbs.pruning != nil {
+			hb := sdbs.pruning.HaveBlock(hash, number)
+			switch hb {
+			case haveBlockNo:
+				right = false
+			case haveBlockYes:
+				right = true
+				// case haveBlockMaybe:
+				// 	right = hint()
+			}
+		} else {
+			right = hint()
+		}
+		haveBlock = left || right
+		if haveBlock {
+			refs := sdbs.pinned[hash]
+			if refs == 0 {
+				log.Println("TRACE: Pinned block:", hash)
+				sdbs.nonCanonical.Pin(hash)
+			}
+			sdbs.pinned[hash] += 1
+			return nil
+		}
+		return ErrInvalidBlock
+	default:
+		panic("wtf?")
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) unpin(hash BlockHash) {
+	entry, ok := sdbs.pinned[hash]
+	if ok {
+		sdbs.pinned[hash] -= 1
+		if entry == 0 {
+			log.Println("TRACE: Unpinned block:", hash)
+			delete(sdbs.pinned, hash)
+			sdbs.nonCanonical.Unpin(hash)
+		} else {
+			log.Println("TRACE: Releasing reference for ", hash)
+		}
+	}
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) sync() {
+	sdbs.nonCanonical.Sync()
+}
+
+func (sdbs *StateDBSync[BlockHash, Key]) get(key Key, db NodeDB[Key]) (*DBValue, error) {
+	val := sdbs.nonCanonical.Get(key)
+	if val != nil {
+		return val, nil
+	}
+	return db.Get(key)
+}
+
+// StateDB database maintenance. Handles canonicalization and pruning in the database.
+//
+// # Canonicalization.
+// Canonicalization window tracks a tree of blocks identified by header hash. The in-memory
+// overlay allows to get any trie node that was inserted in any of the blocks within the window.
+// The overlay is journaled to the backing database and rebuilt on startup.
+// There's a limit of 32 blocks that may have the same block number in the canonicalization window.
+// Can be shared across threads.
+//
+// Canonicalization function selects one root from the top of the tree and discards all other roots
+// and their subtrees. Upon canonicalization all trie nodes that were inserted in the block are
+// added to the backing DB and block tracking is moved to the pruning window, where no forks are
+// allowed.
+//
+// # Canonicalization vs Finality
+// Database engine uses a notion of canonicality, rather then finality. A canonical block may not
+// be yet finalized from the perspective of the consensus engine, but it still can't be reverted in
+// the database. Most of the time during normal operation last canonical block is the same as last
+// finalized. However if finality stall for a long duration for some reason, there's only a certain
+// number of blocks that can fit in the non-canonical overlay, so canonicalization of an
+// unfinalized block may be forced.
+//
+// # Pruning.
+// See `pruningWindow` for pruning algorithm details. `StateDB` prunes on each canonicalization until
+// pruning constraints are satisfied.
+type StateDB[BlockHash Hash, Key Hash] struct {
+	db StateDBSync[BlockHash, Key]
+	sync.RWMutex
+}
+
+func NewStateDB[BlockHash Hash, Key Hash](
+	db MetaDB,
+	requestedMode PruningMode,
+	// refCounting bool,
+	shouldInit bool,
+) (CommitSet[Key], StateDB[BlockHash, Key], error) {
+	storedMode, err := fetchStoredPruningMode(db)
+	if err != nil {
+		return CommitSet[Key]{}, StateDB[BlockHash, Key]{}, err
+	}
+
+	var selectedMode PruningMode
+	switch {
+	case shouldInit:
+		if storedMode != nil {
+			panic("The storage has just been initialized. No meta-data is expected to be found in it.")
+		}
+		if requestedMode != nil {
+			selectedMode = requestedMode
+		} else {
+			maxBlocks := defaultMaxBlockConstraint
+			selectedMode = PruningModeConstrained{
+				MaxBlocks: &maxBlocks,
+			}
+		}
+	case !shouldInit && storedMode == nil:
+		return CommitSet[Key]{}, StateDB[BlockHash, Key]{}, fmt.Errorf("%w An existing StateDb does not have PRUNING_MODE stored in its meta-data", ErrMetadata)
+	case !shouldInit && storedMode != nil && requestedMode == nil:
+		selectedMode = storedMode
+	case !shouldInit && storedMode != nil && requestedMode != nil:
+		mode, err := choosePruningMode(storedMode, requestedMode)
+		if err != nil {
+			return CommitSet[Key]{}, StateDB[BlockHash, Key]{}, err
+		}
+		selectedMode = mode
+	default:
+		panic("wtf?")
+	}
+
+	var dbInitCommitSet CommitSet[Key]
+	if shouldInit {
+		var cs CommitSet[Key]
+
+		key := toMetaKey(pruningMode, struct{}{})
+		value := selectedMode.ID()
+
+		cs.Meta.Inserted = append(cs.Meta.Inserted, HashDBValue[[]byte]{
+			Hash:    key,
+			DBValue: value,
+		})
+		dbInitCommitSet = cs
+	}
+
+	stateDBSync, err := NewStateDBSync[BlockHash, Key](selectedMode, db)
+	if err != nil {
+		return CommitSet[Key]{}, StateDB[BlockHash, Key]{}, err
+	}
+	stateDB := StateDB[BlockHash, Key]{
+		db: stateDBSync,
+	}
+	return dbInitCommitSet, stateDB, nil
+}
+
+func (sdb *StateDB[BlockHash, Key]) PruningMode() PruningMode {
+	sdb.RLock()
+	defer sdb.RUnlock()
+	return sdb.db.mode
+}
+
+// Add a new non-canonical block.
+func (sdb *StateDB[BlockHash, Key]) InsertBlock(
+	hash BlockHash,
+	number uint64,
+	parentHash BlockHash,
+	changeset ChangeSet[Key],
+) (CommitSet[Key], error) {
+	sdb.Lock()
+	defer sdb.Unlock()
+	return sdb.db.insertBlock(hash, number, parentHash, changeset)
+}
+
+// Finalize a previously inserted block.
+func (sdb *StateDB[BlockHash, Key]) CanonicalizeBlock(hash BlockHash) (CommitSet[Key], error) {
+	sdb.Lock()
+	defer sdb.Unlock()
+	return sdb.db.canonicalizeBlock(hash)
+}
+
+// Prevents pruning of specified block and its descendants.
+// `hint` used for further checking if the given block exists
+func (sdb *StateDB[BlockHash, Key]) Pin(hash BlockHash, number uint64, hint func() bool) error {
+	sdb.Lock()
+	defer sdb.Unlock()
+	return sdb.db.pin(hash, number, hint)
+}
+
+// Allows pruning of specified block.
+func (sdb *StateDB[BlockHash, Key]) Unpin(hash BlockHash) {
+	sdb.Lock()
+	defer sdb.Unlock()
+	sdb.db.unpin(hash)
+}
+
+// Confirm that all changes made to commit sets are on disk. Allows for temporarily pinned
+// blocks to be released.
+func (sdb *StateDB[BlockHash, Key]) Sync() {
+	sdb.Lock()
+	defer sdb.Unlock()
+	sdb.db.sync()
+}
+
+// Get a value from non-canonical/pruning overlay or the backing DB.
+func (sdb *StateDB[BlockHash, Key]) Get(key Key, db NodeDB[Key]) (*DBValue, error) {
+	sdb.RLock()
+	defer sdb.RUnlock()
+	return sdb.db.get(key, db)
+}
+
+// Revert all non-canonical blocks with the best block number.
+// Returns a database commit or `None` if not possible.
+// For archive an empty commit set is returned.
+func (sdb *StateDB[BlockHash, Key]) RevertOne() *CommitSet[Key] {
+	sdb.Lock()
+	defer sdb.Unlock()
+	return sdb.db.revertOne()
+}
+
+// Remove specified non-canonical block.
+// Returns a database commit or `None` if not possible.
+func (sdb *StateDB[BlockHash, Key]) Remove(hash BlockHash) *CommitSet[Key] {
+	sdb.Lock()
+	defer sdb.Unlock()
+	return sdb.db.remove(hash)
+}
+
+// Returns last canonicalized block.
+func (sdb *StateDB[BlockHash, Key]) LastCanonicalized() LastCanonicalized {
+	sdb.RLock()
+	defer sdb.RUnlock()
+	return sdb.db.lastCanonicalized()
+}
+
+// Check if block is pruned away.
+func (sdb *StateDB[BlockHash, Key]) IsPruned(hash BlockHash, number uint64) IsPruned {
+	sdb.RLock()
+	defer sdb.RUnlock()
+	return sdb.db.isPruned(hash, number)
+}
+
+// Reset in-memory changes to the last disk-backed state.
+func (sdb *StateDB[BlockHash, Key]) Reset(db MetaDB) error {
+	sdb.Lock()
+	defer sdb.Unlock()
+	new, err := NewStateDBSync[BlockHash, Key](sdb.db.mode, db)
+	if err != nil {
+		return err
+	}
+	sdb.db = new
+	return nil
+}
+
+// The result returned by `StateDB.IsPruned()`
+type IsPruned uint
+
+const (
+	// Definitely pruned
+	IsPrunedPruned IsPruned = iota
+	// Definitely not pruned
+	IsPrunedNotPruned
+	// May or may not pruned, need further checking
+	IsPrunedMaybePruned
+)
+
+func choosePruningMode(stored, requested PruningMode) (PruningMode, error) {
+	switch stored.(type) {
+	case PruningModeArchiveAll:
+		switch requested.(type) {
+		case PruningModeArchiveAll:
+			return PruningModeArchiveAll{}, nil
+		default:
+			return nil, fmt.Errorf("%w [stored: %T; requested: %T]",
+				ErrIncompatiblePruningModes, stored, requested)
+		}
+	case PruningModeArchiveCanonical:
+		switch requested.(type) {
+		case PruningModeArchiveCanonical:
+			return PruningModeArchiveCanonical{}, nil
+		default:
+			return nil, fmt.Errorf("%w [stored: %T; requested: %T]",
+				ErrIncompatiblePruningModes, stored, requested)
+		}
+	case PruningModeConstrained:
+		switch req := requested.(type) {
+		case PruningModeConstrained:
+			return req, nil
+		default:
+			return nil, fmt.Errorf("%w [stored: %T; requested: %T]",
+				ErrIncompatiblePruningModes, stored, requested)
+		}
+	default:
+		return nil, fmt.Errorf("%w [stored: %T; requested: %T]",
+			ErrIncompatiblePruningModes, stored, requested)
+	}
+}
+
+func fetchStoredPruningMode(db MetaDB) (PruningMode, error) {
+	metaKeyNode := toMetaKey(pruningMode, struct{}{})
+	val, err := db.GetMeta(metaKeyNode)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, nil
+	}
+	mode := NewPruningModeFromID(*val)
+	if mode != nil {
+		return mode, nil
+	}
+	return nil, fmt.Errorf("invalid value stored for PRUNING_MODE: %v", *val)
 }

--- a/internal/client/state-db/statedb_test.go
+++ b/internal/client/state-db/statedb_test.go
@@ -4,7 +4,10 @@
 package statedb
 
 import (
+	"testing"
+
 	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestDB struct {
@@ -67,5 +70,212 @@ func NewChangeset(inserted []uint64, deleted []uint64) ChangeSet[hash.H256] {
 	return ChangeSet[hash.H256]{
 		Inserted: insertedHDBVs,
 		Deleted:  deletedHashes,
+	}
+}
+
+func newTestDB(t *testing.T, settings PruningMode) (TestDB, *StateDB[hash.H256, hash.H256]) {
+	t.Helper()
+
+	db := NewTestDB([]uint64{91, 921, 922, 93, 94})
+	stateDBInit, stateDB, err := NewStateDB[hash.H256, hash.H256](db, settings, true)
+	assert.NoError(t, err)
+	db.Commit(stateDBInit)
+
+	commit, err := stateDB.InsertBlock(
+		hash.NewH256FromLowUint64BigEndian(1),
+		1,
+		hash.NewH256FromLowUint64BigEndian(0),
+		NewChangeset([]uint64{1}, []uint64{91}),
+	)
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.InsertBlock(
+		hash.NewH256FromLowUint64BigEndian(21),
+		2,
+		hash.NewH256FromLowUint64BigEndian(1),
+		NewChangeset([]uint64{21}, []uint64{921, 1}),
+	)
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.InsertBlock(
+		hash.NewH256FromLowUint64BigEndian(22),
+		2,
+		hash.NewH256FromLowUint64BigEndian(1),
+		NewChangeset([]uint64{22}, []uint64{922}),
+	)
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.InsertBlock(
+		hash.NewH256FromLowUint64BigEndian(3),
+		3,
+		hash.NewH256FromLowUint64BigEndian(21),
+		NewChangeset([]uint64{3}, []uint64{93}),
+	)
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.CanonicalizeBlock(hash.NewH256FromLowUint64BigEndian(1))
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.InsertBlock(
+		hash.NewH256FromLowUint64BigEndian(4),
+		4,
+		hash.NewH256FromLowUint64BigEndian(3),
+		NewChangeset([]uint64{4}, []uint64{94}),
+	)
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.CanonicalizeBlock(hash.NewH256FromLowUint64BigEndian(21))
+	assert.NoError(t, err)
+	db.Commit(commit)
+	commit, err = stateDB.CanonicalizeBlock(hash.NewH256FromLowUint64BigEndian(3))
+	assert.NoError(t, err)
+	db.Commit(commit)
+
+	return db, &stateDB
+}
+
+func TestStateDB_FullArchiveKeepsEverything(t *testing.T) {
+	db, stateDB := newTestDB(t, PruningModeArchiveAll{})
+	assert.Equal(t, NewTestDB([]uint64{1, 21, 22, 3, 4, 91, 921, 922, 93, 94}).Data, db.Data)
+	assert.Equal(t, IsPrunedNotPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(0), 0))
+}
+
+func TestStateDB_CanonicalArchiveKeepsCanonical(t *testing.T) {
+	db, _ := newTestDB(t, PruningModeArchiveCanonical{})
+	assert.Equal(t, NewTestDB([]uint64{1, 21, 3, 91, 921, 922, 93, 94}).Data, db.Data)
+}
+
+func TestStateDB_BlockRecordUnavailable(t *testing.T) {
+	t.Skipf("this test is for the DB backed pruning where we do not count references")
+	maxBlocks := uint32(1)
+	db, stateDB := newTestDB(t, PruningModeConstrained{MaxBlocks: &maxBlocks})
+	// import 2 blocks
+	for _, i := range []uint64{5, 6} {
+		commit, err := stateDB.InsertBlock(
+			hash.NewH256FromLowUint64BigEndian(i), i,
+			hash.NewH256FromLowUint64BigEndian(i-1),
+			NewChangeset(nil, nil))
+		assert.NoError(t, err)
+		db.Commit(commit)
+	}
+	// canonicalize block 4 but not commit it to db
+	c1, err := stateDB.CanonicalizeBlock(hash.NewH256FromLowUint64BigEndian(4))
+	assert.NoError(t, err)
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(3), 3))
+
+	// canonicalize block 5 but not commit it to db, block 4 is not pruned due to it is not
+	// commit to db yet (unavailable), return `MaybePruned` here because `apply_pending` is not
+	// called and block 3 is still in cache
+	c2, err := stateDB.CanonicalizeBlock(hash.NewH256FromLowUint64BigEndian(5))
+	assert.NoError(t, err)
+	assert.Equal(t, IsPrunedMaybePruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(4), 4))
+	// commit block 4 and 5 to db, and import a new block will prune both block 4 and 5
+	db.Commit(c1)
+	db.Commit(c2)
+	commit, err := stateDB.CanonicalizeBlock(hash.NewH256FromLowUint64BigEndian(6))
+	assert.NoError(t, err)
+	db.Commit(commit)
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(4), 4))
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(4), 4))
+}
+
+func TestStateDB_PruneWindow0(t *testing.T) {
+	var maxBlocks uint32
+	db, _ := newTestDB(t, PruningModeConstrained{MaxBlocks: &maxBlocks})
+	assert.Equal(t, NewTestDB([]uint64{21, 3, 922, 94}).Data, db.Data)
+}
+
+func TestStateDB_PruneWindow1(t *testing.T) {
+	var maxBlocks uint32 = 1
+	db, stateDB := newTestDB(t, PruningModeConstrained{MaxBlocks: &maxBlocks})
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(0), 0))
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(1), 1))
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(21), 2))
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(22), 2))
+	assert.Equal(t, NewTestDB([]uint64{21, 3, 922, 93, 94}).Data, db.Data)
+}
+
+func TestStateDB_PruneWindow2(t *testing.T) {
+	var maxBlocks uint32 = 2
+	db, stateDB := newTestDB(t, PruningModeConstrained{MaxBlocks: &maxBlocks})
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(0), 0))
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(1), 1))
+	assert.Equal(t, IsPrunedNotPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(21), 2))
+	assert.Equal(t, IsPrunedPruned, stateDB.IsPruned(hash.NewH256FromLowUint64BigEndian(22), 2))
+	assert.Equal(t, NewTestDB([]uint64{1, 21, 3, 921, 922, 93, 94}).Data, db.Data)
+}
+
+func TestStateDB_DetectsIncompatibleMode(t *testing.T) {
+	db := NewTestDB(nil)
+	init, stateDB, err := NewStateDB[hash.H256, hash.H256](db, PruningModeArchiveAll{}, true)
+	assert.NoError(t, err)
+	db.Commit(init)
+	commit, err := stateDB.InsertBlock(hash.NewH256FromLowUint64BigEndian(0), 0, hash.NewH256FromLowUint64BigEndian(0), NewChangeset(nil, nil))
+	assert.NoError(t, err)
+	db.Commit(commit)
+	var maxBlocks uint32 = 2
+	newMode := PruningModeConstrained{MaxBlocks: &maxBlocks}
+
+	_, _, err = NewStateDB[hash.H256, hash.H256](db, newMode, false)
+	assert.ErrorIs(t, err, ErrIncompatiblePruningModes)
+}
+
+func checkStoredAndRequestedModeCompatibility(t *testing.T, created PruningMode, reopened PruningMode, expectedMode PruningMode, expectedErr error) {
+	db := NewTestDB(nil)
+	init, stateDB, err := NewStateDB[hash.H256, hash.H256](db, created, true)
+	assert.NoError(t, err)
+	db.Commit(init)
+
+	init, stateDB, err = NewStateDB[hash.H256, hash.H256](db, reopened, false)
+
+	if expectedErr == nil {
+		assert.NoError(t, err)
+		db.Commit(init)
+		assert.Equal(t, expectedMode, stateDB.PruningMode())
+	} else {
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, expectedErr)
+	}
+}
+
+func maxBlocks(m uint32) *uint32 {
+	return &m
+}
+
+func TestStateDB_PruningModeCompatibility(t *testing.T) {
+	for _, test := range []struct {
+		created      PruningMode
+		reopened     PruningMode
+		expectedMode PruningMode
+		expectedErr  error
+	}{
+		{nil, nil, PruningModeConstrained{maxBlocks(256)}, nil},
+		{nil, PruningModeConstrained{maxBlocks(256)}, PruningModeConstrained{maxBlocks(256)}, nil},
+		{nil, PruningModeConstrained{maxBlocks(128)}, PruningModeConstrained{maxBlocks(128)}, nil},
+		{nil, PruningModeConstrained{maxBlocks(512)}, PruningModeConstrained{maxBlocks(512)}, nil},
+		{nil, PruningModeArchiveAll{}, nil, ErrIncompatiblePruningModes},
+		{nil, PruningModeArchiveCanonical{}, nil, ErrIncompatiblePruningModes},
+		{PruningModeConstrained{maxBlocks(256)}, nil, PruningModeConstrained{maxBlocks(256)}, nil},
+		{PruningModeConstrained{maxBlocks(256)}, PruningModeConstrained{maxBlocks(256)}, PruningModeConstrained{maxBlocks(256)}, nil},
+		{PruningModeConstrained{maxBlocks(256)}, PruningModeConstrained{maxBlocks(128)}, PruningModeConstrained{maxBlocks(128)}, nil},
+		{PruningModeConstrained{maxBlocks(256)}, PruningModeConstrained{maxBlocks(512)}, PruningModeConstrained{maxBlocks(512)}, nil},
+		{PruningModeConstrained{maxBlocks(256)}, PruningModeArchiveAll{}, nil, ErrIncompatiblePruningModes},
+		{PruningModeConstrained{maxBlocks(256)}, PruningModeArchiveCanonical{}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveAll{}, nil, PruningModeArchiveAll{}, nil},
+		{PruningModeArchiveAll{}, PruningModeConstrained{maxBlocks(256)}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveAll{}, PruningModeConstrained{maxBlocks(128)}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveAll{}, PruningModeConstrained{maxBlocks(512)}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveAll{}, PruningModeArchiveAll{}, PruningModeArchiveAll{}, nil},
+		{PruningModeArchiveAll{}, PruningModeArchiveCanonical{}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveCanonical{}, nil, PruningModeArchiveCanonical{}, nil},
+		{PruningModeArchiveCanonical{}, PruningModeConstrained{maxBlocks(256)}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveCanonical{}, PruningModeConstrained{maxBlocks(128)}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveCanonical{}, PruningModeConstrained{maxBlocks(512)}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveCanonical{}, PruningModeArchiveAll{}, nil, ErrIncompatiblePruningModes},
+		{PruningModeArchiveCanonical{}, PruningModeArchiveCanonical{}, PruningModeArchiveCanonical{}, nil},
+	} {
+		t.Run("", func(t *testing.T) {
+			checkStoredAndRequestedModeCompatibility(t, test.created, test.reopened, test.expectedMode, test.expectedErr)
+		})
 	}
 }


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Introduces `StateDB` type which combines non-canonical overlays and pruning maintenance.
- Introduces `PruningModes` which determine whether or not things should get pruned, and storage of selected pruning mode for resuming.
- Will be referenced in future work replicating the client db #3900.
- Includes tests ported from parity implementation.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer/internal/client/state-db
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
#3899 

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@dimartiro 
