### PR TITLE
chore(.github): update CODEOWNERS to assign reviewers based on folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,16 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
 # Primary repo maintainers
-*      @edwardmack @timwu20 @EclesioMeloJunior @jimjbrettj @kishansagathiya @dimartiro @axaysagathiya
+* @P1sar @timwu20
+
+/dot/ @EclesioMeloJunior @jimbrettj @timwu20
+
+/internal/ @EclesioMeloJunior @jimbrettj @timwu20
+
+/lib/ @EclesioMeloJunior @jimbrettj @timwu20
+
+/pkg/ @timwu20
+
+/scripts/ @EclesioMeloJunior
+
+/zombienet_tets/ @edwardmack

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,11 @@
 # Primary repo maintainers
 * @P1sar @timwu20
 
-/dot/ @EclesioMeloJunior @jimbrettj @timwu20
+/dot/ @EclesioMeloJunior @jimjbrettj @timwu20
 
-/internal/ @EclesioMeloJunior @jimbrettj @timwu20
+/internal/ @EclesioMeloJunior @jimjbrettj @timwu20
 
-/lib/ @EclesioMeloJunior @jimbrettj @timwu20
+/lib/ @EclesioMeloJunior @jimjbrettj @timwu20
 
 /pkg/ @timwu20
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@
 
 /scripts/ @EclesioMeloJunior
 
-/zombienet_tets/ @edwardmack
+/zombienet_tests/ @edwardmack

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,13 +3,15 @@
 # Primary repo maintainers
 * @P1sar @timwu20
 
-/dot/ @EclesioMeloJunior @jimjbrettj @timwu20
+/dot/ @EclesioMeloJunior @jimjbrettj @timwu20 @kishansagathiya
 
-/internal/ @EclesioMeloJunior @jimjbrettj @timwu20
+/internal/ @EclesioMeloJunior @jimjbrettj @timwu20 
 
-/lib/ @EclesioMeloJunior @jimjbrettj @timwu20
+/lib/ @EclesioMeloJunior @jimjbrettj @timwu20 @kishansagathiya
 
 /pkg/ @timwu20
+
+/pkg/trie/ @dimartiro
 
 /scripts/ @EclesioMeloJunior
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,3 @@ go test -tags integration github.com/ChainSafe/gossamer
 ## Issues
 
 <!-- Write the issue number(s), for example: #123 -->
-
-## Primary Reviewer
-
-<!-- Tag a code owner to review your PR, you can find the list of code owners
-here: https://github.com/ChainSafe/gossamer/blob/development/.github/CODEOWNERS
-If you are an external contributor, you may leave this section empty, and we will
-assign the appropriate reviewer for you -->
-
-@


### PR DESCRIPTION
## Changes
<!-- Brief list of functional changes -->
- Updates `CODEOWNERS` to not automatically assign everyone as a reviewer.  
- Reviewers are now assigned based on folder.  By approving this PR you are saying you're ok with being a reviewer for all PRs that touch a specific folder.

## Tests
- Will have to test after merging, since the `CODEOWNERS` file is referenced on the base branch of PRs.
