### PR TITLE
fix(dot/sync): Check if `network.ErrNilBlockInResponse`

### DIFF
--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -652,17 +652,19 @@ taskResultLoop:
 					logger.Errorf("task result: peer(%s) error: %s",
 						taskResult.who, taskResult.err)
 
+					if errors.Is(taskResult.err, network.ErrNilBlockInResponse) {
+						cs.network.ReportPeer(peerset.ReputationChange{
+							Value:  peerset.BadMessageValue,
+							Reason: peerset.BadMessageReason,
+						}, who)
+					}
+
 					if strings.Contains(taskResult.err.Error(), "protocols not supported") {
 						cs.network.ReportPeer(peerset.ReputationChange{
 							Value:  peerset.BadProtocolValue,
 							Reason: peerset.BadProtocolReason,
 						}, who)
 					}
-				} else if errors.Is(taskResult.err, network.ErrNilBlockInResponse) {
-					cs.network.ReportPeer(peerset.ReputationChange{
-						Value:  peerset.BadMessageValue,
-						Reason: peerset.BadMessageReason,
-					}, who)
 				}
 
 				// TODO: avoid the same peer to get the same task

--- a/dot/sync/chain_sync.go
+++ b/dot/sync/chain_sync.go
@@ -667,7 +667,6 @@ taskResultLoop:
 					}
 				}
 
-				// TODO: avoid the same peer to get the same task
 				err := cs.submitRequest(request, nil, workersResults)
 				if err != nil {
 					return err

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -5,6 +5,7 @@ package sync
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -71,7 +72,7 @@ func executeRequest(who peer.ID, requestMaker network.RequestMaker,
 	sharedGuard <- struct{}{} // Acquire a semaphore slot before starting the request
 
 	request := task.request
-	logger.Debugf("[EXECUTING] worker %s, block request: %s", who, request)
+	fmt.Printf("[EXECUTING] worker %s, block request: %s\n", who, request)
 	response := new(network.BlockResponseMessage)
 	err := requestMaker.Do(who, request, response)
 
@@ -82,5 +83,5 @@ func executeRequest(who peer.ID, requestMaker network.RequestMaker,
 		err:      err,
 	}
 
-	logger.Debugf("[FINISHED] worker %s, err: %s, block data amount: %d", who, err, len(response.BlockData))
+	fmt.Printf("[FINISHED] worker %s, err: %s, block data amount: %d\n", who, err, len(response.BlockData))
 }

--- a/dot/sync/worker.go
+++ b/dot/sync/worker.go
@@ -5,7 +5,6 @@ package sync
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/ChainSafe/gossamer/dot/network"
@@ -72,7 +71,7 @@ func executeRequest(who peer.ID, requestMaker network.RequestMaker,
 	sharedGuard <- struct{}{} // Acquire a semaphore slot before starting the request
 
 	request := task.request
-	fmt.Printf("[EXECUTING] worker %s, block request: %s\n", who, request)
+	logger.Debugf("[EXECUTING] worker %s, block request: %s\n", who, request)
 	response := new(network.BlockResponseMessage)
 	err := requestMaker.Do(who, request, response)
 
@@ -83,5 +82,5 @@ func executeRequest(who peer.ID, requestMaker network.RequestMaker,
 		err:      err,
 	}
 
-	fmt.Printf("[FINISHED] worker %s, err: %s, block data amount: %d\n", who, err, len(response.BlockData))
+	logger.Debugf("[FINISHED] worker %s, err: %s, block data amount: %d", who, err, len(response.BlockData))
 }


### PR DESCRIPTION
## Changes

- If we receive an error that is not `ErrReceivedEmptyMessage` then we should check if the error is `ErrNilBlockInResponse`, so we should place the check correctly inside the:

```go 
if !errors.Is(taskResult.err, network.ErrReceivedEmptyMessage) {
    // should be placed inside
    if errors.Is(taskResult.err, network.ErrNilBlockInResponse) { }
}
```

## Tests

<!-- Detail how to run relevant tests to the changes -->

```go
go test -timeout 10m -run ^TestChainSync_BootstrapSync_SuccessfulSync_WithNilBlockInResponse$ github.com/ChainSafe/gossamer/dot/sync --tags=integration -v
```

## Issues

N/A