### PR TITLE
fix(.github): disable fail fast for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ jobs:
   integration-tests:
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         packages:
           [


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- disables fail-fast for the integration tests workflow
- ensures that all packages in the matrix are tested and not cancelled if one fails

## Tests

<!-- Detail how to run relevant tests to the changes -->
- can be seen on this PR