### PR TITLE
fix(runtime): add child prefix check

### DIFF
--- a/lib/runtime/storage/trie.go
+++ b/lib/runtime/storage/trie.go
@@ -18,8 +18,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var childStorageKeyPrefix = []byte(":child_storage:")
-
 // TrieState relies on `storageDiff` to perform changes over the current state.
 // It has support for transactions using "nested" storageDiff changes
 // If the execution of the call is successful, the changes will be applied to
@@ -208,19 +206,10 @@ func (t *TrieState) NextKey(key []byte) []byte {
 	return t.state.NextKey(key)
 }
 
-// Check if the given prefix starts with the child storage key prefix
-func startsWithChildStorageKey(prefix []byte) bool {
-	return bytes.HasPrefix(prefix, childStorageKeyPrefix)
-}
-
 // ClearPrefix deletes all key-value pairs from the trie where the key starts with the given prefix
 func (t *TrieState) ClearPrefix(prefix []byte) error {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-
-	if startsWithChildStorageKey(prefix) {
-		return fmt.Errorf("cannot clear prefix that is part of or contains a child storage key")
-	}
 
 	if currentTx := t.getCurrentTransaction(); currentTx != nil {
 		keysOnState := make([]string, 0)
@@ -242,10 +231,6 @@ func (t *TrieState) ClearPrefixLimit(prefix []byte, limit uint32) (
 	deleted uint32, allDeleted bool, err error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
-
-	if startsWithChildStorageKey(prefix) {
-		return deleted, allDeleted, fmt.Errorf("cannot clear prefix that is part of or contains a child storage key")
-	}
 
 	if currentTx := t.getCurrentTransaction(); currentTx != nil {
 		keysOnState := make([]string, 0)


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- When clearing a prefix from storage, first do a check to make sure the prefix does not contain the child prefix

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
closes #4142 

<!-- Write the issue number(s), for example: #123 -->