### PR TITLE
fix(sync/paseo): Ignoring config value for min peer

### DIFF
--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -191,7 +191,6 @@ func (s *SyncService) HandleBlockAnnounceHandshake(from peer.ID, msg *network.Bl
 func (s *SyncService) HandleBlockAnnounce(from peer.ID, msg *network.BlockAnnounceMessage) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	logger.Infof("receiving a block announce from %s", from.String())
 
 	repChange, err := s.currentStrategy.OnBlockAnnounce(from, msg)
 

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -125,6 +125,9 @@ func NewSyncService(cfgs ...ServiceConfig) *SyncService {
 		cfg(svc)
 	}
 
+	// Ignore config value, ideally we change minPeersDefault but doing this solution introduces a regression
+	svc.minPeers = minPeersDefault
+
 	return svc
 }
 
@@ -188,6 +191,7 @@ func (s *SyncService) HandleBlockAnnounceHandshake(from peer.ID, msg *network.Bl
 func (s *SyncService) HandleBlockAnnounce(from peer.ID, msg *network.BlockAnnounceMessage) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	logger.Infof("receiving a block announce from %s", from.String())
 
 	repChange, err := s.currentStrategy.OnBlockAnnounce(from, msg)
 


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->

In the sync code, we do not send handshake messages until we have available workers that is >= minPeers. If we do not send handshakes we do not receive announces. When starting up syncing, we send a dummy handshake message so that we receive a block announce which we then use to set the target block. 

This is okay, except that the config value for minPeers overrides the sync packages default and sets it to 0, and thus we get stuck waiting for block announces and syncing stalls because a target is never set.

Ideally, this is solved with something like #4257. However, given that #4257 introduced a regression and this is a very urgent issue, I have come up with a workaround to ignore the config value here and use the default sync package value.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues
#4288 

<!-- Write the issue number(s), for example: #123 -->