### PR TITLE
chore: use `os.MkdirTemp` + `t.Cleanup` for a temp dir

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,4 +72,4 @@ jobs:
           restore-keys: ${{ runner.os }}-go-mod
 
       - name: Run integration tests
-        run: go test -timeout=45m -tags integration ${{ matrix.packages }}
+        run: CI=buildjet go test -timeout=45m -tags integration ${{ matrix.packages }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -78,7 +78,7 @@ jobs:
           cd ..
 
       - name: Run unit tests
-        run: go test -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
+        run: CI=buildjet go test -coverprofile=coverage.out -covermode=atomic -timeout=45m ./...
 
       - name: Trie memory test
         run: |

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -35,7 +35,7 @@ func DefaultTestWestendDevConfig(t *testing.T) *cfg.Config {
 		tmpdir, err := os.MkdirTemp("..", "*_wnd_dev_cfg")
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			require.NoError(t, os.Remove(tmpdir))
+			require.NoError(t, os.RemoveAll(tmpdir))
 		})
 		config.BasePath = tmpdir
 	}

--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -29,7 +29,16 @@ import (
 
 func DefaultTestWestendDevConfig(t *testing.T) *cfg.Config {
 	config := westenddev.DefaultConfig()
+
 	config.BasePath = t.TempDir()
+	if os.Getenv("CI") == "buildjet" {
+		tmpdir, err := os.MkdirTemp("..", "*_wnd_dev_cfg")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(tmpdir))
+		})
+		config.BasePath = tmpdir
+	}
 
 	return config
 }

--- a/dot/test_utils.go
+++ b/dot/test_utils.go
@@ -23,7 +23,7 @@ func NewTestGenesisRawFile(t *testing.T, config *cfg.Config) (filename string) {
 		tmpdir, err := os.MkdirTemp("..", "*_gen_raw_file")
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			require.NoError(t, os.Remove(tmpdir))
+			require.NoError(t, os.RemoveAll(tmpdir))
 		})
 		filename = filepath.Join(tmpdir, "genesis.json")
 	}

--- a/dot/test_utils.go
+++ b/dot/test_utils.go
@@ -19,9 +19,16 @@ import (
 // NewTestGenesisRawFile returns a test genesis file using "westend-dev" raw data
 func NewTestGenesisRawFile(t *testing.T, config *cfg.Config) (filename string) {
 	filename = filepath.Join(t.TempDir(), "genesis.json")
+	if os.Getenv("CI") == "buildjet" {
+		tmpdir, err := os.MkdirTemp("..", "*_gen_raw_file")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(tmpdir))
+		})
+		filename = filepath.Join(tmpdir, "genesis.json")
+	}
 
 	fp := utils.GetWestendDevRawGenesisPath(t)
-
 	westendDevGenesis, err := genesis.NewGenesisFromJSONRaw(fp)
 	require.NoError(t, err)
 


### PR DESCRIPTION
ref: https://github.com/ChainSafe/gossamer/pull/4034

## Tests
- ensure all workflows pass successfully

## Issues
- closes #4035 
