### PR TITLE
fix(dot/sync): ensure node can be stopped before min peers have been acquired

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ const (
 	// DefaultDiscoveryInterval is the default discovery interval
 	DefaultDiscoveryInterval = 10 * time.Second
 	// DefaultMinPeers is the default minimum number of peers
-	DefaultMinPeers = 0
+	DefaultMinPeers = 5
 	// DefaultMaxPeers is the default maximum number of peers
 	DefaultMaxPeers = 50
 

--- a/docs/docs/usage/command-line.md
+++ b/docs/docs/usage/command-line.md
@@ -32,7 +32,7 @@ These are the flags that can be used with the `gossamer` command
 	    By default, all modules log 'info'.
 	    The global log level can be set with --log global=debug
 --max-peers Maximum number of peers to connect to (default 50)
---min-peers Minimum number of peers to connect to (default 0)
+--min-peers Minimum number of peers to connect to (default 5)
 --name Name of the node
 --no-bootstrap Disables network bootstrapping (mdns still enabled)
 --no-mdns Disables network mdns discovery

--- a/dot/sync/service.go
+++ b/dot/sync/service.go
@@ -141,11 +141,7 @@ func (s *SyncService) waitWorkers() {
 		}
 
 		err = s.network.BlockAnnounceHandshake(bestBlockHeader)
-		if err != nil {
-			if errors.Is(err, network.ErrNoPeersConnected) {
-				continue
-			}
-
+		if err != nil && !errors.Is(err, network.ErrNoPeersConnected) {
 			logger.Criticalf("waiting workers: %s", err.Error())
 			break
 		}

--- a/zombienet_tests/functional/0001-basic-network.toml
+++ b/zombienet_tests/functional/0001-basic-network.toml
@@ -7,16 +7,16 @@ chain = "westend-local"
 name = "alice"
 command = "gossamer"
 validator = true
-args = ["--key alice"]
+args = ["--key alice", "--min-peers 0"]
 
 [[relaychain.nodes]]
 name = "bob"
 command = "gossamer"
 validator = true
-args = ["--key bob"]
+args = ["--key bob", "--min-peers 0"]
 
 [[relaychain.nodes]]
 name = "charlie"
 command = "gossamer"
 validator = true
-args = ["--key charlie"]
+args = ["--key charlie", "--min-peers 0"]


### PR DESCRIPTION
## Changes

* set min peers default to 5
* explicitely pass `--min-peers 0` to zombienet processes
* fix bug in sync service that prevented shutdown before min number of workers have been acquired

## Tests

```sh
go test -timeout=2m -tags integration -run TestStartStopNode ./...
```

## Issues

Fixes #4290 
Replaces #4289 