### PR TITLE
chore(dot/parachain): consistently use ParaID type

### DIFF
--- a/dot/core/mock_runtime_instance_test.go
+++ b/dot/core/mock_runtime_instance_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/dot/parachain/availability-store/mock_runtime_instance_test.go
+++ b/dot/parachain/availability-store/mock_runtime_instance_test.go
@@ -71,7 +71,7 @@ func (mr *MockRuntimeInstanceMockRecorder) ParachainHostCheckValidationOutputs(a
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockRuntimeInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockRuntimeInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -116,7 +116,7 @@ func (mr *MockRuntimeInstanceMockRecorder) ParachainHostSessionIndexForChild() *
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockRuntimeInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockRuntimeInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/dot/parachain/backing/active_leaves_update.go
+++ b/dot/parachain/backing/active_leaves_update.go
@@ -337,7 +337,7 @@ func constructPerRelayParentState(
 		case parachaintypes.OccupiedCore:
 			if mode.IsEnabled {
 				// Async backing makes it legal to build on top of occupied core.
-				coreParaID = parachaintypes.ParaID(v.CandidateDescriptor.ParaID)
+				coreParaID = v.CandidateDescriptor.ParaID
 			} else {
 				continue
 			}

--- a/dot/parachain/backing/can_second.go
+++ b/dot/parachain/backing/can_second.go
@@ -88,7 +88,7 @@ func (cb *CandidateBacking) secondingSanityCheck(
 		candidateRelayParent = v.RelayParent
 		candidateHash = v.CandidateHash
 	case parachaintypes.HypotheticalCandidateComplete:
-		candidateParaID = parachaintypes.ParaID(v.CommittedCandidateReceipt.Descriptor.ParaID)
+		candidateParaID = v.CommittedCandidateReceipt.Descriptor.ParaID
 		candidateRelayParent = v.CommittedCandidateReceipt.Descriptor.RelayParent
 		candidateHash = v.CandidateHash
 	}

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -51,7 +51,7 @@ func getDummyCommittedCandidateReceipt(t *testing.T) parachaintypes.CommittedCan
 
 	ccr := parachaintypes.CommittedCandidateReceipt{
 		Descriptor: parachaintypes.CandidateDescriptor{
-			ParaID:                      uint32(1),
+			ParaID:                      1,
 			RelayParent:                 hash5,
 			Collator:                    collatorID,
 			PersistedValidationDataHash: hash5,

--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -101,7 +101,7 @@ func makeErasureRoot(
 // newCommittedCandidate creates a new committed candidate receipt for testing purposes.
 func newCommittedCandidate(
 	t *testing.T,
-	paraID uint32, //nolint:unparam
+	paraID parachaintypes.ParaID, //nolint:unparam
 	headData parachaintypes.HeadData,
 	povHash, relayParent, erasureRoot, pvdHash common.Hash,
 	validationCode parachaintypes.ValidationCode,
@@ -265,7 +265,7 @@ func TestSecondsValidCandidate(t *testing.T) {
 	paraValidators := parachainValidators(t, candidateBacking.Keystore)
 	numOfValidators := uint(len(paraValidators))
 	relayParent := getDummyHash(t, 5)
-	paraID := uint32(1)
+	paraID := parachaintypes.ParaID(1)
 
 	ctrl := gomock.NewController(t)
 	mockBlockState := backing.NewMockBlockState(ctrl)
@@ -443,7 +443,7 @@ func TestCandidateReachesQuorum(t *testing.T) {
 	paraValidators := parachainValidators(t, candidateBacking.Keystore)
 	numOfValidators := uint(len(paraValidators))
 	relayParent := getDummyHash(t, 5)
-	paraID := uint32(1)
+	paraID := parachaintypes.ParaID(1)
 
 	pov := parachaintypes.PoV{BlockData: []byte{1, 2, 3}}
 	povHash, err := pov.Hash()
@@ -635,7 +635,7 @@ func TestValidationFailDoesNotStopSubsystem(t *testing.T) {
 	paraValidators := parachainValidators(t, candidateBacking.Keystore)
 	numOfValidators := uint(len(paraValidators))
 	relayParent := getDummyHash(t, 5)
-	paraID := uint32(1)
+	paraID := parachaintypes.ParaID(1)
 
 	pov := parachaintypes.PoV{BlockData: []byte{1, 2, 3}}
 	povHash, err := pov.Hash()
@@ -778,7 +778,7 @@ func TestCanNotSecondMultipleCandidatesPerRelayParent(t *testing.T) {
 	paraValidators := parachainValidators(t, candidateBacking.Keystore)
 	numOfValidators := uint(len(paraValidators))
 	relayParent := getDummyHash(t, 5)
-	paraID := uint32(1)
+	paraID := parachaintypes.ParaID(1)
 
 	ctrl := gomock.NewController(t)
 	mockBlockState := backing.NewMockBlockState(ctrl)
@@ -922,7 +922,7 @@ func TestNewLeafDoesNotClobberOld(t *testing.T) {
 	numOfValidators := uint(len(paraValidators))
 	relayParent1 := getDummyHash(t, 5)
 	relayParent2 := getDummyHash(t, 6)
-	paraID := uint32(1)
+	paraID := parachaintypes.ParaID(1)
 	validationCode := parachaintypes.ValidationCode{1, 2, 3}
 
 	ctrl := gomock.NewController(t)
@@ -1045,7 +1045,7 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 	paraValidators := parachainValidators(t, candidateBacking.Keystore)
 	numOfValidators := uint(len(paraValidators))
 	relayParent := getDummyHash(t, 5)
-	paraID := uint32(1)
+	paraID := parachaintypes.ParaID(1)
 
 	pov := parachaintypes.PoV{BlockData: []byte{1, 2, 3}}
 	povHash, err := pov.Hash()

--- a/dot/parachain/backing/mocks_runtime_test.go
+++ b/dot/parachain/backing/mocks_runtime_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/dot/parachain/backing/per_relay_parent_state.go
+++ b/dot/parachain/backing/per_relay_parent_state.go
@@ -73,7 +73,7 @@ func (rpState *perRelayParentState) importStatement(
 		return nil, errNilPersistedValidationData
 	}
 
-	paraID := parachaintypes.ParaID(committedCandidateReceipt.Descriptor.ParaID)
+	paraID := committedCandidateReceipt.Descriptor.ParaID
 
 	if rpState.prospectiveParachainsMode.IsEnabled {
 		chIntroduceCandidate := make(chan error)
@@ -161,13 +161,13 @@ func (rpState *perRelayParentState) postImportStatement(subSystemToOverseer chan
 
 		// Inform the prospective parachains subsystem that the candidate is now backed.
 		subSystemToOverseer <- parachaintypes.ProspectiveParachainsMessageCandidateBacked{
-			ParaID:        parachaintypes.ParaID(paraID),
+			ParaID:        paraID,
 			CandidateHash: candidateHash,
 		}
 
 		// Backed candidate potentially unblocks new advertisements, notify collator protocol.
 		subSystemToOverseer <- collatorprotocolmessages.Backed{
-			ParaID:   parachaintypes.ParaID(paraID),
+			ParaID:   paraID,
 			ParaHead: backedCandidate.Candidate.Descriptor.ParaHead,
 		}
 
@@ -393,7 +393,7 @@ func getPovFromValidator(
 	fetchPov := parachaintypes.AvailabilityDistributionMessageFetchPoV{
 		RelayParent:   relayParent,
 		FromValidator: attesting.fromValidator,
-		ParaID:        parachaintypes.ParaID(attesting.candidate.Descriptor.ParaID),
+		ParaID:        attesting.candidate.Descriptor.ParaID,
 		CandidateHash: candidateHash,
 		PovHash:       attesting.povHash,
 		PovCh:         make(chan parachaintypes.OverseerFuncRes[parachaintypes.PoV]),

--- a/dot/parachain/backing/second.go
+++ b/dot/parachain/backing/second.go
@@ -56,7 +56,7 @@ func (cb *CandidateBacking) handleSecondMessage(
 	}
 
 	// Sanity check that candidate is from our assignment.
-	if candidateReceipt.Descriptor.ParaID != uint32(*rpState.assignment) {
+	if candidateReceipt.Descriptor.ParaID != *rpState.assignment {
 		return fmt.Errorf("%w: candidate hash: %s; candidate paraID: %d; assignment: %d",
 			errParaOutsideAssignmentForSeconding,
 			candidateHash,

--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -180,7 +180,7 @@ func (table *statementTable) importCandidate(
 	signature parachaintypes.ValidatorSignature,
 	tableCtx *tableContext,
 ) (*Summary, parachaintypes.Misbehaviour, error) {
-	paraID := parachaintypes.ParaID(candidate.Descriptor.ParaID)
+	paraID := candidate.Descriptor.ParaID
 
 	if !tableCtx.isMemberOf(authority, paraID) {
 		statementSeconded := parachaintypes.NewStatementVDT()

--- a/dot/parachain/backing/statement_table_test.go
+++ b/dot/parachain/backing/statement_table_test.go
@@ -255,7 +255,7 @@ func TestStatementTable_importCandidate(t *testing.T) {
 			expectedMisehaviour: nil,
 			expectedSummary: &Summary{
 				Candidate:     candidateHash,
-				GroupID:       parachaintypes.ParaID(candidate.Descriptor.ParaID),
+				GroupID:       candidate.Descriptor.ParaID,
 				ValidityVotes: 1,
 			},
 		},
@@ -327,7 +327,7 @@ func TestStatementTable_importCandidate(t *testing.T) {
 			expectedMisehaviour: nil,
 			expectedSummary: &Summary{
 				Candidate:     candidateHash,
-				GroupID:       parachaintypes.ParaID(candidate.Descriptor.ParaID),
+				GroupID:       candidate.Descriptor.ParaID,
 				ValidityVotes: 1,
 			},
 		},
@@ -362,7 +362,7 @@ func TestStatementTable_importCandidate(t *testing.T) {
 			expectedMisehaviour: nil,
 			expectedSummary: &Summary{
 				Candidate:     candidateHash,
-				GroupID:       parachaintypes.ParaID(candidate.Descriptor.ParaID),
+				GroupID:       candidate.Descriptor.ParaID,
 				ValidityVotes: 1,
 			},
 		},
@@ -461,7 +461,7 @@ func TestStatementTable_validityVote(t *testing.T) {
 			expectedMisehaviour: nil,
 			expectedSummary: &Summary{
 				Candidate:     candidateHash,
-				GroupID:       parachaintypes.ParaID(committedCandidate.Descriptor.ParaID),
+				GroupID:       committedCandidate.Descriptor.ParaID,
 				ValidityVotes: 1,
 			},
 		},

--- a/dot/parachain/backing/validated_candidate_command.go
+++ b/dot/parachain/backing/validated_candidate_command.go
@@ -234,10 +234,10 @@ func (cb *CandidateBacking) handleCommandSecond(
 			continue
 		}
 
-		secondedAtDepth, ok := leafState.secondedAtDepth[parachaintypes.ParaID(candidate.Descriptor.ParaID)]
+		secondedAtDepth, ok := leafState.secondedAtDepth[candidate.Descriptor.ParaID]
 		if !ok {
 			var btreeMap btree.Map[uint, parachaintypes.CandidateHash]
-			leafState.secondedAtDepth[parachaintypes.ParaID(candidate.Descriptor.ParaID)] = &btreeMap
+			leafState.secondedAtDepth[candidate.Descriptor.ParaID] = &btreeMap
 			secondedAtDepth = &btreeMap
 		}
 

--- a/dot/parachain/candidate-validation/candidate_validation.go
+++ b/dot/parachain/candidate-validation/candidate_validation.go
@@ -126,7 +126,7 @@ type PoVRequestor interface {
 }
 
 // getValidationData gets validation data for a parachain block from the runtime instance
-func getValidationData(runtimeInstance parachainruntime.RuntimeInstance, paraID uint32,
+func getValidationData(runtimeInstance parachainruntime.RuntimeInstance, paraID parachaintypes.ParaID,
 ) (*parachaintypes.PersistedValidationData, *parachaintypes.ValidationCode, error) {
 
 	var mergedError error
@@ -211,8 +211,9 @@ func (cv *CandidateValidation) validateFromChainState(msg ValidateFromChainState
 		}
 		return
 	}
-	valid, err := runtimeInstance.ParachainHostCheckValidationOutputs(parachaintypes.ParaID(msg.CandidateReceipt.
-		Descriptor.ParaID), result.Valid.CandidateCommitments)
+	valid, err := runtimeInstance.ParachainHostCheckValidationOutputs(
+		msg.CandidateReceipt.Descriptor.ParaID,
+		result.Valid.CandidateCommitments)
 	if err != nil {
 		msg.Ch <- parachaintypes.OverseerFuncRes[ValidationResult]{
 			Err: fmt.Errorf("check validation outputs: Bad request: %w", err),

--- a/dot/parachain/candidate-validation/candidate_validation_test.go
+++ b/dot/parachain/candidate-validation/candidate_validation_test.go
@@ -27,7 +27,7 @@ var (
 	badParent        = BadParent
 )
 
-func createTestCandidateReceiptAndValidationCodeWParaId(t *testing.T, id uint32) (
+func createTestCandidateReceiptAndValidationCodeWParaId(t *testing.T, id parachaintypes.ParaID) (
 	parachaintypes.CandidateReceipt, parachaintypes.ValidationCode) {
 	t.Helper()
 	// this wasm was achieved by building polkadot's adder test parachain
@@ -58,7 +58,7 @@ func createTestCandidateReceiptAndValidationCodeWParaId(t *testing.T, id uint32)
 	return candidateReceipt, validationCode
 }
 
-func makeValidCandidateDescriptor(t *testing.T, paraID uint32, relayParent common.Hash,
+func makeValidCandidateDescriptor(t *testing.T, paraID parachaintypes.ParaID, relayParent common.Hash,
 	persistedValidationDataHash common.Hash, povHash common.Hash,
 	validationCodeHash parachaintypes.ValidationCodeHash, paraHead common.Hash, erasureRoot common.Hash,
 	collator sr25519.Keypair,

--- a/dot/parachain/candidate-validation/candidate_validation_test.go
+++ b/dot/parachain/candidate-validation/candidate_validation_test.go
@@ -287,9 +287,6 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 	candidateReceipt7 := candidateReceipt
 	candidateReceipt7.Descriptor.ParaID = 7
 
-	ctrl := gomock.NewController(t)
-	t.Cleanup(ctrl.Finish)
-
 	// NOTE: adder parachain internally compares postState with bd.State in it's validate_block,
 	// so following is necessary.
 	encodedState, err := scale.Marshal(uint64(1))
@@ -318,15 +315,6 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 		MaxPovSize:             uint32(10),
 	}
 
-	mockInstance := NewMockInstance(ctrl)
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(
-			uint32(1000),
-			gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&expectedPersistedValidationData, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(1000), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
 	validCandidateCommitments := parachaintypes.CandidateCommitments{
 		HeadData: parachaintypes.HeadData{Data: []byte{2, 0, 0, 0, 0, 0, 0, 0, 123, 207, 206, 8, 219, 227,
 			136, 82, 236, 169, 14, 100, 45, 100, 31, 177, 154, 160, 220, 245, 59, 106, 76, 168, 122, 109,
@@ -335,65 +323,6 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 		ProcessedDownwardMessages: 0,
 		HrmpWatermark:             1,
 	}
-	mockInstance.EXPECT().ParachainHostCheckValidationOutputs(parachaintypes.ParaID(1000),
-		validCandidateCommitments).Return(true, nil)
-
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(
-			uint32(2),
-			gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&expectedPersistedValidationData, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(2), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
-
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(
-			uint32(3),
-			gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&expectedPersistedValidationDataSmallMax, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(3), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
-
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(
-			uint32(4),
-			gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&expectedPersistedValidationData, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(4), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
-
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(
-			uint32(5),
-			gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&expectedPersistedValidationData, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(5), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
-
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(uint32(6), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&expectedPersistedValidationData, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(6), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
-	mockInstance.EXPECT().ParachainHostCheckValidationOutputs(parachaintypes.ParaID(6),
-		validCandidateCommitments).Return(false, nil)
-
-	mockInstance.EXPECT().
-		ParachainHostPersistedValidationData(uint32(7), gomock.AssignableToTypeOf(parachaintypes.
-			OccupiedCoreAssumption{})).
-		Return(nil, nil)
-	mockInstance.EXPECT().
-		ParachainHostValidationCode(uint32(7), gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
-		Return(&validationCode, nil)
-
-	mockBlockState := NewMockBlockState(ctrl)
-	mockBlockState.EXPECT().GetRuntime(common.MustHexToHash(
-		"0xded542bacb3ca6c033a57676f94ae7c8f36834511deb44e3164256fd3b1c0de0")).Return(mockInstance, nil).Times(7)
 
 	bd, err := scale.Marshal(BlockDataInAdderParachain{
 		State: uint64(1),
@@ -404,19 +333,37 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 		BlockData: bd,
 	}
 
-	toSubsystem := make(chan any)
-	candidateValidationSubsystem := CandidateValidation{
-		pvfHost:    newValidationHost(),
-		BlockState: mockBlockState,
-	}
-	defer candidateValidationSubsystem.Stop()
+	setup := func(
+		t *testing.T,
+		msg *ValidateFromChainState,
+		configMockInstance func(*MockInstance),
+	) (*CandidateValidation, chan any) {
 
-	go candidateValidationSubsystem.Run(context.Background(), toSubsystem)
+		ctrl := gomock.NewController(t)
+		mockInstance := NewMockInstance(ctrl)
+		configMockInstance(mockInstance)
+
+		msg.Ch = make(chan parachaintypes.OverseerFuncRes[ValidationResult])
+
+		mockBlockState := NewMockBlockState(ctrl)
+		mockBlockState.EXPECT().GetRuntime(common.MustHexToHash(
+			"0xded542bacb3ca6c033a57676f94ae7c8f36834511deb44e3164256fd3b1c0de0")).Return(mockInstance, nil).Times(1)
+
+		cv := CandidateValidation{
+			pvfHost:    newValidationHost(),
+			BlockState: mockBlockState,
+		}
+
+		t.Cleanup(cv.Stop)
+		toSubsystem := make(chan any)
+		return &cv, toSubsystem
+	}
 
 	tests := map[string]struct {
-		msg           ValidateFromChainState
-		want          *ValidationResult
-		expectedError error
+		msg                ValidateFromChainState
+		want               *ValidationResult
+		expectedError      error
+		configMockInstance func(*MockInstance)
 	}{
 		"invalid_pov_hash": {
 			msg: ValidateFromChainState{
@@ -425,6 +372,17 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 			},
 			want: &ValidationResult{
 				Invalid: &povHashMismatch,
+			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(
+						parachaintypes.ParaID(2),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&expectedPersistedValidationData, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(2),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
 			},
 		},
 		"invalid_pov_size": {
@@ -435,6 +393,17 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 			want: &ValidationResult{
 				Invalid: &paramsTooLarge,
 			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(
+						parachaintypes.ParaID(3),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&expectedPersistedValidationDataSmallMax, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(3),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
+			},
 		},
 		"code_mismatch": {
 			msg: ValidateFromChainState{
@@ -443,6 +412,17 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 			},
 			want: &ValidationResult{
 				Invalid: &codeHashMismatch,
+			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(
+						parachaintypes.ParaID(4),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&expectedPersistedValidationData, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(4),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
 			},
 		},
 		"bad_signature": {
@@ -453,6 +433,17 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 			want: &ValidationResult{
 				Invalid: &badSignature,
 			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(
+						parachaintypes.ParaID(5),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&expectedPersistedValidationData, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(5),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
+			},
 		},
 		"invalid_outputs": {
 			msg: ValidateFromChainState{
@@ -462,6 +453,18 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 			want: &ValidationResult{
 				Invalid: &invalidOutputs,
 			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(parachaintypes.ParaID(6),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&expectedPersistedValidationData, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(6),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
+				mi.EXPECT().ParachainHostCheckValidationOutputs(parachaintypes.ParaID(6),
+					validCandidateCommitments).Return(false, nil)
+			},
 		},
 		"bad_parent": {
 			msg: ValidateFromChainState{
@@ -470,6 +473,16 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 			},
 			want: &ValidationResult{
 				Invalid: &badParent,
+			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(parachaintypes.ParaID(7), gomock.AssignableToTypeOf(parachaintypes.
+						OccupiedCoreAssumption{})).
+					Return(nil, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(7),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
 			},
 		},
 		"happy_path": {
@@ -493,6 +506,20 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 					},
 				},
 			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().
+					ParachainHostPersistedValidationData(
+						parachaintypes.ParaID(1000),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&expectedPersistedValidationData, nil)
+				mi.EXPECT().
+					ParachainHostValidationCode(parachaintypes.ParaID(1000),
+						gomock.AssignableToTypeOf(parachaintypes.OccupiedCoreAssumption{})).
+					Return(&validationCode, nil)
+				mi.EXPECT().ParachainHostCheckValidationOutputs(parachaintypes.ParaID(1000),
+					validCandidateCommitments).Return(true, nil)
+
+			},
 		},
 	}
 	for name, tt := range tests {
@@ -500,11 +527,12 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			sender := make(chan parachaintypes.OverseerFuncRes[ValidationResult])
-			tt.msg.Ch = sender
+			candidateValidationSubsystem, toSubsystem := setup(t, &tt.msg, tt.configMockInstance)
+
+			go candidateValidationSubsystem.Run(context.Background(), toSubsystem)
 
 			toSubsystem <- tt.msg
-			result := <-sender
+			result := <-tt.msg.Ch
 			require.Equal(t, tt.want, &result.Data)
 		})
 	}

--- a/dot/parachain/candidate-validation/mocks_instance_test.go
+++ b/dot/parachain/candidate-validation/mocks_instance_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/dot/parachain/collator-protocol/collation_fetching_test.go
+++ b/dot/parachain/collator-protocol/collation_fetching_test.go
@@ -40,7 +40,7 @@ func TestCollationFetchingResponse(t *testing.T) {
 	collation := parachaintypes.Collation{
 		CandidateReceipt: parachaintypes.CandidateReceipt{
 			Descriptor: parachaintypes.CandidateDescriptor{
-				ParaID:                      uint32(1),
+				ParaID:                      1,
 				RelayParent:                 testHash,
 				Collator:                    collatorID,
 				PersistedValidationDataHash: testHash,

--- a/dot/parachain/collator-protocol/message.go
+++ b/dot/parachain/collator-protocol/message.go
@@ -388,11 +388,11 @@ func (cpvs CollatorProtocolValidatorSide) processCollatorProtocolMessage(sender 
 		}
 
 		// NOTE: assignments are setting when we handle view changes
-		_, ok = cpvs.currentAssignments[parachaintypes.ParaID(declareMessage.ParaID)]
+		_, ok = cpvs.currentAssignments[declareMessage.ParaID]
 		if ok {
 			logger.Errorf("declared as collator for current para: %d", declareMessage.ParaID)
 
-			peerData.SetCollating(declareMessage.CollatorId, parachaintypes.ParaID(declareMessage.ParaID))
+			peerData.SetCollating(declareMessage.CollatorId, declareMessage.ParaID)
 			cpvs.peerData[sender] = peerData
 		} else {
 			logger.Errorf("declared as collator for unneeded para: %d", declareMessage.ParaID)

--- a/dot/parachain/collator-protocol/message_test.go
+++ b/dot/parachain/collator-protocol/message_test.go
@@ -61,7 +61,7 @@ func TestCollationProtocol(t *testing.T) {
 
 	secondedEnumValue := parachaintypes.Seconded{
 		Descriptor: parachaintypes.CandidateDescriptor{
-			ParaID:                      uint32(1),
+			ParaID:                      1,
 			RelayParent:                 hash5,
 			Collator:                    collatorID,
 			PersistedValidationDataHash: hash5,
@@ -95,7 +95,7 @@ func TestCollationProtocol(t *testing.T) {
 			name: "Declare",
 			enumValue: collatorprotocolmessages.Declare{
 				CollatorId:        collatorID,
-				ParaID:            uint32(5),
+				ParaID:            5,
 				CollatorSignature: collatorSignature,
 			},
 			encodingValue: common.MustHexToBytes(testDataCollationProtocol["declare"]),
@@ -263,7 +263,7 @@ func TestHandleCollationMessageDeclare(t *testing.T) {
 			description: "fail if collator signature could not be verified",
 			declareMsg: collatorprotocolmessages.Declare{
 				CollatorId:        collatorID.AsBytes(),
-				ParaID:            uint32(5),
+				ParaID:            5,
 				CollatorSignature: parachaintypes.CollatorSignature{},
 			},
 			peerData: map[peer.ID]PeerData{
@@ -280,7 +280,7 @@ func TestHandleCollationMessageDeclare(t *testing.T) {
 			description: "fail if collator signature is invalid and report the sender",
 			declareMsg: collatorprotocolmessages.Declare{
 				CollatorId:        collatorID.AsBytes(),
-				ParaID:            uint32(5),
+				ParaID:            5,
 				CollatorSignature: invalidCollatorSignature,
 			},
 			peerData: map[peer.ID]PeerData{
@@ -307,7 +307,7 @@ func TestHandleCollationMessageDeclare(t *testing.T) {
 			description: "fail if paraID in Declare message is not assigned to our peer and report the sender",
 			declareMsg: collatorprotocolmessages.Declare{
 				CollatorId:        collatorID.AsBytes(),
-				ParaID:            uint32(5),
+				ParaID:            5,
 				CollatorSignature: collatorSignature,
 			},
 			peerData: map[peer.ID]PeerData{
@@ -337,7 +337,7 @@ func TestHandleCollationMessageDeclare(t *testing.T) {
 			description: "success case: check if PeerState of the sender has changed to Collating from Connected",
 			declareMsg: collatorprotocolmessages.Declare{
 				CollatorId:        collatorID.AsBytes(),
-				ParaID:            uint32(5),
+				ParaID:            5,
 				CollatorSignature: collatorSignature,
 			},
 			peerData: map[peer.ID]PeerData{
@@ -349,7 +349,7 @@ func TestHandleCollationMessageDeclare(t *testing.T) {
 				},
 			},
 			currentAssignments: map[parachaintypes.ParaID]uint{
-				parachaintypes.ParaID(5): 1,
+				5: 1,
 			},
 			success: true,
 		},
@@ -479,7 +479,7 @@ func TestHandleCollationMessageAdvertiseCollation(t *testing.T) {
 					state: PeerStateInfo{
 						PeerState: Collating,
 						CollatingPeerState: CollatingPeerState{
-							ParaID: parachaintypes.ParaID(6),
+							ParaID: 6,
 						},
 					},
 				},
@@ -643,7 +643,7 @@ func TestInsertAdvertisement(t *testing.T) {
 				state: PeerStateInfo{
 					PeerState: Collating,
 					CollatingPeerState: CollatingPeerState{
-						ParaID: parachaintypes.ParaID(5),
+						ParaID: 5,
 						advertisements: map[common.Hash][]parachaintypes.CandidateHash{
 							relayParent: {},
 						},
@@ -666,7 +666,7 @@ func TestInsertAdvertisement(t *testing.T) {
 				state: PeerStateInfo{
 					PeerState: Collating,
 					CollatingPeerState: CollatingPeerState{
-						ParaID:         parachaintypes.ParaID(5),
+						ParaID:         5,
 						advertisements: map[common.Hash][]parachaintypes.CandidateHash{},
 					},
 				},

--- a/dot/parachain/collator-protocol/messages/protocol_messages.go
+++ b/dot/parachain/collator-protocol/messages/protocol_messages.go
@@ -143,7 +143,7 @@ func NewCollatorProtocolMessage() CollatorProtocolMessage {
 // signature of the `PeerId` of the node using the given collator ID key.
 type Declare struct {
 	CollatorId        parachaintypes.CollatorID        `scale:"1"`
-	ParaID            uint32                           `scale:"2"`
+	ParaID            parachaintypes.ParaID            `scale:"2"`
 	CollatorSignature parachaintypes.CollatorSignature `scale:"3"`
 }
 

--- a/dot/parachain/collator-protocol/validator_side.go
+++ b/dot/parachain/collator-protocol/validator_side.go
@@ -267,7 +267,7 @@ func (cpvs *CollatorProtocolValidatorSide) assignIncoming(relayParent common.Has
 
 	switch c := coreNow.(type) {
 	case parachaintypes.OccupiedCore:
-		*paraNow = parachaintypes.ParaID(c.CandidateDescriptor.ParaID)
+		*paraNow = c.CandidateDescriptor.ParaID
 	case parachaintypes.ScheduledCore:
 		*paraNow = c.ParaID
 	case parachaintypes.Free:
@@ -960,7 +960,7 @@ func newFetchedCollationInfo(candidateReceipt parachaintypes.CandidateReceipt) (
 		return nil, fmt.Errorf("getting candidate hash: %w", err)
 	}
 	return &fetchedCollationInfo{
-		paraID:      parachaintypes.ParaID(candidateReceipt.Descriptor.ParaID),
+		paraID:      candidateReceipt.Descriptor.ParaID,
 		relayParent: candidateReceipt.Descriptor.RelayParent,
 		collatorID:  candidateReceipt.Descriptor.Collator,
 		candidateHash: parachaintypes.CandidateHash{

--- a/dot/parachain/collator-protocol/validator_side_test.go
+++ b/dot/parachain/collator-protocol/validator_side_test.go
@@ -43,7 +43,7 @@ func TestProcessOverseerMessage(t *testing.T) {
 
 	testCandidateReceipt := parachaintypes.CandidateReceipt{
 		Descriptor: parachaintypes.CandidateDescriptor{
-			ParaID:                      uint32(1000),
+			ParaID:                      1000,
 			RelayParent:                 common.MustHexToHash("0xded542bacb3ca6c033a57676f94ae7c8f36834511deb44e3164256fd3b1c0de0"), //nolint:lll
 			Collator:                    testCollatorID,
 			PersistedValidationDataHash: common.MustHexToHash("0x690d8f252ef66ab0f969c3f518f90012b849aa5ac94e1752c5e5ae5a8996de37"), //nolint:lll
@@ -109,7 +109,7 @@ func TestProcessOverseerMessage(t *testing.T) {
 						PeerState: Collating,
 						CollatingPeerState: CollatingPeerState{
 							CollatorID: testCollatorID,
-							ParaID:     parachaintypes.ParaID(6),
+							ParaID:     6,
 						},
 					},
 				},
@@ -173,7 +173,7 @@ func TestProcessOverseerMessage(t *testing.T) {
 						PeerState: Collating,
 						CollatingPeerState: CollatingPeerState{
 							CollatorID: testCollatorID,
-							ParaID:     parachaintypes.ParaID(6),
+							ParaID:     6,
 						},
 					},
 				},
@@ -255,7 +255,7 @@ func TestProcessOverseerMessage(t *testing.T) {
 						PeerState: Collating,
 						CollatingPeerState: CollatingPeerState{
 							CollatorID: testCollatorID,
-							ParaID:     parachaintypes.ParaID(6),
+							ParaID:     6,
 						},
 					},
 				},
@@ -354,7 +354,7 @@ func TestProcessBackedOverseerMessage(t *testing.T) {
 		{
 			description: "Backed message fails with unknown relay parent",
 			msg: collatorprotocolmessages.Backed{
-				ParaID:   parachaintypes.ParaID(6),
+				ParaID:   6,
 				ParaHead: common.Hash{},
 			},
 			canSecond:                   true,
@@ -382,7 +382,7 @@ func TestProcessBackedOverseerMessage(t *testing.T) {
 		{
 			description: "Backed message gets processed successfully when seconding is not allowed",
 			msg: collatorprotocolmessages.Backed{
-				ParaID:   parachaintypes.ParaID(6),
+				ParaID:   6,
 				ParaHead: common.Hash{},
 			},
 			canSecond: false,

--- a/dot/parachain/runtime/instance.go
+++ b/dot/parachain/runtime/instance.go
@@ -97,9 +97,11 @@ type ValidatorInstance interface {
 
 // RuntimeInstance for runtime methods
 type RuntimeInstance interface {
-	ParachainHostPersistedValidationData(parachaidID uint32, assumption parachaintypes.OccupiedCoreAssumption,
+	ParachainHostPersistedValidationData(
+		parachaidID parachaintypes.ParaID,
+		assumption parachaintypes.OccupiedCoreAssumption,
 	) (*parachaintypes.PersistedValidationData, error)
-	ParachainHostValidationCode(parachaidID uint32, assumption parachaintypes.OccupiedCoreAssumption,
+	ParachainHostValidationCode(parachaidID parachaintypes.ParaID, assumption parachaintypes.OccupiedCoreAssumption,
 	) (*parachaintypes.ValidationCode, error)
 	ParachainHostValidationCodeByHash(validationCodeHash common.Hash) (*parachaintypes.ValidationCode, error)
 	ParachainHostCheckValidationOutputs(parachainID parachaintypes.ParaID, outputs parachaintypes.CandidateCommitments) (

--- a/dot/parachain/statement_fetching_test.go
+++ b/dot/parachain/statement_fetching_test.go
@@ -101,7 +101,7 @@ func TestStatementFetchingResponse(t *testing.T) {
 
 	missingDataInStatement := MissingDataInStatement{
 		Descriptor: parachaintypes.CandidateDescriptor{
-			ParaID:                      uint32(1),
+			ParaID:                      1,
 			RelayParent:                 testHash,
 			Collator:                    collatorID,
 			PersistedValidationDataHash: testHash,

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -54,7 +54,7 @@ func TestStatementVDT(t *testing.T) {
 
 	secondedEnumValue := Seconded{
 		Descriptor: CandidateDescriptor{
-			ParaID:                      uint32(1),
+			ParaID:                      1,
 			RelayParent:                 hash5,
 			Collator:                    collatorID,
 			PersistedValidationDataHash: hash5,

--- a/dot/parachain/types/types.go
+++ b/dot/parachain/types/types.go
@@ -96,7 +96,7 @@ type ValidationCodeHash common.Hash
 // CandidateDescriptor is a unique descriptor of the candidate receipt.
 type CandidateDescriptor struct {
 	// The ID of the para this is a candidate for.
-	ParaID uint32 `scale:"1"`
+	ParaID ParaID `scale:"1"`
 
 	// RelayParent is the hash of the relay-chain block this should be executed in
 	// the context of.

--- a/dot/parachain/validation-protocol/statement_distribution_message_test.go
+++ b/dot/parachain/validation-protocol/statement_distribution_message_test.go
@@ -63,7 +63,7 @@ func TestStatementDistributionMessage(t *testing.T) {
 
 	secondedEnumValue := parachaintypes.Seconded{
 		Descriptor: parachaintypes.CandidateDescriptor{
-			ParaID:                      uint32(1),
+			ParaID:                      1,
 			RelayParent:                 hash5,
 			Collator:                    collatorID,
 			PersistedValidationDataHash: hash5,

--- a/dot/state/mocks_runtime_test.go
+++ b/dot/state/mocks_runtime_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/dot/sync/mock_runtime_test.go
+++ b/dot/sync/mock_runtime_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/lib/babe/mocks/runtime.go
+++ b/lib/babe/mocks/runtime.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/lib/blocktree/mocks_test.go
+++ b/lib/blocktree/mocks_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/lib/genesis/genesis.go
+++ b/lib/genesis/genesis.go
@@ -6,6 +6,8 @@ package genesis
 import (
 	"encoding/json"
 
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+
 	"github.com/ChainSafe/gossamer/dot/types"
 	"github.com/ChainSafe/gossamer/lib/common"
 )
@@ -197,7 +199,7 @@ type hrmp struct {
 }
 
 type registrar struct {
-	NextFreeParaID *uint `json:"nextFreeParaId,omitempty"`
+	NextFreeParaID *parachaintypes.ParaID `json:"nextFreeParaId,omitempty"`
 }
 
 type xcmPallet struct {

--- a/lib/grandpa/mocks_runtime_test.go
+++ b/lib/grandpa/mocks_runtime_test.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -50,10 +50,10 @@ type Instance interface {
 		equivocationProof types.GrandpaEquivocationProof, keyOwnershipProof types.GrandpaOpaqueKeyOwnershipProof,
 	) error
 	ParachainHostPersistedValidationData(
-		parachaidID uint32,
+		parachaidID parachaintypes.ParaID,
 		assumption parachaintypes.OccupiedCoreAssumption,
 	) (*parachaintypes.PersistedValidationData, error)
-	ParachainHostValidationCode(parachaidID uint32, assumption parachaintypes.OccupiedCoreAssumption,
+	ParachainHostValidationCode(parachaidID parachaintypes.ParaID, assumption parachaintypes.OccupiedCoreAssumption,
 	) (*parachaintypes.ValidationCode, error)
 	ParachainHostValidationCodeByHash(validationCodeHash common.Hash) (*parachaintypes.ValidationCode, error)
 	ParachainHostValidators() ([]parachaintypes.ValidatorID, error)

--- a/lib/runtime/mocks/mocks.go
+++ b/lib/runtime/mocks/mocks.go
@@ -435,7 +435,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostMinimumBackingVotes() *gomock.C
 }
 
 // ParachainHostPersistedValidationData mocks base method.
-func (m *MockInstance) ParachainHostPersistedValidationData(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
+func (m *MockInstance) ParachainHostPersistedValidationData(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.PersistedValidationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostPersistedValidationData", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.PersistedValidationData)
@@ -495,7 +495,7 @@ func (mr *MockInstanceMockRecorder) ParachainHostSessionInfo(arg0 any) *gomock.C
 }
 
 // ParachainHostValidationCode mocks base method.
-func (m *MockInstance) ParachainHostValidationCode(arg0 uint32, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
+func (m *MockInstance) ParachainHostValidationCode(arg0 parachaintypes.ParaID, arg1 parachaintypes.OccupiedCoreAssumption) (*parachaintypes.ValidationCode, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidationCode", arg0, arg1)
 	ret0, _ := ret[0].(*parachaintypes.ValidationCode)

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -1121,7 +1121,7 @@ func (in *Instance) GrandpaSubmitReportEquivocationUnsignedExtrinsic(
 
 // ParachainHostPersistedValidationData returns persisted validation data for the given parachain id.
 func (in *Instance) ParachainHostPersistedValidationData(
-	parachaidID uint32,
+	parachaidID parachaintypes.ParaID,
 	assumption parachaintypes.OccupiedCoreAssumption,
 ) (*parachaintypes.PersistedValidationData, error) {
 	buffer := bytes.NewBuffer(nil)
@@ -1150,7 +1150,9 @@ func (in *Instance) ParachainHostPersistedValidationData(
 }
 
 // ParachainHostValidationCode returns validation code for the given parachain id.
-func (in *Instance) ParachainHostValidationCode(parachaidID uint32, assumption parachaintypes.OccupiedCoreAssumption,
+func (in *Instance) ParachainHostValidationCode(
+	parachaidID parachaintypes.ParaID,
+	assumption parachaintypes.OccupiedCoreAssumption,
 ) (*parachaintypes.ValidationCode, error) {
 	buffer := bytes.NewBuffer(nil)
 	encoder := scale.NewEncoder(buffer)

--- a/lib/runtime/wazero/instance_test.go
+++ b/lib/runtime/wazero/instance_test.go
@@ -1399,7 +1399,7 @@ func TestInstance_ParachainHostPersistedValidationData(t *testing.T) {
 	tt := getParachainHostTrie(t, parachainTestData.Storage)
 	rt := NewTestInstance(t, runtime.WESTEND_RUNTIME_v0942, TestWithTrie(tt))
 
-	parachainID := uint32(1000)
+	parachainID := parachaintypes.ParaID(1000)
 	assumption := parachaintypes.NewOccupiedCoreAssumption()
 	err := assumption.SetValue(parachaintypes.IncludedOccupiedCoreAssumption{})
 	require.NoError(t, err)
@@ -1425,7 +1425,7 @@ func TestInstance_ParachainHostValidationCode(t *testing.T) {
 	tt := getParachainHostTrie(t, parachainTestData.Storage)
 	rt := NewTestInstance(t, runtime.WESTEND_RUNTIME_v0942, TestWithTrie(tt))
 
-	parachainID := uint32(1000)
+	parachainID := parachaintypes.ParaID(1000)
 	assumption := parachaintypes.NewOccupiedCoreAssumption()
 	err := assumption.SetValue(parachaintypes.IncludedOccupiedCoreAssumption{})
 	require.NoError(t, err)


### PR DESCRIPTION
## Changes

No functional changes, just mechanically replacing `uint32` with `parachaintypes.ParaID`.

## Tests

```sh
go test ./...
```

## Issues

Closes #3883 