### PR TITLE
Fix(Config Setting): Updated DefaultMinPeers to 5 as per documentation  #4252

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ const (
 	// DefaultDiscoveryInterval is the default discovery interval
 	DefaultDiscoveryInterval = 10 * time.Second
 	// DefaultMinPeers is the default minimum number of peers
-	DefaultMinPeers = 0
+	DefaultMinPeers = 5
 	// DefaultMaxPeers is the default maximum number of peers
 	DefaultMaxPeers = 50
 


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
According to [the CLI documentation](https://github.com/ChainSafe/gossamer/blob/04c7e6e57674a07fa1d4da90db128b57d8733351/docs/docs/usage/command-line.md?plain=1#L35),  DefaultMinPeers is 5 But in code it was 0. So Updated to 5 as per the documentation
## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
#4252
<!-- Write the issue number(s), for example: #123 -->