### PR TITLE
fix(pkg/trie): Add missing prefixed key

### DIFF
--- a/pkg/trie/triedb/triedb.go
+++ b/pkg/trie/triedb/triedb.go
@@ -774,7 +774,8 @@ func (t *TrieDB) commit() error {
 				switch n := node.(type) {
 				case newNodeToEncode:
 					hash := common.MustBlake2bHash(n.value)
-					err := dbBatch.Put(hash[:], n.value)
+					prefixedKey := bytes.Join([][]byte{n.partialKey, hash.ToBytes()}, nil)
+					err := dbBatch.Put(prefixedKey, n.value)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/trie/triedb/triedb.go
+++ b/pkg/trie/triedb/triedb.go
@@ -774,7 +774,7 @@ func (t *TrieDB) commit() error {
 				switch n := node.(type) {
 				case newNodeToEncode:
 					hash := common.MustBlake2bHash(n.value)
-					prefixedKey := bytes.Join([][]byte{n.partialKey, hash.ToBytes()}, nil)
+					prefixedKey := append(n.partialKey, hash.ToBytes()...)
 					err := dbBatch.Put(prefixedKey, n.value)
 					if err != nil {
 						return nil, err
@@ -849,8 +849,8 @@ func (t *TrieDB) commitChild(
 
 				switch n := node.(type) {
 				case newNodeToEncode:
-					valueHash := common.MustBlake2bHash(n.value)
-					prefixedKey := bytes.Join([][]byte{n.partialKey, valueHash.ToBytes()}, nil)
+					hash := common.MustBlake2bHash(n.value)
+					prefixedKey := append(n.partialKey, hash.ToBytes()...)
 					err := dbBatch.Put(prefixedKey, n.value)
 					if err != nil {
 						panic("inserting in db")
@@ -861,7 +861,7 @@ func (t *TrieDB) commitChild(
 					}
 
 					prefixKey = prefixKey[:mov]
-					return HashChildReference{hash: valueHash}, nil
+					return HashChildReference{hash: hash}, nil
 				case trieNodeToEncode:
 					result, err := t.commitChild(dbBatch, n.child, prefixKey)
 					if err != nil {

--- a/pkg/trie/triedb/triedb_test.go
+++ b/pkg/trie/triedb/triedb_test.go
@@ -651,6 +651,52 @@ func TestDBCommits(t *testing.T) {
 		assert.Equal(t, make([]byte, 40), value)
 	})
 
+	t.Run("commit_leaf_with_hashed_value", func(t *testing.T) {
+		t.Parallel()
+
+		inmemoryDB := NewMemoryDB(emptyNode)
+		tr := NewEmptyTrieDB(inmemoryDB)
+		tr.SetVersion(trie.V1)
+
+		err := tr.Put([]byte("leaf"), make([]byte, 40))
+		assert.NoError(t, err)
+
+		err = tr.commit()
+		assert.NoError(t, err)
+
+		// 1 hashed leaf with hashed value
+		// 1 hashed value
+		assert.Len(t, inmemoryDB.data, 2)
+
+		// Get values using lazy loading
+		value := tr.Get([]byte("leaf"))
+		assert.Equal(t, make([]byte, 40), value)
+	})
+
+	t.Run("commit_leaf_with_hashed_value_then_remove_it", func(t *testing.T) {
+		t.Parallel()
+
+		inmemoryDB := NewMemoryDB(emptyNode)
+		tr := NewEmptyTrieDB(inmemoryDB)
+		tr.SetVersion(trie.V1)
+
+		err := tr.Put([]byte("leaf"), make([]byte, 40))
+		assert.NoError(t, err)
+
+		err = tr.commit()
+		assert.NoError(t, err)
+
+		// 1 hashed leaf with hashed value
+		// 1 hashed value
+		assert.Len(t, inmemoryDB.data, 2)
+
+		// Get values using lazy loading
+		err = tr.Delete([]byte("leaf"))
+		assert.NoError(t, err)
+		tr.commit()
+		assert.Len(t, inmemoryDB.data, 0)
+	})
+
 	t.Run("commit_branch_and_hashed_leaf_with_hashed_value", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Changes

Small fix to add missing prefixed key when storing leaf values to solve an issue when looking up and deleting leaf with hashed values

<!-- Brief list of functional changes -->

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
make test
```