### PR TITLE
test(dot/parachain/backing): ensure new lead view doesn't clobber the old view

### DIFF
--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -1018,8 +1018,11 @@ func TestNewLeafDoesNotClobberOld(t *testing.T) {
 	}
 
 	// If the old leaf view is clobbered, the candidate will be ignored and in that case,
-	// overseer should not expect `StatementDistributionMessageShare` and `collatorprotocolmessages.Seconded`
-	// overseer messages.
+	// overseer does not expect `StatementDistributionMessageShare` and `collatorprotocolmessages.Seconded`
+	// overseer messages. So, test will fail.
+	//
+	// But, when the old leaf view is not clobbered, the candidate will be seconded.
+	// so, oversee expects all four overseer messages.
 	overseer.ExpectActions(validate, storeAvailableData, distribute, informSeconded)
 
 	overseer.ReceiveMessage(backing.SecondMessage{

--- a/dot/parachain/overseer/mockable_overseer.go
+++ b/dot/parachain/overseer/mockable_overseer.go
@@ -101,6 +101,10 @@ func (m *MockableOverseer) processMessages() {
 				return
 			}
 		case <-m.ctx.Done():
+			if actionIndex < len(m.actionsForExpectedMessages) {
+				m.t.Errorf("expected %d overseer actions, but got only %d", len(m.actionsForExpectedMessages), actionIndex)
+			}
+
 			if err := m.ctx.Err(); err != nil {
 				m.t.Logf("ctx error: %v\n", err)
 			}


### PR DESCRIPTION
## Changes
test that the new leaf view doesn't clobber the old view when we update active leaves.

- update the active leaves to add relay parent 1.
- again, update the active leaves to add relay parent 2.
- now, we should be able to second a candidate with relay parent 1 if the old view hasn't been clobbered.

<!-- Brief list of functional changes -->

## Tests
```sh
go test ./dot/parachain/... -v -timeout 1m
```

## Issues
Closes #4014 