### PR TITLE
docs(cli): fix default value of --min-peers

### DIFF
--- a/docs/docs/usage/command-line.md
+++ b/docs/docs/usage/command-line.md
@@ -32,7 +32,7 @@ These are the flags that can be used with the `gossamer` command
 	    By default, all modules log 'info'.
 	    The global log level can be set with --log global=debug
 --max-peers Maximum number of peers to connect to (default 50)
---min-peers Minimum number of peers to connect to (default 5)
+--min-peers Minimum number of peers to connect to (default 0)
 --name Name of the node
 --no-bootstrap Disables network bootstrapping (mdns still enabled)
 --no-mdns Disables network mdns discovery


### PR DESCRIPTION
## Changes

This brings documentation of the `--min-peers` CLI flag in line with the code.

## Tests

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

#4252 (again)