### PR TITLE
fix(ci): update test utils to write temp files to directory outside of `/tmp` for CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,4 +72,4 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod
 
       - name: Run integration tests
-        run: go test -timeout=45m -tags integration ${{ matrix.packages }}
+        run: CI=buildjet go test -timeout=45m -tags integration ${{ matrix.packages }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -78,7 +78,7 @@ jobs:
           cd ..
 
       - name: Run unit tests
-        run: go test -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
+        run: CI=buildjet go test -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
 
       - name: Trie memory test
         run: |

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -29,7 +29,17 @@ import (
 
 func DefaultTestWestendDevConfig(t *testing.T) *cfg.Config {
 	config := westenddev.DefaultConfig()
-	config.BasePath = t.TempDir()
+	var tempDir string
+	if os.Getenv("CI") == "buildjet" {
+		var err error
+		tempDir, err = os.MkdirTemp("..", "DefaultTestWestendDevConfig")
+		if err != nil {
+			t.Error(err)
+		}
+	} else {
+		tempDir = t.TempDir()
+	}
+	config.BasePath = tempDir
 
 	return config
 }

--- a/dot/test_utils.go
+++ b/dot/test_utils.go
@@ -21,7 +21,7 @@ func NewTestGenesisRawFile(t *testing.T, config *cfg.Config) (filename string) {
 	var tempDir string
 	if os.Getenv("CI") == "buildjet" {
 		var err error
-		tempDir, err = os.MkdirTemp("", "NewTestGenesisRawFile")
+		tempDir, err = os.MkdirTemp("..", "NewTestGenesisRawFile")
 		if err != nil {
 			t.Error(err)
 		}

--- a/dot/test_utils.go
+++ b/dot/test_utils.go
@@ -18,7 +18,17 @@ import (
 
 // NewTestGenesisRawFile returns a test genesis file using "westend-dev" raw data
 func NewTestGenesisRawFile(t *testing.T, config *cfg.Config) (filename string) {
-	filename = filepath.Join(t.TempDir(), "genesis.json")
+	var tempDir string
+	if os.Getenv("CI") == "buildjet" {
+		var err error
+		tempDir, err = os.MkdirTemp("", "NewTestGenesisRawFile")
+		if err != nil {
+			t.Error(err)
+		}
+	} else {
+		tempDir = t.TempDir()
+	}
+	filename = filepath.Join(tempDir, "genesis.json")
 
 	fp := utils.GetWestendDevRawGenesisPath(t)
 


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- runs `unit-tests` and `integration-tests` github workflows using a `CI=buildjet` env variable
- introduces code that checks this environment variable, and writes temp files to separate **unpruned** directory when running in CI
- `dot` package tests are only flakey on CI

## Tests

- ensure all workflows pass successfully

## Issues
- closes #4035 
<!-- Write the issue number(s), for example: #123 -->