### PR TITLE
fix(lib/runtime): Remove duplicate keys from storageDiff.clearPrefix

### DIFF
--- a/lib/runtime/storage/storagediff.go
+++ b/lib/runtime/storage/storagediff.go
@@ -143,7 +143,11 @@ func (cs *storageDiff) clearPrefixInChild(keyToChild string, prefix []byte,
 func (cs *storageDiff) clearPrefix(prefix []byte, trieKeys []string, limit int) (deleted uint32, allDeleted bool) {
 	allKeys := slices.Clone(trieKeys)
 	newKeys := maps.Keys(cs.upserts)
-	allKeys = append(allKeys, newKeys...)
+	for _, k := range newKeys {
+		if !slices.Contains(allKeys, k) {
+			allKeys = append(allKeys, k)
+		}
+	}
 
 	deleted = 0
 	sort.Strings(allKeys)

--- a/lib/runtime/storage/storagediff.go
+++ b/lib/runtime/storage/storagediff.go
@@ -141,17 +141,17 @@ func (cs *storageDiff) clearPrefixInChild(keyToChild string, prefix []byte,
 // optional limit. It returns the number of keys deleted and a boolean
 // indicating if all keys with the prefix were removed.
 func (cs *storageDiff) clearPrefix(prefix []byte, trieKeys []string, limit int) (deleted uint32, allDeleted bool) {
-	allKeys := slices.Clone(trieKeys)
 	newKeys := maps.Keys(cs.upserts)
-	for _, k := range newKeys {
-		if !slices.Contains(allKeys, k) {
-			allKeys = append(allKeys, k)
+	keysToClear := newKeys
+	for _, k := range trieKeys {
+		if _, ok := cs.upserts[k]; !ok {
+			keysToClear = append(keysToClear, k)
 		}
 	}
 
 	deleted = 0
-	sort.Strings(allKeys)
-	for _, k := range allKeys {
+	sort.Strings(keysToClear)
+	for _, k := range keysToClear {
 		if limit == 0 {
 			break
 		}
@@ -165,7 +165,7 @@ func (cs *storageDiff) clearPrefix(prefix []byte, trieKeys []string, limit int) 
 		}
 	}
 
-	return deleted, deleted == uint32(len(allKeys))
+	return deleted, deleted == uint32(len(keysToClear))
 }
 
 // getFromChild attempts to retrieve a value associated with a specific key

--- a/lib/runtime/storage/storagediff.go
+++ b/lib/runtime/storage/storagediff.go
@@ -142,7 +142,7 @@ func (cs *storageDiff) clearPrefixInChild(keyToChild string, prefix []byte,
 // indicating if all keys with the prefix were removed.
 func (cs *storageDiff) clearPrefix(prefix []byte, trieKeys []string, limit int) (deleted uint32, allDeleted bool) {
 	newKeys := maps.Keys(cs.upserts)
-	keysToClear := newKeys
+	keysToClear := maps.Keys(cs.upserts)
 	for _, k := range trieKeys {
 		if _, ok := cs.upserts[k]; !ok {
 			keysToClear = append(keysToClear, k)


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Only append keys that are not already in the set

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
#4141 

<!-- Write the issue number(s), for example: #123 -->