### PR TITLE
fix(pkg/triedb): Encode node headers

### DIFF
--- a/pkg/trie/triedb/codec/node.go
+++ b/pkg/trie/triedb/codec/node.go
@@ -147,7 +147,7 @@ func EncodeHeader(partialKey []byte, kind NodeKind, writer io.Writer) (err error
 	case LeafWithHashedValue:
 		nodeVariant = leafWithHashedValueVariant
 	case BranchWithoutValue:
-		nodeVariant = branchWithValueVariant
+		nodeVariant = branchVariant
 	case BranchWithValue:
 		nodeVariant = branchWithValueVariant
 	case BranchWithHashedValue:


### PR DESCRIPTION
## Changes

Fix encoding branch without values header.
We were using the wrong variant resulting in issues when encoding / decoding intermediate branches.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make test
```