### PR TITLE
fix(parachain/availabiltystore): Fix inconsistent test 

### DIFF
--- a/dot/parachain/availability-store/availability_store_test.go
+++ b/dot/parachain/availability-store/availability_store_test.go
@@ -986,8 +986,10 @@ func (h *testHarness) processMessages() {
 	for {
 		select {
 		case msg := <-h.overseer.SubsystemsToOverseer:
-			h.processes[processIndex](msg)
-			processIndex++
+			if h.processes != nil && processIndex < len(h.processes) {
+				h.processes[processIndex](msg)
+				processIndex++
+			}
 		case <-h.overseer.ctx.Done():
 			if err := h.overseer.ctx.Err(); err != nil {
 				logger.Errorf("ctx error: %v\n", err)
@@ -1022,13 +1024,6 @@ func (h *testHarness) importLeaf(t *testing.T, parentHash common.Hash,
 	}
 	activatedLeaf := header.Hash()
 
-	h.overseer.broadcast(parachaintypes.ActiveLeavesUpdateSignal{
-		Activated: &parachaintypes.ActivatedLeaf{
-			Hash:   activatedLeaf,
-			Number: uint32(1),
-		},
-	})
-
 	h.processes = append(h.processes, func(msg any) {
 		msg2, _ := msg.(chainapi.ChainAPIMessage[chainapi.BlockHeader])
 		msg2.ResponseChannel <- header
@@ -1052,6 +1047,13 @@ func (h *testHarness) importLeaf(t *testing.T, parentHash common.Hash,
 		inst.EXPECT().ParachainHostCandidateEvents().Return(&candidateEvents, nil)
 
 		msg2.Resp <- inst
+	})
+
+	h.overseer.broadcast(parachaintypes.ActiveLeavesUpdateSignal{
+		Activated: &parachaintypes.ActivatedLeaf{
+			Hash:   activatedLeaf,
+			Number: uint32(1),
+		},
 	})
 
 	return activatedLeaf


### PR DESCRIPTION
## Changes
Test `TestStoredDataKeptUntilFinalized` is sometimes failing because of panics in CI caused when `processes` field is nil.  
failed job: https://github.com/ChainSafe/gossamer/actions/runs/9098763148/job/25215041290?pr=3939

To fix this:
- Changed the order in which these fields are assigned values, so that `processes` field will have data before it is queried.
- Added check before using this field so that it is not used if it is nil.


<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test github.com/ChainSafe/gossamer/dot/parachain/availability-store -run ^TestStoredDataKeptUntilFinalized$ -v
```

## Issues
This bug is mentioned in PR comments #3939  
<!-- Write the issue number(s), for example: #123 -->

## Primary Reviewer

<!-- Tag a code owner to review your PR, you can find the list of code owners
here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
If you are an external contributor, you may leave this section empty, and we will
assign the appropriate reviewer for you -->

@axaysagathiya 
