### PR TITLE
 (dot/parachain): handle view update message for receiver side of the network bridge

### DIFF
--- a/dot/parachain/network-bridge/collation_protocol_message.go
+++ b/dot/parachain/network-bridge/collation_protocol_message.go
@@ -10,25 +10,12 @@ import (
 
 func decodeCollationMessage(in []byte) (network.NotificationsMessage, error) {
 	wireMessage := WireMessage{}
-	// err := wireMessage.SetValue(collatorprotocolmessages.CollationProtocol{})
-	// if err != nil {
-	// 	return nil, fmt.Errorf("setting collation protocol message: %w", err)
-	// }
 	err := scale.Unmarshal(in, &wireMessage)
 	if err != nil {
 		return nil, fmt.Errorf("decoding message: %w", err)
 	}
 
 	wireMessage.SetType(network.CollationMsgType)
-	// collationMessageV, err := wireMessage.Value()
-	// if err != nil {
-	// 	return nil, fmt.Errorf("getting collation protocol message value: %w", err)
-	// }
-	// collationMessage, ok := collationMessageV.(collatorprotocolmessages.CollationProtocol)
-	// if !ok {
-	// 	return nil, fmt.Errorf("casting to collation protocol message")
-	// }
-	// return &collationMessage, nil
 	return wireMessage, nil
 }
 

--- a/dot/parachain/network-bridge/collation_protocol_message.go
+++ b/dot/parachain/network-bridge/collation_protocol_message.go
@@ -4,31 +4,32 @@ import (
 	"fmt"
 
 	"github.com/ChainSafe/gossamer/dot/network"
-	collatorprotocolmessages "github.com/ChainSafe/gossamer/dot/parachain/collator-protocol/messages"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 func decodeCollationMessage(in []byte) (network.NotificationsMessage, error) {
 	wireMessage := WireMessage{}
-	err := wireMessage.SetValue(collatorprotocolmessages.CollationProtocol{})
-	if err != nil {
-		return nil, fmt.Errorf("setting collation protocol message: %w", err)
-	}
-	err = scale.Unmarshal(in, &wireMessage)
+	// err := wireMessage.SetValue(collatorprotocolmessages.CollationProtocol{})
+	// if err != nil {
+	// 	return nil, fmt.Errorf("setting collation protocol message: %w", err)
+	// }
+	err := scale.Unmarshal(in, &wireMessage)
 	if err != nil {
 		return nil, fmt.Errorf("decoding message: %w", err)
 	}
 
-	collationMessageV, err := wireMessage.Value()
-	if err != nil {
-		return nil, fmt.Errorf("getting collation protocol message value: %w", err)
-	}
-	collationMessage, ok := collationMessageV.(collatorprotocolmessages.CollationProtocol)
-	if !ok {
-		return nil, fmt.Errorf("casting to collation protocol message")
-	}
-	return &collationMessage, nil
+	wireMessage.SetType(network.CollationMsgType)
+	// collationMessageV, err := wireMessage.Value()
+	// if err != nil {
+	// 	return nil, fmt.Errorf("getting collation protocol message value: %w", err)
+	// }
+	// collationMessage, ok := collationMessageV.(collatorprotocolmessages.CollationProtocol)
+	// if !ok {
+	// 	return nil, fmt.Errorf("casting to collation protocol message")
+	// }
+	// return &collationMessage, nil
+	return wireMessage, nil
 }
 
 func getCollatorHandshake() (network.Handshake, error) {

--- a/dot/parachain/network-bridge/events/events.go
+++ b/dot/parachain/network-bridge/events/events.go
@@ -60,6 +60,20 @@ type View struct {
 	FinalizedNumber uint32
 }
 
+func (v View) Equals(v2 View) bool {
+	if v.FinalizedNumber != v.FinalizedNumber {
+		return false
+	}
+
+	for i, head := range v.Heads {
+		if head != v2.Heads[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 type OurViewChange struct {
 	View View
 }

--- a/dot/parachain/network-bridge/events/events.go
+++ b/dot/parachain/network-bridge/events/events.go
@@ -60,20 +60,6 @@ type View struct {
 	FinalizedNumber uint32
 }
 
-func (v View) Equals(v2 View) bool {
-	if v.FinalizedNumber != v.FinalizedNumber {
-		return false
-	}
-
-	for i, head := range v.Heads {
-		if head != v2.Heads[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 type OurViewChange struct {
 	View View
 }

--- a/dot/parachain/network-bridge/wire_message.go
+++ b/dot/parachain/network-bridge/wire_message.go
@@ -70,6 +70,7 @@ func (mvdt WireMessage) ValueAt(index uint) (value any, err error) {
 }
 
 func (w *WireMessage) SetType(messageType network.MessageType) {
+	// NOTE: We need a message type only to know where to send it
 	w.messageType = messageType
 }
 


### PR DESCRIPTION
## Changes

Over the network through collation and validation protocol, as part of WireMessage we could get a PeerMessage or a ViewUpdate.

ViewUpdate tells us about latest blocks (heads) and finalized number with our peers.

We are supposed to be update our peer data with these views.

This PR, reads ViewUpdate from both collation and validation protocol and handles them inside network bridge by updating our peer data. Later, it sends that view to other subsystems so that each subsystem can update their view too.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
Fixes #3864

<!-- Write the issue number(s), for example: #123 -->