### PR TITLE
fix(cli): update default min-peers value to 5 to match documentation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ const (
 	// DefaultDiscoveryInterval is the default discovery interval
 	DefaultDiscoveryInterval = 10 * time.Second
 	// DefaultMinPeers is the default minimum number of peers
-	DefaultMinPeers = 0
+	DefaultMinPeers = 5
 	// DefaultMaxPeers is the default maximum number of peers
 	DefaultMaxPeers = 50
 


### PR DESCRIPTION
## Changes

- Updated the default value of the `--min-peers` flag to 5 in the code to align with the documented default.
- Ensured consistency between the CLI documentation and actual implementation.

## Tests

To verify the changes, you can run the integration tests:

```sh
go test -tags integration github.com/ChainSafe/gossamer

## Issues

Fixes: #4252