### PR TITLE
test(dot/parachain/backing): ensure conflicting statments treated as misbehavior

### DIFF
--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -1181,11 +1181,11 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 		}
 
 		require.Equal(t, relayParent, provisionerMessage.RelayParent)
-		misbehvaiorReport, ok := provisionerMessage.ProvisionableData.(parachaintypes.ProvisionableDataMisbehaviorReport)
+		misbehaviorReport, ok := provisionerMessage.ProvisionableData.(parachaintypes.ProvisionableDataMisbehaviorReport)
 		require.True(t, ok)
 
-		require.Equal(t, parachaintypes.ValidatorIndex(2), misbehvaiorReport.ValidatorIndex)
-		doubleVote, ok := misbehvaiorReport.Misbehaviour.(parachaintypes.ValidityDoubleVoteIssuedAndValidity)
+		require.Equal(t, parachaintypes.ValidatorIndex(2), misbehaviorReport.ValidatorIndex)
+		doubleVote, ok := misbehaviorReport.Misbehaviour.(parachaintypes.ValidityDoubleVoteIssuedAndValidity)
 		require.True(t, ok)
 
 		signForSeconded := doubleVote.CommittedCandidateReceiptAndSign.Signature

--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -481,7 +481,7 @@ func TestCandidateReachesQuorum(t *testing.T) {
 		Return(&validationCode, nil)
 	mockRuntime.EXPECT().
 		ParachainHostSessionExecutorParams(gomock.AssignableToTypeOf(parachaintypes.SessionIndex(0))).
-		Return(nil, wazero_runtime.ErrExportFunctionNotFound).Times(1)
+		Return(nil, wazero_runtime.ErrExportFunctionNotFound)
 
 	//mock ImplicitView
 	mockImplicitView.EXPECT().AllAllowedRelayParents().
@@ -673,7 +673,7 @@ func TestValidationFailDoesNotStopSubsystem(t *testing.T) {
 		Return(&validationCode, nil)
 	mockRuntime.EXPECT().
 		ParachainHostSessionExecutorParams(gomock.AssignableToTypeOf(parachaintypes.SessionIndex(0))).
-		Return(nil, wazero_runtime.ErrExportFunctionNotFound).Times(1)
+		Return(nil, wazero_runtime.ErrExportFunctionNotFound)
 
 	//mock ImplicitView
 	mockImplicitView.EXPECT().AllAllowedRelayParents().
@@ -952,7 +952,7 @@ func TestNewLeafDoesNotClobberOld(t *testing.T) {
 		Return(&validationCode, nil)
 	mockRuntime.EXPECT().
 		ParachainHostSessionExecutorParams(gomock.AssignableToTypeOf(parachaintypes.SessionIndex(0))).
-		Return(nil, wazero_runtime.ErrExportFunctionNotFound).Times(1)
+		Return(nil, wazero_runtime.ErrExportFunctionNotFound)
 
 	//mock ImplicitView
 	mockImplicitView.EXPECT().AllAllowedRelayParents().
@@ -1032,5 +1032,191 @@ func TestNewLeafDoesNotClobberOld(t *testing.T) {
 		PoV:                     pov,
 	})
 
+	time.Sleep(1 * time.Second)
+}
+
+// Issuing conflicting statements on the same candidate should be a misbehaviour.
+func TestConflictingStatementIsMisbehavior(t *testing.T) {
+	candidateBacking, overseer := initBackingAndOverseerMock(t)
+	defer stopOverseerAndWaitForCompletion(overseer)
+
+	paraValidators := parachainValidators(t, candidateBacking.Keystore)
+	numOfValidators := uint(len(paraValidators))
+	relayParent := getDummyHash(t, 5)
+	paraID := uint32(1)
+
+	pov := parachaintypes.PoV{BlockData: []byte{1, 2, 3}}
+	povHash, err := pov.Hash()
+	require.NoError(t, err)
+
+	pvd := dummyPVD(t)
+	validationCode := parachaintypes.ValidationCode{1, 2, 3}
+
+	signingContext := signingContext(t)
+
+	ctrl := gomock.NewController(t)
+	mockBlockState := backing.NewMockBlockState(ctrl)
+	mockRuntime := backing.NewMockInstance(ctrl)
+	mockImplicitView := backing.NewMockImplicitView(ctrl)
+
+	candidateBacking.BlockState = mockBlockState
+	candidateBacking.ImplicitView = mockImplicitView
+
+	// mock BlockState methods
+	mockBlockState.EXPECT().GetRuntime(gomock.AssignableToTypeOf(common.Hash{})).
+		Return(mockRuntime, nil).Times(3)
+
+	// mock Runtime Instance methods
+	mockRuntime.EXPECT().ParachainHostAsyncBackingParams().
+		Return(nil, wazero_runtime.ErrExportFunctionNotFound)
+	mockRuntime.EXPECT().ParachainHostSessionIndexForChild().
+		Return(parachaintypes.SessionIndex(1), nil).Times(2)
+	mockRuntime.EXPECT().ParachainHostValidators().
+		Return(paraValidators, nil)
+	mockRuntime.EXPECT().ParachainHostValidatorGroups().
+		Return(validatorGroups(t), nil)
+	mockRuntime.EXPECT().ParachainHostAvailabilityCores().
+		Return(availabilityCores(t), nil)
+	mockRuntime.EXPECT().ParachainHostMinimumBackingVotes().
+		Return(backing.LEGACY_MIN_BACKING_VOTES, nil)
+	mockRuntime.EXPECT().ParachainHostValidationCodeByHash(gomock.AssignableToTypeOf(common.Hash{})).
+		Return(&validationCode, nil)
+	mockRuntime.EXPECT().
+		ParachainHostSessionExecutorParams(gomock.AssignableToTypeOf(parachaintypes.SessionIndex(0))).
+		Return(nil, wazero_runtime.ErrExportFunctionNotFound)
+
+	//mock ImplicitView
+	mockImplicitView.EXPECT().AllAllowedRelayParents().
+		Return([]common.Hash{})
+
+	// to make entry in perRelayParent map
+	overseer.ReceiveMessage(parachaintypes.ActiveLeavesUpdateSignal{
+		Activated: &parachaintypes.ActivatedLeaf{Hash: relayParent, Number: 1},
+	})
+	time.Sleep(500 * time.Millisecond)
+
+	headData := parachaintypes.HeadData{Data: []byte{4, 5, 6}}
+
+	candidate := newCommittedCandidate(
+		t,
+		paraID,
+		headData,
+		povHash,
+		relayParent,
+		makeErasureRoot(t, numOfValidators, pov, pvd),
+		common.Hash{},
+		validationCode,
+	)
+
+	statementSeconded := parachaintypes.NewStatementVDT()
+	err = statementSeconded.SetValue(parachaintypes.Seconded(candidate))
+	require.NoError(t, err)
+
+	statementSecondedSign, err := statementSeconded.Sign(candidateBacking.Keystore, signingContext, paraValidators[2])
+	require.NoError(t, err)
+
+	signedStatementSeconded := parachaintypes.SignedFullStatementWithPVD{
+		SignedFullStatement: parachaintypes.SignedFullStatement{
+			Payload:        statementSeconded,
+			ValidatorIndex: 2,
+			Signature:      *statementSecondedSign,
+		},
+		PersistedValidationData: &pvd,
+	}
+
+	fetchPov := func(msg any) bool {
+		fetch, ok := msg.(parachaintypes.AvailabilityDistributionMessageFetchPoV)
+		if !ok {
+			return false
+		}
+
+		fetch.PovCh <- parachaintypes.OverseerFuncRes[parachaintypes.PoV]{Data: pov}
+		return true
+	}
+
+	validate := validResponseForValidateFromExhaustive(headData, pvd)
+
+	distribute := func(msg any) bool {
+		_, ok := msg.(parachaintypes.StatementDistributionMessageShare)
+		return ok
+	}
+
+	provisionerMessageProvisionableData := func(msg any) bool {
+		_, ok := msg.(parachaintypes.ProvisionerMessageProvisionableData)
+		return ok
+	}
+
+	// set expected actions for overseer messages we send from the subsystem.
+	overseer.ExpectActions(fetchPov, validate, storeAvailableData, distribute, provisionerMessageProvisionableData)
+
+	// receive statement message from overseer to candidate backing subsystem containing `Seconded` statement
+	overseer.ReceiveMessage(backing.StatementMessage{
+		RelayParent:         relayParent,
+		SignedFullStatement: signedStatementSeconded,
+	})
+	time.Sleep(1 * time.Second)
+
+	candidateHash, err := parachaintypes.GetCandidateHash(candidate)
+	require.NoError(t, err)
+
+	statementValid := parachaintypes.NewStatementVDT()
+	err = statementValid.SetValue(parachaintypes.Valid(candidateHash))
+	require.NoError(t, err)
+
+	statementValidSign, err := statementValid.Sign(candidateBacking.Keystore, signingContext, paraValidators[2])
+	require.NoError(t, err)
+
+	signedStatementValid := parachaintypes.SignedFullStatementWithPVD{
+		SignedFullStatement: parachaintypes.SignedFullStatement{
+			Payload:        statementValid,
+			ValidatorIndex: 2,
+			Signature:      *statementValidSign,
+		},
+	}
+
+	reportMisbehavior := func(msg any) bool {
+		provisionerMessage, ok := msg.(parachaintypes.ProvisionerMessageProvisionableData)
+		if !ok {
+			return false
+		}
+
+		require.Equal(t, relayParent, provisionerMessage.RelayParent)
+		misbehvaiorReport, ok := provisionerMessage.ProvisionableData.(parachaintypes.ProvisionableDataMisbehaviorReport)
+		require.True(t, ok)
+
+		require.Equal(t, parachaintypes.ValidatorIndex(2), misbehvaiorReport.ValidatorIndex)
+		doubleVote, ok := misbehvaiorReport.Misbehaviour.(parachaintypes.ValidityDoubleVoteIssuedAndValidity)
+		require.True(t, ok)
+
+		signForSeconded := doubleVote.CommittedCandidateReceiptAndSign.Signature
+		statementSeconded := parachaintypes.NewStatementVDT()
+		err := statementSeconded.SetValue(
+			parachaintypes.Seconded(doubleVote.CommittedCandidateReceiptAndSign.CommittedCandidateReceipt))
+		require.NoError(t, err)
+
+		ok, err = statementSeconded.VerifySignature(paraValidators[2], signingContext, signForSeconded)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		signForValid := doubleVote.CandidateHashAndSign.Signature
+		statementValid := parachaintypes.NewStatementVDT()
+		err = statementValid.SetValue(parachaintypes.Valid(doubleVote.CandidateHashAndSign.CandidateHash))
+		require.NoError(t, err)
+
+		ok, err = statementValid.VerifySignature(paraValidators[2], signingContext, signForValid)
+		require.NoError(t, err)
+		require.True(t, ok)
+
+		return true
+	}
+
+	overseer.ExpectActions(reportMisbehavior)
+
+	// receive statement message from overseer to candidate backing subsystem containing `Valid` statement.
+	// this candidate is already seconded by the same validator So, it is a misbehaviour for conflicting statements.
+	overseer.ReceiveMessage(backing.StatementMessage{
+		RelayParent:         relayParent,
+		SignedFullStatement: signedStatementValid,
+	})
 	time.Sleep(1 * time.Second)
 }

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -91,12 +91,12 @@ func (s *StatementVDT) Sign(
 	signingContext SigningContext,
 	key ValidatorID,
 ) (*ValidatorSignature, error) {
-	statementVDTAndSigningContext := statementVDTAndSigningContext{
+	statementAndSigningCtx := statementVDTAndSigningContext{
 		Statement: *s,
 		Context:   signingContext,
 	}
 
-	encodedData, err := scale.Marshal(statementVDTAndSigningContext)
+	encodedData, err := scale.Marshal(statementAndSigningCtx)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling statement and signing-context: %w", err)
 	}
@@ -123,12 +123,12 @@ func (s *StatementVDT) VerifySignature(
 	signingContext SigningContext,
 	validatorSignature ValidatorSignature,
 ) (bool, error) {
-	statementVDTAndSigningContext := statementVDTAndSigningContext{
+	statementAndSigningCtx := statementVDTAndSigningContext{
 		Statement: *s,
 		Context:   signingContext,
 	}
 
-	encodedMsg, err := scale.Marshal(statementVDTAndSigningContext)
+	encodedMsg, err := scale.Marshal(statementAndSigningCtx)
 	if err != nil {
 		return false, fmt.Errorf("marshalling statement and signing-context: %w", err)
 	}

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -80,22 +80,26 @@ type Seconded CommittedCandidateReceipt
 // Valid represents a statement that a validator has deemed a candidate valid.
 type Valid CandidateHash
 
+// statementVDTAndSigningContext is just a wrapper struct to hold both the statement and the signing context.
+type statementVDTAndSigningContext struct {
+	Statement StatementVDT
+	Context   SigningContext
+}
+
 func (s *StatementVDT) Sign(
 	keystore keystore.Keystore,
 	signingContext SigningContext,
 	key ValidatorID,
 ) (*ValidatorSignature, error) {
-	encodedData, err := scale.Marshal(*s)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling payload: %w", err)
+	statementVDTAndSigningContext := statementVDTAndSigningContext{
+		Statement: *s,
+		Context:   signingContext,
 	}
 
-	encodedSigningContext, err := scale.Marshal(signingContext)
+	encodedData, err := scale.Marshal(statementVDTAndSigningContext)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling signing context: %w", err)
+		return nil, fmt.Errorf("marshalling statement and signing-context: %w", err)
 	}
-
-	encodedData = append(encodedData, encodedSigningContext...)
 
 	validatorPublicKey, err := sr25519.NewPublicKey(key[:])
 	if err != nil {
@@ -119,25 +123,22 @@ func (s *StatementVDT) VerifySignature(
 	signingContext SigningContext,
 	validatorSignature ValidatorSignature,
 ) (bool, error) {
-	encodedMsg, err := scale.Marshal(s)
-	if err != nil {
-		return false, fmt.Errorf("marshalling statementVDT: %w", err)
+	statementVDTAndSigningContext := statementVDTAndSigningContext{
+		Statement: *s,
+		Context:   signingContext,
 	}
 
-	signingContextBytes, err := scale.Marshal(signingContext)
+	encodedMsg, err := scale.Marshal(statementVDTAndSigningContext)
 	if err != nil {
-		return false, fmt.Errorf("marshalling signing context: %w", err)
+		return false, fmt.Errorf("marshalling statement and signing-context: %w", err)
 	}
-
-	encodedMsg = append(encodedMsg, signingContextBytes...)
 
 	publicKey, err := sr25519.NewPublicKey(validator[:])
 	if err != nil {
 		return false, fmt.Errorf("getting public key: %w", err)
 	}
 
-	ok, err := publicKey.Verify(encodedMsg, validatorSignature[:])
-	return ok, err
+	return publicKey.Verify(encodedMsg, validatorSignature[:])
 }
 
 // UncheckedSignedFullStatement is a Variant of `SignedFullStatement` where the signature has not yet been verified.

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -165,14 +165,7 @@ func TestStatementVDT_Sign(t *testing.T) {
 	valSign, err := statement.Sign(ks, signingContext, validatorID)
 	require.NoError(t, err)
 
-	encodedMsg, err := scale.Marshal(statement)
-	require.NoError(t, err)
-
-	signingContextBytes, err := scale.Marshal(signingContext)
-	require.NoError(t, err)
-
-	encodedMsg = append(encodedMsg, signingContextBytes...)
-	ok, err := keyPair.Public().Verify(encodedMsg, valSign[:])
+	ok, err := statement.VerifySignature(validatorID, signingContext, *valSign)
 	require.NoError(t, err)
 	require.True(t, ok)
 }


### PR DESCRIPTION
## Changes
- I have written the test to ensure conflicting statements issued by a validator on the same candidate are treated as misbehaviour.
    - sent statement message with `Seconded` validity statement from overseer to candidate backing.
    - sent another message with a `Valid` validity statement for the same candidate from overseer to candidate backing. But as we have already seconded the statement, it is a misbehaviour.
- Added the method to verify the signature for the issued validity statement.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./dot/parachain/... -v -timeout 1m
```

## Issues
Closes #4006 
<!-- Write the issue number(s), for example: #123 -->