### PR TITLE
refactor(client/consensus/grandpa): make `DecodeGrandpaJustificationVerifyFinalizes` public

### DIFF
--- a/internal/client/consensus/grandpa/authorities.go
+++ b/internal/client/consensus/grandpa/authorities.go
@@ -149,7 +149,7 @@ func (sas *SharedAuthoritySet[H, N]) applyForcedChanges(bestHash H, //nolint //s
 // method ensures that if there are multiple changes in the same branch,
 // finalising this block won't finalise past multiple transitions (i.e.
 // transitions must be finalised in-order). The given function
-// `is_descendent_of` should return `true` if the second hash (target) is a
+// `isDescendentOf` should return `true` if the second hash (target) is a
 // descendent of the first hash (base).
 //
 // When the set has changed, the return value will be a status type where newSetBlockInfo
@@ -172,7 +172,7 @@ func (sas *SharedAuthoritySet[H, N]) applyStandardChanges(finalisedHash H, //nol
 // change that can be immediately applied, *false if the block being
 // finalised enacts a change but it cannot be applied yet since there are
 // other dependent changes, and nil if no change is enacted. The given
-// function `is_descendent_of` should return `true` if the second hash
+// function `isDescendentOf` should return `true` if the second hash
 // (target) is a descendent of the first hash (base).
 func (sas *SharedAuthoritySet[H, N]) EnactsStandardChange(finalisedHash H,
 	finalisedNumber N,
@@ -277,7 +277,7 @@ func (authSet *AuthoritySet[H, N]) revert() { //nolint //skipcq: SCC-U1000 //ski
 }
 
 // Returns the block hash and height at which the next pending HashNumber in
-// the given chain (i.e. it includes `best_hash`) was signalled, nil if
+// the given chain (i.e. it includes `bestHash`) was signalled, nil if
 // there are no pending changes for the given chain.
 func (authSet *AuthoritySet[H, N]) nextChange(bestHash H, //skipcq:  RVV-B0001
 	isDescendentOf IsDescendentOf[H]) (*HashNumber[H, N], error) {
@@ -432,7 +432,7 @@ func (authSet *AuthoritySet[H, N]) addForcedChange(
 // on the same branch can be added as long as they don't overlap. Forced
 // changes are restricted to one per fork. This method assumes that changes
 // on the same branch will be added in-order. The given function
-// `is_descendent_of` should return `true` if the second hash (target) is a
+// `isDescendentOf` should return `true` if the second hash (target) is a
 // descendent of the first hash (base).
 func (authSet *AuthoritySet[H, N]) addPendingChange(
 	pending PendingChange[H, N],
@@ -570,7 +570,7 @@ func (authSet *AuthoritySet[H, N]) applyForcedChanges(bestHash H, //skipcq:  RVV
 // method ensures that if there are multiple changes in the same branch,
 // finalising this block won't finalise past multiple transitions (i.e.
 // transitions must be finalised in-order). The given function
-// `is_descendent_of` should return `true` if the second hash (target) is a
+// `isDescendantOf` should return `true` if the second hash (target) is a
 // descendent of the first hash (base).
 //
 // When the set has changed, the return value will be a status type where newSetBlock
@@ -651,7 +651,7 @@ func (authSet *AuthoritySet[H, N]) applyStandardChanges( //skipcq:  RVV-B0001
 // HashNumber that can be immediately applied, *false if the block being
 // finalised enacts a HashNumber but it cannot be applied yet since there are
 // other dependent changes, and nil if no HashNumber is enacted. The given
-// function `is_descendent_of` should return `true` if the second hash
+// function `isDescendentOf` should return `true` if the second hash
 // (target) is a descendent of the first hash (base).
 func (authSet *AuthoritySet[H, N]) EnactsStandardChange( //skipcq:  RVV-B0001
 	finalisedHash H, finalisedNumber N, isDescendentOf IsDescendentOf[H]) (*bool, error) {

--- a/internal/client/consensus/grandpa/authorities_test.go
+++ b/internal/client/consensus/grandpa/authorities_test.go
@@ -16,8 +16,6 @@ const (
 	hashB = "hash_b"
 	hashC = "hash_c"
 	hashD = "hash_d"
-	// key   = dummyAuthID(1)
-	// key2  = dummyAuthID(2)
 )
 
 func staticIsDescendentOf[H comparable](value bool) IsDescendentOf[H] {

--- a/internal/client/consensus/grandpa/aux_schema.go
+++ b/internal/client/consensus/grandpa/aux_schema.go
@@ -193,7 +193,7 @@ func UpdateAuthoritySet[H comparable, N constraints.Unsigned, ID primitives.Auth
 // We always keep around the justification for the best finalized block and overwrite it
 // as we finalize new blocks, this makes sure that we don't store useless justifications
 // but can always prove finality of the latest block.
-func updateBestJustification[
+func updateBestJustification[ //nolint:unused
 	Hash runtime.Hash,
 	N runtime.Number,
 ](

--- a/internal/client/consensus/grandpa/change_tree.go
+++ b/internal/client/consensus/grandpa/change_tree.go
@@ -54,7 +54,7 @@ func (ct *ChangeTree[H, N]) Roots() []*PendingChangeNode[H, N] { //skipcq: RVV-B
 
 // Import a new node into the roots.
 //
-// The given function `is_descendent_of` should return `true` if the second
+// The given function `isDescendentOf` should return `true` if the second
 // hash (target) is a descendent of the first hash (base).
 //
 // This method assumes that children in the same branch are imported in order.
@@ -62,7 +62,7 @@ func (ct *ChangeTree[H, N]) Roots() []*PendingChangeNode[H, N] { //skipcq: RVV-B
 // Returns `true` if the imported node is a root.
 // WARNING: some users of this method (i.e. consensus epoch changes roots) currently silently
 // rely on a **post-order DFS** traversal. If we are using instead a top-down traversal method
-// then the `is_descendent_of` closure, when used after a warp-sync, may end up querying the
+// then the `isDescendentOf` closure, when used after a warp-sync, may end up querying the
 // backend for a block (the one corresponding to the root) that is not present and thus will
 // return a wrong result.
 func (ct *ChangeTree[H, N]) Import(hash H,
@@ -127,7 +127,7 @@ func (ct *ChangeTree[H, N]) getPreOrderChangeNodes() []*PendingChangeNode[H, N] 
 // a root, *false if the node being finalized is not a root, and
 // nil if no node in the tree is finalized. The given `Predicate` is
 // checked on the prospective finalized root and must pass for finalisation
-// to occur. The given function `is_descendent_of` should return `true` if
+// to occur. The given function `isDescendentOf` should return `true` if
 // the second hash (target) is a descendent of the first hash (base). func(T) bool
 func (ct *ChangeTree[H, N]) FinalizesAnyWithDescendentIf(
 	hash *H,
@@ -249,7 +249,7 @@ type unchanged struct{}
 // being finalized isn't a descendent of (or equal to) any of the root's
 // children. The given `Predicate` is checked on the prospective finalized
 // root and must pass for finalisation to occur. The given function
-// `is_descendent_of` should return `true` if the second hash (target) is a
+// `isDescendentOf` should return `true` if the second hash (target) is a
 // descendent of the first hash (base).
 func (ct *ChangeTree[H, N]) FinalizeWithDescendentIf(
 	hash *H,

--- a/internal/client/consensus/grandpa/change_tree.go
+++ b/internal/client/consensus/grandpa/change_tree.go
@@ -459,12 +459,10 @@ func (ct *ChangeTree[H, N]) swapRemove(roots []*PendingChangeNode[H, N], index N
 		panic("swap_remove index out of bounds")
 	}
 
-	val := PendingChangeNode[H, N]{}
-	if roots[index] != nil {
-		val = *roots[index]
-	} else {
+	if roots[index] == nil {
 		panic("nil pending HashNumber node")
 	}
+	val := *roots[index]
 
 	lastElem := roots[len(roots)-1]
 

--- a/internal/client/consensus/grandpa/finality_proof.go
+++ b/internal/client/consensus/grandpa/finality_proof.go
@@ -184,7 +184,7 @@ func proveFinality[
 				block)
 			return nil, nil //nolint
 		}
-		justification := justifications.IntoJustification(primitives.GrandpaEngineID)
+		justification := justifications.EncodedJustification(primitives.GrandpaEngineID)
 		if justification != nil {
 			encJustification = *justification
 			justBlock = val.inner.BlockNumber

--- a/internal/client/consensus/grandpa/finality_proof_test.go
+++ b/internal/client/consensus/grandpa/finality_proof_test.go
@@ -299,7 +299,7 @@ func TestFinalityProof_UsingAuthoritySetChangesWorks(t *testing.T) {
 		ConsensusEngineID:    primitives.GrandpaEngineID,
 		EncodedJustification: scale.MustMarshal(grandpaJust8),
 	}
-	blockchainBackend.EXPECT().Justifications(block8.Hash()).Return(&runtime.Justifications{justification}, nil)
+	blockchainBackend.EXPECT().Justifications(block8.Hash()).Return(runtime.Justifications{justification}, nil)
 
 	blockchainBackend.EXPECT().ExpectBlockHashFromID(uint64(7)).Return(block7.Hash(), nil)
 	blockchainBackend.EXPECT().ExpectHeader(block7.Hash()).Return(block7.Header(), nil)

--- a/internal/client/consensus/grandpa/justification.go
+++ b/internal/client/consensus/grandpa/justification.go
@@ -140,7 +140,7 @@ func NewJustificationFromCommit[
 					fmt.Errorf("%w: invalid precommits for target commit", errBadJustification)
 			}
 
-			currentHeader := *header
+			currentHeader := header
 
 			// NOTE: this should never happen as we pick the lowest block
 			// as base and only traverse backwards from the other blocks

--- a/internal/client/consensus/grandpa/justification_test.go
+++ b/internal/client/consensus/grandpa/justification_test.go
@@ -123,7 +123,7 @@ func TestJustification_fromCommit(t *testing.T) {
 		"",
 		runtime.Digest{})
 
-	client.EXPECT().Header(hash.H256("b")).Return(&header, nil)
+	client.EXPECT().Header(hash.H256("b")).Return(header, nil)
 	_, err = NewJustificationFromCommit[hash.H256, uint64](
 		client,
 		2,
@@ -142,7 +142,7 @@ func TestJustification_fromCommit(t *testing.T) {
 		runtime.Digest{})
 
 	client = mocks.NewHeaderBackend[hash.H256, uint64](t)
-	client.EXPECT().Header(hash.H256("b")).Return(&header, nil)
+	client.EXPECT().Header(hash.H256("b")).Return(header, nil)
 
 	expAncestries := make([]runtime.Header[uint64, hash.H256], 0)
 	expAncestries = append(expAncestries, generic.NewHeader[uint64, hash.H256, runtime.BlakeTwo256](

--- a/internal/client/consensus/grandpa/justification_test.go
+++ b/internal/client/consensus/grandpa/justification_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/internal/client/consensus/grandpa/mocks"
 	primitives "github.com/ChainSafe/gossamer/internal/primitives/consensus/grandpa"
 	ced25519 "github.com/ChainSafe/gossamer/internal/primitives/core/ed25519"
 	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
@@ -79,6 +80,93 @@ func TestJustificationEncoding(t *testing.T) {
 	justification, err := decodeJustification[hash.H256, uint64, runtime.BlakeTwo256](encodedJustification)
 	require.NoError(t, err)
 	require.Equal(t, expected, justification.Justification)
+}
+
+func TestJustification_fromCommit(t *testing.T) {
+	commit := primitives.Commit[hash.H256, uint64]{}
+	client := mocks.NewHeaderBackend[hash.H256, uint64](t)
+	_, err := NewJustificationFromCommit[hash.H256, uint64](client, 2, commit)
+	require.NotNil(t, err)
+	require.ErrorIs(t, err, errBadJustification)
+	require.Equal(t, "bad justification for header: invalid precommits for target commit", err.Error())
+
+	// nil header
+	var precommits []grandpa.SignedPrecommit[hash.H256, uint64, primitives.AuthoritySignature, primitives.AuthorityID]
+	precommit := makePrecommit(t, "a", 1, 1, 1, ed25519.Alice)
+	precommits = append(precommits, precommit)
+
+	precommit = makePrecommit(t, "b", 2, 1, 1, ed25519.Alice)
+	precommits = append(precommits, precommit)
+
+	validCommit := primitives.Commit[hash.H256, uint64]{
+		TargetHash:   "a",
+		TargetNumber: 1,
+		Precommits:   precommits,
+	}
+
+	clientNil := mocks.NewHeaderBackend[hash.H256, uint64](t)
+	clientNil.EXPECT().Header(hash.H256("b")).Return(nil, nil)
+	_, err = NewJustificationFromCommit[hash.H256, uint64](
+		clientNil,
+		2,
+		validCommit,
+	)
+	require.NotNil(t, err)
+	require.ErrorIs(t, err, errBadJustification)
+	require.Equal(t, "bad justification for header: invalid precommits for target commit", err.Error())
+
+	// currentHeader.Number() <= baseNumber
+	var header runtime.Header[uint64, hash.H256] = generic.NewHeader[uint64, hash.H256, runtime.BlakeTwo256](
+		1,
+		hash.H256(""),
+		hash.H256(""),
+		"",
+		runtime.Digest{})
+
+	client.EXPECT().Header(hash.H256("b")).Return(&header, nil)
+	_, err = NewJustificationFromCommit[hash.H256, uint64](
+		client,
+		2,
+		validCommit,
+	)
+	require.NotNil(t, err)
+	require.ErrorIs(t, err, errBadJustification)
+	require.Equal(t, "bad justification for header: invalid precommits for target commit", err.Error())
+
+	// happy path
+	header = generic.NewHeader[uint64, hash.H256, runtime.BlakeTwo256](
+		100,
+		hash.H256(""),
+		hash.H256(""),
+		hash.H256("a"),
+		runtime.Digest{})
+
+	client = mocks.NewHeaderBackend[hash.H256, uint64](t)
+	client.EXPECT().Header(hash.H256("b")).Return(&header, nil)
+
+	expAncestries := make([]runtime.Header[uint64, hash.H256], 0)
+	expAncestries = append(expAncestries, generic.NewHeader[uint64, hash.H256, runtime.BlakeTwo256](
+		100,
+		hash.H256(""),
+		hash.H256(""),
+		hash.H256("a"),
+		runtime.Digest{}),
+	)
+	expJustification := primitives.GrandpaJustification[hash.H256, uint64]{
+		Round: 2,
+		Commit: primitives.Commit[hash.H256, uint64]{
+			TargetHash:   "a",
+			TargetNumber: 1,
+			Precommits:   precommits,
+		},
+		VoteAncestries: expAncestries,
+	}
+	justification, err := NewJustificationFromCommit[hash.H256, uint64](
+		client,
+		2,
+		validCommit)
+	require.NoError(t, err)
+	require.Equal(t, expJustification, justification.Justification)
 }
 
 func TestDecodeGrandpaJustificationVerifyFinalizes(t *testing.T) {

--- a/internal/client/consensus/grandpa/mocks/blockchain_backend.go
+++ b/internal/client/consensus/grandpa/mocks/blockchain_backend.go
@@ -85,23 +85,23 @@ func (_c *BlockchainBackend_BlockHashFromID_Call[Hash, N]) RunAndReturn(run func
 }
 
 // BlockIndexedBody provides a mock function with given fields: hash
-func (_m *BlockchainBackend[Hash, N]) BlockIndexedBody(hash Hash) (*[][]byte, error) {
+func (_m *BlockchainBackend[Hash, N]) BlockIndexedBody(hash Hash) ([][]byte, error) {
 	ret := _m.Called(hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BlockIndexedBody")
 	}
 
-	var r0 *[][]byte
+	var r0 [][]byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(Hash) (*[][]byte, error)); ok {
+	if rf, ok := ret.Get(0).(func(Hash) ([][]byte, error)); ok {
 		return rf(hash)
 	}
-	if rf, ok := ret.Get(0).(func(Hash) *[][]byte); ok {
+	if rf, ok := ret.Get(0).(func(Hash) [][]byte); ok {
 		r0 = rf(hash)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*[][]byte)
+			r0 = ret.Get(0).([][]byte)
 		}
 	}
 
@@ -132,12 +132,12 @@ func (_c *BlockchainBackend_BlockIndexedBody_Call[Hash, N]) Run(run func(hash Ha
 	return _c
 }
 
-func (_c *BlockchainBackend_BlockIndexedBody_Call[Hash, N]) Return(_a0 *[][]byte, _a1 error) *BlockchainBackend_BlockIndexedBody_Call[Hash, N] {
+func (_c *BlockchainBackend_BlockIndexedBody_Call[Hash, N]) Return(_a0 [][]byte, _a1 error) *BlockchainBackend_BlockIndexedBody_Call[Hash, N] {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *BlockchainBackend_BlockIndexedBody_Call[Hash, N]) RunAndReturn(run func(Hash) (*[][]byte, error)) *BlockchainBackend_BlockIndexedBody_Call[Hash, N] {
+func (_c *BlockchainBackend_BlockIndexedBody_Call[Hash, N]) RunAndReturn(run func(Hash) ([][]byte, error)) *BlockchainBackend_BlockIndexedBody_Call[Hash, N] {
 	_c.Call.Return(run)
 	return _c
 }
@@ -201,23 +201,23 @@ func (_c *BlockchainBackend_BlockNumberFromID_Call[Hash, N]) RunAndReturn(run fu
 }
 
 // Body provides a mock function with given fields: hash
-func (_m *BlockchainBackend[Hash, N]) Body(hash Hash) (*[]runtime.Extrinsic, error) {
+func (_m *BlockchainBackend[Hash, N]) Body(hash Hash) ([]runtime.Extrinsic, error) {
 	ret := _m.Called(hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Body")
 	}
 
-	var r0 *[]runtime.Extrinsic
+	var r0 []runtime.Extrinsic
 	var r1 error
-	if rf, ok := ret.Get(0).(func(Hash) (*[]runtime.Extrinsic, error)); ok {
+	if rf, ok := ret.Get(0).(func(Hash) ([]runtime.Extrinsic, error)); ok {
 		return rf(hash)
 	}
-	if rf, ok := ret.Get(0).(func(Hash) *[]runtime.Extrinsic); ok {
+	if rf, ok := ret.Get(0).(func(Hash) []runtime.Extrinsic); ok {
 		r0 = rf(hash)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*[]runtime.Extrinsic)
+			r0 = ret.Get(0).([]runtime.Extrinsic)
 		}
 	}
 
@@ -248,12 +248,12 @@ func (_c *BlockchainBackend_Body_Call[Hash, N]) Run(run func(hash Hash)) *Blockc
 	return _c
 }
 
-func (_c *BlockchainBackend_Body_Call[Hash, N]) Return(_a0 *[]runtime.Extrinsic, _a1 error) *BlockchainBackend_Body_Call[Hash, N] {
+func (_c *BlockchainBackend_Body_Call[Hash, N]) Return(_a0 []runtime.Extrinsic, _a1 error) *BlockchainBackend_Body_Call[Hash, N] {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *BlockchainBackend_Body_Call[Hash, N]) RunAndReturn(run func(Hash) (*[]runtime.Extrinsic, error)) *BlockchainBackend_Body_Call[Hash, N] {
+func (_c *BlockchainBackend_Body_Call[Hash, N]) RunAndReturn(run func(Hash) ([]runtime.Extrinsic, error)) *BlockchainBackend_Body_Call[Hash, N] {
 	_c.Call.Return(run)
 	return _c
 }
@@ -659,23 +659,23 @@ func (_c *BlockchainBackend_Hash_Call[Hash, N]) RunAndReturn(run func(N) (*Hash,
 }
 
 // Header provides a mock function with given fields: hash
-func (_m *BlockchainBackend[Hash, N]) Header(hash Hash) (*runtime.Header[N, Hash], error) {
+func (_m *BlockchainBackend[Hash, N]) Header(hash Hash) (runtime.Header[N, Hash], error) {
 	ret := _m.Called(hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Header")
 	}
 
-	var r0 *runtime.Header[N, Hash]
+	var r0 runtime.Header[N, Hash]
 	var r1 error
-	if rf, ok := ret.Get(0).(func(Hash) (*runtime.Header[N, Hash], error)); ok {
+	if rf, ok := ret.Get(0).(func(Hash) (runtime.Header[N, Hash], error)); ok {
 		return rf(hash)
 	}
-	if rf, ok := ret.Get(0).(func(Hash) *runtime.Header[N, Hash]); ok {
+	if rf, ok := ret.Get(0).(func(Hash) runtime.Header[N, Hash]); ok {
 		r0 = rf(hash)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*runtime.Header[N, Hash])
+			r0 = ret.Get(0).(runtime.Header[N, Hash])
 		}
 	}
 
@@ -706,34 +706,34 @@ func (_c *BlockchainBackend_Header_Call[Hash, N]) Run(run func(hash Hash)) *Bloc
 	return _c
 }
 
-func (_c *BlockchainBackend_Header_Call[Hash, N]) Return(_a0 *runtime.Header[N, Hash], _a1 error) *BlockchainBackend_Header_Call[Hash, N] {
+func (_c *BlockchainBackend_Header_Call[Hash, N]) Return(_a0 runtime.Header[N, Hash], _a1 error) *BlockchainBackend_Header_Call[Hash, N] {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *BlockchainBackend_Header_Call[Hash, N]) RunAndReturn(run func(Hash) (*runtime.Header[N, Hash], error)) *BlockchainBackend_Header_Call[Hash, N] {
+func (_c *BlockchainBackend_Header_Call[Hash, N]) RunAndReturn(run func(Hash) (runtime.Header[N, Hash], error)) *BlockchainBackend_Header_Call[Hash, N] {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IndexedTransaction provides a mock function with given fields: hash
-func (_m *BlockchainBackend[Hash, N]) IndexedTransaction(hash Hash) (*[]byte, error) {
+func (_m *BlockchainBackend[Hash, N]) IndexedTransaction(hash Hash) ([]byte, error) {
 	ret := _m.Called(hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for IndexedTransaction")
 	}
 
-	var r0 *[]byte
+	var r0 []byte
 	var r1 error
-	if rf, ok := ret.Get(0).(func(Hash) (*[]byte, error)); ok {
+	if rf, ok := ret.Get(0).(func(Hash) ([]byte, error)); ok {
 		return rf(hash)
 	}
-	if rf, ok := ret.Get(0).(func(Hash) *[]byte); ok {
+	if rf, ok := ret.Get(0).(func(Hash) []byte); ok {
 		r0 = rf(hash)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*[]byte)
+			r0 = ret.Get(0).([]byte)
 		}
 	}
 
@@ -764,12 +764,12 @@ func (_c *BlockchainBackend_IndexedTransaction_Call[Hash, N]) Run(run func(hash 
 	return _c
 }
 
-func (_c *BlockchainBackend_IndexedTransaction_Call[Hash, N]) Return(_a0 *[]byte, _a1 error) *BlockchainBackend_IndexedTransaction_Call[Hash, N] {
+func (_c *BlockchainBackend_IndexedTransaction_Call[Hash, N]) Return(_a0 []byte, _a1 error) *BlockchainBackend_IndexedTransaction_Call[Hash, N] {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *BlockchainBackend_IndexedTransaction_Call[Hash, N]) RunAndReturn(run func(Hash) (*[]byte, error)) *BlockchainBackend_IndexedTransaction_Call[Hash, N] {
+func (_c *BlockchainBackend_IndexedTransaction_Call[Hash, N]) RunAndReturn(run func(Hash) ([]byte, error)) *BlockchainBackend_IndexedTransaction_Call[Hash, N] {
 	_c.Call.Return(run)
 	return _c
 }
@@ -820,23 +820,23 @@ func (_c *BlockchainBackend_Info_Call[Hash, N]) RunAndReturn(run func() blockcha
 }
 
 // Justifications provides a mock function with given fields: hash
-func (_m *BlockchainBackend[Hash, N]) Justifications(hash Hash) (*runtime.Justifications, error) {
+func (_m *BlockchainBackend[Hash, N]) Justifications(hash Hash) (runtime.Justifications, error) {
 	ret := _m.Called(hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Justifications")
 	}
 
-	var r0 *runtime.Justifications
+	var r0 runtime.Justifications
 	var r1 error
-	if rf, ok := ret.Get(0).(func(Hash) (*runtime.Justifications, error)); ok {
+	if rf, ok := ret.Get(0).(func(Hash) (runtime.Justifications, error)); ok {
 		return rf(hash)
 	}
-	if rf, ok := ret.Get(0).(func(Hash) *runtime.Justifications); ok {
+	if rf, ok := ret.Get(0).(func(Hash) runtime.Justifications); ok {
 		r0 = rf(hash)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*runtime.Justifications)
+			r0 = ret.Get(0).(runtime.Justifications)
 		}
 	}
 
@@ -867,12 +867,12 @@ func (_c *BlockchainBackend_Justifications_Call[Hash, N]) Run(run func(hash Hash
 	return _c
 }
 
-func (_c *BlockchainBackend_Justifications_Call[Hash, N]) Return(_a0 *runtime.Justifications, _a1 error) *BlockchainBackend_Justifications_Call[Hash, N] {
+func (_c *BlockchainBackend_Justifications_Call[Hash, N]) Return(_a0 runtime.Justifications, _a1 error) *BlockchainBackend_Justifications_Call[Hash, N] {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *BlockchainBackend_Justifications_Call[Hash, N]) RunAndReturn(run func(Hash) (*runtime.Justifications, error)) *BlockchainBackend_Justifications_Call[Hash, N] {
+func (_c *BlockchainBackend_Justifications_Call[Hash, N]) RunAndReturn(run func(Hash) (runtime.Justifications, error)) *BlockchainBackend_Justifications_Call[Hash, N] {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/client/consensus/grandpa/mocks/header_backend.go
+++ b/internal/client/consensus/grandpa/mocks/header_backend.go
@@ -369,23 +369,23 @@ func (_c *HeaderBackend_Hash_Call[Hash, N]) RunAndReturn(run func(N) (*Hash, err
 }
 
 // Header provides a mock function with given fields: hash
-func (_m *HeaderBackend[Hash, N]) Header(hash Hash) (*runtime.Header[N, Hash], error) {
+func (_m *HeaderBackend[Hash, N]) Header(hash Hash) (runtime.Header[N, Hash], error) {
 	ret := _m.Called(hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Header")
 	}
 
-	var r0 *runtime.Header[N, Hash]
+	var r0 runtime.Header[N, Hash]
 	var r1 error
-	if rf, ok := ret.Get(0).(func(Hash) (*runtime.Header[N, Hash], error)); ok {
+	if rf, ok := ret.Get(0).(func(Hash) (runtime.Header[N, Hash], error)); ok {
 		return rf(hash)
 	}
-	if rf, ok := ret.Get(0).(func(Hash) *runtime.Header[N, Hash]); ok {
+	if rf, ok := ret.Get(0).(func(Hash) runtime.Header[N, Hash]); ok {
 		r0 = rf(hash)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*runtime.Header[N, Hash])
+			r0 = ret.Get(0).(runtime.Header[N, Hash])
 		}
 	}
 
@@ -416,12 +416,12 @@ func (_c *HeaderBackend_Header_Call[Hash, N]) Run(run func(hash Hash)) *HeaderBa
 	return _c
 }
 
-func (_c *HeaderBackend_Header_Call[Hash, N]) Return(_a0 *runtime.Header[N, Hash], _a1 error) *HeaderBackend_Header_Call[Hash, N] {
+func (_c *HeaderBackend_Header_Call[Hash, N]) Return(_a0 runtime.Header[N, Hash], _a1 error) *HeaderBackend_Header_Call[Hash, N] {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *HeaderBackend_Header_Call[Hash, N]) RunAndReturn(run func(Hash) (*runtime.Header[N, Hash], error)) *HeaderBackend_Header_Call[Hash, N] {
+func (_c *HeaderBackend_Header_Call[Hash, N]) RunAndReturn(run func(Hash) (runtime.Header[N, Hash], error)) *HeaderBackend_Header_Call[Hash, N] {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/primitives/blockchain/backend.go
+++ b/internal/primitives/blockchain/backend.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ChainSafe/gossamer/internal/primitives/runtime/generic"
 )
 
-// Blockchain database header backend. Does not perform any validation.
+// Header is the blockchain database header backend. Does not perform any validation.
 type HeaderBackend[Hash runtime.Hash, N runtime.Number] interface {
-	// Get block header. Returns `None` if block is not found.
-	Header(hash Hash) (*runtime.Header[N, Hash], error)
+	// Get block header. Returns `nil` if block is not found.
+	Header(hash Hash) (runtime.Header[N, Hash], error)
 
 	// Get blockchain info.
 	Info() Info[Hash, N]
@@ -21,10 +21,10 @@ type HeaderBackend[Hash runtime.Hash, N runtime.Number] interface {
 	// Get block status.
 	Status(hash Hash) (BlockStatus, error)
 
-	// Get block number by hash. Returns `None` if the header is not in the chain.
+	// Get block number by hash. Returns `nil` if the header is not in the chain.
 	Number(hash Hash) (*N, error)
 
-	// Get block hash by number. Returns `None` if the header is not in the chain.
+	// Get block hash by number. Returns `nil` if the header is not in the chain.
 	Hash(number N) (*Hash, error)
 
 	// Convert an arbitrary block ID into a block hash.
@@ -48,12 +48,12 @@ type HeaderBackend[Hash runtime.Hash, N runtime.Number] interface {
 // Blockchain database backend. Does not perform any validation.
 type Backend[Hash runtime.Hash, N runtime.Number] interface {
 	HeaderBackend[Hash, N]
-	// HeaderMetaData[Hash, N]
+	// HeaderMetadata[Hash, N]
 
-	// Get block body. Returns `None` if block is not found.
-	Body(hash Hash) (*[]runtime.Extrinsic, error)
-	// Get block justifications. Returns `None` if no justification exists.
-	Justifications(hash Hash) (*runtime.Justifications, error)
+	// Get block body. Returns `nil` if block is not found.
+	Body(hash Hash) ([]runtime.Extrinsic, error)
+	// Get block justifications. Returns `nil` if no justification exists.
+	Justifications(hash Hash) (runtime.Justifications, error)
 	// Get last finalized block hash.
 	LastFinalized() (Hash, error)
 
@@ -64,30 +64,29 @@ type Backend[Hash runtime.Hash, N runtime.Number] interface {
 
 	// Returns displaced leaves after the given block would be finalized.
 	//
-	// The returned leaves do not contain the leaves from the same height as `block_number`.
+	// The returned leaves do not contain the leaves from the same height as `blockNumber`.
 	DisplacedLeavesAfterFinalizing(blockNumber N) ([]Hash, error)
 
-	// Return hashes of all blocks that are children of the block with `parent_hash`.
+	// Return hashes of all blocks that are children of the block with `parentHash`.
 	Children(parentHash Hash) ([]Hash, error)
 
 	// Get the most recent block hash of the longest chain that contains
-	// a block with the given `base_hash`.
+	// a block with the given `baseHash`.
 	//
 	// The search space is always limited to blocks which are in the finalized
 	// chain or descendents of it.
 	//
-	// Returns `Ok(None)` if `base_hash` is not found in search space.
-	// TODO: document time complexity of this, see [#1444](https://github.com/paritytech/substrate/issues/1444)
+	// Returns `nil` if `basehash` is not found in search space.
 	LongestContaining(baseHash Hash, importLock *sync.RWMutex) (*Hash, error)
 
 	// Get single indexed transaction by content hash. Note that this will only fetch transactions
 	// that are indexed by the runtime with `storage_index_transaction`.
-	IndexedTransaction(hash Hash) (*[]byte, error)
+	IndexedTransaction(hash Hash) ([]byte, error)
 
 	// Check if indexed transaction exists.
 	HasIndexedTransaction(hash Hash) (bool, error)
 
-	BlockIndexedBody(hash Hash) (*[][]byte, error)
+	BlockIndexedBody(hash Hash) ([][]byte, error)
 }
 
 // Blockchain info
@@ -113,7 +112,7 @@ type Info[H, N any] struct {
 	BlockGap *[2]N
 }
 
-// Block status.
+// BlockStatus is block status.
 type BlockStatus uint
 
 const (

--- a/internal/primitives/runtime/runtime.go
+++ b/internal/primitives/runtime/runtime.go
@@ -3,32 +3,28 @@
 
 package runtime
 
-// An abstraction over justification for a block's validity under a consensus algorithm.
+// Justification is an abstraction over justification for a block's validity under a consensus algorithm.
 //
-// Essentially a finality proof. The exact formulation will vary between consensus
-// algorithms. In the case where there are multiple valid proofs, inclusion within
-// the block itself would allow swapping justifications to change the block's hash
-// (and thus fork the chain). Sending a `Justification` alongside a block instead
-// bypasses this problem.
+// Essentially a finality proof. The exact formulation will vary between consensus algorithms. In the case where there
+// are multiple valid proofs, inclusion within the block itself would allow swapping justifications to change the
+// block's hash (and thus fork the chain). Sending a `Justification` alongside a block instead bypasses this problem.
 //
-// Each justification is provided as an encoded blob, and is tagged with an ID
-// to identify the consensus engine that generated the proof (we might have
-// multiple justifications from different engines for the same block).
+// Each justification is provided as an encoded blob, and is tagged with an ID to identify the consensus engine that
+// generated the proof (we might have multiple justifications from different engines for the same block).
 type Justification struct {
 	ConsensusEngineID
 	EncodedJustification
 }
 
-// The encoded justification specific to a consensus engine.
+// EncodedJustification is the encoded justification specific to a consensus engine.
 type EncodedJustification []byte
 
-// Collection of justifications for a given block, multiple justifications may
-// be provided by different consensus engines for the same block.
+// Justifications is a collection of justifications for a given block, multiple justifications may be provided by
+// different consensus engines for the same block.
 type Justifications []Justification
 
-// IntoJustification returns a copy of the encoded justification for the given consensus
-// engine, if it exists
-func (j Justifications) IntoJustification(engineID ConsensusEngineID) *EncodedJustification {
+// EncodedJustification returns a copy of the encoded justification for the given consensus engine, if it exists
+func (j Justifications) EncodedJustification(engineID ConsensusEngineID) *EncodedJustification {
 	for _, justification := range j {
 		if justification.ConsensusEngineID == engineID {
 			return &justification.EncodedJustification
@@ -39,80 +35,3 @@ func (j Justifications) IntoJustification(engineID ConsensusEngineID) *EncodedJu
 
 // Consensus engine unique ID.
 type ConsensusEngineID [4]byte
-
-// // Header number.
-// type Number interface {
-// 	~uint | ~uint32 | ~uint64
-// }
-
-// type Hash interface {
-// 	constraints.Ordered
-
-// 	Bytes() []byte
-// 	String() string
-// }
-
-// // Abstraction around hashing
-// // Stupid bug in the Rust compiler believes derived
-// // traits must be fulfilled by all type parameters.
-// type Hasher[H Hash] interface {
-// 	hashdb.Hasher[H]
-// 	// Produce the hash of some byte-slice.
-// 	Hash(s []byte) H
-
-// 	// Produce the hash of some codec-encodable value.
-// 	HashOf(s any) H
-// }
-
-// // Blake2-256 Hash implementation.
-// type BlakeTwo256 struct{}
-
-// // Produce the hash of some byte-slice.
-// func (bt256 BlakeTwo256) Hash(s []byte) hash.H256 {
-// 	h := hashing.Blake2_256(s)
-// 	return hash.H256(h[:])
-// }
-
-// // Produce the hash of some codec-encodable value.
-// func (bt256 BlakeTwo256) HashOf(s any) hash.H256 {
-// 	bytes := scale.MustMarshal(s)
-// 	return bt256.Hash(bytes)
-// }
-
-// var _ Hasher[hash.H256] = BlakeTwo256{}
-
-// // Something which fulfils the abstract idea of a Substrate header. It has types for a `Number`,
-// // a `Hash` and a `Hashing`. It provides access to an `extrinsics_root`, `state_root` and
-// // `parent_hash`, as well as a `digest` and a block `number`.
-// //
-// // You can also create a `new` one from those fields.
-// type Header[N Number, H Hash] interface {
-// 	// Returns a reference to the header number.
-// 	Number() N
-// 	// Returns a reference to the parent hash.
-// 	ParentHash() H
-// 	// Returns the hash of the header.
-// 	Hash() H
-// }
-
-// // Something which fulfils the abstract idea of a Substrate block. It has types for
-// // `Extrinsic` pieces of information as well as a `Header`.
-// //
-// // You can get an iterator over each of the `extrinsics` and retrieve the `header`.
-// type Block[N Number, H Hash] interface {
-// 	// Returns a reference to the header.
-// 	Header() Header[N, H]
-// 	// Returns a reference to the list of extrinsics.
-// 	Extrinsics() []Extrinsic
-// 	// Split the block into header and list of extrinsics.
-// 	Deconstruct() (header Header[N, H], extrinsics []Extrinsic)
-// 	// Returns the hash of the block.
-// 	Hash() H
-// }
-
-// // Something that acts like an `Extrinsic`.
-// type Extrinsic interface {
-// 	// Is this `Extrinsic` signed?
-// 	// If no information are available about signed/unsigned, `None` should be returned.
-// 	IsSigned() *bool
-// }


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- rename `decodeAndVerifyFinalizes` to `DecodeGrandpaJustificationVerifyFinalizes` which makes it public
- also make `HashNumber` public 

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
contributes to #3468