### PR TITLE
refactor(pkg/trie/triedb): Revise `NewValueFromEncoded` to only store a hash instead of prefixed key

### DIFF
--- a/pkg/trie/triedb/node.go
+++ b/pkg/trie/triedb/node.go
@@ -111,13 +111,12 @@ func NewValue(data []byte, threshold int) nodeValue {
 	return inline(data)
 }
 
-func NewValueFromEncoded(prefix []byte, encodedValue codec.EncodedValue) nodeValue {
+func NewValueFromEncoded(encodedValue codec.EncodedValue) nodeValue {
 	switch v := encodedValue.(type) {
 	case codec.InlineValue:
 		return inline(v)
 	case codec.HashedValue:
-		prefixedKey := bytes.Join([][]byte{prefix, v[:]}, nil)
-		return valueRef(common.NewHash(prefixedKey))
+		return valueRef(v)
 	}
 
 	return nil
@@ -178,7 +177,7 @@ func newNodeFromEncoded(nodeHash common.Hash, data []byte, storage nodeStorage) 
 	case codec.Empty:
 		return Empty{}, nil
 	case codec.Leaf:
-		return Leaf{partialKey: encoded.PartialKey, value: NewValueFromEncoded(encoded.PartialKey, encoded.Value)}, nil
+		return Leaf{partialKey: encoded.PartialKey, value: NewValueFromEncoded(encoded.Value)}, nil
 	case codec.Branch:
 		key := encoded.PartialKey
 		encodedChildren := encoded.Children
@@ -204,7 +203,7 @@ func newNodeFromEncoded(nodeHash common.Hash, data []byte, storage nodeStorage) 
 			children[i] = child
 		}
 
-		return Branch{partialKey: key, children: children, value: NewValueFromEncoded(encoded.PartialKey, value)}, nil
+		return Branch{partialKey: key, children: children, value: NewValueFromEncoded(value)}, nil
 	default:
 		panic("unreachable")
 	}


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Changes `NewValueFromEncoded` to store a hash instead of a prefixed key
- Changes `deathRow` from `map[common.Hash]any` to `map[string]any` since the deathRow could contain prefixed keys to be removed in `TrieDB.commit`.
- Changes `TrieDB.replaceOldValue` to populate death row with prefixed key.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
- contributes to #4157 

<!-- Write the issue number(s), for example: #123 -->