### PR TITLE
fix(lib/runtime): minimum size mismatch bug at block `#20056997`

### DIFF
--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -28,7 +28,10 @@ import (
 )
 
 // Name represents the name of the interpreter
-const Name = "wazero"
+const (
+	Name                = "wazero"
+	MaxWasmPages uint32 = 65536
+)
 
 type runtimeContextKeyType struct{}
 
@@ -117,7 +120,7 @@ func newRuntime(ctx context.Context,
 
 	hostCompiledModule, err := rt.NewHostModuleBuilder("env").
 		// values from newer kusama/polkadot runtimes
-		ExportMemory("memory", 23).
+		ExportMemory("memory", MaxWasmPages).
 		NewFunctionBuilder().
 		WithGoModuleFunction(
 			tripleArgFn(ext_logging_log_version_1),

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -29,8 +29,8 @@ import (
 
 // Name represents the name of the interpreter
 const (
-	Name                = "wazero"
-	MaxWasmPages uint32 = 65536
+	Name                  = "wazero"
+	MemoryMinPages uint32 = 2070
 )
 
 type runtimeContextKeyType struct{}
@@ -120,7 +120,7 @@ func newRuntime(ctx context.Context,
 
 	hostCompiledModule, err := rt.NewHostModuleBuilder("env").
 		// values from newer kusama/polkadot runtimes
-		ExportMemory("memory", MaxWasmPages).
+		ExportMemory("memory", MemoryMinPages).
 		NewFunctionBuilder().
 		WithGoModuleFunction(
 			tripleArgFn(ext_logging_log_version_1),

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -29,8 +29,8 @@ import (
 
 // Name represents the name of the interpreter
 const (
-	Name                = "wazero"
-	MaxWasmPages uint32 = 65536
+	Name                  = "wazero"
+	MemoryMinPages uint32 = 128 * 1024
 )
 
 type runtimeContextKeyType struct{}
@@ -120,7 +120,7 @@ func newRuntime(ctx context.Context,
 
 	hostCompiledModule, err := rt.NewHostModuleBuilder("env").
 		// values from newer kusama/polkadot runtimes
-		ExportMemory("memory", MaxWasmPages).
+		ExportMemory("memory", MemoryMinPages).
 		NewFunctionBuilder().
 		WithGoModuleFunction(
 			tripleArgFn(ext_logging_log_version_1),


### PR DESCRIPTION
## Changes

- This PR increases the amount of bytes reserved for instantiate a runtime (a.k.a min pages)
- Needed for fix the bug: `minimum size mismatch: 24 > 23`
- Values based on substrate https://github.com/paritytech/polkadot-sdk/blob/216e8fa126df9ee819d524834e75a82881681e02/substrate/client/executor/wasmtime/src/runtime.rs#L298

## Tests

N/A

## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/4099