### PR TITLE
fix(lib/trie): Implement `TrieIterator` for `InMemoryTrie` 

### DIFF
--- a/lib/runtime/storage/storagediff.go
+++ b/lib/runtime/storage/storagediff.go
@@ -293,7 +293,6 @@ func (cs *storageDiff) applyToTrie(t trie.Trie) {
 				panic("Error deleting key from trie")
 			}
 		}
-
 	}
 }
 

--- a/pkg/trie/inmemory/in_memory_test.go
+++ b/pkg/trie/inmemory/in_memory_test.go
@@ -20,6 +20,8 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+var alwaysTrue = func([]byte) bool { return true }
+
 func Test_EmptyHash(t *testing.T) {
 	t.Parallel()
 
@@ -781,7 +783,7 @@ func Test_Trie_NextKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			nextKey := testCase.trie.NextKey(testCase.key)
+			nextKey := testCase.trie.NextKey(testCase.key, alwaysTrue)
 
 			assert.Equal(t, testCase.nextKey, nextKey)
 		})
@@ -1067,7 +1069,7 @@ func Test_nextKey(t *testing.T) {
 
 			originalTrie := testCase.trie.DeepCopy()
 
-			nextKey := findNextKey(testCase.trie.root, nil, testCase.key)
+			nextKey := findNextKey(testCase.trie.root, nil, testCase.key, alwaysTrue)
 
 			assert.Equal(t, testCase.nextKey, nextKey)
 			assert.Equal(t, *originalTrie, testCase.trie) // ensure no mutation

--- a/pkg/trie/inmemory/trie_endtoend_test.go
+++ b/pkg/trie/inmemory/trie_endtoend_test.go
@@ -673,7 +673,7 @@ func Test_Trie_NextKey_Random(t *testing.T) {
 
 	for i, key := range sortedKeys {
 
-		nextKey := trie.NextKey(key)
+		nextKey := trie.NextKey(key, alwaysTrue)
 
 		var expectedNextKey []byte
 		isLastKey := i == len(sortedKeys)-1

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -36,7 +36,7 @@ type KVStoreWrite interface {
 
 type TrieIterator interface {
 	Entries() (keyValueMap map[string][]byte)
-	NextKey(key []byte) []byte
+	NextKey(key []byte, predicate func([]byte) bool) []byte
 	GetKeysWithPrefix(prefix []byte) (keysLE [][]byte)
 }
 

--- a/pkg/trie/triedb/in_memory_to_triedb_migration_test.go
+++ b/pkg/trie/triedb/in_memory_to_triedb_migration_test.go
@@ -96,8 +96,8 @@ func TestReadTrieDB_Migration(t *testing.T) {
 		key := []byte("no")
 
 		for key != nil {
-			expected := inMemoryTrie.NextKey(key)
-			actual := trieDB.NextKey(key)
+			expected := inMemoryTrie.NextKey(key, alwaysTrue)
+			actual := trieDB.NextKey(key, alwaysTrue)
 			assert.Equal(t, expected, actual)
 
 			key = actual

--- a/pkg/trie/triedb/iterator.go
+++ b/pkg/trie/triedb/iterator.go
@@ -18,7 +18,7 @@ func (t *TrieDB) Entries() (keyValueMap map[string][]byte) {
 
 // NextKey returns the next key in the trie in lexicographic order.
 // It returns nil if no next key is found.
-func (t *TrieDB) NextKey(key []byte) []byte {
+func (t *TrieDB) NextKey(key []byte, _ func([]byte) bool) []byte {
 	iter := NewTrieDBIterator(t)
 
 	// TODO: Seek will potentially skip a lot of keys, we need to find a way to

--- a/pkg/trie/triedb/triedb_iterator_test.go
+++ b/pkg/trie/triedb/triedb_iterator_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var alwaysTrue = func(key []byte) bool { return true }
+
 func TestIterator(t *testing.T) {
 	db := newTestDB(t)
 	inMemoryTrie := inmemory.NewEmptyTrie()
@@ -40,11 +42,11 @@ func TestIterator(t *testing.T) {
 	t.Run("iterate_over_all_entries", func(t *testing.T) {
 		iter := NewTrieDBIterator(trieDB)
 
-		expected := inMemoryTrie.NextKey([]byte{})
+		expected := inMemoryTrie.NextKey([]byte{}, alwaysTrue)
 		i := 0
 		for key := iter.NextKey(); key != nil; key = iter.NextKey() {
 			assert.Equal(t, expected, key)
-			expected = inMemoryTrie.NextKey(expected)
+			expected = inMemoryTrie.NextKey(expected, alwaysTrue)
 			i++
 		}
 
@@ -56,7 +58,7 @@ func TestIterator(t *testing.T) {
 
 		iter.Seek([]byte("not"))
 
-		expected := inMemoryTrie.NextKey([]byte("not"))
+		expected := inMemoryTrie.NextKey([]byte("not"), alwaysTrue)
 		actual := iter.NextKey()
 
 		assert.Equal(t, expected, actual)


### PR DESCRIPTION
## Changes

- Remove the usage of `sortedKeys`
- While under a transaction compare the next key acquire from the state with the one acquire from the `upserts` from the current transaction, the lower one is returned

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -run ^TestNextKeysUsingDifferentTransactions$ github.com/ChainSafe/gossamer/lib/runtime/storage
go test -run ^TestNextKeysWhitinSameTransaction$ github.com/ChainSafe/gossamer/lib/runtime/storage
```

## Issues

- Related to https://github.com/ChainSafe/gossamer/issues/4057