### PR TITLE
Fix(dot/sync): panic in handleWorkersResults

### DIFF
--- a/dot/network/errors.go
+++ b/dot/network/errors.go
@@ -10,7 +10,7 @@ import (
 var (
 	ErrNoPeersConnected     = errors.New("no peers connected")
 	ErrReceivedEmptyMessage = errors.New("received empty message")
-	ErrNilBlock             = errors.New("nil block in response")
+	ErrNilBlockInResponse   = errors.New("nil block in response")
 
 	errCannotValidateHandshake       = errors.New("failed to validate handshake")
 	errMessageTypeNotValid           = errors.New("message type is not valid")

--- a/dot/network/errors.go
+++ b/dot/network/errors.go
@@ -10,6 +10,7 @@ import (
 var (
 	ErrNoPeersConnected     = errors.New("no peers connected")
 	ErrReceivedEmptyMessage = errors.New("received empty message")
+	ErrNilBlock             = errors.New("nil block in response")
 
 	errCannotValidateHandshake       = errors.New("failed to validate handshake")
 	errMessageTypeNotValid           = errors.New("message type is not valid")

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -226,7 +226,7 @@ func (bm *BlockResponseMessage) Decode(in []byte) (err error) {
 		}
 
 		if block == nil {
-			return fmt.Errorf("decoding blockResponseMessage: %w", ErrNilBlock)
+			return fmt.Errorf("decoding blockResponseMessage: %w", ErrNilBlockInResponse)
 		}
 		bm.BlockData[i] = block
 	}

--- a/dot/network/message.go
+++ b/dot/network/message.go
@@ -224,6 +224,10 @@ func (bm *BlockResponseMessage) Decode(in []byte) (err error) {
 		if err != nil {
 			return err
 		}
+
+		if block == nil {
+			return fmt.Errorf("decoding blockResponseMessage: %w", ErrNilBlock)
+		}
 		bm.BlockData[i] = block
 	}
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -731,16 +731,10 @@ taskResultLoop:
 					continue taskResultLoop
 				}
 
-				// What if i can just do a bounds check here? is that hacky or is that okay?
-				// Maybe I can do a temp fix now, and create issue to look into this in greater depth later?
-
 				blockExactIndex := blockInResponse.Header.Number - startAtBlock
-
 				if blockExactIndex < uint(expectedSyncedBlocks) {
 					syncingChain[blockExactIndex] = blockInResponse
 				}
-
-				//syncingChain[blockExactIndex] = blockInResponse
 			}
 
 			// we need to check if we've filled all positions

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -1014,6 +1014,9 @@ func doResponseGrowsTheChain(response, ongoingChain []*types.BlockData, startAtB
 	firstBlockInResponse := response[0]
 	firstBlockExactIndex := firstBlockInResponse.Header.Number - startAtBlock
 	if firstBlockExactIndex != 0 {
+		if firstBlockExactIndex-1 >= uint(len(ongoingChain)) {
+			return false
+		}
 		leftElement := ongoingChain[firstBlockExactIndex-1]
 		if leftElement != nil && !compareParentHash(leftElement, firstBlockInResponse) {
 			return false

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -1018,7 +1018,7 @@ func doResponseGrowsTheChain(response, ongoingChain []*types.BlockData, startAtB
 	firstBlockInResponse := response[0]
 	firstBlockExactIndex := firstBlockInResponse.Header.Number - startAtBlock
 	if firstBlockExactIndex != 0 {
-		if firstBlockExactIndex < uint(expectedTotal) {
+		if firstBlockExactIndex != 0 && firstBlockExactIndex < uint(expectedTotal) {
 			leftElement := ongoingChain[firstBlockExactIndex-1]
 			if leftElement != nil && !compareParentHash(leftElement, firstBlockInResponse) {
 				return false

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -1024,10 +1024,6 @@ func doResponseGrowsTheChain(response, ongoingChain []*types.BlockData, startAtB
 				return false
 			}
 		}
-		//leftElement := ongoingChain[firstBlockExactIndex-1]
-		//if leftElement != nil && !compareParentHash(leftElement, firstBlockInResponse) {
-		//	return false
-		//}
 	}
 
 	switch {

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -658,7 +658,7 @@ taskResultLoop:
 							Reason: peerset.BadProtocolReason,
 						}, who)
 					}
-				} else if errors.Is(taskResult.err, network.ErrNilBlock) {
+				} else if errors.Is(taskResult.err, network.ErrNilBlockInResponse) {
 					cs.network.ReportPeer(peerset.ReputationChange{
 						Value:  peerset.BadMessageValue,
 						Reason: peerset.BadMessageReason,

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -731,8 +731,16 @@ taskResultLoop:
 					continue taskResultLoop
 				}
 
+				// What if i can just do a bounds check here? is that hacky or is that okay?
+				// Maybe I can do a temp fix now, and create issue to look into this in greater depth later?
+
 				blockExactIndex := blockInResponse.Header.Number - startAtBlock
-				syncingChain[blockExactIndex] = blockInResponse
+
+				if blockExactIndex < uint(expectedSyncedBlocks) {
+					syncingChain[blockExactIndex] = blockInResponse
+				}
+
+				//syncingChain[blockExactIndex] = blockInResponse
 			}
 
 			// we need to check if we've filled all positions

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -658,6 +658,11 @@ taskResultLoop:
 							Reason: peerset.BadProtocolReason,
 						}, who)
 					}
+				} else if errors.Is(taskResult.err, network.ErrNilBlock) {
+					cs.network.ReportPeer(peerset.ReputationChange{
+						Value:  peerset.BadMessageValue,
+						Reason: peerset.BadMessageReason,
+					}, who)
 				}
 
 				// TODO: avoid the same peer to get the same task
@@ -731,17 +736,9 @@ taskResultLoop:
 					continue taskResultLoop
 				}
 
-				if blockInResponse != nil {
-					blockExactIndex := blockInResponse.Header.Number - startAtBlock
-					if blockExactIndex < uint(expectedSyncedBlocks) {
-						syncingChain[blockExactIndex] = blockInResponse
-					}
-				} else {
-					err = cs.submitRequest(taskResult.request, nil, workersResults)
-					if err != nil {
-						return err
-					}
-					continue taskResultLoop
+				blockExactIndex := blockInResponse.Header.Number - startAtBlock
+				if blockExactIndex < uint(expectedSyncedBlocks) {
+					syncingChain[blockExactIndex] = blockInResponse
 				}
 			}
 

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -785,6 +785,10 @@ taskResultLoop:
 }
 
 func (cs *chainSync) handleReadyBlock(bd *types.BlockData, origin blockOrigin) error {
+	if bd == nil {
+		logger.Debugf("nil block data provided to handleReadyBlock")
+		return fmt.Errorf("nil block data provided to handleReadyBlock")
+	}
 	// if header was not requested, get it from the pending set
 	// if we're expecting headers, validate should ensure we have a header
 	if bd.Header == nil {
@@ -1014,14 +1018,16 @@ func doResponseGrowsTheChain(response, ongoingChain []*types.BlockData, startAtB
 	firstBlockInResponse := response[0]
 	firstBlockExactIndex := firstBlockInResponse.Header.Number - startAtBlock
 	if firstBlockExactIndex != 0 {
-		if firstBlockExactIndex-1 >= uint(len(ongoingChain)) {
-			return false
+		if firstBlockExactIndex < uint(expectedTotal) {
+			leftElement := ongoingChain[firstBlockExactIndex-1]
+			if leftElement != nil && !compareParentHash(leftElement, firstBlockInResponse) {
+				return false
+			}
 		}
-		leftElement := ongoingChain[firstBlockExactIndex-1]
-		if leftElement != nil && !compareParentHash(leftElement, firstBlockInResponse) {
-			return false
-		}
-
+		//leftElement := ongoingChain[firstBlockExactIndex-1]
+		//if leftElement != nil && !compareParentHash(leftElement, firstBlockInResponse) {
+		//	return false
+		//}
 	}
 
 	switch {


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Sometimes in the handleWorkersResults function we would get an index out of bounds error that caused the node to panic
- By doing a simple bounds check (as well as adding a few more bounds checks in other places) the node is able to ignore blocks it shouldn't process while also still making sure every block we need gets processed thus allowing us to keep processing the chain as expected.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
Closes #3850

<!-- Write the issue number(s), for example: #123 -->