### PR TITLE
docs: add new labels for prs and issues

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -5,6 +5,12 @@
   description: Issue used to track development status of a complex feature, aggregates
     several issues
 
+- name: good first issue
+  color: "#7057ff"
+  aliases: []
+  description: issues that are suitable for first-time contributors.
+
+
 - name: Feature-branch
   color: "#8ceac8"
   aliases: []
@@ -15,13 +21,12 @@
   aliases: []
   description: pull request with next release changes.
 
+# Action/attention needed label. Marks that there is a specific action needed for issue/PR
 - name: A-tooBig
   color: "#FBCA04"
   aliases: []
-  description: Action needed label. Marks that there is a specific action needed for
-    issue/PR
+  description: issue or PR needs to be broken down to smaller parts.
 
-# Action/attention needed label. Marks that there is a specific action needed for issue/PR
 - name: A-stale
   color: "#FBCA04"
   aliases: []
@@ -72,6 +77,16 @@
   color: "#FEF2C0"
   aliases: []
   description: this issue/pr covers security sensitive problem.
+
+- name: T-research
+  color: "#FEF2C0"
+  aliases: []
+  description: this issue/pr is a research type issue.
+
+- name: T-investigation
+  color: "#FEF2C0"
+  aliases: []
+  description: this issue/pr is an investigation, probably related to some bug with unknown causes.
 
 - name: T-question
   color: "#FEF2C0"

--- a/docs/docs/repo/labels.md
+++ b/docs/docs/repo/labels.md
@@ -1,14 +1,13 @@
 ## Labels
 
-
-
 Below is the list of labels and their descriptions used in Gossamer repository.
 
 
 - **Epic** - Issue used to track development status of a complex feature, aggregates several issues.
 - **Feature-branch** - pull request from feature branch to origin.
 - **Release** - pull request with next release changes.
-- **`A-`**  Action needed label. Marks that there is a specific action needed for issue/PR
+- **good first issue** - issues that are suitable for first-time contributors.
+- **`A-`**  Action needed label. Marks that there is a specific action needed for issue/PR.
   - **A-tooBig** - issue or PR needs to be broken down to smaller parts.
   - **A-stale** - issue or PR is deprecated and needs to be closed. 
   - **A-blocked** - issue or PR is blocked  until something else changes.
@@ -20,7 +19,9 @@ Below is the list of labels and their descriptions used in Gossamer repository.
   - **T-feat** - this issue/pr is a new feature or functionality.
   - **T-enhancement** - this issue/pr covers improvement of existing functionality. 
   - **T-refactor** - this issue/pr covers refactoring of existing code.  
-  - **T-security** - this issue/pr covers security sensitive problem. 
+  - **T-security** - this issue/pr covers security sensitive problem.
+  - **T-research** - this issue/pr is a research type issue.
+  - **T-investigation** - this issue/pr is an investigation, probably related to some bug with unknown causes.
 - **`C-`** Complexity label. We operate only 3 complexity levels.
   - **C-simple** -  Minor changes changes, no additional research needed. Good first issue/review.
   - **C-complex** - Complex changes across multiple modules. Possibly will require additional research.


### PR DESCRIPTION
## Changes
<!-- Brief list of functional changes -->
Added some new labels. 
`good first issue` labels since our Org defaults for this are set to this particular label name.
`investigation` and `research` types for issues that requires investigation or research issues, hence can have estimates 8

## Tests

<!-- Detail how to run relevant tests to the changes -->
n/a

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
n/a