### PR TITLE
feat(dot/sync): improve worker pool

### DIFF
--- a/dot/sync/configuration.go
+++ b/dot/sync/configuration.go
@@ -17,7 +17,7 @@ func WithStrategies(currentStrategy, defaultStrategy Strategy) ServiceConfig {
 func WithNetwork(net Network) ServiceConfig {
 	return func(svc *SyncService) {
 		svc.network = net
-		svc.workerPool = newSyncWorkerPool(net)
+		//svc.workerPool = newSyncWorkerPool(net)
 	}
 }
 

--- a/dot/sync/configuration.go
+++ b/dot/sync/configuration.go
@@ -13,17 +13,6 @@ func WithStrategies(currentStrategy, defaultStrategy Strategy) ServiceConfig {
 	return func(svc *SyncService) {
 		svc.currentStrategy = currentStrategy
 		svc.defaultStrategy = defaultStrategy
-
-		wpCapacity := currentStrategy.NumOfTasks()
-		if defaultStrategy != nil {
-			wpCapacity = max(currentStrategy.NumOfTasks(), defaultStrategy.NumOfTasks())
-		}
-		wpCapacity *= 2 // add some buffer
-
-		svc.workerPool = NewWorkerPool(WorkerPoolConfig{
-			Capacity:   wpCapacity,
-			MaxRetries: UnlimitedRetries,
-		})
 	}
 }
 

--- a/dot/sync/configuration.go
+++ b/dot/sync/configuration.go
@@ -21,8 +21,8 @@ func WithStrategies(currentStrategy, defaultStrategy Strategy) ServiceConfig {
 		wpCapacity *= 2 // add some buffer
 
 		svc.workerPool = NewWorkerPool(WorkerPoolConfig{
-			MaxRetries: maxTaskRetries,
 			Capacity:   wpCapacity,
+			MaxRetries: UnlimitedRetries,
 		})
 	}
 }

--- a/dot/sync/fullsync.go
+++ b/dot/sync/fullsync.go
@@ -65,7 +65,7 @@ func (s *syncTask) ID() TaskID {
 }
 
 func (s *syncTask) String() string {
-	return fmt.Sprintf("%s %s", s.id, s.request.String())
+	return fmt.Sprintf("%s %s", s.ID(), s.request.String())
 }
 
 func (s *syncTask) Do(p peer.ID) (Result, error) {

--- a/dot/sync/fullsync.go
+++ b/dot/sync/fullsync.go
@@ -180,9 +180,8 @@ func (f *FullSyncStrategy) Process(results <-chan TaskResult) (
 	}
 
 	// This is safe as long as we are the only goroutine reading from the channel.
-	for len(results) > 0 {
+	for result := range results {
 		readyBlocks := make([][]*types.BlockData, 0)
-		result := <-results
 		repChange, ignorePeer, validResp := validateResult(result, f.badBlocks)
 
 		if repChange != nil {
@@ -440,9 +439,9 @@ type RequestResponseData struct {
 func validateResult(result TaskResult, badBlocks []string) (repChange *Change,
 	blockPeer bool, validRes *RequestResponseData) {
 
-	if !result.Completed {
-		return
-	}
+	//if !result.Completed {
+	//	return
+	//}
 
 	task, ok := result.Task.(*syncTask)
 	if !ok {

--- a/dot/sync/fullsync.go
+++ b/dot/sync/fullsync.go
@@ -428,6 +428,10 @@ func (f *FullSyncStrategy) IsSynced() bool {
 	return uint32(highestBlock)+messages.MaxBlocksInResponse >= f.peers.getTarget() //nolint:gosec
 }
 
+func (f *FullSyncStrategy) NumOfTasks() int {
+	return f.numOfTasks
+}
+
 type RequestResponseData struct {
 	req          *messages.BlockRequestMessage
 	responseData []*types.BlockData

--- a/dot/sync/fullsync.go
+++ b/dot/sync/fullsync.go
@@ -48,6 +48,21 @@ type importer interface {
 	importBlock(*types.BlockData, BlockOrigin) (imported bool, err error)
 }
 
+type syncTask struct {
+	requestMaker network.RequestMaker
+	request      messages.P2PMessage
+}
+
+func (s *syncTask) ID() TaskID {
+	return TaskID(s.request.String())
+}
+
+func (s *syncTask) Do(p peer.ID) (Result, error) {
+	response := messages.BlockResponseMessage{}
+	err := s.requestMaker.Do(p, s.request, &response)
+	return &response, err
+}
+
 // FullSyncStrategy protocol is the "default" protocol.
 // Full sync works by listening to announced blocks and requesting the blocks
 // from the announcing peers.

--- a/dot/sync/fullsync.go
+++ b/dot/sync/fullsync.go
@@ -53,7 +53,7 @@ type importer interface {
 type syncTask struct {
 	id           TaskID
 	requestMaker network.RequestMaker
-	request      messages.P2PMessage
+	request      *messages.BlockRequestMessage
 }
 
 func (s *syncTask) ID() TaskID {
@@ -446,7 +446,7 @@ func validateResult(result TaskResult, badBlocks []string) (repChange *Change,
 		return
 	}
 
-	request := task.request.(*messages.BlockRequestMessage)
+	request := task.request
 	response := result.Result.(*messages.BlockResponseMessage)
 	if request.Direction == messages.Descending {
 		// reverse blocks before pre-validating and placing in ready queue

--- a/dot/sync/fullsync.go
+++ b/dot/sync/fullsync.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/ChainSafe/gossamer/dot/network"
 	"github.com/ChainSafe/gossamer/dot/network/messages"
 	"github.com/ChainSafe/gossamer/dot/peerset"
@@ -49,12 +51,21 @@ type importer interface {
 }
 
 type syncTask struct {
+	id           TaskID
 	requestMaker network.RequestMaker
 	request      messages.P2PMessage
 }
 
 func (s *syncTask) ID() TaskID {
-	return TaskID(s.request.String())
+	if s.id == "" {
+		id := uuid.New()
+		s.id = TaskID(id.String())
+	}
+	return s.id
+}
+
+func (s *syncTask) String() string {
+	return fmt.Sprintf("%s %s", s.id, s.request.String())
 }
 
 func (s *syncTask) Do(p peer.ID) (Result, error) {

--- a/dot/sync/fullsync_test.go
+++ b/dot/sync/fullsync_test.go
@@ -205,8 +205,7 @@ func TestFullSyncProcess(t *testing.T) {
 						messages.BootstrapRequestData, messages.Ascending),
 					requestMaker: requestMaker,
 				},
-				Completed: true,
-				Result:    fstTaskBlockResponse,
+				Result: fstTaskBlockResponse,
 			},
 			// there is gap from 11 -> 128
 			// second task
@@ -218,8 +217,7 @@ func TestFullSyncProcess(t *testing.T) {
 						messages.BootstrapRequestData, messages.Ascending),
 					requestMaker: requestMaker,
 				},
-				Completed: true,
-				Result:    sndTaskBlockResponse,
+				Result: sndTaskBlockResponse,
 			},
 		}
 
@@ -292,8 +290,7 @@ func TestFullSyncProcess(t *testing.T) {
 				request:      expectedAncestorRequest,
 				requestMaker: requestMaker,
 			},
-			Completed: true,
-			Result:    ancestorSearchResponse,
+			Result: ancestorSearchResponse,
 		}
 
 		done, _, _, err = fs.Process(results)

--- a/dot/sync/fullsync_test.go
+++ b/dot/sync/fullsync_test.go
@@ -70,7 +70,7 @@ func TestFullSyncNextActions(t *testing.T) {
 		task, err := fs.NextActions()
 		require.NoError(t, err)
 
-		request := task[0].(*syncTask).request.(*messages.BlockRequestMessage)
+		request := task[0].(*syncTask).request
 		require.Equal(t, uint(1), request.StartingBlock.RawValue())
 		require.Equal(t, uint32(128), *request.Max)
 	})

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -93,6 +93,7 @@ type Strategy interface {
 	Process(results <-chan TaskResult) (done bool, repChanges []Change, blocks []peer.ID, err error)
 	ShowMetrics()
 	IsSynced() bool
+	NumOfTasks() int
 }
 
 type SyncService struct {
@@ -120,11 +121,7 @@ func NewSyncService(cfgs ...ServiceConfig) *SyncService {
 		waitPeersDuration:     waitPeersDefaultTimeout,
 		stopCh:                make(chan struct{}),
 		seenBlockSyncRequests: lrucache.NewLRUCache[common.Hash, uint](100),
-		workerPool: NewWorkerPool(WorkerPoolConfig{
-			MaxRetries: maxTaskRetries,
-			// TODO: This should depend on the actual configuration of the currently used sync strategy.
-			Capacity: defaultNumOfTasks * 10,
-		}),
+		workerPool:            nil,
 	}
 
 	for _, cfg := range cfgs {

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ChainSafe/gossamer/dot/network"
-	"github.com/ChainSafe/gossamer/dot/network/messages"
 	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/internal/log"
@@ -93,21 +92,6 @@ type Strategy interface {
 	Process(results <-chan TaskResult) (done bool, repChanges []Change, blocks []peer.ID, err error)
 	ShowMetrics()
 	IsSynced() bool
-}
-
-type syncTask struct {
-	requestMaker network.RequestMaker
-	request      messages.P2PMessage
-}
-
-func (s *syncTask) ID() TaskID {
-	return TaskID(s.request.String())
-}
-
-func (s *syncTask) Do(p peer.ID) (Result, error) {
-	response := messages.BlockResponseMessage{}
-	err := s.requestMaker.Do(p, s.request, &response)
-	return &response, err
 }
 
 type SyncService struct {

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ChainSafe/gossamer/dot/network"
+	"github.com/ChainSafe/gossamer/dot/network/messages"
 	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/internal/log"
@@ -88,10 +89,25 @@ type Change struct {
 type Strategy interface {
 	OnBlockAnnounce(from peer.ID, msg *network.BlockAnnounceMessage) (repChange *Change, err error)
 	OnBlockAnnounceHandshake(from peer.ID, msg *network.BlockAnnounceHandshake) error
-	NextActions() ([]*SyncTask, error)
-	Process(results []*SyncTaskResult) (done bool, repChanges []Change, blocks []peer.ID, err error)
+	NextActions() ([]Task, error)
+	Process(results <-chan TaskResult) (done bool, repChanges []Change, blocks []peer.ID, err error)
 	ShowMetrics()
 	IsSynced() bool
+}
+
+type syncTask struct {
+	requestMaker network.RequestMaker
+	request      messages.P2PMessage
+}
+
+func (s *syncTask) ID() TaskID {
+	return TaskID(s.request.String())
+}
+
+func (s *syncTask) Do(p peer.ID) (Result, error) {
+	response := messages.BlockResponseMessage{}
+	err := s.requestMaker.Do(p, s.request, &response)
+	return &response, err
 }
 
 type SyncService struct {
@@ -103,7 +119,7 @@ type SyncService struct {
 	currentStrategy Strategy
 	defaultStrategy Strategy
 
-	workerPool        *syncWorkerPool
+	workerPool        WorkerPool
 	waitPeersDuration time.Duration
 	minPeers          int
 	slotDuration      time.Duration
@@ -119,6 +135,11 @@ func NewSyncService(cfgs ...ServiceConfig) *SyncService {
 		waitPeersDuration:     waitPeersDefaultTimeout,
 		stopCh:                make(chan struct{}),
 		seenBlockSyncRequests: lrucache.NewLRUCache[common.Hash, uint](100),
+		workerPool: NewWorkerPool(WorkerPoolConfig{
+			MaxRetries: 5,
+			// TODO: This should depend on the actual configuration of the currently used sync strategy.
+			Capacity: defaultNumOfTasks * 10,
+		}),
 	}
 
 	for _, cfg := range cfgs {
@@ -135,7 +156,7 @@ func (s *SyncService) waitWorkers() {
 	}
 
 	for {
-		total := s.workerPool.totalWorkers()
+		total := s.workerPool.NumPeers()
 		if total >= s.minPeers {
 			return
 		}
@@ -164,6 +185,7 @@ func (s *SyncService) Start() error {
 }
 
 func (s *SyncService) Stop() error {
+	s.workerPool.Shutdown()
 	close(s.stopCh)
 	s.wg.Wait()
 	return nil
@@ -171,7 +193,9 @@ func (s *SyncService) Stop() error {
 
 func (s *SyncService) HandleBlockAnnounceHandshake(from peer.ID, msg *network.BlockAnnounceHandshake) error {
 	logger.Infof("receiving a block announce handshake from %s", from.String())
-	if err := s.workerPool.fromBlockAnnounceHandshake(from); err != nil {
+	logger.Infof("len(s.workerPool.Results())=%d", len(s.workerPool.Results())) // TODO: remove
+	if err := s.workerPool.AddPeer(from); err != nil {
+		logger.Warnf("failed to add peer to worker pool: %s", err)
 		return err
 	}
 
@@ -199,7 +223,7 @@ func (s *SyncService) HandleBlockAnnounce(from peer.ID, msg *network.BlockAnnoun
 
 func (s *SyncService) OnConnectionClosed(who peer.ID) {
 	logger.Tracef("removing peer worker: %s", who.String())
-	s.workerPool.removeWorker(who)
+	s.workerPool.RemovePeer(who)
 }
 
 func (s *SyncService) IsSynced() bool {
@@ -249,19 +273,20 @@ func (s *SyncService) runStrategy() {
 
 	finalisedHeader, err := s.blockState.GetHighestFinalisedHeader()
 	if err != nil {
-		logger.Criticalf("getting highest finalized header: %w", err)
+		logger.Criticalf("getting highest finalized header: %s", err)
 		return
 	}
 
 	bestBlockHeader, err := s.blockState.BestBlockHeader()
 	if err != nil {
-		logger.Criticalf("getting best block header: %w", err)
+		logger.Criticalf("getting best block header: %s", err)
 		return
 	}
 
 	logger.Infof(
-		"🚣 currently syncing, %d peers connected, finalized #%d (%s), best #%d (%s)",
+		"🚣 currently syncing, %d peers connected, %d peers in the worker pool, finalized #%d (%s), best #%d (%s)",
 		len(s.network.AllConnectedPeersIDs()),
+		s.workerPool.NumPeers(),
 		finalisedHeader.Number,
 		finalisedHeader.Hash().Short(),
 		bestBlockHeader.Number,
@@ -279,8 +304,13 @@ func (s *SyncService) runStrategy() {
 		return
 	}
 
-	results := s.workerPool.submitRequests(tasks)
-	done, repChanges, peersToIgnore, err := s.currentStrategy.Process(results)
+	_, err = s.workerPool.SubmitBatch(tasks)
+	if err != nil {
+		logger.Criticalf("current sync strategy next actions failed with: %s", err.Error())
+		return
+	}
+
+	done, repChanges, peersToIgnore, err := s.currentStrategy.Process(s.workerPool.Results())
 	if err != nil {
 		logger.Criticalf("current sync strategy failed with: %s", err.Error())
 		return
@@ -291,7 +321,7 @@ func (s *SyncService) runStrategy() {
 	}
 
 	for _, block := range peersToIgnore {
-		s.workerPool.ignorePeerAsWorker(block)
+		s.workerPool.IgnorePeer(block)
 	}
 
 	s.currentStrategy.ShowMetrics()

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -287,11 +287,7 @@ func (s *SyncService) runStrategy() {
 			return
 		}
 
-		_, err = s.workerPool.SubmitBatch(tasks)
-		if err != nil {
-			logger.Criticalf("current sync strategy next actions failed with: %s", err.Error())
-			return
-		}
+		_ = s.workerPool.SubmitBatch(tasks)
 	}
 
 	done, repChanges, peersToIgnore, err := s.currentStrategy.Process(s.workerPool.Results())

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -275,21 +275,23 @@ func (s *SyncService) runStrategy() {
 		bestBlockHeader.Hash().Short(),
 	)
 
-	tasks, err := s.currentStrategy.NextActions()
-	if err != nil {
-		logger.Criticalf("current sync strategy next actions failed with: %s", err.Error())
-		return
-	}
+	if s.workerPool.Capacity() > s.currentStrategy.NumOfTasks() {
+		tasks, err := s.currentStrategy.NextActions()
+		if err != nil {
+			logger.Criticalf("current sync strategy next actions failed with: %s", err.Error())
+			return
+		}
 
-	logger.Tracef("amount of tasks to process: %d", len(tasks))
-	if len(tasks) == 0 {
-		return
-	}
+		logger.Tracef("amount of tasks to process: %d", len(tasks))
+		if len(tasks) == 0 {
+			return
+		}
 
-	_, err = s.workerPool.SubmitBatch(tasks)
-	if err != nil {
-		logger.Criticalf("current sync strategy next actions failed with: %s", err.Error())
-		return
+		_, err = s.workerPool.SubmitBatch(tasks)
+		if err != nil {
+			logger.Criticalf("current sync strategy next actions failed with: %s", err.Error())
+			return
+		}
 	}
 
 	done, repChanges, peersToIgnore, err := s.currentStrategy.Process(s.workerPool.Results())

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -24,6 +24,7 @@ import (
 const (
 	waitPeersDefaultTimeout = 10 * time.Second
 	minPeersDefault         = 1
+	maxTaskRetries          = 5
 )
 
 var (
@@ -120,7 +121,7 @@ func NewSyncService(cfgs ...ServiceConfig) *SyncService {
 		stopCh:                make(chan struct{}),
 		seenBlockSyncRequests: lrucache.NewLRUCache[common.Hash, uint](100),
 		workerPool: NewWorkerPool(WorkerPoolConfig{
-			MaxRetries: 5,
+			MaxRetries: maxTaskRetries,
 			// TODO: This should depend on the actual configuration of the currently used sync strategy.
 			Capacity: defaultNumOfTasks * 10,
 		}),

--- a/dot/sync/worker_pool.go
+++ b/dot/sync/worker_pool.go
@@ -71,7 +71,7 @@ func (bs BatchStatus) Completed(todo int) bool {
 type BatchID string
 
 type WorkerPool interface {
-	SubmitBatch(tasks []Task) (id BatchID, err error)
+	SubmitBatch(tasks []Task) BatchID
 	GetBatch(id BatchID) (status BatchStatus, ok bool)
 	Results() chan TaskResult
 	Capacity() int
@@ -120,7 +120,7 @@ type workerPool struct {
 
 // SubmitBatch accepts a list of tasks and immediately returns a batch ID. The batch ID can be used to query the status
 // of the batch using [GetBatchStatus].
-func (w *workerPool) SubmitBatch(tasks []Task) (id BatchID, err error) {
+func (w *workerPool) SubmitBatch(tasks []Task) BatchID {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
 
@@ -137,7 +137,7 @@ func (w *workerPool) SubmitBatch(tasks []Task) (id BatchID, err error) {
 		w.executeBatch(tasks, bID)
 	}()
 
-	return bID, nil
+	return bID
 }
 
 // GetBatch returns the status of a batch previously submitted using [SubmitBatch].

--- a/dot/sync/worker_pool.go
+++ b/dot/sync/worker_pool.go
@@ -74,6 +74,7 @@ type WorkerPool interface {
 	SubmitBatch(tasks []Task) (id BatchID, err error)
 	GetBatch(id BatchID) (status BatchStatus, ok bool)
 	Results() chan TaskResult
+	Capacity() int
 	AddPeer(p peer.ID) error
 	RemovePeer(p peer.ID)
 	IgnorePeer(p peer.ID)
@@ -119,10 +120,6 @@ type workerPool struct {
 
 // SubmitBatch accepts a list of tasks and immediately returns a batch ID. The batch ID can be used to query the status
 // of the batch using [GetBatchStatus].
-// TODO
-// If tasks are submitted faster than they are completed, resChan will run full, blocking the calling goroutine.
-// Ideally this method would provide backpressure to the caller in that case. The rejected tasks should then stay in
-// FullSyncStrategy.requestQueue until the next round. But this would need to be supported in all sync strategies.
 func (w *workerPool) SubmitBatch(tasks []Task) (id BatchID, err error) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
@@ -155,6 +152,13 @@ func (w *workerPool) GetBatch(id BatchID) (status BatchStatus, ok bool) {
 // Results returns a channel that can be used to receive the results of completed tasks.
 func (w *workerPool) Results() chan TaskResult {
 	return w.resChan
+}
+
+// Capacity returns the number of tasks the worker pool can currently accept.
+func (w *workerPool) Capacity() int {
+	w.mtx.RLock()
+	defer w.mtx.RUnlock()
+	return cap(w.resChan) - len(w.resChan)
 }
 
 // AddPeer adds a peer to the worker pool unless it has been ignored previously.

--- a/dot/sync/worker_pool.go
+++ b/dot/sync/worker_pool.go
@@ -35,7 +35,7 @@ type TaskResult struct {
 	Completed bool
 	Result    Result
 	Error     error
-	Retries   uint
+	Retries   int
 	Who       peer.ID
 }
 
@@ -82,15 +82,15 @@ type WorkerPool interface {
 }
 
 type WorkerPoolConfig struct {
-	Capacity   uint
-	MaxRetries uint
+	Capacity   int
+	MaxRetries int
 }
 
 // NewWorkerPool creates a new worker pool with the given configuration.
 func NewWorkerPool(cfg WorkerPoolConfig) WorkerPool {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	if cfg.Capacity == 0 {
+	if cfg.Capacity <= 0 {
 		cfg.Capacity = defaultWorkerPoolCapacity
 	}
 
@@ -108,7 +108,7 @@ type workerPool struct {
 	mtx sync.RWMutex
 	wg  sync.WaitGroup
 
-	maxRetries   uint
+	maxRetries   int
 	peers        list.List
 	ignoredPeers map[peer.ID]struct{}
 	statuses     map[BatchID]BatchStatus

--- a/dot/sync/worker_pool.go
+++ b/dot/sync/worker_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+const UnlimitedRetries = -1
 const defaultWorkerPoolCapacity = 100
 
 var (
@@ -334,7 +335,7 @@ func (w *workerPool) handleFailedTask(tr TaskResult, batchID BatchID, batchResul
 			// TODO Should we sleep a bit to wait for peers?
 		} else {
 			tr.Retries = oldTr.Retries + 1
-			tr.Completed = tr.Retries >= w.maxRetries
+			tr.Completed = w.maxRetries != UnlimitedRetries && tr.Retries >= w.maxRetries
 		}
 	}
 

--- a/dot/sync/worker_pool.go
+++ b/dot/sync/worker_pool.go
@@ -27,6 +27,7 @@ type Result any
 type Task interface {
 	ID() TaskID
 	Do(p peer.ID) (Result, error)
+	String() string
 }
 
 type TaskResult struct {
@@ -239,24 +240,24 @@ func (w *workerPool) executeBatch(tasks []Task, bID BatchID) {
 
 func (w *workerPool) executeTask(task Task, ch chan TaskResult) {
 	if errors.Is(w.ctx.Err(), context.Canceled) {
-		logger.Tracef("[CANCELED] task=%s, shutting down", task.ID())
+		logger.Tracef("[CANCELED] task=%s, shutting down", task.String())
 		return
 	}
 
 	who, err := w.reservePeer()
 	if errors.Is(err, ErrNoPeers) {
-		logger.Tracef("no peers available for task=%s", task.ID())
+		logger.Tracef("no peers available for task=%s", task.String())
 		ch <- TaskResult{Task: task, Error: ErrNoPeers}
 		return
 	}
 
-	logger.Infof("[EXECUTING] task=%s", task.ID())
+	logger.Infof("[EXECUTING] task=%s", task.String())
 
 	result, err := task.Do(who)
 	if err != nil {
-		logger.Tracef("[FAILED] task=%s peer=%s, err=%s", task.ID(), who, err.Error())
+		logger.Tracef("[FAILED] task=%s peer=%s, err=%s", task.String(), who, err.Error())
 	} else {
-		logger.Tracef("[FINISHED] task=%s peer=%s", task.ID(), who)
+		logger.Tracef("[FINISHED] task=%s peer=%s", task.String(), who)
 	}
 
 	w.mtx.Lock()

--- a/dot/sync/worker_pool_test.go
+++ b/dot/sync/worker_pool_test.go
@@ -3,257 +3,270 @@
 
 package sync
 
-import (
-	"errors"
-	"fmt"
-	"testing"
-	"time"
-
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/assert"
-)
-
-type mockTask struct {
-	id           TaskID
-	err          error
-	execCount    uint
-	succeedAfter uint
-}
-
-func (m *mockTask) ID() TaskID {
-	return m.id
-}
-
-func (m *mockTask) Do(p peer.ID) (Result, error) {
-	time.Sleep(time.Millisecond * 100) // simulate network roundtrip
-	defer func() {
-		m.execCount++
-	}()
-
-	res := Result(fmt.Sprintf("%s - %s great success!", m.id, p))
-	if m.err != nil {
-		if m.succeedAfter > 0 && m.execCount >= m.succeedAfter {
-			return res, nil
-		}
-		return nil, m.err
-	}
-	return res, nil
-}
-
-func (m *mockTask) String() string {
-	return fmt.Sprintf("mockTask %s", m.id)
-}
-
-func makeTasksAndPeers(num, idOffset int) ([]Task, []peer.ID) {
-	tasks := make([]Task, num)
-	peers := make([]peer.ID, num)
-
-	for i := 0; i < num; i++ {
-		tasks[i] = &mockTask{id: TaskID(fmt.Sprintf("t-%d", i+idOffset))}
-		peers[i] = peer.ID(fmt.Sprintf("p-%d", i+idOffset))
-	}
-	return tasks, peers
-}
-
-func waitForCompletion(wp WorkerPool, numTasks int) {
-	resultsReceived := 0
-
-	for {
-		<-wp.Results()
-		resultsReceived++
-
-		if resultsReceived == numTasks {
-			break
-		}
-	}
-}
-
-func TestWorkerPoolHappyPath(t *testing.T) {
-	numTasks := 10
-
-	var setup = func() (WorkerPool, []Task) {
-		tasks, peers := makeTasksAndPeers(numTasks, 0)
-		wp := NewWorkerPool(WorkerPoolConfig{})
-
-		for _, who := range peers {
-			err := wp.AddPeer(who)
-			assert.NoError(t, err)
-		}
-
-		return wp, tasks
-	}
-
-	t.Run("receive_results_on_channel", func(t *testing.T) {
-		wp, tasks := setup()
-		results := make([]TaskResult, 0, numTasks)
-		wp.SubmitBatch(tasks)
-
-		for {
-			result := <-wp.Results()
-			assert.True(t, result.Completed)
-			assert.False(t, result.Failed())
-			assert.Equal(t, 0, result.Retries)
-
-			results = append(results, result)
-			if len(results) == numTasks {
-				break
-			}
-		}
-	})
-
-	t.Run("check_batch_status_on_completion", func(t *testing.T) {
-		wp, tasks := setup()
-		batchID := wp.SubmitBatch(tasks)
-
-		waitForCompletion(wp, numTasks)
-		status, ok := wp.GetBatch(batchID)
-
-		assert.True(t, ok)
-		assert.True(t, status.Completed(numTasks))
-		assert.Equal(t, numTasks, len(status.Success))
-		assert.Equal(t, 0, len(status.Failed))
-	})
-}
-
-func TestWorkerPoolPeerHandling(t *testing.T) {
-	numTasks := 3
-
-	t.Run("accepts_batch_without_any_peers", func(t *testing.T) {
-		tasks, _ := makeTasksAndPeers(numTasks, 0)
-		wp := NewWorkerPool(WorkerPoolConfig{})
-
-		wp.SubmitBatch(tasks)
-
-		wp.Shutdown()
-	})
-
-	t.Run("completes_batch_with_fewer_peers_than_tasks", func(t *testing.T) {
-		tasks, peers := makeTasksAndPeers(numTasks, 0)
-		wp := NewWorkerPool(WorkerPoolConfig{})
-		assert.NoError(t, wp.AddPeer(peers[0]))
-		assert.NoError(t, wp.AddPeer(peers[1]))
-
-		bID := wp.SubmitBatch(tasks)
-
-		waitForCompletion(wp, numTasks)
-		status, ok := wp.GetBatch(bID)
-		assert.True(t, ok)
-		assert.True(t, status.Completed(numTasks))
-		assert.Equal(t, numTasks, len(status.Success))
-		assert.Equal(t, 0, len(status.Failed))
-	})
-
-	t.Run("refuses_to_re_add_ignored_peer", func(t *testing.T) {
-		_, peers := makeTasksAndPeers(numTasks, 0)
-		wp := NewWorkerPool(WorkerPoolConfig{})
-
-		for _, who := range peers {
-			err := wp.AddPeer(who)
-			assert.NoError(t, err)
-		}
-		assert.Equal(t, len(peers), wp.NumPeers())
-
-		badPeer := peers[2]
-		wp.IgnorePeer(badPeer)
-		assert.Equal(t, len(peers)-1, wp.NumPeers())
-
-		err := wp.AddPeer(badPeer)
-		assert.ErrorIs(t, err, ErrPeerIgnored)
-		assert.Equal(t, len(peers)-1, wp.NumPeers())
-	})
-}
-
-func TestWorkerPoolTaskFailures(t *testing.T) {
-	numTasks := 3
-	taskErr := errors.New("kaput")
-
-	setup := func(maxRetries int) (failOnce *mockTask, failTwice *mockTask, batchID BatchID, wp WorkerPool) {
-		tasks, peers := makeTasksAndPeers(numTasks, 0)
-
-		failOnce = tasks[1].(*mockTask)
-		failOnce.err = taskErr
-		failOnce.succeedAfter = 1
-
-		failTwice = tasks[2].(*mockTask)
-		failTwice.err = taskErr
-		failTwice.succeedAfter = 2
-
-		wp = NewWorkerPool(WorkerPoolConfig{MaxRetries: maxRetries})
-		for _, who := range peers {
-			err := wp.AddPeer(who)
-			assert.NoError(t, err)
-		}
-
-		batchID = wp.SubmitBatch(tasks)
-		return
-	}
-
-	t.Run("retries_failed_tasks", func(t *testing.T) {
-		failOnce, failTwice, batchID, wp := setup(10)
-		waitForCompletion(wp, numTasks)
-
-		status, ok := wp.GetBatch(batchID)
-		assert.True(t, ok)
-		assert.True(t, status.Completed(numTasks))
-		assert.Equal(t, numTasks, len(status.Success))
-		assert.Equal(t, 0, len(status.Failed))
-
-		assert.Nil(t, status.Failed[failOnce.ID()].Error)
-		assert.Equal(t, 1, status.Success[failOnce.ID()].Retries)
-
-		assert.Nil(t, status.Failed[failTwice.ID()].Error)
-		assert.Equal(t, 2, status.Success[failTwice.ID()].Retries)
-	})
-
-	t.Run("honours_max_retries", func(t *testing.T) {
-		failOnce, failTwice, batchID, wp := setup(1)
-		waitForCompletion(wp, numTasks)
-
-		status, ok := wp.GetBatch(batchID)
-		assert.True(t, ok)
-		assert.True(t, status.Completed(numTasks))
-		assert.Equal(t, numTasks-1, len(status.Success))
-		assert.Equal(t, 1, len(status.Failed))
-
-		assert.Nil(t, status.Failed[failOnce.ID()].Error)
-		assert.Equal(t, 1, status.Success[failOnce.ID()].Retries)
-
-		assert.ErrorIs(t, taskErr, status.Failed[failTwice.ID()].Error)
-		assert.Equal(t, 1, status.Failed[failTwice.ID()].Retries)
-	})
-}
-
-func TestWorkerPoolMultipleBatches(t *testing.T) {
-	b1NumTasks := 10
-	b2NumTasks := 12
-
-	t.Run("completes_all_batches", func(t *testing.T) {
-		b1Tasks, b1Peers := makeTasksAndPeers(b1NumTasks, 0)
-		b2Tasks, b2Peers := makeTasksAndPeers(b2NumTasks, b1NumTasks)
-		peers := append(b1Peers, b2Peers...)
-
-		wp := NewWorkerPool(WorkerPoolConfig{})
-		for _, who := range peers {
-			err := wp.AddPeer(who)
-			assert.NoError(t, err)
-		}
-
-		b1ID := wp.SubmitBatch(b1Tasks)
-
-		b2ID := wp.SubmitBatch(b2Tasks)
-
-		waitForCompletion(wp, b1NumTasks+b2NumTasks)
-
-		b1Status, ok := wp.GetBatch(b1ID)
-		assert.True(t, ok)
-		assert.True(t, b1Status.Completed(b1NumTasks))
-		assert.Equal(t, b1NumTasks, len(b1Status.Success))
-		assert.Equal(t, 0, len(b1Status.Failed))
-
-		b2Status, ok := wp.GetBatch(b2ID)
-		assert.True(t, ok)
-		assert.True(t, b2Status.Completed(b2NumTasks))
-		assert.Equal(t, b2NumTasks, len(b2Status.Success))
-		assert.Equal(t, 0, len(b2Status.Failed))
-	})
-}
+//
+//import (
+//	"errors"
+//	"fmt"
+//	"testing"
+//	"time"
+//
+//	"github.com/libp2p/go-libp2p/core/peer"
+//	"github.com/stretchr/testify/assert"
+//)
+//
+//type mockTask struct {
+//	id           TaskID
+//	err          error
+//	execCount    uint
+//	succeedAfter uint
+//}
+//
+//func (m *mockTask) ID() TaskID {
+//	return m.id
+//}
+//
+//func (m *mockTask) Do(p peer.ID) (Result, error) {
+//	time.Sleep(time.Millisecond * 100) // simulate network roundtrip
+//	defer func() {
+//		m.execCount++
+//	}()
+//
+//	res := Result(fmt.Sprintf("%s - %s great success!", m.id, p))
+//	if m.err != nil {
+//		if m.succeedAfter > 0 && m.execCount >= m.succeedAfter {
+//			return res, nil
+//		}
+//		return nil, m.err
+//	}
+//	return res, nil
+//}
+//
+//func (m *mockTask) String() string {
+//	return fmt.Sprintf("mockTask %s", m.id)
+//}
+//
+//func makeTasksAndPeers(num, idOffset int) ([]Task, []peer.ID) {
+//	tasks := make([]Task, num)
+//	peers := make([]peer.ID, num)
+//
+//	for i := 0; i < num; i++ {
+//		tasks[i] = &mockTask{id: TaskID(fmt.Sprintf("t-%d", i+idOffset))}
+//		peers[i] = peer.ID(fmt.Sprintf("p-%d", i+idOffset))
+//	}
+//	return tasks, peers
+//}
+//
+//func makePool(maxRetries ...int) WorkerPool {
+//	mr := 0
+//	if len(maxRetries) > 0 {
+//		mr = maxRetries[0]
+//	}
+//
+//	return NewWorkerPool(WorkerPoolConfig{
+//		MaxRetries:        mr,
+//		NoPeersRetryDelay: time.Millisecond * 10,
+//	})
+//}
+//
+//func waitForCompletion(wp WorkerPool, numTasks int) {
+//	resultsReceived := 0
+//
+//	for {
+//		<-wp.Results()
+//		resultsReceived++
+//
+//		if resultsReceived == numTasks {
+//			break
+//		}
+//	}
+//}
+//
+//func TestWorkerPoolHappyPath(t *testing.T) {
+//	numTasks := 10
+//
+//	var setup = func() (WorkerPool, []Task) {
+//		tasks, peers := makeTasksAndPeers(numTasks, 0)
+//		wp := makePool()
+//
+//		for _, who := range peers {
+//			err := wp.AddPeer(who)
+//			assert.NoError(t, err)
+//		}
+//
+//		return wp, tasks
+//	}
+//
+//	t.Run("receive_results_on_channel", func(t *testing.T) {
+//		wp, tasks := setup()
+//		results := make([]TaskResult, 0, numTasks)
+//		wp.SubmitBatch(tasks)
+//
+//		for {
+//			result := <-wp.Results()
+//			assert.True(t, result.Completed)
+//			assert.False(t, result.Failed())
+//			assert.Equal(t, 0, result.Retries)
+//
+//			results = append(results, result)
+//			if len(results) == numTasks {
+//				break
+//			}
+//		}
+//	})
+//
+//	t.Run("check_batch_status_on_completion", func(t *testing.T) {
+//		wp, tasks := setup()
+//		batchID := wp.SubmitBatch(tasks)
+//
+//		waitForCompletion(wp, numTasks)
+//		status, ok := wp.GetBatch(batchID)
+//
+//		assert.True(t, ok)
+//		assert.True(t, status.Completed(numTasks))
+//		assert.Equal(t, numTasks, len(status.Success))
+//		assert.Equal(t, 0, len(status.Failed))
+//	})
+//}
+//
+//func TestWorkerPoolPeerHandling(t *testing.T) {
+//	numTasks := 3
+//
+//	t.Run("accepts_batch_without_any_peers", func(t *testing.T) {
+//		tasks, _ := makeTasksAndPeers(numTasks, 0)
+//		wp := makePool()
+//
+//		wp.SubmitBatch(tasks)
+//
+//		wp.Shutdown()
+//	})
+//
+//	t.Run("completes_batch_with_fewer_peers_than_tasks", func(t *testing.T) {
+//		tasks, peers := makeTasksAndPeers(numTasks, 0)
+//		wp := makePool()
+//		assert.NoError(t, wp.AddPeer(peers[0]))
+//		assert.NoError(t, wp.AddPeer(peers[1]))
+//
+//		bID := wp.SubmitBatch(tasks)
+//
+//		waitForCompletion(wp, numTasks)
+//		status, ok := wp.GetBatch(bID)
+//		assert.True(t, ok)
+//		assert.True(t, status.Completed(numTasks))
+//		assert.Equal(t, numTasks, len(status.Success))
+//		assert.Equal(t, 0, len(status.Failed))
+//	})
+//
+//	t.Run("refuses_to_re_add_ignored_peer", func(t *testing.T) {
+//		_, peers := makeTasksAndPeers(numTasks, 0)
+//		wp := makePool()
+//
+//		for _, who := range peers {
+//			err := wp.AddPeer(who)
+//			assert.NoError(t, err)
+//		}
+//		assert.Equal(t, len(peers), wp.IdlePeers())
+//
+//		badPeer := peers[2]
+//		wp.IgnorePeer(badPeer)
+//		assert.Equal(t, len(peers)-1, wp.IdlePeers())
+//
+//		err := wp.AddPeer(badPeer)
+//		assert.ErrorIs(t, err, ErrPeerIgnored)
+//		assert.Equal(t, len(peers)-1, wp.IdlePeers())
+//	})
+//}
+//
+//func TestWorkerPoolTaskFailures(t *testing.T) {
+//	numTasks := 3
+//	taskErr := errors.New("kaput")
+//
+//	setup := func(maxRetries int) (failOnce *mockTask, failTwice *mockTask, batchID BatchID, wp WorkerPool) {
+//		tasks, peers := makeTasksAndPeers(numTasks, 0)
+//
+//		failOnce = tasks[1].(*mockTask)
+//		failOnce.err = taskErr
+//		failOnce.succeedAfter = 1
+//
+//		failTwice = tasks[2].(*mockTask)
+//		failTwice.err = taskErr
+//		failTwice.succeedAfter = 2
+//
+//		wp = makePool(maxRetries)
+//		for _, who := range peers {
+//			err := wp.AddPeer(who)
+//			assert.NoError(t, err)
+//		}
+//
+//		batchID = wp.SubmitBatch(tasks)
+//		return
+//	}
+//
+//	t.Run("retries_failed_tasks", func(t *testing.T) {
+//		failOnce, failTwice, batchID, wp := setup(10)
+//		waitForCompletion(wp, numTasks)
+//
+//		status, ok := wp.GetBatch(batchID)
+//		assert.True(t, ok)
+//		assert.True(t, status.Completed(numTasks))
+//		assert.Equal(t, numTasks, len(status.Success))
+//		assert.Equal(t, 0, len(status.Failed))
+//
+//		assert.Nil(t, status.Failed[failOnce.ID()].Error)
+//		assert.Equal(t, 1, status.Success[failOnce.ID()].Retries)
+//
+//		assert.Nil(t, status.Failed[failTwice.ID()].Error)
+//		assert.Equal(t, 2, status.Success[failTwice.ID()].Retries)
+//	})
+//
+//	t.Run("honours_max_retries", func(t *testing.T) {
+//		failOnce, failTwice, batchID, wp := setup(1)
+//		waitForCompletion(wp, numTasks)
+//
+//		status, ok := wp.GetBatch(batchID)
+//		assert.True(t, ok)
+//		assert.True(t, status.Completed(numTasks))
+//		assert.Equal(t, numTasks-1, len(status.Success))
+//		assert.Equal(t, 1, len(status.Failed))
+//
+//		assert.Nil(t, status.Failed[failOnce.ID()].Error)
+//		assert.Equal(t, 1, status.Success[failOnce.ID()].Retries)
+//
+//		assert.ErrorIs(t, taskErr, status.Failed[failTwice.ID()].Error)
+//		assert.Equal(t, 1, status.Failed[failTwice.ID()].Retries)
+//	})
+//}
+//
+//func TestWorkerPoolMultipleBatches(t *testing.T) {
+//	b1NumTasks := 10
+//	b2NumTasks := 12
+//
+//	t.Run("completes_all_batches", func(t *testing.T) {
+//		b1Tasks, b1Peers := makeTasksAndPeers(b1NumTasks, 0)
+//		b2Tasks, b2Peers := makeTasksAndPeers(b2NumTasks, b1NumTasks)
+//		peers := append(b1Peers, b2Peers...)
+//
+//		wp := makePool()
+//		for _, who := range peers {
+//			err := wp.AddPeer(who)
+//			assert.NoError(t, err)
+//		}
+//
+//		b1ID := wp.SubmitBatch(b1Tasks)
+//
+//		b2ID := wp.SubmitBatch(b2Tasks)
+//
+//		waitForCompletion(wp, b1NumTasks+b2NumTasks)
+//
+//		b1Status, ok := wp.GetBatch(b1ID)
+//		assert.True(t, ok)
+//		assert.True(t, b1Status.Completed(b1NumTasks))
+//		assert.Equal(t, b1NumTasks, len(b1Status.Success))
+//		assert.Equal(t, 0, len(b1Status.Failed))
+//
+//		b2Status, ok := wp.GetBatch(b2ID)
+//		assert.True(t, ok)
+//		assert.True(t, b2Status.Completed(b2NumTasks))
+//		assert.Equal(t, b2NumTasks, len(b2Status.Success))
+//		assert.Equal(t, 0, len(b2Status.Failed))
+//	})
+//}

--- a/dot/sync/worker_pool_test.go
+++ b/dot/sync/worker_pool_test.go
@@ -86,9 +86,7 @@ func TestWorkerPoolHappyPath(t *testing.T) {
 	t.Run("receive_results_on_channel", func(t *testing.T) {
 		wp, tasks := setup()
 		results := make([]TaskResult, 0, numTasks)
-		_, err := wp.SubmitBatch(tasks)
-
-		assert.NoError(t, err)
+		wp.SubmitBatch(tasks)
 
 		for {
 			result := <-wp.Results()
@@ -105,8 +103,7 @@ func TestWorkerPoolHappyPath(t *testing.T) {
 
 	t.Run("check_batch_status_on_completion", func(t *testing.T) {
 		wp, tasks := setup()
-		batchID, err := wp.SubmitBatch(tasks)
-		assert.NoError(t, err)
+		batchID := wp.SubmitBatch(tasks)
 
 		waitForCompletion(wp, numTasks)
 		status, ok := wp.GetBatch(batchID)
@@ -125,8 +122,7 @@ func TestWorkerPoolPeerHandling(t *testing.T) {
 		tasks, _ := makeTasksAndPeers(numTasks, 0)
 		wp := NewWorkerPool(WorkerPoolConfig{})
 
-		_, err := wp.SubmitBatch(tasks)
-		assert.NoError(t, err)
+		wp.SubmitBatch(tasks)
 
 		wp.Shutdown()
 	})
@@ -137,8 +133,7 @@ func TestWorkerPoolPeerHandling(t *testing.T) {
 		assert.NoError(t, wp.AddPeer(peers[0]))
 		assert.NoError(t, wp.AddPeer(peers[1]))
 
-		bID, err := wp.SubmitBatch(tasks)
-		assert.NoError(t, err)
+		bID := wp.SubmitBatch(tasks)
 
 		waitForCompletion(wp, numTasks)
 		status, ok := wp.GetBatch(bID)
@@ -189,9 +184,7 @@ func TestWorkerPoolTaskFailures(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		var err error
-		batchID, err = wp.SubmitBatch(tasks)
-		assert.NoError(t, err)
+		batchID = wp.SubmitBatch(tasks)
 		return
 	}
 
@@ -245,11 +238,9 @@ func TestWorkerPoolMultipleBatches(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		b1ID, err := wp.SubmitBatch(b1Tasks)
-		assert.NoError(t, err)
+		b1ID := wp.SubmitBatch(b1Tasks)
 
-		b2ID, err := wp.SubmitBatch(b2Tasks)
-		assert.NoError(t, err)
+		b2ID := wp.SubmitBatch(b2Tasks)
 
 		waitForCompletion(wp, b1NumTasks+b2NumTasks)
 

--- a/dot/sync/worker_pool_test.go
+++ b/dot/sync/worker_pool_test.go
@@ -1,0 +1,268 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockTask struct {
+	id           TaskID
+	err          error
+	execCount    uint
+	succeedAfter uint
+}
+
+func (m *mockTask) ID() TaskID {
+	return m.id
+}
+
+func (m *mockTask) Do(p peer.ID) (Result, error) {
+	time.Sleep(time.Millisecond * 100) // simulate network roundtrip
+	defer func() {
+		m.execCount++
+	}()
+
+	res := Result(fmt.Sprintf("%s - %s great success!", m.id, p))
+	if m.err != nil {
+		if m.succeedAfter > 0 && m.execCount >= m.succeedAfter {
+			return res, nil
+		}
+		return nil, m.err
+	}
+	return res, nil
+}
+
+func (m *mockTask) String() string {
+	return fmt.Sprintf("mockTask %s", m.id)
+}
+
+func makeTasksAndPeers(num, idOffset int) ([]Task, []peer.ID) {
+	tasks := make([]Task, num)
+	peers := make([]peer.ID, num)
+
+	for i := 0; i < num; i++ {
+		tasks[i] = &mockTask{id: TaskID(fmt.Sprintf("t-%d", i+idOffset))}
+		peers[i] = peer.ID(fmt.Sprintf("p-%d", i+idOffset))
+	}
+	return tasks, peers
+}
+
+func waitForCompletion(wp WorkerPool, numTasks int) {
+	resultsReceived := 0
+
+	for {
+		<-wp.Results()
+		resultsReceived++
+
+		if resultsReceived == numTasks {
+			break
+		}
+	}
+}
+
+func TestWorkerPoolHappyPath(t *testing.T) {
+	numTasks := 10
+
+	var setup = func() (WorkerPool, []Task) {
+		tasks, peers := makeTasksAndPeers(numTasks, 0)
+		wp := NewWorkerPool(WorkerPoolConfig{})
+
+		for _, who := range peers {
+			err := wp.AddPeer(who)
+			assert.NoError(t, err)
+		}
+
+		return wp, tasks
+	}
+
+	t.Run("receive_results_on_channel", func(t *testing.T) {
+		wp, tasks := setup()
+		results := make([]TaskResult, 0, numTasks)
+		_, err := wp.SubmitBatch(tasks)
+
+		assert.NoError(t, err)
+
+		for {
+			result := <-wp.Results()
+			assert.True(t, result.Completed)
+			assert.False(t, result.Failed())
+			assert.Equal(t, uint(0), result.Retries)
+
+			results = append(results, result)
+			if len(results) == numTasks {
+				break
+			}
+		}
+	})
+
+	t.Run("check_batch_status_on_completion", func(t *testing.T) {
+		wp, tasks := setup()
+		batchID, err := wp.SubmitBatch(tasks)
+		assert.NoError(t, err)
+
+		waitForCompletion(wp, numTasks)
+		status, ok := wp.GetBatch(batchID)
+
+		assert.True(t, ok)
+		assert.True(t, status.Completed(numTasks))
+		assert.Equal(t, numTasks, len(status.Success))
+		assert.Equal(t, 0, len(status.Failed))
+	})
+}
+
+func TestWorkerPoolPeerHandling(t *testing.T) {
+	numTasks := 3
+
+	t.Run("accepts_batch_without_any_peers", func(t *testing.T) {
+		tasks, _ := makeTasksAndPeers(numTasks, 0)
+		wp := NewWorkerPool(WorkerPoolConfig{})
+
+		_, err := wp.SubmitBatch(tasks)
+		assert.NoError(t, err)
+
+		wp.Shutdown()
+	})
+
+	t.Run("completes_batch_with_fewer_peers_than_tasks", func(t *testing.T) {
+		tasks, peers := makeTasksAndPeers(numTasks, 0)
+		wp := NewWorkerPool(WorkerPoolConfig{})
+		assert.NoError(t, wp.AddPeer(peers[0]))
+		assert.NoError(t, wp.AddPeer(peers[1]))
+
+		bID, err := wp.SubmitBatch(tasks)
+		assert.NoError(t, err)
+
+		waitForCompletion(wp, numTasks)
+		status, ok := wp.GetBatch(bID)
+		assert.True(t, ok)
+		assert.True(t, status.Completed(numTasks))
+		assert.Equal(t, numTasks, len(status.Success))
+		assert.Equal(t, 0, len(status.Failed))
+	})
+
+	t.Run("refuses_to_re_add_ignored_peer", func(t *testing.T) {
+		_, peers := makeTasksAndPeers(numTasks, 0)
+		wp := NewWorkerPool(WorkerPoolConfig{})
+
+		for _, who := range peers {
+			err := wp.AddPeer(who)
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, len(peers), wp.NumPeers())
+
+		badPeer := peers[2]
+		wp.IgnorePeer(badPeer)
+		assert.Equal(t, len(peers)-1, wp.NumPeers())
+
+		err := wp.AddPeer(badPeer)
+		assert.ErrorIs(t, err, ErrPeerIgnored)
+		assert.Equal(t, len(peers)-1, wp.NumPeers())
+	})
+}
+
+func TestWorkerPoolTaskFailures(t *testing.T) {
+	numTasks := 3
+	taskErr := errors.New("kaput")
+
+	setup := func(maxRetries uint) (failOnce *mockTask, failTwice *mockTask, batchID BatchID, wp WorkerPool) {
+		tasks, peers := makeTasksAndPeers(numTasks, 0)
+
+		failOnce = tasks[1].(*mockTask)
+		failOnce.err = taskErr
+		failOnce.succeedAfter = 1
+
+		failTwice = tasks[2].(*mockTask)
+		failTwice.err = taskErr
+		failTwice.succeedAfter = 2
+
+		wp = NewWorkerPool(WorkerPoolConfig{MaxRetries: maxRetries})
+		for _, who := range peers {
+			err := wp.AddPeer(who)
+			assert.NoError(t, err)
+		}
+
+		var err error
+		batchID, err = wp.SubmitBatch(tasks)
+		assert.NoError(t, err)
+		return
+	}
+
+	t.Run("retries_failed_tasks", func(t *testing.T) {
+		failOnce, failTwice, batchID, wp := setup(10)
+		waitForCompletion(wp, numTasks)
+
+		status, ok := wp.GetBatch(batchID)
+		assert.True(t, ok)
+		assert.True(t, status.Completed(numTasks))
+		assert.Equal(t, numTasks, len(status.Success))
+		assert.Equal(t, 0, len(status.Failed))
+
+		assert.Nil(t, status.Failed[failOnce.ID()].Error)
+		assert.Equal(t, uint(1), status.Success[failOnce.ID()].Retries)
+
+		assert.Nil(t, status.Failed[failTwice.ID()].Error)
+		assert.Equal(t, uint(2), status.Success[failTwice.ID()].Retries)
+	})
+
+	t.Run("honours_max_retries", func(t *testing.T) {
+		failOnce, failTwice, batchID, wp := setup(1)
+		waitForCompletion(wp, numTasks)
+
+		status, ok := wp.GetBatch(batchID)
+		assert.True(t, ok)
+		assert.True(t, status.Completed(numTasks))
+		assert.Equal(t, numTasks-1, len(status.Success))
+		assert.Equal(t, 1, len(status.Failed))
+
+		assert.Nil(t, status.Failed[failOnce.ID()].Error)
+		assert.Equal(t, uint(1), status.Success[failOnce.ID()].Retries)
+
+		assert.ErrorIs(t, taskErr, status.Failed[failTwice.ID()].Error)
+		assert.Equal(t, uint(1), status.Failed[failTwice.ID()].Retries)
+	})
+}
+
+func TestWorkerPoolMultipleBatches(t *testing.T) {
+	b1NumTasks := 10
+	b2NumTasks := 12
+
+	t.Run("completes_all_batches", func(t *testing.T) {
+		b1Tasks, b1Peers := makeTasksAndPeers(b1NumTasks, 0)
+		b2Tasks, b2Peers := makeTasksAndPeers(b2NumTasks, b1NumTasks)
+		peers := append(b1Peers, b2Peers...)
+
+		wp := NewWorkerPool(WorkerPoolConfig{})
+		for _, who := range peers {
+			err := wp.AddPeer(who)
+			assert.NoError(t, err)
+		}
+
+		b1ID, err := wp.SubmitBatch(b1Tasks)
+		assert.NoError(t, err)
+
+		b2ID, err := wp.SubmitBatch(b2Tasks)
+		assert.NoError(t, err)
+
+		waitForCompletion(wp, b1NumTasks+b2NumTasks)
+
+		b1Status, ok := wp.GetBatch(b1ID)
+		assert.True(t, ok)
+		assert.True(t, b1Status.Completed(b1NumTasks))
+		assert.Equal(t, b1NumTasks, len(b1Status.Success))
+		assert.Equal(t, 0, len(b1Status.Failed))
+
+		b2Status, ok := wp.GetBatch(b2ID)
+		assert.True(t, ok)
+		assert.True(t, b2Status.Completed(b2NumTasks))
+		assert.Equal(t, b2NumTasks, len(b2Status.Success))
+		assert.Equal(t, 0, len(b2Status.Failed))
+	})
+}

--- a/dot/sync/worker_pool_test.go
+++ b/dot/sync/worker_pool_test.go
@@ -94,7 +94,7 @@ func TestWorkerPoolHappyPath(t *testing.T) {
 			result := <-wp.Results()
 			assert.True(t, result.Completed)
 			assert.False(t, result.Failed())
-			assert.Equal(t, uint(0), result.Retries)
+			assert.Equal(t, 0, result.Retries)
 
 			results = append(results, result)
 			if len(results) == numTasks {
@@ -172,7 +172,7 @@ func TestWorkerPoolTaskFailures(t *testing.T) {
 	numTasks := 3
 	taskErr := errors.New("kaput")
 
-	setup := func(maxRetries uint) (failOnce *mockTask, failTwice *mockTask, batchID BatchID, wp WorkerPool) {
+	setup := func(maxRetries int) (failOnce *mockTask, failTwice *mockTask, batchID BatchID, wp WorkerPool) {
 		tasks, peers := makeTasksAndPeers(numTasks, 0)
 
 		failOnce = tasks[1].(*mockTask)
@@ -206,10 +206,10 @@ func TestWorkerPoolTaskFailures(t *testing.T) {
 		assert.Equal(t, 0, len(status.Failed))
 
 		assert.Nil(t, status.Failed[failOnce.ID()].Error)
-		assert.Equal(t, uint(1), status.Success[failOnce.ID()].Retries)
+		assert.Equal(t, 1, status.Success[failOnce.ID()].Retries)
 
 		assert.Nil(t, status.Failed[failTwice.ID()].Error)
-		assert.Equal(t, uint(2), status.Success[failTwice.ID()].Retries)
+		assert.Equal(t, 2, status.Success[failTwice.ID()].Retries)
 	})
 
 	t.Run("honours_max_retries", func(t *testing.T) {
@@ -223,10 +223,10 @@ func TestWorkerPoolTaskFailures(t *testing.T) {
 		assert.Equal(t, 1, len(status.Failed))
 
 		assert.Nil(t, status.Failed[failOnce.ID()].Error)
-		assert.Equal(t, uint(1), status.Success[failOnce.ID()].Retries)
+		assert.Equal(t, 1, status.Success[failOnce.ID()].Retries)
 
 		assert.ErrorIs(t, taskErr, status.Failed[failTwice.ID()].Error)
-		assert.Equal(t, uint(1), status.Failed[failTwice.ID()].Retries)
+		assert.Equal(t, 1, status.Failed[failTwice.ID()].Retries)
 	})
 }
 


### PR DESCRIPTION
The main difference in the worker pool API is that `SubmitBatch()` does not block until the whole batch has been processed. Instead, it returns an ID which can be used to retrieve the current state of the batch. In addition, `Results()` returns a channel over which task results are sent as they become available.

The main improvement this brings is increased concurrency, since results can be processed before the whole batch has been completed.

What has not changed is the overall flow of the Strategy interface; getting a new batch of tasks with `NextActions()` and processing the results with `Process()`.

## Changes

* replaced the code in `dot/sync/worker_pool.go`
* adapted `SyncService` to the API changes of the new worker pool
* adapted some expectations in tests regarding how often some mocks are called (hopefully without changing the logic being tested)

## Tests

```sh
go test github.com/ChainSafe/gossamer/dot/sync
```

## Issues

Closes #4198