### PR TITLE
fix(lib/runtime/storage): `removePrefixedSortedKey` was not considering the limit

### DIFF
--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -255,7 +255,7 @@ func (t *TrieState) ClearPrefix(prefix []byte) error {
 	if err != nil {
 		return err
 	}
-	t.sortedKeys = t.removePrefixedSortedKey(t.sortedKeys, string(prefix), -1)
+	t.sortedKeys = removePrefixedSortedKey(t.sortedKeys, string(prefix), -1)
 	return nil
 }
 
@@ -274,7 +274,7 @@ func (t *TrieState) ClearPrefixLimit(prefix []byte, limit uint32) (
 	if err != nil {
 		return 0, false, err
 	}
-	t.sortedKeys = t.removePrefixedSortedKey(t.sortedKeys, string(prefix), int(limit))
+	t.sortedKeys = removePrefixedSortedKey(t.sortedKeys, string(prefix), int(limit))
 	return
 }
 
@@ -481,7 +481,7 @@ func (t *TrieState) ClearPrefixInChild(keyToChild, prefix []byte) error {
 	if err != nil {
 		return fmt.Errorf("clearing prefix in child trie located at key 0x%x: %w", keyToChild, err)
 	}
-	t.childSortedKeys[string(keyToChild)] = t.removePrefixedSortedKey(
+	t.childSortedKeys[string(keyToChild)] = removePrefixedSortedKey(
 		t.childSortedKeys[string(keyToChild)],
 		string(prefix),
 		-1,
@@ -509,7 +509,7 @@ func (t *TrieState) ClearPrefixInChildWithLimit(keyToChild, prefix []byte, limit
 	if err != nil {
 		return 0, false, err
 	}
-	t.childSortedKeys[string(keyToChild)] = t.removePrefixedSortedKey(
+	t.childSortedKeys[string(keyToChild)] = removePrefixedSortedKey(
 		t.childSortedKeys[string(keyToChild)],
 		string(prefix),
 		-1,
@@ -637,24 +637,23 @@ func (t *TrieState) GetChangedNodeHashes() (inserted, deleted map[common.Hash]st
 }
 
 func (t *TrieState) addMainTrieSortedKey(key string) {
-	t.sortedKeys = t.insertSortedKey(t.sortedKeys, key)
+	t.sortedKeys = insertSortedKey(t.sortedKeys, key)
 }
 
 func (t *TrieState) removeMainTrieSortedKey(key string) {
-	t.sortedKeys = t.removeSortedKey(t.sortedKeys, key)
+	t.sortedKeys = removeSortedKey(t.sortedKeys, key)
 }
 
 func (t *TrieState) addChildTrieSortedKey(keyToChild, key string) {
-	t.childSortedKeys[keyToChild] = t.insertSortedKey(t.childSortedKeys[keyToChild], key)
+	t.childSortedKeys[keyToChild] = insertSortedKey(t.childSortedKeys[keyToChild], key)
 }
 
 func (t *TrieState) removeChildTrieSortedKey(keyToChild, key string) {
-	t.childSortedKeys[keyToChild] = t.removeSortedKey(t.childSortedKeys[keyToChild], key)
+	t.childSortedKeys[keyToChild] = removeSortedKey(t.childSortedKeys[keyToChild], key)
 }
 
-func (t *TrieState) insertSortedKey(keys []string, key string) []string {
+func insertSortedKey(keys []string, key string) []string {
 	pos, found := slices.BinarySearch(keys, key)
-
 	if found {
 		return keys // key already exists
 	}
@@ -665,7 +664,7 @@ func (t *TrieState) insertSortedKey(keys []string, key string) []string {
 	return keys
 }
 
-func (t *TrieState) removeSortedKey(keys []string, key string) []string {
+func removeSortedKey(keys []string, key string) []string {
 	pos, found := slices.BinarySearch(keys, key)
 
 	if found {
@@ -675,7 +674,7 @@ func (t *TrieState) removeSortedKey(keys []string, key string) []string {
 	return keys
 }
 
-func (t *TrieState) removePrefixedSortedKey(keys []string, prefix string, limit int) []string {
+func removePrefixedSortedKey(keys []string, prefix string, limit int) []string {
 	if limit == 0 {
 		return keys
 	}

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -212,7 +212,6 @@ func (t *TrieState) NextKey(key []byte) []byte {
 	defer t.mtx.RUnlock()
 
 	if currentTx := t.getCurrentTransaction(); currentTx != nil {
-		fmt.Printf("next key: %v\n", t.sortedKeys)
 		mainStateSortedKeys := make([]string, len(t.sortedKeys))
 		copy(mainStateSortedKeys, t.sortedKeys)
 

--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -496,8 +496,8 @@ func (t *TrieState) ClearPrefixInChildWithLimit(keyToChild, prefix []byte, limit
 	defer t.mtx.Unlock()
 
 	if currentTx := t.getCurrentTransaction(); currentTx != nil {
-
-		deleted, allDeleted := currentTx.clearPrefixInChild(string(keyToChild), prefix, t.childSortedKeys[string(keyToChild)], int(limit))
+		deleted, allDeleted := currentTx.clearPrefixInChild(string(keyToChild), prefix,
+			t.childSortedKeys[string(keyToChild)], int(limit))
 		return deleted, allDeleted, nil
 	}
 

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -503,34 +503,31 @@ func TestClearPrefixSortedKeys(t *testing.T) {
 			[]byte("same_prefix_key::E"),
 		}
 
-		{
-			// insert the keys under a transaction
-			ts.StartTransaction()
-			for _, k := range setOfKeysWithSamePrefix {
-				ts.Put(k, []byte("some_value"))
-			}
-			ts.CommitTransaction()
+		// insert the keys under a transaction
+		ts.StartTransaction()
+		for _, k := range setOfKeysWithSamePrefix {
+			ts.Put(k, []byte("some_value"))
 		}
+		ts.CommitTransaction()
 
 		// clear just 1 key using the prefix
 		commonPrefix := []byte("same_prefix_key::")
 		ts.ClearPrefixLimit(commonPrefix, 1)
 
-		{
-			ts.StartTransaction()
-			lastKey := commonPrefix
+		ts.StartTransaction()
+		lastKey := commonPrefix
 
-			// we should be able to retrieve
-			for i := 0; i < len(setOfKeysWithSamePrefix)-1; i++ {
-				nextKey := ts.NextKey(lastKey)
-				require.True(t, bytes.HasPrefix(nextKey, commonPrefix), "%v does not have prefix %s", nextKey, commonPrefix)
-				lastKey = nextKey
-			}
-
-			// the 5th next key call should return nil
-			require.Nil(t, ts.NextKey(lastKey))
-			ts.CommitTransaction()
+		// we should be able to retrieve
+		for i := 0; i < len(setOfKeysWithSamePrefix)-1; i++ {
+			nextKey := ts.NextKey(lastKey)
+			require.True(t, bytes.HasPrefix(nextKey, commonPrefix), "%v does not have prefix %s", nextKey, commonPrefix)
+			lastKey = nextKey
 		}
+
+		// the 5th next key call should return nil
+		require.Nil(t, ts.NextKey(lastKey))
+		ts.CommitTransaction()
+
 	})
 
 	t.Run("without_limit", func(t *testing.T) {
@@ -558,12 +555,11 @@ func TestClearPrefixSortedKeys(t *testing.T) {
 		commonPrefix := []byte("same_prefix_key::")
 		ts.ClearPrefix(commonPrefix)
 
-		{
-			ts.StartTransaction()
-			// should not exist any key
-			require.Nil(t, ts.NextKey(commonPrefix))
-			ts.CommitTransaction()
-		}
+		ts.StartTransaction()
+		// should not exist any key
+		require.Nil(t, ts.NextKey(commonPrefix))
+		ts.CommitTransaction()
+
 	})
 }
 

--- a/lib/runtime/storage/trie_test.go
+++ b/lib/runtime/storage/trie_test.go
@@ -551,7 +551,7 @@ func TestClearPrefixSortedKeys(t *testing.T) {
 			ts.CommitTransaction()
 		}
 
-		// clear just 1 key using the prefix
+		// clear all keys using the prefix
 		commonPrefix := []byte("same_prefix_key::")
 		ts.ClearPrefix(commonPrefix)
 


### PR DESCRIPTION
## Changes

- The function `removePrefixedSortedKey` was not considering the limit parameter

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -timeout 10m -run ^TestClearPrefixSortedKeys$ github.com/ChainSafe/gossamer/lib/runtime/storage --tags=integration -v
```

## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/4064