### PR TITLE
fix(config): fix zombienet tests and `TestStartStopNode`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ const (
 	// DefaultDiscoveryInterval is the default discovery interval
 	DefaultDiscoveryInterval = 10 * time.Second
 	// DefaultMinPeers is the default minimum number of peers
-	DefaultMinPeers = 5
+	DefaultMinPeers = 0
 	// DefaultMaxPeers is the default maximum number of peers
 	DefaultMaxPeers = 50
 


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Reverts PR #4257 which reduces the minimum clients.
- zombienet tests are fixed again.
- `TestStartStopNode` is fixed again.
  - This actually uncovered a problem with stopping the node when minimum peers haven't been acquired.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```