### PR TITLE
feat(primitives/state-machine) `TrieBackend` implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/dgraph-io/ristretto v1.0.0
 	github.com/disiqueira/gotree v1.0.0
 	github.com/dolthub/maphash v0.1.0
-	github.com/elastic/go-freelru v0.14.0
+	github.com/elastic/go-freelru v0.15.0
 	github.com/ethereum/go-ethereum v1.14.11
 	github.com/fatih/color v1.18.0
 	github.com/gammazero/deque v0.2.1
@@ -229,5 +229,3 @@ toolchain go1.23.2
 replace github.com/tetratelabs/wazero => github.com/ChainSafe/wazero v0.0.0-20240319130522-78b21a59bd5f
 
 replace github.com/centrifuge/go-substrate-rpc-client/v4 => github.com/timwu20/go-substrate-rpc-client/v4 v4.0.0-20231110032757-3d8e441b7303
-
-replace github.com/elastic/go-freelru => github.com/timwu20/go-freelru v0.0.0-20241023201517-deb64adeae4c

--- a/go.mod
+++ b/go.mod
@@ -229,3 +229,5 @@ toolchain go1.23.2
 replace github.com/tetratelabs/wazero => github.com/ChainSafe/wazero v0.0.0-20240319130522-78b21a59bd5f
 
 replace github.com/centrifuge/go-substrate-rpc-client/v4 => github.com/timwu20/go-substrate-rpc-client/v4 v4.0.0-20231110032757-3d8e441b7303
+
+replace github.com/elastic/go-freelru => github.com/timwu20/go-freelru v0.0.0-20241023201517-deb64adeae4c

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/dgraph-io/badger/v4 v4.3.1
 	github.com/dgraph-io/ristretto v1.0.0
 	github.com/disiqueira/gotree v1.0.0
+	github.com/dolthub/maphash v0.1.0
+	github.com/elastic/go-freelru v0.14.0
 	github.com/ethereum/go-ethereum v1.14.11
 	github.com/fatih/color v1.18.0
 	github.com/gammazero/deque v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9pu
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/elastic/go-freelru v0.14.0 h1:3XpQW+bsRsAR6tQ4DJHTFRcLJXqOIZJJGagR+bTLOjw=
-github.com/elastic/go-freelru v0.14.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
+github.com/elastic/go-freelru v0.15.0 h1:Jo1aY8JAvpyxbTDJEudrsBfjFDaALpfVv8mxuh9sfvI=
+github.com/elastic/go-freelru v0.15.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
@@ -638,8 +638,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
-github.com/timwu20/go-freelru v0.0.0-20241023201517-deb64adeae4c h1:WKEqrNAA0DIVpTHGV70TonOX7pN0tB8CSkT8Z8Jbxjw=
-github.com/timwu20/go-freelru v0.0.0-20241023201517-deb64adeae4c/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/timwu20/go-substrate-rpc-client/v4 v4.0.0-20231110032757-3d8e441b7303 h1:FX7wMjDD0sWGWsC9k+stJaYwThbaq6BDT7ArlInU0KI=
 github.com/timwu20/go-substrate-rpc-client/v4 v4.0.0-20231110032757-3d8e441b7303/go.mod h1:1p5145LS4BacYYKFstnHScydK9MLjZ15l72v8mbngPQ=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/go.sum
+++ b/go.sum
@@ -128,9 +128,13 @@ github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tL
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dolthub/maphash v0.1.0 h1:bsQ7JsF4FkkWyrP3oCnFJgrCUAFbFf3kOl4L/QxPDyQ=
+github.com/dolthub/maphash v0.1.0/go.mod h1:gkg4Ch4CdCDu5h6PMriVLawB7koZ+5ijb9puGMV50a4=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/elastic/go-freelru v0.14.0 h1:3XpQW+bsRsAR6tQ4DJHTFRcLJXqOIZJJGagR+bTLOjw=
+github.com/elastic/go-freelru v0.14.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=

--- a/go.sum
+++ b/go.sum
@@ -638,6 +638,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
+github.com/timwu20/go-freelru v0.0.0-20241023201517-deb64adeae4c h1:WKEqrNAA0DIVpTHGV70TonOX7pN0tB8CSkT8Z8Jbxjw=
+github.com/timwu20/go-freelru v0.0.0-20241023201517-deb64adeae4c/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/timwu20/go-substrate-rpc-client/v4 v4.0.0-20231110032757-3d8e441b7303 h1:FX7wMjDD0sWGWsC9k+stJaYwThbaq6BDT7ArlInU0KI=
 github.com/timwu20/go-substrate-rpc-client/v4 v4.0.0-20231110032757-3d8e441b7303/go.mod h1:1p5145LS4BacYYKFstnHScydK9MLjZ15l72v8mbngPQ=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=

--- a/internal/client/state-db/pruning.go
+++ b/internal/client/state-db/pruning.go
@@ -207,11 +207,11 @@ func (drqim *inMemDeathRowQueue[BlockHash, Key]) Import(
 		block, ok := drqim.deathIndex[k]
 		if ok {
 			delete(drqim.deathIndex, k)
-			delete(drqim.deathRows.At(int(block-base)).deleted, k)
+			delete(drqim.deathRows.At(int(block-base)).deleted, k) //nolint:gosec
 		}
 	}
 	// add new keys
-	importedBlock := base + uint64(drqim.deathRows.Len())
+	importedBlock := base + uint64(drqim.deathRows.Len()) //nolint:gosec
 	deletedMap := make(map[Key]any)
 	for _, k := range deleted {
 		drqim.deathIndex[k] = importedBlock
@@ -236,7 +236,7 @@ func (drqim *inMemDeathRowQueue[BlockHash, Key]) PopFront(base uint64) (*deathRo
 // Check if the block at the given `index` of the queue exist
 // it is the caller's responsibility to ensure `index` won't be out of bounds
 func (drqim *inMemDeathRowQueue[BlockHash, Key]) HaveBlock(hash BlockHash, index uint) haveBlock {
-	if drqim.deathRows.At(int(index)).hash == hash {
+	if drqim.deathRows.At(int(index)).hash == hash { //nolint:gosec
 		return haveBlockYes
 	}
 	return haveBlockNo
@@ -244,7 +244,7 @@ func (drqim *inMemDeathRowQueue[BlockHash, Key]) HaveBlock(hash BlockHash, index
 
 // Return the number of block in the pruning window
 func (drqim *inMemDeathRowQueue[BlockHash, Key]) Len(base uint64) uint64 {
-	return uint64(drqim.deathRows.Len())
+	return uint64(drqim.deathRows.Len()) //nolint:gosec
 }
 
 // Get the hash of the next pruning block

--- a/internal/client/state-db/pruning.go
+++ b/internal/client/state-db/pruning.go
@@ -207,11 +207,11 @@ func (drqim *inMemDeathRowQueue[BlockHash, Key]) Import(
 		block, ok := drqim.deathIndex[k]
 		if ok {
 			delete(drqim.deathIndex, k)
-			delete(drqim.deathRows.At(int(block-base)).deleted, k) //nolint:gosec
+			delete(drqim.deathRows.At(int(block-base)).deleted, k)
 		}
 	}
 	// add new keys
-	importedBlock := base + uint64(drqim.deathRows.Len()) //nolint:gosec
+	importedBlock := base + uint64(drqim.deathRows.Len())
 	deletedMap := make(map[Key]any)
 	for _, k := range deleted {
 		drqim.deathIndex[k] = importedBlock
@@ -236,7 +236,7 @@ func (drqim *inMemDeathRowQueue[BlockHash, Key]) PopFront(base uint64) (*deathRo
 // Check if the block at the given `index` of the queue exist
 // it is the caller's responsibility to ensure `index` won't be out of bounds
 func (drqim *inMemDeathRowQueue[BlockHash, Key]) HaveBlock(hash BlockHash, index uint) haveBlock {
-	if drqim.deathRows.At(int(index)).hash == hash { //nolint:gosec
+	if drqim.deathRows.At(int(index)).hash == hash {
 		return haveBlockYes
 	}
 	return haveBlockNo
@@ -244,7 +244,7 @@ func (drqim *inMemDeathRowQueue[BlockHash, Key]) HaveBlock(hash BlockHash, index
 
 // Return the number of block in the pruning window
 func (drqim *inMemDeathRowQueue[BlockHash, Key]) Len(base uint64) uint64 {
-	return uint64(drqim.deathRows.Len()) //nolint:gosec
+	return uint64(drqim.deathRows.Len())
 }
 
 // Get the hash of the next pruning block

--- a/internal/cost-lru/cost_lru.go
+++ b/internal/cost-lru/cost_lru.go
@@ -1,0 +1,101 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package costlru
+
+import (
+	"math"
+	"time"
+
+	"github.com/elastic/go-freelru"
+)
+
+// LRU is a cost based LRU wrapped around [freelru.LRU].
+type LRU[K comparable, V any] struct {
+	currentCost     uint
+	maxCost         uint
+	costFunc        func(K, V) uint32
+	onEvictCallback freelru.OnEvictCallback[K, V]
+	*freelru.LRU[K, V]
+}
+
+// Costructor for [LRU].
+func New[K comparable, V any](maxCost uint, hash freelru.HashKeyCallback[K], costFunc func(K, V) uint32) (*LRU[K, V], error) {
+	var capacity = uint32(math.MaxUint32)
+	if maxCost < math.MaxUint32 {
+		capacity = uint32(maxCost)
+	}
+	lru, err := freelru.New[K, V](capacity, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	l := LRU[K, V]{
+		maxCost:  maxCost,
+		costFunc: costFunc,
+		LRU:      lru,
+	}
+	lru.SetOnEvict(l.evictCallback)
+
+	return &l, nil
+}
+
+func (l *LRU[K, V]) costRemove(key K, value V) (cost uint32, removed bool, canAdd bool) {
+	if l.LRU.Contains(key) {
+		oldVal, ok := l.LRU.Peek(key)
+		if !ok {
+			panic("should be in lru")
+		}
+		cost := l.costFunc(key, oldVal)
+		l.currentCost -= uint(cost)
+	}
+	cost = l.costFunc(key, value)
+	if uint(cost) > l.maxCost {
+		return cost, removed, false
+	}
+	for uint(cost)+l.currentCost > l.maxCost {
+		_, _, removed = l.LRU.RemoveOldest()
+		if !removed {
+			panic("huh?")
+		}
+	}
+	return cost, removed, true
+}
+
+func (l *LRU[K, V]) Add(key K, value V) (added bool, evicted bool) {
+	cost, removed, canAdd := l.costRemove(key, value)
+	l.currentCost += uint(cost)
+	evicted = l.LRU.Add(key, value)
+	return canAdd, evicted || removed
+}
+
+func (l *LRU[K, V]) AddWithLifetime(key K, value V, lifetime time.Duration) (added bool, evicted bool) {
+	cost, removed, canAdd := l.costRemove(key, value)
+	l.currentCost += uint(cost)
+	evicted = l.LRU.AddWithLifetime(key, value, lifetime)
+	return canAdd, evicted || removed
+}
+
+func (l *LRU[K, V]) evictCallback(key K, value V) {
+	cost := l.costFunc(key, value)
+	if uint(cost) <= l.currentCost {
+		l.currentCost -= uint(cost)
+	} else {
+		l.currentCost = 0
+	}
+	if l.onEvictCallback != nil {
+		l.onEvictCallback(key, value)
+	}
+}
+
+func (l *LRU[K, V]) SetOnEvict(onEvict freelru.OnEvictCallback[K, V]) {
+	l.onEvictCallback = onEvict
+}
+
+func (l *LRU[K, V]) Cost() uint {
+	return l.currentCost
+}
+
+func (l *LRU[K, V]) MaxCost() uint {
+	return l.maxCost
+}

--- a/internal/cost-lru/cost_lru.go
+++ b/internal/cost-lru/cost_lru.go
@@ -20,7 +20,9 @@ type LRU[K comparable, V any] struct {
 }
 
 // Costructor for [LRU].
-func New[K comparable, V any](maxCost uint, hash freelru.HashKeyCallback[K], costFunc func(K, V) uint32) (*LRU[K, V], error) {
+func New[K comparable, V any](
+	maxCost uint, hash freelru.HashKeyCallback[K], costFunc func(K, V) uint32,
+) (*LRU[K, V], error) {
 	var capacity = uint32(math.MaxUint32)
 	if maxCost < math.MaxUint32 {
 		capacity = uint32(maxCost)

--- a/internal/cost-lru/cost_lru_test.go
+++ b/internal/cost-lru/cost_lru_test.go
@@ -1,0 +1,188 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package costlru
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/dolthub/maphash"
+	"github.com/stretchr/testify/require"
+)
+
+type Hasher struct {
+	maphash.Hasher[ValueCacheKeyHash[hash.H256]]
+}
+
+func (h Hasher) Hash(key ValueCacheKeyHash[hash.H256]) uint32 {
+	return uint32(h.Hasher.Hash(key))
+}
+
+type ValueCacheKeyHash[H runtime.Hash] struct {
+	StorageRoot H
+	StorageKey  string
+}
+
+func TestLRU(t *testing.T) {
+	hasher := Hasher{maphash.NewHasher[ValueCacheKeyHash[hash.H256]]()}
+
+	var costFunc = func(key ValueCacheKeyHash[hash.H256], val []byte) uint32 {
+		keyCost := uint32(len(key.StorageKey))
+		return keyCost + uint32(len(val))
+	}
+
+	maxNum := uint(1024)
+	maxSize := uint(costFunc(ValueCacheKeyHash[hash.H256]{
+		StorageRoot: hash.NewRandomH256(),
+		StorageKey:  string(hash.NewRandomH256()),
+	}, []byte{1})) * maxNum
+
+	l, err := New[ValueCacheKeyHash[hash.H256], []byte](maxSize, hasher.Hash, costFunc)
+	require.NoError(t, err)
+
+	someRoot := hash.NewRandomH256()
+	allKeys := make([]ValueCacheKeyHash[hash.H256], 0)
+	for i := 0; i < int(maxNum)*2; i++ {
+		hash := ValueCacheKeyHash[hash.H256]{
+			StorageRoot: someRoot,
+			StorageKey:  string(hash.NewRandomH256()),
+		}
+		allKeys = append(allKeys, hash)
+		added, evicted := l.Add(hash, []byte{uint8(i)})
+		require.True(t, added)
+		if i >= int(maxNum) {
+			require.True(t, evicted)
+		} else {
+			require.False(t, evicted)
+		}
+	}
+
+	require.Equal(t, maxSize, l.currentCost)
+
+	for i, key := range l.Keys() {
+		require.Equal(t, allKeys[int(maxNum)+i], key)
+	}
+}
+
+func TestLRU_EvictCallback(t *testing.T) {
+	hasher := Hasher{maphash.NewHasher[ValueCacheKeyHash[hash.H256]]()}
+
+	var costFunc = func(key ValueCacheKeyHash[hash.H256], val []byte) uint32 {
+		keyCost := uint32(len(key.StorageKey))
+		return keyCost + uint32(len(val))
+	}
+
+	maxNum := uint(1024)
+	maxSize := uint(costFunc(ValueCacheKeyHash[hash.H256]{
+		StorageRoot: hash.NewRandomH256(),
+		StorageKey:  string(hash.NewRandomH256()),
+	}, []byte{1})) * maxNum
+
+	evictCount := 0
+	l, err := New[ValueCacheKeyHash[hash.H256], []byte](maxSize, hasher.Hash, costFunc)
+	require.NoError(t, err)
+	l.SetOnEvict(func(vckh ValueCacheKeyHash[hash.H256], b []byte) {
+		evictCount++
+	})
+
+	someRoot := hash.NewRandomH256()
+	allKeys := make([]ValueCacheKeyHash[hash.H256], 0)
+	for i := 0; i < int(maxNum)*2; i++ {
+		hash := ValueCacheKeyHash[hash.H256]{
+			StorageRoot: someRoot,
+			StorageKey:  string(hash.NewRandomH256()),
+		}
+		allKeys = append(allKeys, hash)
+		added, evicted := l.Add(hash, []byte{uint8(i)})
+		require.True(t, added)
+		if i >= int(maxNum) {
+			require.True(t, evicted)
+		} else {
+			require.False(t, evicted)
+		}
+	}
+
+	require.Equal(t, maxSize, l.currentCost)
+
+	for i, key := range l.Keys() {
+		require.Equal(t, allKeys[int(maxNum)+i], key)
+	}
+
+	require.Equal(t, int(maxNum), evictCount)
+}
+
+func TestLRU_Purge(t *testing.T) {
+	hasher := Hasher{maphash.NewHasher[ValueCacheKeyHash[hash.H256]]()}
+
+	var costFunc = func(key ValueCacheKeyHash[hash.H256], val []byte) uint32 {
+		keyCost := uint32(len(key.StorageKey))
+		return keyCost + uint32(len(val))
+	}
+
+	maxNum := uint(3)
+	maxSize := uint(costFunc(ValueCacheKeyHash[hash.H256]{
+		StorageRoot: hash.NewRandomH256(),
+		StorageKey:  string(hash.NewRandomH256()),
+	}, []byte{1})) * maxNum
+
+	l, err := New[ValueCacheKeyHash[hash.H256], []byte](maxSize, hasher.Hash, costFunc)
+	require.NoError(t, err)
+
+	someRoot := hash.NewRandomH256()
+	allKeys := make([]ValueCacheKeyHash[hash.H256], 0)
+	for i := 0; i < int(maxNum)*2; i++ {
+		hash := ValueCacheKeyHash[hash.H256]{
+			StorageRoot: someRoot,
+			StorageKey:  string(hash.NewRandomH256()),
+		}
+		allKeys = append(allKeys, hash)
+		added, evicted := l.Add(hash, []byte{uint8(i)})
+		require.True(t, added)
+		if i >= int(maxNum) {
+			require.True(t, evicted)
+		} else {
+			require.False(t, evicted)
+		}
+	}
+
+	require.Equal(t, maxSize, l.currentCost)
+
+	for i, key := range l.Keys() {
+		require.Equal(t, allKeys[int(maxNum)+i], key)
+	}
+
+	l.Purge()
+	require.Equal(t, 0, l.Len())
+	require.Equal(t, uint(0), l.currentCost)
+}
+
+func TestLRU_Same_Entries(t *testing.T) {
+	hasher := Hasher{maphash.NewHasher[ValueCacheKeyHash[hash.H256]]()}
+
+	var costFunc = func(key ValueCacheKeyHash[hash.H256], val []byte) uint32 {
+		keyCost := uint32(len(key.StorageKey))
+		return keyCost + uint32(len(val))
+	}
+
+	someKey := ValueCacheKeyHash[hash.H256]{
+		StorageRoot: hash.NewRandomH256(),
+		StorageKey:  string(hash.NewRandomH256()),
+	}
+
+	maxNum := uint(5)
+	maxSize := uint(costFunc(someKey, []byte{1})) * maxNum
+
+	l, err := New[ValueCacheKeyHash[hash.H256], []byte](maxSize, hasher.Hash, costFunc)
+	require.NoError(t, err)
+
+	for i := 0; i < int(maxNum); i++ {
+		added, evicted := l.Add(someKey, []byte{1})
+		require.True(t, added)
+		require.False(t, evicted)
+	}
+	require.Equal(t, 1, l.Len())
+	require.Equal(t, int(l.Cost()), int(costFunc(someKey, []byte{1})))
+
+}

--- a/internal/primitives/consensus/grandpa/grandpa.go
+++ b/internal/primitives/consensus/grandpa/grandpa.go
@@ -55,6 +55,12 @@ type SignedMessage[H, N any] grandpa.SignedMessage[H, N, AuthoritySignature, Aut
 // Commit is a commit message for this chain's block type.
 type Commit[H, N any] grandpa.Commit[H, N, AuthoritySignature, AuthorityID]
 
+// ScheduledChange is a scheduled authority change.
+type ScheduledChange[N runtime.Number] struct {
+	NextAuthorities AuthorityList
+	Delay           N
+}
+
 // GrandpaJustification is A GRANDPA justification for block finality, it includes
 // a commit message and an ancestry proof including all headers routing all
 // precommit target blocks to the commit target block. Due to the current voting

--- a/internal/primitives/consensus/grandpa/grandpa.go
+++ b/internal/primitives/consensus/grandpa/grandpa.go
@@ -55,12 +55,6 @@ type SignedMessage[H, N any] grandpa.SignedMessage[H, N, AuthoritySignature, Aut
 // Commit is a commit message for this chain's block type.
 type Commit[H, N any] grandpa.Commit[H, N, AuthoritySignature, AuthorityID]
 
-// ScheduledChange is a scheduled authority change.
-type ScheduledChange[N runtime.Number] struct {
-	NextAuthorities AuthorityList
-	Delay           N
-}
-
 // GrandpaJustification is A GRANDPA justification for block finality, it includes
 // a commit message and an ancestry proof including all headers routing all
 // precommit target blocks to the commit target block. Due to the current voting

--- a/internal/primitives/core/hash/hash.go
+++ b/internal/primitives/core/hash/hash.go
@@ -68,3 +68,9 @@ func NewRandomH256() H256 {
 	}
 	return H256(token)
 }
+
+// NewH256 is constructor for a zero case H256
+func NewH256() H256 {
+	token := make([]byte, 32)
+	return H256(token)
+}

--- a/internal/primitives/database/mem.go
+++ b/internal/primitives/database/mem.go
@@ -52,35 +52,35 @@ func (mdb *MemDB[H]) Commit(transaction Transaction[H]) error {
 			if !ok {
 				mdb.inner[change.ColumnID] = make(map[string]refCountValue)
 			}
-			cv, ok := mdb.inner[change.ColumnID][change.Hash.String()]
+			cv, ok := mdb.inner[change.ColumnID][string(change.Hash.Bytes())]
 			if ok {
 				cv.refCount += 1
-				mdb.inner[change.ColumnID][change.Hash.String()] = cv
+				mdb.inner[change.ColumnID][string(change.Hash.Bytes())] = cv
 			} else {
-				mdb.inner[change.ColumnID][change.Hash.String()] = refCountValue{1, change.Preimage}
+				mdb.inner[change.ColumnID][string(change.Hash.Bytes())] = refCountValue{1, change.Preimage}
 			}
 		case Reference[H]:
 			_, ok := mdb.inner[change.ColumnID]
 			if !ok {
 				mdb.inner[change.ColumnID] = make(map[string]refCountValue)
 			}
-			cv, ok := mdb.inner[change.ColumnID][change.Hash.String()]
+			cv, ok := mdb.inner[change.ColumnID][string(change.Hash.Bytes())]
 			if ok {
 				cv.refCount += 1
-				mdb.inner[change.ColumnID][change.Hash.String()] = cv
+				mdb.inner[change.ColumnID][string(change.Hash.Bytes())] = cv
 			}
 		case Release[H]:
 			_, ok := mdb.inner[change.ColumnID]
 			if !ok {
 				mdb.inner[change.ColumnID] = make(map[string]refCountValue)
 			}
-			cv, ok := mdb.inner[change.ColumnID][change.Hash.String()]
+			cv, ok := mdb.inner[change.ColumnID][string(change.Hash.Bytes())]
 			if ok {
 				cv.refCount -= 1
 				if cv.refCount == 0 {
-					delete(mdb.inner[change.ColumnID], change.Hash.String())
+					delete(mdb.inner[change.ColumnID], string(change.Hash.Bytes()))
 				} else {
-					mdb.inner[change.ColumnID][change.Hash.String()] = cv
+					mdb.inner[change.ColumnID][string(change.Hash.Bytes())] = cv
 				}
 			}
 		}

--- a/internal/primitives/runtime/interfaces.go
+++ b/internal/primitives/runtime/interfaces.go
@@ -22,6 +22,8 @@ type Hash interface {
 	Bytes() []byte
 	// String returns a unique string representation of the hash
 	String() string
+	// Length return the byte length of the hash
+	Length() int
 }
 
 // Hasher is an interface around hashing
@@ -31,6 +33,9 @@ type Hasher[H Hash] interface {
 
 	// Produce the hash of some codec-encodable value.
 	HashEncoded(s any) H
+
+	// Construct new hash from source data
+	NewHash(data []byte) H
 }
 
 // Blake2-256 Hash implementation.
@@ -48,11 +53,15 @@ func (bt256 BlakeTwo256) HashEncoded(s any) hash.H256 {
 	return bt256.Hash(bytes)
 }
 
+func (bt256 BlakeTwo256) NewHash(data []byte) hash.H256 {
+	return hash.H256(data)
+}
+
 var _ Hasher[hash.H256] = BlakeTwo256{}
 
-// Header is the interface for a header. It has types for a `Number`,
-// and `Hash`. It provides access to an `ExtrinsicsRoot`, `StateRoot` and
-// `ParentHash`, as well as a `Digest` and a block `Number`.
+// Header is the interface for a header. It has types for a Number,
+// and Hash. It provides access to an ExtrinsicsRoot, StateRoot and
+// ParentHash, as well as a Digest and a block Number.
 type Header[N Number, H Hash] interface {
 	// Returns a reference to the header number.
 	Number() N
@@ -83,9 +92,9 @@ type Header[N Number, H Hash] interface {
 	Hash() H
 }
 
-// Block represents a block. It has types for `Extrinsic` pieces of information as well as a `Header`.
+// Block represents a block. It has types for Extrinsic pieces of information as well as a Header.
 //
-// You can iterate over each of the `Extrinsics` and retrieve the `Header`.
+// You can iterate over each of the Extrinsics and retrieve the Header.
 type Block[N Number, H Hash] interface {
 	// Returns a reference to the header.
 	Header() Header[N, H]
@@ -97,9 +106,9 @@ type Block[N Number, H Hash] interface {
 	Hash() H
 }
 
-// Extrinisic is the interface for an `Extrinsic`.
+// Extrinisic is the interface for an Extrinsic.
 type Extrinsic interface {
-	// Is this `Extrinsic` signed?
-	// If no information are available about signed/unsigned, `nil` should be returned.
+	// Is this Extrinsic signed?
+	// If no information are available about signed/unsigned, nil should be returned.
 	IsSigned() *bool
 }

--- a/internal/primitives/state-machine/backend.go
+++ b/internal/primitives/state-machine/backend.go
@@ -1,0 +1,188 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"iter"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+)
+
+// A struct containing arguments for iterating over the storage.
+type IterArgs struct {
+	// The prefix of the keys over which to iterate.
+	Prefix []byte
+
+	// The prefix from which to start the iteration from.
+	//
+	// This is inclusive and the iteration will include the key which is specified here.
+	StartAt []byte
+
+	// If this is true then the iteration will *not* include
+	// the key specified in StartAt, if there is such a key.
+	StartAtExclusive bool
+
+	// The info of the child trie over which to iterate over.
+	ChildInfo storage.ChildInfo
+
+	// Whether to stop iteration when a missing trie node is reached.
+	//
+	// When a missing trie node is reached the iterator will:
+	//   - return an error if this is set to false (default)
+	//   - return nil if this is set to true
+	StopOnIncompleteDatabase bool
+}
+
+// An interface for a raw storage iterator.
+type StorageIterator[Hash runtime.Hash, Hasher runtime.Hasher[Hash]] interface {
+	// Fetches the next key from the storage.
+	NextKey(backend *TrieBackend[Hash, Hasher]) (StorageKey, error)
+
+	// Fetches the next key and value from the storage.
+	NextKeyValue(backend *TrieBackend[Hash, Hasher]) (*StorageKeyValue, error)
+
+	// Returns whether the end of iteration was reached without an error.
+	Complete() bool
+}
+
+// An iterator over storage keys and values.
+type PairsIter[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	backend *TrieBackend[H, Hasher]
+	rawIter StorageIterator[H, Hasher]
+}
+
+func (pi *PairsIter[H, Hasher]) Next() (*StorageKeyValue, error) {
+	return pi.rawIter.NextKeyValue(pi.backend)
+}
+
+func (pi *PairsIter[H, Hasher]) All() iter.Seq2[StorageKeyValue, error] {
+	return func(yield func(StorageKeyValue, error) bool) {
+		for {
+			item, err := pi.Next()
+			if err != nil {
+				return
+			}
+			if item == nil {
+				return
+			}
+			if !yield(*item, err) {
+				return
+			}
+		}
+	}
+}
+
+// An iterator over storage keys.
+type KeysIter[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	backend *TrieBackend[H, Hasher]
+	rawIter StorageIterator[H, Hasher]
+}
+
+func (ki *KeysIter[H, Hasher]) Next() (StorageKey, error) {
+	return ki.rawIter.NextKey(ki.backend)
+}
+
+func (ki *KeysIter[H, Hasher]) All() iter.Seq2[StorageKey, error] {
+	return func(yield func(StorageKey, error) bool) {
+		for {
+			item, err := ki.Next()
+			if err != nil {
+				return
+			}
+			if item == nil {
+				return
+			}
+			if !yield(item, err) {
+				return
+			}
+		}
+	}
+}
+
+// The transaction type used by [Backend].
+//
+// This transaction contains all the changes that need to be applied to the backend to create the
+// state for a new block.
+type BackendTransaction[Hash runtime.Hash, Hasher runtime.Hasher[Hash]] struct {
+	*trie.PrefixedMemoryDB[Hash, Hasher]
+}
+
+func NewBackendTransaction[Hash runtime.Hash, Hasher runtime.Hasher[Hash]]() BackendTransaction[Hash, Hasher] {
+	return BackendTransaction[Hash, Hasher]{trie.NewPrefixedMemoryDB[Hash, Hasher]()}
+}
+
+// Reexport of [trie.KeyValue]
+type Delta = trie.KeyValue
+
+type ChildDelta struct {
+	storage.ChildInfo
+	Deltas []Delta
+}
+
+// A state backend is used to read state data and can have changes committed
+// to it.
+//
+// The clone operation (if implemented) should be cheap.
+type Backend[Hash runtime.Hash, H runtime.Hasher[Hash]] interface {
+	// Get keyed storage or nil if there is nothing associated.
+	Storage(key []byte) (StorageValue, error)
+
+	// Get keyed storage value hash or nil if there is nothing associated.
+	StorageHash(key []byte) (*Hash, error)
+
+	// Get the merkle value or nil if there is nothing associated.
+	ClosestMerkleValue(key []byte) (triedb.MerkleValue[Hash], error)
+
+	// Get the child merkle value or nil if there is nothing associated.
+	ChildClosestMerkleValue(childInfo storage.ChildInfo, key []byte) (triedb.MerkleValue[Hash], error)
+
+	// Get keyed child storage or nil if there is nothing associated.
+	ChildStorage(childInfo storage.ChildInfo, key []byte) (StorageValue, error)
+
+	// Get child keyed storage value hash or nil if there is nothing associated.
+	ChildStorageHash(childInfo storage.ChildInfo, key []byte) (*Hash, error)
+
+	// true if a key exists in storage.
+	ExistsStorage(key []byte) (bool, error)
+
+	// true if a key exists in child storage.
+	ExistsChildStorage(childInfo storage.ChildInfo, key []byte) (bool, error)
+
+	// Return the next key in storage in lexicographic order or nil if there is no value.
+	NextStorageKey(key []byte) (StorageKey, error)
+
+	// Return the next key in child storage in lexicographic order or nil if there is no value.
+	NextChildStorageKey(childInfo storage.ChildInfo, key []byte) (StorageKey, error)
+
+	// Calculate the storage root, with given delta over what is already stored in
+	// the backend, and produce a "transaction" that can be used to commit.
+	// Does not include child storage updates.
+	StorageRoot(delta []Delta, stateVersion storage.StateVersion) (Hash, BackendTransaction[Hash, H])
+
+	// Calculate the child storage root, with given delta over what is already stored in
+	// the backend, and produce a "transaction" that can be used to commit. The second argument
+	// is true if child storage root equals default storage root.
+	ChildStorageRoot(childInfo storage.ChildInfo, delta []Delta, stateVersion storage.StateVersion) (Hash, bool, BackendTransaction[Hash, H])
+
+	// Returns a lifetimeless raw storage iterator.
+	RawIter(args IterArgs) (StorageIterator[Hash, H], error)
+
+	// Get an iterator over key/value pairs.
+	Pairs(args IterArgs) (PairsIter[Hash, H], error)
+
+	// Get an iterator over keys.
+	Keys(args IterArgs) (KeysIter[Hash, H], error)
+
+	// Calculate the storage root, with given delta over what is already stored
+	// in the backend, and produce a "transaction" that can be used to commit.
+	// Does include child storage updates.
+	FullStorageRoot(
+		delta []Delta,
+		childDeltas []ChildDelta,
+		stateVersion storage.StateVersion,
+	) (Hash, BackendTransaction[Hash, H])
+}

--- a/internal/primitives/state-machine/backend.go
+++ b/internal/primitives/state-machine/backend.go
@@ -166,7 +166,9 @@ type Backend[Hash runtime.Hash, H runtime.Hasher[Hash]] interface {
 	// Calculate the child storage root, with given delta over what is already stored in
 	// the backend, and produce a "transaction" that can be used to commit. The second argument
 	// is true if child storage root equals default storage root.
-	ChildStorageRoot(childInfo storage.ChildInfo, delta []Delta, stateVersion storage.StateVersion) (Hash, bool, BackendTransaction[Hash, H])
+	ChildStorageRoot(
+		childInfo storage.ChildInfo, delta []Delta, stateVersion storage.StateVersion,
+	) (Hash, bool, BackendTransaction[Hash, H])
 
 	// Returns a lifetimeless raw storage iterator.
 	RawIter(args IterArgs) (StorageIterator[Hash, H], error)
@@ -181,8 +183,6 @@ type Backend[Hash runtime.Hash, H runtime.Hasher[Hash]] interface {
 	// in the backend, and produce a "transaction" that can be used to commit.
 	// Does include child storage updates.
 	FullStorageRoot(
-		delta []Delta,
-		childDeltas []ChildDelta,
-		stateVersion storage.StateVersion,
+		delta []Delta, childDeltas []ChildDelta, stateVersion storage.StateVersion,
 	) (Hash, BackendTransaction[Hash, H])
 }

--- a/internal/primitives/state-machine/in_memory_backend.go
+++ b/internal/primitives/state-machine/in_memory_backend.go
@@ -14,7 +14,7 @@ type MemoryDBTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
 	*TrieBackend[H, Hasher]
 }
 
-// / Create a new empty instance of in-memory backend.
+// Create a new empty instance of in-memory backend.
 func NewMemoryDBTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]]() MemoryDBTrieBackend[H, Hasher] {
 	mdb := trie.NewPrefixedMemoryDB[H, Hasher]()
 	root := (*new(Hasher)).Hash([]byte{0})

--- a/internal/primitives/state-machine/in_memory_backend.go
+++ b/internal/primitives/state-machine/in_memory_backend.go
@@ -1,0 +1,86 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+)
+
+// MemoryDBTrieBackend is [TrieBackend] fulfilled with [trie.PrefixedMemoryDB]
+type MemoryDBTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	*TrieBackend[H, Hasher]
+}
+
+// / Create a new empty instance of in-memory backend.
+func NewMemoryDBTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]]() MemoryDBTrieBackend[H, Hasher] {
+	mdb := trie.NewPrefixedMemoryDB[H, Hasher]()
+	root := (*new(Hasher)).Hash([]byte{0})
+	return MemoryDBTrieBackend[H, Hasher]{
+		TrieBackend: NewTrieBackend[H, Hasher](HashDBTrieBackendStorage[H]{mdb}, root, nil, nil),
+	}
+}
+
+type change struct {
+	storage.ChildInfo // can be nil
+	StorageCollection
+}
+
+func (tb *MemoryDBTrieBackend[H, Hasher]) clone() MemoryDBTrieBackend[H, Hasher] {
+	return MemoryDBTrieBackend[H, Hasher]{
+		NewTrieBackend[H, Hasher](tb.essence.BackendStorage(), tb.essence.root, nil, nil),
+	}
+}
+
+// Copy the state, with applied updates
+func (tb *MemoryDBTrieBackend[H, Hasher]) update(changes []change, stateVersion storage.StateVersion) MemoryDBTrieBackend[H, Hasher] {
+	clone := tb.clone()
+	clone.insert(changes, stateVersion)
+	return clone
+}
+
+// Insert values into backend trie.
+func (tb *MemoryDBTrieBackend[H, Hasher]) insert(changes []change, stateVersion storage.StateVersion) {
+	top := make([]change, 0)
+	child := make([]change, 0)
+	for _, change := range changes {
+		if change.ChildInfo == nil {
+			top = append(top, change)
+		} else {
+			child = append(child, change)
+		}
+	}
+	var deltas []Delta
+	for _, change := range top {
+		for _, skv := range change.StorageCollection {
+			deltas = append(deltas, Delta{skv.StorageKey, skv.StorageValue})
+		}
+	}
+
+	var childDeltas []ChildDelta
+	for _, change := range child {
+		var delta []Delta
+		for _, skv := range change.StorageCollection {
+			delta = append(delta, Delta{skv.StorageKey, skv.StorageValue})
+		}
+		childDeltas = append(childDeltas, ChildDelta{
+			ChildInfo: change.ChildInfo,
+			Deltas:    delta,
+		})
+	}
+	root, tx := tb.FullStorageRoot(deltas, childDeltas, stateVersion)
+
+	tb.applyTransaction(root, tx)
+}
+
+// Apply the given transaction to this backend and set the root to the given value.
+func (tb *MemoryDBTrieBackend[H, Hasher]) applyTransaction(root H, transaction BackendTransaction[H, Hasher]) {
+	hdbtbs := tb.essence.storage.(HashDBTrieBackendStorage[H])
+	storage := hdbtbs.HashDB.(*trie.PrefixedMemoryDB[H, Hasher])
+
+	storage.Consolidate(&transaction.MemoryDB)
+	new := NewTrieBackend[H, Hasher](hdbtbs, root, nil, nil)
+	tb.TrieBackend = new
+}

--- a/internal/primitives/state-machine/in_memory_backend.go
+++ b/internal/primitives/state-machine/in_memory_backend.go
@@ -35,7 +35,9 @@ func (tb *MemoryDBTrieBackend[H, Hasher]) clone() MemoryDBTrieBackend[H, Hasher]
 }
 
 // Copy the state, with applied updates
-func (tb *MemoryDBTrieBackend[H, Hasher]) update(changes []change, stateVersion storage.StateVersion) MemoryDBTrieBackend[H, Hasher] {
+func (tb *MemoryDBTrieBackend[H, Hasher]) update(
+	changes []change, stateVersion storage.StateVersion,
+) MemoryDBTrieBackend[H, Hasher] {
 	clone := tb.clone()
 	clone.insert(changes, stateVersion)
 	return clone
@@ -55,7 +57,7 @@ func (tb *MemoryDBTrieBackend[H, Hasher]) insert(changes []change, stateVersion 
 	var deltas []Delta
 	for _, change := range top {
 		for _, skv := range change.StorageCollection {
-			deltas = append(deltas, Delta{skv.StorageKey, skv.StorageValue})
+			deltas = append(deltas, Delta{Key: skv.StorageKey, Value: skv.StorageValue})
 		}
 	}
 
@@ -63,7 +65,7 @@ func (tb *MemoryDBTrieBackend[H, Hasher]) insert(changes []change, stateVersion 
 	for _, change := range child {
 		var delta []Delta
 		for _, skv := range change.StorageCollection {
-			delta = append(delta, Delta{skv.StorageKey, skv.StorageValue})
+			delta = append(delta, Delta{Key: skv.StorageKey, Value: skv.StorageValue})
 		}
 		childDeltas = append(childDeltas, ChildDelta{
 			ChildInfo: change.ChildInfo,

--- a/internal/primitives/state-machine/in_memory_backend_test.go
+++ b/internal/primitives/state-machine/in_memory_backend_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryDBTrieBackend(t *testing.T) {
+	t.Run("in_memory_with_child_trie_only", func(t *testing.T) {
+		mdbtb := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+		childInfo := storage.NewDefaultChildInfo([]byte("1"))
+		tb := mdbtb.update([]change{
+			{
+				ChildInfo: childInfo,
+				StorageCollection: StorageCollection{
+					StorageKeyValue{
+						StorageKey:   []byte("2"),
+						StorageValue: []byte("3"),
+					},
+				},
+			},
+		}, storage.StateVersionV1)
+		val, err := tb.ChildStorage(childInfo, []byte("2"))
+		require.NoError(t, err)
+		require.Equal(t, StorageValue([]byte("3")), val)
+		require.NotNil(t, childInfo.PrefixedStorageKey())
+	})
+
+	t.Run("insert_multiple_times_child_data_works", func(t *testing.T) {
+		mdbtb := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+		childInfo := storage.NewDefaultChildInfo([]byte("1"))
+
+		mdbtb.insert([]change{
+			{
+				ChildInfo:         childInfo,
+				StorageCollection: StorageCollection{{StorageKey: []byte("2"), StorageValue: []byte("3")}},
+			},
+		}, storage.StateVersionV1)
+		mdbtb.insert([]change{
+			{
+				ChildInfo:         childInfo,
+				StorageCollection: StorageCollection{{StorageKey: []byte("1"), StorageValue: []byte("3")}},
+			},
+		}, storage.StateVersionV1)
+
+		val, err := mdbtb.ChildStorage(childInfo, []byte("2"))
+		require.NoError(t, err)
+		require.Equal(t, StorageValue([]byte("3")), val)
+
+		val, err = mdbtb.ChildStorage(childInfo, []byte("1"))
+		require.NoError(t, err)
+		require.Equal(t, StorageValue([]byte("3")), val)
+	})
+}

--- a/internal/primitives/state-machine/overlayed_changes.go
+++ b/internal/primitives/state-machine/overlayed_changes.go
@@ -1,0 +1,19 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+// Storage key.
+type StorageKey []byte
+
+// Storage value. Value can be nil
+type StorageValue []byte
+
+// Storage key and value.
+type StorageKeyValue struct {
+	StorageKey
+	StorageValue
+}
+
+// In memory array of storage values.
+type StorageCollection []StorageKeyValue

--- a/internal/primitives/state-machine/trie_backend.go
+++ b/internal/primitives/state-machine/trie_backend.go
@@ -1,0 +1,276 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+
+	hashdb "github.com/ChainSafe/gossamer/internal/hash-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/cache"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/recorder"
+	"github.com/ChainSafe/gossamer/pkg/scale"
+	triedb "github.com/ChainSafe/gossamer/pkg/trie/triedb"
+)
+
+// A provider of trie caches that are compatible with [triedb.TrieDB].
+type TrieCacheProvider[H runtime.Hash, Cache triedb.TrieCache[H]] interface {
+	// Return a [triedb.TrieDB] compatible cache.
+	//
+	// The storage_root parameter *must* be the storage root of the trie this cache is used for.
+	//
+	// NOTE: Implementors should use the storage_root to differentiate between storage keys that
+	// may belong to different tries.
+	TrieCache(storageRoot H) (cache Cache, unlock func())
+
+	// Returns a cache that can be used with a [triedb.TrieDB] where mutations are performed.
+	//
+	// When finished with the operation on the trie, it is required to call [TrieCacheProvider.Merge] to
+	// merge the cached items for the correct storage root.
+	TrieCacheMut() (cache Cache, unlock func())
+
+	// Merge the cached data in other into the provider using the given new_root.
+	//
+	// This must be used for the cache returned by [TrieCacheProvivder.TrieCacheMut] as otherwise the
+	// cached data is just thrown away.
+	Merge(other Cache, newRoot H)
+}
+
+type cachedIter[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	lastKey []byte
+	iter    rawIter[H, Hasher]
+}
+
+// Patricia trie-based backend. Transaction type is an overlay of changes to commit.
+type TrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	essence                trieBackendEssence[H, Hasher]
+	nextStorageKeyCache    *cachedIter[H, Hasher]
+	nextStorageKeyCacheMtx sync.Mutex
+}
+
+// Constructor for [TrieBackend].
+func NewTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]](
+	storage TrieBackendStorage[H],
+	root H,
+	cache TrieCacheProvider[H, *cache.TrieCache[H]],
+	recorder *recorder.Recorder[H],
+) *TrieBackend[H, Hasher] {
+	return &TrieBackend[H, Hasher]{
+		essence: newTrieBackendEssence[H, Hasher](storage, root, cache, recorder),
+	}
+}
+
+// Wrap the given [TrieBackend].
+//
+// This can be used for example if all accesses to the trie should
+// be recorded while some other functionality still uses the non-recording
+// backend.
+//
+// The backend storage and the cache will be taken from other.
+func NewWrappedTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]](
+	other *TrieBackend[H, Hasher],
+) *TrieBackend[H, Hasher] {
+	return NewTrieBackend[H, Hasher](
+		other.essence.BackendStorage(),
+		other.essence.root,
+		other.essence.trieNodeCache,
+		nil,
+	)
+}
+
+// Create a backend used for checking the proof.
+//
+// proof and root must match, i.e. root must be the correct root of proof nodes.
+func NewProofCheckTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]](
+	root H, proof trie.StorageProof,
+) (*TrieBackend[H, Hasher], error) {
+	db := trie.NewMemoryDBFromStorageProof[H, Hasher](proof)
+
+	if db.Contains(root, hashdb.EmptyPrefix) {
+		return NewTrieBackend[H, Hasher](HashDBTrieBackendStorage[H]{db}, root, nil, nil), nil
+	}
+	return nil, fmt.Errorf("invalid execution proof")
+}
+
+func (tb *TrieBackend[H, Hasher]) Storage(key []byte) (StorageValue, error) {
+	return tb.essence.Storage(key)
+}
+
+func (tb *TrieBackend[H, Hasher]) StorageHash(key []byte) (*H, error) {
+	return tb.essence.StorageHash(key)
+}
+
+func (tb *TrieBackend[H, Hasher]) ChildStorage(childInfo storage.ChildInfo, key []byte) (StorageValue, error) {
+	return tb.essence.ChildStorage(childInfo, key)
+}
+
+func (tb *TrieBackend[H, Hasher]) ChildStorageHash(childInfo storage.ChildInfo, key []byte) (*H, error) {
+	return tb.essence.ChildStorageHash(childInfo, key)
+}
+
+func (tb *TrieBackend[H, Hasher]) ClosestMerkleValue(key []byte) (triedb.MerkleValue[H], error) {
+	return tb.essence.ClosestMerkleValue(key)
+}
+
+func (tb *TrieBackend[H, Hasher]) ChildClosestMerkleValue(childInfo storage.ChildInfo, key []byte) (triedb.MerkleValue[H], error) {
+	return tb.essence.ChildClosestMerkleValue(childInfo, key)
+}
+
+func (tb *TrieBackend[H, Hasher]) ExistsStorage(key []byte) (bool, error) {
+	h, err := tb.StorageHash(key)
+	if err != nil {
+		return false, err
+	}
+	if h != nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (tb *TrieBackend[H, Hasher]) ExistsChildStorage(childInfo storage.ChildInfo, key []byte) (bool, error) {
+	h, err := tb.ChildStorageHash(childInfo, key)
+	if err != nil {
+		return false, err
+	}
+	if h != nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (tb *TrieBackend[H, Hasher]) NextStorageKey(key []byte) (StorageKey, error) {
+	var isCached bool
+	tb.nextStorageKeyCacheMtx.Lock()
+	defer tb.nextStorageKeyCacheMtx.Unlock()
+	var cache *cachedIter[H, Hasher]
+	if tb.nextStorageKeyCache != nil {
+		isCached = bytes.Equal(tb.nextStorageKeyCache.lastKey, key)
+	} else {
+		tb.nextStorageKeyCache = &cachedIter[H, Hasher]{}
+	}
+	cache = tb.nextStorageKeyCache
+
+	if !isCached {
+		iter, err := tb.essence.RawIter(IterArgs{
+			StartAt:          key,
+			StartAtExclusive: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		cache.iter = *iter
+		tb.nextStorageKeyCache = cache
+	}
+
+	nextKey, err := cache.iter.NextKey(tb)
+	if err != nil {
+		return nil, err
+	}
+	if nextKey == nil {
+		return nil, nil
+	}
+
+	cache.lastKey = nextKey
+	return nextKey, nil
+}
+
+func (tb *TrieBackend[H, Hasher]) NextChildStorageKey(childInfo storage.ChildInfo, key []byte) (StorageKey, error) {
+	return tb.essence.NextChildStorageKey(childInfo, key)
+}
+
+func (tb *TrieBackend[H, Hasher]) RawIter(args IterArgs) (StorageIterator[H, Hasher], error) {
+	return tb.essence.RawIter(args)
+}
+
+func (tb *TrieBackend[H, Hasher]) StorageRoot(delta []Delta, stateVersion storage.StateVersion) (H, BackendTransaction[H, Hasher]) {
+	h, pmdb := tb.essence.StorageRoot(delta, stateVersion)
+	return h, BackendTransaction[H, Hasher]{pmdb}
+}
+
+func (tb *TrieBackend[H, Hasher]) ChildStorageRoot(childInfo storage.ChildInfo, delta []Delta, stateVersion storage.StateVersion) (H, bool, BackendTransaction[H, Hasher]) {
+	h, b, pmdb := tb.essence.ChildStorageRoot(childInfo, delta, stateVersion)
+	return h, b, BackendTransaction[H, Hasher]{pmdb}
+}
+
+func (tb *TrieBackend[H, Hasher]) Pairs(args IterArgs) (PairsIter[H, Hasher], error) {
+	rawIter, err := tb.RawIter(args)
+	if err != nil {
+		return PairsIter[H, Hasher]{}, err
+	}
+	return PairsIter[H, Hasher]{
+		backend: tb,
+		rawIter: rawIter,
+	}, nil
+}
+
+func (tb *TrieBackend[H, Hasher]) Keys(args IterArgs) (KeysIter[H, Hasher], error) {
+	rawIter, err := tb.RawIter(args)
+	if err != nil {
+		return KeysIter[H, Hasher]{}, err
+	}
+	return KeysIter[H, Hasher]{
+		backend: tb,
+		rawIter: rawIter,
+	}, nil
+}
+
+func (tb *TrieBackend[H, Hasher]) FullStorageRoot(
+	delta []Delta,
+	childDeltas []ChildDelta,
+	stateVersion storage.StateVersion,
+) (H, BackendTransaction[H, Hasher]) {
+	type ChildRoot struct {
+		StorageKey       []byte
+		EncodedChildRoot []byte
+	}
+	var childRoots []ChildRoot
+	var txs BackendTransaction[H, Hasher] = NewBackendTransaction[H, Hasher]()
+
+	// child first
+	for _, cd := range childDeltas {
+		childInfo := cd.ChildInfo
+		childDeltas := cd.Deltas
+
+		childRoot, empty, childTxs := tb.ChildStorageRoot(childInfo, childDeltas, stateVersion)
+		prefixedStorageKey := childInfo.PrefixedStorageKey()
+
+		txs.Consolidate(&childTxs.MemoryDB)
+		if empty {
+			childRoots = append(childRoots, ChildRoot{
+				StorageKey: prefixedStorageKey,
+			})
+		} else {
+			childRoots = append(childRoots, ChildRoot{
+				StorageKey:       prefixedStorageKey,
+				EncodedChildRoot: scale.MustMarshal(childRoot),
+			})
+		}
+	}
+
+	chainedDelta := delta
+	for _, cr := range childRoots {
+		chainedDelta = append(chainedDelta, Delta{
+			Key:   cr.StorageKey,
+			Value: cr.EncodedChildRoot,
+		})
+	}
+	root, parentTxs := tb.StorageRoot(chainedDelta, stateVersion)
+	txs.Consolidate(&parentTxs.MemoryDB)
+
+	return root, txs
+}
+
+func (tb *TrieBackend[H, Hasher]) ExtractProof() *trie.StorageProof {
+	recorder := tb.essence.recorder
+	tb.essence.recorder = nil
+	if recorder != nil {
+		proof := recorder.DrainStorageProof()
+		return &proof
+	}
+	return nil
+}

--- a/internal/primitives/state-machine/trie_backend.go
+++ b/internal/primitives/state-machine/trie_backend.go
@@ -74,12 +74,14 @@ func NewTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]](
 // The backend storage and the cache will be taken from other.
 func NewWrappedTrieBackend[H runtime.Hash, Hasher runtime.Hasher[H]](
 	other *TrieBackend[H, Hasher],
+	cache TrieCacheProvider[H, *cache.TrieCache[H]],
+	recorder *recorder.Recorder[H],
 ) *TrieBackend[H, Hasher] {
 	return NewTrieBackend[H, Hasher](
 		other.essence.BackendStorage(),
 		other.essence.root,
 		other.essence.trieNodeCache,
-		nil,
+		recorder,
 	)
 }
 

--- a/internal/primitives/state-machine/trie_backend.go
+++ b/internal/primitives/state-machine/trie_backend.go
@@ -117,7 +117,9 @@ func (tb *TrieBackend[H, Hasher]) ClosestMerkleValue(key []byte) (triedb.MerkleV
 	return tb.essence.ClosestMerkleValue(key)
 }
 
-func (tb *TrieBackend[H, Hasher]) ChildClosestMerkleValue(childInfo storage.ChildInfo, key []byte) (triedb.MerkleValue[H], error) {
+func (tb *TrieBackend[H, Hasher]) ChildClosestMerkleValue(
+	childInfo storage.ChildInfo, key []byte,
+) (triedb.MerkleValue[H], error) {
 	return tb.essence.ChildClosestMerkleValue(childInfo, key)
 }
 
@@ -187,12 +189,16 @@ func (tb *TrieBackend[H, Hasher]) RawIter(args IterArgs) (StorageIterator[H, Has
 	return tb.essence.RawIter(args)
 }
 
-func (tb *TrieBackend[H, Hasher]) StorageRoot(delta []Delta, stateVersion storage.StateVersion) (H, BackendTransaction[H, Hasher]) {
+func (tb *TrieBackend[H, Hasher]) StorageRoot(
+	delta []Delta, stateVersion storage.StateVersion,
+) (H, BackendTransaction[H, Hasher]) {
 	h, pmdb := tb.essence.StorageRoot(delta, stateVersion)
 	return h, BackendTransaction[H, Hasher]{pmdb}
 }
 
-func (tb *TrieBackend[H, Hasher]) ChildStorageRoot(childInfo storage.ChildInfo, delta []Delta, stateVersion storage.StateVersion) (H, bool, BackendTransaction[H, Hasher]) {
+func (tb *TrieBackend[H, Hasher]) ChildStorageRoot(
+	childInfo storage.ChildInfo, delta []Delta, stateVersion storage.StateVersion,
+) (H, bool, BackendTransaction[H, Hasher]) {
 	h, b, pmdb := tb.essence.ChildStorageRoot(childInfo, delta, stateVersion)
 	return h, b, BackendTransaction[H, Hasher]{pmdb}
 }

--- a/internal/primitives/state-machine/trie_backend_essence.go
+++ b/internal/primitives/state-machine/trie_backend_essence.go
@@ -1,0 +1,642 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"slices"
+	"sync"
+
+	hashdb "github.com/ChainSafe/gossamer/internal/hash-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/cache"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/recorder"
+	ptrie "github.com/ChainSafe/gossamer/pkg/trie"
+	triedb "github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"golang.org/x/exp/constraints"
+)
+
+type IterState uint
+
+const (
+	Pending IterState = iota
+	FinishedComplete
+	FinishedIncomplete
+)
+
+// A raw iterator over the storage.
+type rawIter[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	stopOnImcompleteDatabase bool
+	skipIfFirst              StorageKey
+	root                     H
+	childInfo                storage.ChildInfo
+	trieIter                 triedb.TrieDBRawIterator[H, Hasher]
+	state                    IterState
+}
+
+func prepare[H runtime.Hash, Hasher runtime.Hasher[H], R any](
+	ri *rawIter[H, Hasher],
+	backend *trieBackendEssence[H, Hasher],
+	callback func(*triedb.TrieDB[H, Hasher], *triedb.TrieDBRawIterator[H, Hasher]) (*R, error),
+) (*R, error) {
+	if ri.state != Pending {
+		return nil, nil
+	}
+
+	var result *R
+	var err error
+	withTrieDB[H, Hasher](backend, ri.root, ri.childInfo, func(db *triedb.TrieDB[H, Hasher]) {
+		result, err = callback(db, &ri.trieIter)
+	})
+	if err != nil {
+		ri.state = FinishedIncomplete
+		if errors.Is(err, triedb.ErrIncompleteDB) && ri.stopOnImcompleteDatabase {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if result != nil {
+		return result, nil
+	}
+	ri.state = FinishedComplete
+	return nil, nil
+}
+
+func (ri *rawIter[H, Hasher]) NextKey(backend *TrieBackend[H, Hasher]) (StorageKey, error) {
+	skipIfFirst := ri.skipIfFirst
+	ri.skipIfFirst = nil
+
+	key, err := prepare[H, Hasher, []byte](
+		ri,
+		&backend.essence,
+		func(trie *triedb.TrieDB[H, Hasher], trieIter *triedb.TrieDBRawIterator[H, Hasher]) (*[]byte, error) {
+			result, err := trieIter.NextKey()
+			if err != nil {
+				return nil, err
+			}
+			if skipIfFirst != nil {
+				if result != nil {
+					if slices.Equal(result, skipIfFirst) {
+						result, err = trieIter.NextKey()
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+			}
+			return &result, nil
+		})
+
+	if key == nil {
+		return nil, err
+	}
+	storageKey := StorageKey(*key)
+	return storageKey, nil
+}
+
+func (ri *rawIter[H, Hasher]) NextKeyValue(backend *TrieBackend[H, Hasher]) (*StorageKeyValue, error) {
+	skipIfFirst := ri.skipIfFirst
+	ri.skipIfFirst = nil
+
+	pair, err := prepare[H, Hasher, StorageKeyValue](
+		ri,
+		&backend.essence,
+		func(trie *triedb.TrieDB[H, Hasher], trieIter *triedb.TrieDBRawIterator[H, Hasher]) (*StorageKeyValue, error) {
+			result, err := trieIter.NextItem()
+			if err != nil {
+				return nil, err
+			}
+			if skipIfFirst != nil {
+				if result != nil {
+					if bytes.Equal(result.Key, skipIfFirst) {
+						result, err = trieIter.NextItem()
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+			}
+			if result != nil {
+				return &StorageKeyValue{result.Key, result.Value}, nil
+			}
+			return nil, nil
+		})
+	return pair, err
+}
+
+func (ri *rawIter[H, Hasher]) Complete() bool {
+	return ri.state == FinishedComplete
+}
+
+// Patricia trie-based pairs storage essence.
+type trieBackendEssence[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	storage TrieBackendStorage[H]
+	root    H
+	empty   H
+	cache   struct {
+		childRoot map[string]*H
+		sync.RWMutex
+	}
+	trieNodeCache TrieCacheProvider[H, *cache.TrieCache[H]]
+	recorder      *recorder.Recorder[H]
+}
+
+func newTrieBackendEssence[H runtime.Hash, Hasher runtime.Hasher[H]](
+	storage TrieBackendStorage[H],
+	root H,
+	cache TrieCacheProvider[H, *cache.TrieCache[H]],
+	recorder *recorder.Recorder[H],
+) trieBackendEssence[H, Hasher] {
+	return trieBackendEssence[H, Hasher]{
+		storage: storage,
+		root:    root,
+		cache: struct {
+			childRoot map[string]*H
+			sync.RWMutex
+		}{childRoot: make(map[string]*H)},
+		trieNodeCache: cache,
+		recorder:      recorder,
+	}
+}
+
+// Get backend storage reference.
+func (tbe *trieBackendEssence[H, Hasher]) BackendStorage() TrieBackendStorage[H] {
+	return tbe.storage
+}
+
+// Get trie root.
+func (tbe *trieBackendEssence[H, Hasher]) Root() H {
+	return tbe.root
+}
+
+// Set trie root. This is useful for testing.
+func (tbe *trieBackendEssence[H, Hasher]) SetRoot(root H) {
+	tbe.resetCache()
+	tbe.root = root
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) resetCache() {
+	tbe.cache = struct {
+		childRoot map[string]*H
+		sync.RWMutex
+	}{childRoot: make(map[string]*H)}
+}
+
+func withRecorderAndCache[H runtime.Hash, Hasher runtime.Hasher[H]](
+	tbe *trieBackendEssence[H, Hasher],
+	storageRoot *H,
+	callback func(triedb.TrieRecorder, triedb.TrieCache[H]),
+) {
+	root := tbe.root
+	if storageRoot != nil {
+		root = *storageRoot
+	}
+
+	var cache triedb.TrieCache[H]
+	var unlock func()
+	if tbe.trieNodeCache != nil {
+		cache, unlock = tbe.trieNodeCache.TrieCache(root)
+	}
+
+	var recorder triedb.TrieRecorder
+	if tbe.recorder != nil {
+		recorder = tbe.recorder.TrieRecorder(root)
+	}
+	callback(recorder, cache)
+	if unlock != nil {
+		unlock()
+	}
+}
+
+// Call the given closure passing it the recorder and the cache.
+//
+// This function must only be used when the operation in callback is
+// calculating a storageRoot. It is expected that callback returns
+// the new storage root. This is required to register the changes in the cache
+// for the correct storage root. The given storageRoot corresponds to the root of the "old"
+// trie. If the value is not given, tbe.root is used.
+func withRecorderAndCacheForStorageRoot[H runtime.Hash, Hasher runtime.Hasher[H], R any](
+	tbe *trieBackendEssence[H, Hasher],
+	storageRoot *H,
+	callback func(triedb.TrieRecorder, triedb.TrieCache[H]) (*H, R),
+) R {
+	root := tbe.root
+	if storageRoot != nil {
+		root = *storageRoot
+	}
+
+	var recorder triedb.TrieRecorder
+	if tbe.recorder != nil {
+		recorder = tbe.recorder.TrieRecorder(root)
+	}
+
+	if tbe.trieNodeCache != nil {
+		cache, unlock := tbe.trieNodeCache.TrieCacheMut()
+		newRoot, r := callback(recorder, cache)
+		if newRoot != nil {
+			tbe.trieNodeCache.Merge(cache, *newRoot)
+		}
+		unlock()
+		return r
+	} else {
+		_, r := callback(recorder, nil)
+		return r
+	}
+}
+
+// Calls the given closure with a [triedb.TrieDB] constructed for the given
+// storage root and (optionally) child trie.
+func withTrieDB[H runtime.Hash, Hasher runtime.Hasher[H]](
+	tbe *trieBackendEssence[H, Hasher],
+	root H,
+	childInfo storage.ChildInfo,
+	callback func(*triedb.TrieDB[H, Hasher]),
+) {
+	var backend hashdb.HashDB[H] = tbe
+	var db hashdb.HashDB[H] = tbe
+	if childInfo != nil {
+		db = trie.NewKeyspacedDB[H](backend, childInfo.Keyspace())
+	}
+
+	withRecorderAndCache(tbe, &root, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+		trieDB.SetVersion(ptrie.V1)
+		callback(trieDB)
+	})
+}
+
+// Access the root of the child storage in its parent trie
+func (tbe *trieBackendEssence[H, Hasher]) childRoot(childInfo storage.ChildInfo) (*H, error) {
+	tbe.cache.RLock()
+	{
+		result, ok := tbe.cache.childRoot[string(childInfo.StorageKey())]
+		tbe.cache.RUnlock()
+		if ok {
+			return result, nil
+		}
+	}
+
+	r, err := tbe.Storage(childInfo.PrefixedStorageKey())
+	if err != nil {
+		return nil, err
+	}
+	var result *H
+	if r != nil {
+		h := (*(new(Hasher))).NewHash(r)
+		result = &h
+	}
+	tbe.cache.Lock()
+	defer tbe.cache.Unlock()
+	tbe.cache.childRoot[string(childInfo.StorageKey())] = result
+
+	return result, nil
+}
+
+// Return the next key in the child trie i.e. the minimum key that is strictly superior to
+// key in lexicographic order.
+func (tbe *trieBackendEssence[H, Hasher]) NextChildStorageKey(childInfo storage.ChildInfo, key []byte) (StorageKey, error) {
+	childRoot, err := tbe.childRoot(childInfo)
+	if err != nil {
+		return nil, err
+	}
+	if childRoot == nil {
+		return nil, nil
+	}
+
+	return tbe.NextStorageKeyFromRoot(*childRoot, childInfo, key)
+}
+
+// Return next key from main trie or child trie by providing corresponding root.
+func (tbe *trieBackendEssence[H, Hasher]) NextStorageKeyFromRoot(root H, childInfo storage.ChildInfo, key []byte) (StorageKey, error) {
+	var err error
+	var nextKey []byte
+	withTrieDB(tbe, root, childInfo, func(trie *triedb.TrieDB[H, Hasher]) {
+		var iter triedb.TrieIterator[H, []byte]
+		iter, err = trie.KeyIterator()
+		if err != nil {
+			return
+		}
+
+		// The key just after the one given in input, basically key++0.
+		// Note: We are sure this is the next key if:
+		// * size of key has no limit (i.e. we can always add 0 to the path),
+		// * and no keys can be inserted between key and key++0
+		potentialNextKey := key
+		potentialNextKey = append(potentialNextKey, 0)
+
+		err = iter.Seek(potentialNextKey)
+		if err != nil {
+			return
+		}
+
+		var nextElement []byte
+		nextElement, err = iter.Next()
+		if err != nil {
+			return
+		}
+		nextKey = nextElement
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return nextKey, err
+}
+
+// Get the value of storage at given key.
+func (tbe *trieBackendEssence[H, Hasher]) Storage(key []byte) (val StorageValue, err error) {
+	withRecorderAndCache(tbe, nil, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		val, err = trie.ReadTrieValue[H, Hasher](tbe, tbe.root, key, recorder, cache, triedb.V1)
+	})
+	return
+}
+
+// Returns the hash value
+func (tbe *trieBackendEssence[H, Hasher]) StorageHash(key []byte) (hash *H, err error) {
+	withRecorderAndCache[H, Hasher](tbe, nil, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		trieDB := triedb.NewTrieDB[H, Hasher](tbe.root, tbe, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+		trieDB.SetVersion(ptrie.V1)
+		hash, err = trieDB.GetHash(key)
+	})
+	return
+}
+
+// Get the value of child storage at given key.
+func (tbe *trieBackendEssence[H, Hasher]) ChildStorage(childInfo storage.ChildInfo, key []byte) (StorageValue, error) {
+	var childRoot H
+	root, err := tbe.childRoot(childInfo)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return nil, nil
+	}
+	childRoot = *root
+
+	var val StorageValue
+	withRecorderAndCache(tbe, &childRoot, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		val, err = trie.ReadChildTrieValue[H, Hasher](
+			childInfo.Keyspace(),
+			tbe,
+			childRoot,
+			key,
+			recorder,
+			cache,
+			triedb.V1,
+		)
+	})
+	return val, err
+}
+
+// Returns the hash value
+func (tbe *trieBackendEssence[H, Hasher]) ChildStorageHash(childInfo storage.ChildInfo, key []byte) (*H, error) {
+	var childRoot H
+	root, err := tbe.childRoot(childInfo)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return nil, nil
+	}
+	childRoot = *root
+
+	var hash *H
+	withRecorderAndCache(tbe, &childRoot, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		hash, err = trie.ReadChildTrieHash[H, Hasher](
+			childInfo.Keyspace(),
+			tbe,
+			childRoot,
+			key,
+			recorder,
+			cache,
+			triedb.V1,
+		)
+	})
+	return hash, err
+}
+
+// Get the closest merkle value at given key.
+func (tbe *trieBackendEssence[H, Hasher]) ClosestMerkleValue(key []byte) (val triedb.MerkleValue[H], err error) {
+	withRecorderAndCache(tbe, nil, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		val, err = trie.ReadTrieFirstDescendantValue[H, Hasher](tbe, tbe.root, key, recorder, cache, triedb.V1)
+	})
+	return
+}
+
+// Get the child closest merkle value at given key.
+func (tbe *trieBackendEssence[H, Hasher]) ChildClosestMerkleValue(childInfo storage.ChildInfo, key []byte) (val triedb.MerkleValue[H], err error) {
+	var childRoot H
+	root, err := tbe.childRoot(childInfo)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return nil, nil
+	}
+	childRoot = *root
+
+	withRecorderAndCache(tbe, &childRoot, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) {
+		val, err = trie.ReadChildTrieFirstDescendantValue[H, Hasher](childInfo.Keyspace(), tbe, tbe.root, key, recorder, cache, triedb.V1)
+	})
+	return
+}
+
+// Create a raw iterator over the storage.
+func (tbe *trieBackendEssence[H, Hasher]) RawIter(args IterArgs) (*rawIter[H, Hasher], error) {
+	var root H = tbe.root
+	if args.ChildInfo != nil {
+		childRoot, err := tbe.childRoot(args.ChildInfo)
+		if err != nil {
+			return &rawIter[H, Hasher]{}, err
+		}
+		if childRoot != nil {
+			root = *childRoot
+		} else {
+			return &rawIter[H, Hasher]{
+				state: FinishedComplete,
+			}, nil
+		}
+	}
+
+	if root == (*new(H)) {
+		return &rawIter[H, Hasher]{
+			state: FinishedComplete,
+		}, nil
+	}
+
+	var trieIter *triedb.TrieDBRawIterator[H, Hasher]
+	var err error
+	withTrieDB[H, Hasher](tbe, root, args.ChildInfo, func(db *triedb.TrieDB[H, Hasher]) {
+		var prefix []byte
+		if args.Prefix != nil {
+			prefix = args.Prefix
+		}
+
+		if args.StartAt != nil {
+			trieIter, err = triedb.NewPrefixedTrieDBRawIteratorThenSeek[H, Hasher](db, prefix, args.StartAt)
+		} else {
+			trieIter, err = triedb.NewPrefixedTrieDBRawIterator[H, Hasher](db, prefix)
+		}
+	})
+	if err != nil {
+		return &rawIter[H, Hasher]{}, err
+	}
+
+	var skipIfFirst StorageKey
+	if args.StartAtExclusive {
+		if args.StartAt != nil {
+			storageKey := StorageKey(args.StartAt)
+			skipIfFirst = storageKey
+		}
+	}
+
+	return &rawIter[H, Hasher]{
+		stopOnImcompleteDatabase: args.StopOnIncompleteDatabase,
+		skipIfFirst:              skipIfFirst,
+		childInfo:                args.ChildInfo,
+		root:                     root,
+		trieIter:                 *trieIter,
+		state:                    Pending,
+	}, nil
+}
+
+// Return the storage root after applying the given delta.
+func (tbe *trieBackendEssence[H, Hasher]) StorageRoot(delta []Delta, stateVersion storage.StateVersion) (H, *trie.PrefixedMemoryDB[H, Hasher]) {
+	writeOverlay := trie.NewPrefixedMemoryDB[H, Hasher]()
+
+	root := withRecorderAndCacheForStorageRoot[H, Hasher, H](tbe, nil, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) (*H, H) {
+		eph := newEphemeral[H, Hasher](tbe.BackendStorage(), writeOverlay)
+		root, err := trie.DeltaTrieRoot[H, Hasher](eph, tbe.root, delta, recorder, cache, stateVersion.TrieLayout())
+		if err != nil {
+			log.Printf("WARN: failed to write to trie: %v", err)
+			return nil, tbe.root
+		}
+		return &root, root
+	})
+
+	return root, writeOverlay
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) ChildStorageRoot(
+	childInfo storage.ChildInfo,
+	delta []Delta,
+	stateVersion storage.StateVersion,
+) (H, bool, *trie.PrefixedMemoryDB[H, Hasher]) {
+	defaultRoot := trie.EmptyChildTrieRoot[H, Hasher]()
+	writeOverlay := trie.NewPrefixedMemoryDB[H, Hasher]()
+	var childRoot H
+	hash, err := tbe.childRoot(childInfo)
+	if err != nil {
+		log.Printf("WARN: Failed to read child storage root: %v", childInfo)
+	}
+	if hash == nil {
+		childRoot = defaultRoot
+	} else {
+		childRoot = *hash
+	}
+
+	newChildRoot := withRecorderAndCacheForStorageRoot(
+		tbe, &childRoot, func(recorder triedb.TrieRecorder, cache triedb.TrieCache[H]) (*H, H) {
+			eph := newEphemeral(tbe.BackendStorage(), writeOverlay)
+			root, err := trie.ChildDeltaTrieRoot[H, Hasher](
+				childInfo.Keyspace(), eph, childRoot, delta, recorder, cache, stateVersion.TrieLayout())
+			if err != nil {
+				log.Printf("WARN: Failed to write to trie: %v", err)
+				return nil, childRoot
+			}
+			return &root, root
+		})
+
+	isDefault := newChildRoot == defaultRoot
+	return newChildRoot, isDefault, writeOverlay
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) Get(key H, prefix hashdb.Prefix) []byte {
+	if key == tbe.empty {
+		val := []byte{0}
+		return val
+	}
+	val, err := tbe.storage.Get(key, prefix)
+	if err != nil {
+		log.Printf("WARN: failed to write to trie: %v\n", err)
+		return nil
+	}
+	return val
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) Contains(key H, prefix hashdb.Prefix) bool {
+	return tbe.Get(key, prefix) != nil
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) Insert(prefix hashdb.Prefix, value []byte) H {
+	panic("unimplemented")
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) Emplace(key H, prefix hashdb.Prefix, value []byte) {
+	panic("unimplemented")
+}
+
+func (tbe *trieBackendEssence[H, Hasher]) Remove(key H, prefix hashdb.Prefix) {
+	panic("unimplemented")
+}
+
+type ephemeral[H runtime.Hash, Hasher runtime.Hasher[H]] struct {
+	storage TrieBackendStorage[H]
+	overlay *trie.PrefixedMemoryDB[H, Hasher]
+}
+
+func newEphemeral[H runtime.Hash, Hasher runtime.Hasher[H]](
+	storage TrieBackendStorage[H],
+	overlay *trie.PrefixedMemoryDB[H, Hasher],
+) *ephemeral[H, Hasher] {
+	return &ephemeral[H, Hasher]{
+		storage, overlay,
+	}
+}
+
+func (e *ephemeral[H, Hasher]) Get(key H, prefix hashdb.Prefix) []byte {
+	val := e.overlay.Get(key, prefix)
+	if val == nil {
+		val, err := e.storage.Get(key, prefix)
+		if err != nil {
+			log.Printf("WARN: failed to read from DB: %v\n", err)
+			return nil
+		}
+		return val
+	}
+	return val
+}
+
+func (e *ephemeral[H, Hasher]) Contains(key H, prefix hashdb.Prefix) bool {
+	return e.Get(key, prefix) != nil
+}
+
+func (e *ephemeral[H, Hasher]) Insert(prefix hashdb.Prefix, value []byte) H {
+	return e.overlay.Insert(prefix, value)
+}
+
+func (e *ephemeral[H, Hasher]) Emplace(key H, prefix hashdb.Prefix, value []byte) {
+	e.overlay.Emplace(key, prefix, value)
+}
+
+func (e *ephemeral[H, Hasher]) Remove(key H, prefix hashdb.Prefix) {
+	e.overlay.Remove(key, prefix)
+}
+
+// Key-value pairs storage that is used by trie backend essence.
+type TrieBackendStorage[H constraints.Ordered] interface {
+	Get(key H, prefix hashdb.Prefix) ([]byte, error)
+}
+
+type HashDBTrieBackendStorage[H runtime.Hash] struct {
+	hashdb.HashDB[H]
+}
+
+func (hdbtbs HashDBTrieBackendStorage[H]) Get(key H, prefix hashdb.Prefix) ([]byte, error) {
+	return hdbtbs.HashDB.Get(key, prefix), nil
+}

--- a/internal/primitives/state-machine/trie_backend_essence_test.go
+++ b/internal/primitives/state-machine/trie_backend_essence_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"slices"
+	"testing"
+
+	hashdb "github.com/ChainSafe/gossamer/internal/hash-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	triedb "github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ hashdb.HashDB[hash.H256] = &trieBackendEssence[hash.H256, runtime.BlakeTwo256]{}
+	_ hashdb.HashDB[hash.H256] = &ephemeral[hash.H256, runtime.BlakeTwo256]{}
+)
+
+func TestTrieBackendEssence(t *testing.T) {
+	t.Run("next_storage_key_and_next_child_storage_key_work", func(t *testing.T) {
+		childInfo := storage.NewDefaultChildInfo([]byte("MyChild"))
+		// Contains values
+		var root1 hash.H256
+		// Contains child trie
+		var root2 hash.H256
+
+		mdb := trie.NewPrefixedMemoryDB[hash.H256, runtime.BlakeTwo256]()
+		{
+			trie := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](mdb)
+			trie.SetVersion(triedb.V1)
+			require.NoError(t, trie.Set([]byte("3"), []byte{1}))
+			require.NoError(t, trie.Set([]byte("4"), []byte{1}))
+			require.NoError(t, trie.Set([]byte("6"), []byte{1}))
+			root1 = trie.MustHash()
+
+		}
+		{
+			ksdb := trie.NewKeyspacedDB(mdb, childInfo.Keyspace())
+			// reuse of root_1 implicitly assert child trie root is same
+			// as top trie (contents must remain the same).
+			trie := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](ksdb)
+			trie.SetVersion(triedb.V1)
+			err := trie.Set([]byte("3"), []byte{1})
+			require.NoError(t, err)
+			require.NoError(t, trie.Set([]byte("3"), []byte{1}))
+			require.NoError(t, trie.Set([]byte("4"), []byte{1}))
+			require.NoError(t, trie.Set([]byte("6"), []byte{1}))
+			root := trie.MustHash()
+			require.Equal(t, root1, root)
+		}
+		{
+			trie := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](mdb)
+			trie.SetVersion(triedb.V1)
+			bleh := childInfo.PrefixedStorageKey()
+			require.NoError(t, trie.Set(slices.Clone(bleh), root1.Bytes()))
+			root2 = trie.MustHash()
+
+			val, err := trie.Get(bleh)
+			require.NoError(t, err)
+			require.Equal(t, root1.Bytes(), val)
+		}
+
+		essence1 := newTrieBackendEssence[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root1, nil, nil)
+		tb1 := TrieBackend[hash.H256, runtime.BlakeTwo256]{essence: essence1}
+
+		key, err := tb1.NextStorageKey([]byte("2"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("3"), key)
+
+		key, err = tb1.NextStorageKey([]byte("3"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("4"), key)
+
+		key, err = tb1.NextStorageKey([]byte("4"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("6"), key)
+
+		key, err = tb1.NextStorageKey([]byte("5"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("6"), key)
+
+		key, err = tb1.NextStorageKey([]byte("6"))
+		require.NoError(t, err)
+		require.Nil(t, key)
+
+		essence2 := newTrieBackendEssence[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root2, nil, nil)
+
+		key, err = essence2.NextChildStorageKey(childInfo, []byte("2"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("3"), key)
+
+		key, err = essence2.NextChildStorageKey(childInfo, []byte("3"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("4"), key)
+
+		key, err = essence2.NextChildStorageKey(childInfo, []byte("4"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("6"), key)
+
+		key, err = essence2.NextChildStorageKey(childInfo, []byte("5"))
+		require.NoError(t, err)
+		require.Equal(t, StorageKey("6"), key)
+
+		key, err = essence2.NextChildStorageKey(childInfo, []byte("6"))
+		require.NoError(t, err)
+		require.Nil(t, key)
+	})
+}

--- a/internal/primitives/state-machine/trie_backend_essence_test.go
+++ b/internal/primitives/state-machine/trie_backend_essence_test.go
@@ -65,8 +65,9 @@ func TestTrieBackendEssence(t *testing.T) {
 			require.Equal(t, root1.Bytes(), val)
 		}
 
-		essence1 := newTrieBackendEssence[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root1, nil, nil)
-		tb1 := TrieBackend[hash.H256, runtime.BlakeTwo256]{essence: essence1}
+		essence1 := newTrieBackendEssence[hash.H256, runtime.BlakeTwo256](
+			HashDBTrieBackendStorage[hash.H256]{mdb}, root1, nil, nil)
+		tb1 := TrieBackend[hash.H256, runtime.BlakeTwo256]{essence: essence1} //nolint:govet
 
 		key, err := tb1.NextStorageKey([]byte("2"))
 		require.NoError(t, err)
@@ -88,7 +89,8 @@ func TestTrieBackendEssence(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, key)
 
-		essence2 := newTrieBackendEssence[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root2, nil, nil)
+		essence2 := newTrieBackendEssence[hash.H256, runtime.BlakeTwo256](
+			HashDBTrieBackendStorage[hash.H256]{mdb}, root2, nil, nil)
 
 		key, err = essence2.NextChildStorageKey(childInfo, []byte("2"))
 		require.NoError(t, err)

--- a/internal/primitives/state-machine/trie_backend_test.go
+++ b/internal/primitives/state-machine/trie_backend_test.go
@@ -496,7 +496,8 @@ func TestTrieBackend(t *testing.T) {
 
 	t.Run("proof_record_works_with_iter", func(t *testing.T) {
 		for _, stateVersion := range []storage.StateVersion{storage.StateVersionV0, storage.StateVersionV1} {
-			for _, sharedCache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+			for _, sharedCache := range []*cache.SharedTrieCache[hash.H256]{
+				cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
 				// Run multiple times to have a different cache conditions.
 				for i := 0; i < 5; i++ {
 					if sharedCache != nil {
@@ -607,7 +608,8 @@ func TestTrieBackend(t *testing.T) {
 				require.Equal(t, []byte{i}, []byte(val))
 			}
 
-			for _, sharedCache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+			for _, sharedCache := range []*cache.SharedTrieCache[hash.H256]{
+				cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
 				// Run multiple times to have a different cache conditions.
 				for i := 0; i < 5; i++ {
 					if sharedCache != nil {
@@ -899,7 +901,8 @@ func TestTrieBackend(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, childTrie2Val, []byte(val))
 
-			for _, sharedCache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+			for _, sharedCache := range []*cache.SharedTrieCache[hash.H256]{
+				cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
 				// Run multiple times to have a different cache conditions.
 				for i := 0; i < 5; i++ {
 					if sharedCache != nil {

--- a/internal/primitives/state-machine/trie_backend_test.go
+++ b/internal/primitives/state-machine/trie_backend_test.go
@@ -1,0 +1,964 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statemachine
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/storage"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/cache"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/recorder"
+	"github.com/ChainSafe/gossamer/pkg/scale"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb/codec"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ StorageIterator[hash.H256, runtime.BlakeTwo256] = &rawIter[hash.H256, runtime.BlakeTwo256]{}
+	_ Backend[hash.H256, runtime.BlakeTwo256]         = &TrieBackend[hash.H256, runtime.BlakeTwo256]{}
+)
+
+var ChildKey1 = []byte("sub1")
+
+func testDB(
+	t *testing.T,
+	stateVersion storage.StateVersion,
+) (*trie.PrefixedMemoryDB[hash.H256, runtime.BlakeTwo256], hash.H256) {
+	t.Helper()
+	childInfo := storage.NewDefaultChildInfo(ChildKey1)
+	mdb := trie.NewPrefixedMemoryDB[hash.H256, runtime.BlakeTwo256]()
+	var root hash.H256
+
+	{
+		ksdb := trie.NewKeyspacedDB(mdb, childInfo.Keyspace())
+		trie := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](ksdb)
+		trie.SetVersion(stateVersion.TrieLayout())
+		require.NoError(t, trie.Set([]byte("value3"), bytes.Repeat([]byte{142}, 33)))
+		require.NoError(t, trie.Set([]byte("value4"), bytes.Repeat([]byte{124}, 33)))
+		root = trie.MustHash()
+	}
+
+	{
+		subRoot := scale.MustMarshal(root)
+
+		var build = func(trie *triedb.TrieDB[hash.H256, runtime.BlakeTwo256], childInfo storage.ChildInfo, subRoot []byte) {
+			require.NoError(t, trie.Set(childInfo.PrefixedStorageKey(), subRoot))
+			require.NoError(t, trie.Set([]byte("key"), []byte("value")))
+			require.NoError(t, trie.Set([]byte("value1"), []byte{42}))
+			require.NoError(t, trie.Set([]byte("value2"), []byte{24}))
+			require.NoError(t, trie.Set([]byte(":code"), []byte("return 42")))
+			for i := uint8(128); i < 255; i++ {
+				require.NoError(t, trie.Set([]byte{i}, []byte{i}))
+			}
+		}
+
+		trie := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](mdb)
+		trie.SetVersion(stateVersion.TrieLayout())
+		build(trie, childInfo, subRoot)
+		root = trie.MustHash()
+	}
+
+	return mdb, root
+}
+
+func testTrie(
+	t *testing.T,
+	hashedValue storage.StateVersion,
+	cache *cache.LocalTrieCache[hash.H256],
+	recorder *recorder.Recorder[hash.H256],
+) *TrieBackend[hash.H256, runtime.BlakeTwo256] {
+	t.Helper()
+	mdb, root := testDB(t, hashedValue)
+
+	var tb *TrieBackend[hash.H256, runtime.BlakeTwo256]
+	if cache == nil {
+		tb = NewTrieBackend[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root, nil, recorder)
+	} else {
+		tb = NewTrieBackend[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root, cache, recorder)
+	}
+	return tb
+}
+func TestTrieBackend(t *testing.T) {
+	type parameters struct {
+		storage.StateVersion
+		*cache.SharedTrieCache[hash.H256]
+		*recorder.Recorder[hash.H256]
+	}
+	params := []parameters{
+		{StateVersion: storage.StateVersionV0},
+		{StateVersion: storage.StateVersionV0, SharedTrieCache: cache.NewSharedTrieCache[hash.H256](1024 * 10)},
+		{
+			StateVersion:    storage.StateVersionV0,
+			SharedTrieCache: cache.NewSharedTrieCache[hash.H256](1024 * 10),
+			Recorder:        recorder.NewRecorder[hash.H256](),
+		},
+		{StateVersion: storage.StateVersionV1},
+		{StateVersion: storage.StateVersionV1, SharedTrieCache: cache.NewSharedTrieCache[hash.H256](1024 * 10)},
+		{
+			StateVersion:    storage.StateVersionV1,
+			SharedTrieCache: cache.NewSharedTrieCache[hash.H256](1024 * 10),
+			Recorder:        recorder.NewRecorder[hash.H256](),
+		},
+	}
+
+	t.Run("read_from_returns_some", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			val, err := tb.Storage([]byte("key"))
+			require.NoError(t, err)
+			require.Equal(t, StorageValue("value"), val)
+		}
+	})
+
+	t.Run("read_from_child_storage_returns_some", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			val, err := tb.ChildStorage(storage.NewDefaultChildInfo(ChildKey1), []byte("value3"))
+			require.NoError(t, err)
+			require.Equal(t, bytes.Repeat([]byte{142}, 33), []byte(val))
+
+			// Change cache entry to check that caching is active.
+			tb.essence.cache.childRoot["sub1"] = nil
+			val, err = tb.ChildStorage(storage.NewDefaultChildInfo(ChildKey1), []byte("value3"))
+			require.NoError(t, err)
+			require.Nil(t, val)
+		}
+	})
+
+	t.Run("read_from_storage_returns_none", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			val, err := tb.ChildStorage(storage.NewDefaultChildInfo(ChildKey1), []byte("non-existing-key"))
+			require.NoError(t, err)
+			require.Nil(t, val)
+		}
+	})
+
+	t.Run("pairs_are_not_empty_on_non_empty_storage", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			iter, err := tb.Pairs(IterArgs{})
+			require.NoError(t, err)
+			skv, err := iter.Next()
+			require.NoError(t, err)
+			require.NotNil(t, skv)
+		}
+	})
+
+	t.Run("pairs_are_empty_on_empty_storage", func(t *testing.T) {
+		mdb := trie.NewPrefixedMemoryDB[hash.H256, runtime.BlakeTwo256]()
+		var root hash.H256
+		tb := NewTrieBackend[hash.H256, runtime.BlakeTwo256](HashDBTrieBackendStorage[hash.H256]{mdb}, root, nil, nil)
+		iter, err := tb.Pairs(IterArgs{})
+		require.NoError(t, err)
+		skv, err := iter.Next()
+		require.NoError(t, err)
+		require.Nil(t, skv)
+	})
+
+	t.Run("storage_iteration_works", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			iter, err := tb.Keys(IterArgs{})
+			require.NoError(t, err)
+
+			// Fetch everything.
+			sk, err := iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey(":child_storage:default:sub1"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey(":code"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("key"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value1"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value2"), sk)
+
+			// Fetch starting at a given key (full key).
+			iter, err = tb.Keys(IterArgs{StartAt: []byte("key")})
+			require.NoError(t, err)
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("key"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value1"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value2"), sk)
+
+			// Fetch starting at a given key (partial key).
+			iter, err = tb.Keys(IterArgs{StartAt: []byte("ke")})
+			require.NoError(t, err)
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("key"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value1"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value2"), sk)
+
+			// Fetch starting at a given key and with prefix which doesn't match that key.
+			// (Start *before* the prefix.)
+			iter, err = tb.Keys(IterArgs{StartAt: []byte("key"), Prefix: []byte("value")})
+			require.NoError(t, err)
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value1"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value2"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Nil(t, sk)
+
+			// Fetch starting at a given key and with prefix which doesn't match that key.
+			// (Start *after* the prefix.)
+			iter, err = tb.Keys(IterArgs{StartAt: []byte("vblue"), Prefix: []byte("value")})
+			require.NoError(t, err)
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Nil(t, sk)
+
+			// Fetch starting at a given key and with prefix which does match that key.
+			iter, err = tb.Keys(IterArgs{StartAt: []byte("value"), Prefix: []byte("value")})
+			require.NoError(t, err)
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value1"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Equal(t, StorageKey("value2"), sk)
+
+			sk, err = iter.Next()
+			require.NoError(t, err)
+			require.Nil(t, sk)
+		}
+	})
+
+	t.Run("storage_root_is_non_default", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			h, _ := tb.StorageRoot(nil, param.StateVersion)
+			var expected = hash.H256(bytes.Repeat([]byte{0}, 32))
+			require.NotEqual(t, expected, h)
+		}
+	})
+
+	t.Run("storage_root_transaction_is_non_empty", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			newRoot, tx := tb.StorageRoot([]Delta{{Key: []byte("new-key"), Value: []byte("new-value")}}, param.StateVersion)
+			expected, _ := testTrie(t, param.StateVersion, cache, param.Recorder).StorageRoot(nil, param.StateVersion)
+			require.NotEmpty(t, tx.Drain())
+			require.NotEqual(t, expected, newRoot)
+		}
+	})
+
+	t.Run("keys_with_empty_prefix_returns_all_keys", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			testDB, testRoot := testDB(t, param.StateVersion)
+			iter, err := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](testRoot, testDB).Iterator()
+			require.NoError(t, err)
+			expected := make([][]byte, 0)
+			for {
+				item, err := iter.Next()
+				require.NoError(t, err)
+				if item != nil {
+					expected = append(expected, item.Key)
+				} else {
+					break
+				}
+			}
+
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			keysIter, err := tb.Keys(IterArgs{})
+			require.NoError(t, err)
+			keys := make([][]byte, 0)
+			for {
+				item, err := keysIter.Next()
+				require.NoError(t, err)
+				if item != nil {
+					keys = append(keys, item)
+				} else {
+					break
+				}
+			}
+
+			require.Equal(t, expected, keys)
+		}
+	})
+
+	t.Run("proof_is_empty_until_value_is_read", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			tb1 := NewWrappedTrieBackend[hash.H256, runtime.BlakeTwo256](tb)
+			tb1.essence.recorder = recorder.NewRecorder[hash.H256]()
+			proof := tb1.ExtractProof()
+			require.NotNil(t, proof)
+			require.True(t, proof.Empty())
+		}
+	})
+
+	t.Run("proof_is_non_empty_after_value_is_read", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			tb1 := NewWrappedTrieBackend[hash.H256, runtime.BlakeTwo256](tb)
+			tb1.essence.recorder = recorder.NewRecorder[hash.H256]()
+
+			sv, err := tb1.Storage([]byte("key"))
+			require.NoError(t, err)
+			require.Equal(t, StorageValue("value"), sv)
+			proof := tb1.ExtractProof()
+			require.NotNil(t, proof)
+			require.False(t, proof.Empty())
+		}
+	})
+
+	t.Run("proof_is_invalid_when_does_not_contains_root", func(t *testing.T) {
+		_, err := NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](
+			hash.NewH256FromLowUint64BigEndian(1), trie.NewStorageProof(nil))
+		require.Error(t, err)
+	})
+
+	t.Run("passes_through_backend_calls_inner", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			provingBackend := NewWrappedTrieBackend[hash.H256, runtime.BlakeTwo256](tb)
+			provingBackend.essence.recorder = recorder.NewRecorder[hash.H256]()
+
+			sv, err := provingBackend.Storage([]byte("key"))
+			require.NoError(t, err)
+			require.Equal(t, StorageValue("value"), sv)
+
+			pairs, err := tb.Pairs(IterArgs{})
+			require.NoError(t, err)
+			tbPairs := make([]StorageKeyValue, 0)
+			for pair, err := range pairs.All() {
+				require.NoError(t, err)
+				tbPairs = append(tbPairs, pair)
+			}
+			pairs, err = provingBackend.Pairs(IterArgs{})
+			require.NoError(t, err)
+			pbPairs := make([]StorageKeyValue, 0)
+			for pair, err := range pairs.All() {
+				require.NoError(t, err)
+				pbPairs = append(pbPairs, pair)
+			}
+			require.Equal(t, tbPairs, pbPairs)
+
+			trieRoot, trieMDB := tb.StorageRoot(nil, param.StateVersion)
+			provingRoot, provingMDB := provingBackend.StorageRoot(nil, param.StateVersion)
+			require.Equal(t, trieRoot, provingRoot)
+			require.Equal(t, trieMDB.Drain(), provingMDB.Drain())
+		}
+	})
+
+	t.Run("proof_recorded_and_checked", func(t *testing.T) {
+		for _, stateVersion := range []storage.StateVersion{storage.StateVersionV0, storage.StateVersionV1} {
+			contents := make([]StorageKeyValue, 0)
+			for i := uint8(0); i < 64; i++ {
+				contents = append(contents, StorageKeyValue{[]byte{i}, bytes.Repeat([]byte{i}, 34)})
+			}
+
+			inMemory := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+			inMemory = inMemory.update([]change{{
+				ChildInfo:         nil,
+				StorageCollection: contents,
+			}}, stateVersion)
+			inMemoryRoot, _ := inMemory.StorageRoot(nil, stateVersion)
+			for i := uint8(0); i < 64; i++ {
+				val, err := inMemory.Storage([]byte{i})
+				require.NoError(t, err)
+				require.Equal(t, bytes.Repeat([]byte{i}, 34), []byte(val))
+			}
+
+			trie := inMemory.TrieBackend
+			trieRoot, _ := trie.StorageRoot(nil, stateVersion)
+			require.Equal(t, inMemoryRoot, trieRoot)
+			for i := uint8(0); i < 64; i++ {
+				val, err := trie.Storage([]byte{i})
+				require.NoError(t, err)
+				require.Equal(t, bytes.Repeat([]byte{i}, 34), []byte(val))
+			}
+
+			for _, cache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+				// Run multiple times to have a different cache conditions.
+				for i := 0; i < 5; i++ {
+					if cache != nil {
+						if i == 2 {
+							cache.ResetNodeCache()
+						} else if i == 3 {
+							cache.ResetValueCache()
+						}
+					}
+
+					proving := NewWrappedTrieBackend(trie)
+					proving.essence.recorder = recorder.NewRecorder[hash.H256]()
+					if cache != nil {
+						local := cache.LocalTrieCache()
+						proving.essence.trieNodeCache = &local
+					}
+					val, err := proving.Storage([]byte{42})
+					require.NoError(t, err)
+					require.NotNil(t, val)
+					require.Equal(t, StorageValue(bytes.Repeat([]byte{42}, 34)), val)
+
+					proof := proving.ExtractProof()
+					require.NotNil(t, proof)
+
+					proofCheck, err := NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](inMemoryRoot, *proof)
+					require.NoError(t, err)
+
+					val, err = proofCheck.Storage([]byte{42})
+					require.NoError(t, err)
+					require.NotNil(t, val)
+					require.Equal(t, StorageValue(bytes.Repeat([]byte{42}, 34)), val)
+				}
+			}
+		}
+	})
+
+	t.Run("proof_record_works_with_iter", func(t *testing.T) {
+		for _, stateVersion := range []storage.StateVersion{storage.StateVersionV0, storage.StateVersionV1} {
+			for _, cache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+				// Run multiple times to have a different cache conditions.
+				for i := 0; i < 5; i++ {
+					if cache != nil {
+						if i == 2 {
+							cache.ResetNodeCache()
+						} else if i == 3 {
+							cache.ResetValueCache()
+						}
+					}
+
+					contents := make([]StorageKeyValue, 0)
+					for i := uint8(0); i < 64; i++ {
+						contents = append(contents, StorageKeyValue{[]byte{i}, []byte{i}})
+					}
+					inMemory := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+					inMemory = inMemory.update([]change{{
+						ChildInfo:         nil,
+						StorageCollection: contents,
+					}}, stateVersion)
+					inMemoryRoot, _ := inMemory.StorageRoot(nil, stateVersion)
+					for i := uint8(0); i < 64; i++ {
+						val, err := inMemory.Storage([]byte{i})
+						require.NoError(t, err)
+						require.Equal(t, []byte{i}, []byte(val))
+					}
+
+					trie := inMemory.TrieBackend
+					trieRoot, _ := trie.StorageRoot(nil, stateVersion)
+					require.Equal(t, inMemoryRoot, trieRoot)
+					for i := uint8(0); i < 64; i++ {
+						val, err := trie.Storage([]byte{i})
+						require.NoError(t, err)
+						require.Equal(t, []byte{i}, []byte(val))
+					}
+
+					proving := NewWrappedTrieBackend(trie)
+					proving.essence.recorder = recorder.NewRecorder[hash.H256]()
+					if cache != nil {
+						local := cache.LocalTrieCache()
+						proving.essence.trieNodeCache = &local
+					}
+					for i := uint8(0); i < 63; i++ {
+						sk, err := proving.NextStorageKey([]byte{i})
+						require.NoError(t, err)
+						require.Equal(t, StorageKey([]byte{i + 1}), sk)
+					}
+
+					proof := proving.ExtractProof()
+					require.NotNil(t, proof)
+
+					proofCheck, err := NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](inMemoryRoot, *proof)
+					require.NoError(t, err)
+					for i := uint8(0); i < 63; i++ {
+						sk, err := proofCheck.NextStorageKey([]byte{i})
+						require.NoError(t, err)
+						require.Equal(t, StorageKey([]byte{i + 1}), sk)
+					}
+				}
+			}
+		}
+	})
+
+	t.Run("proof_recorded_and_checked_with_child", func(t *testing.T) {
+		for _, stateVersion := range []storage.StateVersion{storage.StateVersionV0, storage.StateVersionV1} {
+			childInfo1 := storage.NewDefaultChildInfo([]byte("sub1"))
+			childInfo2 := storage.NewDefaultChildInfo([]byte("sub2"))
+			var contents []change
+			var sc StorageCollection
+			for i := uint8(0); i < 64; i++ {
+				sc = append(sc, StorageKeyValue{[]byte{i}, []byte{i}})
+			}
+			contents = append(contents, change{StorageCollection: sc})
+			sc = nil
+			for i := uint8(28); i < 65; i++ {
+				sc = append(sc, StorageKeyValue{[]byte{i}, []byte{i}})
+			}
+			contents = append(contents, change{ChildInfo: childInfo1, StorageCollection: sc})
+			sc = nil
+			for i := uint8(10); i < 15; i++ {
+				sc = append(sc, StorageKeyValue{[]byte{i}, []byte{i}})
+			}
+			contents = append(contents, change{ChildInfo: childInfo2, StorageCollection: sc})
+			inMemory := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+			inMemory = inMemory.update(contents, stateVersion)
+			childStorageKeys := []storage.ChildInfo{childInfo1, childInfo2}
+			var childDeltas []ChildDelta
+			for _, childStorageKey := range childStorageKeys {
+				childDeltas = append(childDeltas, ChildDelta{
+					ChildInfo: childStorageKey,
+					Deltas:    nil,
+				})
+			}
+			inMemoryRoot, _ := inMemory.FullStorageRoot(nil, childDeltas, stateVersion)
+			for i := uint8(0); i < 64; i++ {
+				val, err := inMemory.Storage([]byte{i})
+				require.NoError(t, err)
+				require.Equal(t, []byte{i}, []byte(val))
+			}
+			for i := uint8(28); i < 65; i++ {
+				val, err := inMemory.ChildStorage(childInfo1, []byte{i})
+				require.NoError(t, err)
+				require.Equal(t, []byte{i}, []byte(val))
+			}
+			for i := uint8(10); i < 15; i++ {
+				val, err := inMemory.ChildStorage(childInfo2, []byte{i})
+				require.NoError(t, err)
+				require.Equal(t, []byte{i}, []byte(val))
+			}
+
+			for _, cache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+				// Run multiple times to have a different cache conditions.
+				for i := 0; i < 5; i++ {
+					if cache != nil {
+						if i == 2 {
+							cache.ResetNodeCache()
+						} else if i == 3 {
+							cache.ResetValueCache()
+						}
+					}
+
+					trie := inMemory.TrieBackend
+					trieRoot, _ := trie.StorageRoot(nil, stateVersion)
+					require.Equal(t, inMemoryRoot, trieRoot)
+					for i := uint8(0); i < 64; i++ {
+						val, err := trie.Storage([]byte{i})
+						require.NoError(t, err)
+						require.Equal(t, []byte{i}, []byte(val))
+					}
+
+					proving := NewWrappedTrieBackend(trie)
+					proving.essence.recorder = recorder.NewRecorder[hash.H256]()
+					if cache != nil {
+						local := cache.LocalTrieCache()
+						proving.essence.trieNodeCache = &local
+					}
+					val, err := proving.Storage([]byte{42})
+					require.NoError(t, err)
+					require.Equal(t, []byte{42}, []byte(val))
+
+					proof := proving.ExtractProof()
+					require.NotNil(t, proof)
+
+					proofCheck, err := NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](inMemoryRoot, *proof)
+					require.NoError(t, err)
+					_, err = proofCheck.Storage([]byte{0})
+					require.Error(t, err)
+					val, err = proofCheck.Storage([]byte{42})
+					require.NoError(t, err)
+					require.Equal(t, []byte{42}, []byte(val))
+					// note that it is include in root because proof close
+					val, err = proofCheck.Storage([]byte{41})
+					require.NoError(t, err)
+					require.Equal(t, []byte{41}, []byte(val))
+					val, err = proofCheck.Storage([]byte{64})
+					require.NoError(t, err)
+					require.Nil(t, val)
+
+					proving = NewWrappedTrieBackend(trie)
+					proving.essence.recorder = recorder.NewRecorder[hash.H256]()
+					if cache != nil {
+						local := cache.LocalTrieCache()
+						proving.essence.trieNodeCache = &local
+					}
+					val, err = proving.ChildStorage(childInfo1, []byte{64})
+					require.NoError(t, err)
+					require.Equal(t, []byte{64}, []byte(val))
+					val, err = proving.ChildStorage(childInfo1, []byte{25})
+					require.NoError(t, err)
+					require.Nil(t, val)
+					val, err = proving.ChildStorage(childInfo2, []byte{14})
+					require.NoError(t, err)
+					require.Equal(t, []byte{14}, []byte(val))
+					val, err = proving.ChildStorage(childInfo2, []byte{25})
+					require.NoError(t, err)
+					require.Nil(t, val)
+
+					proof = proving.ExtractProof()
+					require.NotNil(t, proof)
+
+					proofCheck, err = NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](inMemoryRoot, *proof)
+					require.NoError(t, err)
+					val, err = proofCheck.ChildStorage(childInfo1, []byte{64})
+					require.NoError(t, err)
+					require.Equal(t, []byte{64}, []byte(val))
+					val, err = proofCheck.ChildStorage(childInfo1, []byte{25})
+					require.NoError(t, err)
+					require.Nil(t, val)
+
+					val, err = proofCheck.ChildStorage(childInfo2, []byte{14})
+					require.NoError(t, err)
+					require.Equal(t, []byte{14}, []byte(val))
+					val, err = proofCheck.ChildStorage(childInfo2, []byte{25})
+					require.NoError(t, err)
+					require.Nil(t, val)
+				}
+			}
+		}
+	})
+
+	// This tests an edge case when recording a child trie access with a cache.
+	//
+	// The accessed value/node is in the cache, but not the nodes to get to this value. So,
+	// the recorder will need to traverse the trie to access these nodes from the backend when the
+	// storage proof is generated.
+	t.Run("child_proof_recording_with_edge_cases_works", func(t *testing.T) {
+		for _, stateVersion := range []storage.StateVersion{storage.StateVersionV0, storage.StateVersionV1} {
+			childInfo1 := storage.NewDefaultChildInfo([]byte("sub1"))
+			var contents []change
+			var sc StorageCollection
+			for i := uint8(0); i < 64; i++ {
+				sc = append(sc, StorageKeyValue{[]byte{i}, []byte{i}})
+			}
+			contents = append(contents, change{StorageCollection: sc})
+			sc = nil
+			for i := uint8(28); i < 65; i++ {
+				sc = append(sc, StorageKeyValue{[]byte{i}, []byte{i}})
+			}
+			sc = append(sc, StorageKeyValue{[]byte{65}, bytes.Repeat([]byte{65}, 128)})
+			contents = append(contents, change{ChildInfo: childInfo1, StorageCollection: sc})
+
+			inMemory := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+			inMemory = inMemory.update(contents, stateVersion)
+			childStorageKeys := []storage.ChildInfo{childInfo1}
+			var childDeltas []ChildDelta
+			for _, childStorageKey := range childStorageKeys {
+				childDeltas = append(childDeltas, ChildDelta{
+					ChildInfo: childStorageKey,
+					Deltas:    nil,
+				})
+			}
+			inMemoryRoot, _ := inMemory.FullStorageRoot(nil, childDeltas, stateVersion)
+			child1Root, _, _ := inMemory.ChildStorageRoot(childInfo1, nil, stateVersion)
+			trie := inMemory.TrieBackend
+
+			type hashNode struct {
+				hash.H256
+				triedb.CachedNode[hash.H256]
+			}
+			var nodes []hashNode
+			{
+				backend := NewWrappedTrieBackend(trie)
+				backend.essence.recorder = recorder.NewRecorder[hash.H256]()
+				val, err := backend.ChildStorage(childInfo1, []byte{65})
+				require.NoError(t, err)
+				require.NotNil(t, val)
+				require.Equal(t, bytes.Repeat([]byte{65}, 128), []byte(val))
+				valueHash := runtime.BlakeTwo256{}.Hash(val)
+
+				proof := backend.ExtractProof()
+				require.NotNil(t, proof)
+
+				for _, node := range proof.Nodes() {
+					h := runtime.BlakeTwo256{}.Hash(node)
+					// Only insert the node/value that contains the important data.
+					if h != valueHash {
+						node, err := codec.Decode[hash.H256](bytes.NewBuffer(node))
+						require.NoError(t, err)
+						cachedNode, err := triedb.NewCachedNodeFromNode[hash.H256, runtime.BlakeTwo256](node)
+						require.NoError(t, err)
+
+						if data := cachedNode.Data(); data != nil {
+							if bytes.Equal(data, bytes.Repeat([]byte{65}, 128)) {
+								nodes = append(nodes, hashNode{h, cachedNode})
+							}
+						}
+					} else if h == valueHash {
+						nodes = append(nodes, hashNode{h, triedb.ValueCachedNode[hash.H256]{Value: node, Hash: h}})
+					}
+				}
+			}
+
+			cache := cache.NewSharedTrieCache[hash.H256](1024 * 10)
+			{
+				localCache := cache.LocalTrieCache()
+				trieCache, unlock := localCache.TrieCache(child1Root)
+
+				// Put the value/node into the cache.
+				for _, hn := range nodes {
+					trieCache.GetOrInsertNode(hn.H256, func() (triedb.CachedNode[hash.H256], error) {
+						return hn.CachedNode, nil
+					})
+
+					if data := hn.CachedNode.Data(); data != nil {
+						trieCache.SetValue([]byte{65}, triedb.ExistingCachedValue[hash.H256]{Hash: hn.H256, Data: data})
+					}
+				}
+				unlock()
+				localCache.Commit()
+			}
+
+			{
+				// Record the access
+				proving := NewWrappedTrieBackend(trie)
+				proving.essence.recorder = recorder.NewRecorder[hash.H256]()
+				if cache != nil {
+					local := cache.LocalTrieCache()
+					proving.essence.trieNodeCache = &local
+				}
+				val, err := proving.ChildStorage(childInfo1, []byte{65})
+				require.NoError(t, err)
+				require.Equal(t, bytes.Repeat([]byte{65}, 128), []byte(val))
+
+				proof := proving.ExtractProof()
+				require.NotNil(t, proof)
+
+				proofCheck, err := NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](inMemoryRoot, *proof)
+				require.NoError(t, err)
+				val, err = proofCheck.ChildStorage(childInfo1, []byte{65})
+				require.NoError(t, err)
+				require.Equal(t, bytes.Repeat([]byte{65}, 128), []byte(val))
+			}
+		}
+	})
+
+	t.Run("storage_proof_encoded_size_estimation_works", func(t *testing.T) {
+		for _, param := range params {
+			var cache *cache.LocalTrieCache[hash.H256]
+			if param.SharedTrieCache != nil {
+				local := param.SharedTrieCache.LocalTrieCache()
+				cache = &local
+			}
+
+			hasCache := cache != nil
+			tb := testTrie(t, param.StateVersion, cache, param.Recorder)
+			keys := [][]byte{
+				[]byte("key"),
+				[]byte("value1"),
+				[]byte("value2"),
+				[]byte("doesnotexist"),
+				[]byte("doesnotexist2"),
+			}
+
+			var checkEstimation = func(backend *TrieBackend[hash.H256, runtime.BlakeTwo256], hasCache bool) {
+				estimation := backend.essence.recorder.EstimateEncodedSize()
+				storageProof := backend.ExtractProof()
+				require.NotNil(t, storageProof)
+				var storageProofSize uint
+				for _, n := range storageProof.Nodes() {
+					storageProofSize += uint(len(scale.MustMarshal(n)))
+				}
+
+				if hasCache {
+					// Estimation is not entirely correct when we have values already cached.
+					require.True(t, estimation >= storageProofSize)
+				} else {
+					require.Equal(t, storageProofSize, estimation)
+				}
+			}
+
+			for n := 0; n < len(keys); n++ {
+				backend := NewWrappedTrieBackend(tb)
+				backend.essence.recorder = recorder.NewRecorder[hash.H256]()
+
+				// Read n keys
+				for i := 0; i < n; i++ {
+					_, err := backend.Storage(keys[i])
+					require.NoError(t, err)
+				}
+
+				// Check the estimation
+				checkEstimation(backend, hasCache)
+			}
+		}
+	})
+
+	// Test to ensure that recording the same `key` for different tries works as expected.
+	//
+	// Each trie stores a different value under the same key. The values are big enough to
+	// be not inlined with `StateVersion::V1`, this is important to test the expected behavior. The
+	// trie recorder is expected to differentiate key access based on the different storage roots
+	// of the tries.
+	t.Run("recording_same_key_access_in_different_tries", func(t *testing.T) {
+		for _, stateVersion := range []storage.StateVersion{storage.StateVersionV0, storage.StateVersionV1} {
+			key := []byte("test_key")
+			// Use some big values to ensure that we don't keep them inline
+			topTrieVal := bytes.Repeat([]byte{1}, 1024)
+			childTrie1Val := bytes.Repeat([]byte{2}, 1024)
+			childTrie2Val := bytes.Repeat([]byte{3}, 1024)
+
+			childInfo1 := storage.NewDefaultChildInfo([]byte("sub1"))
+			childInfo2 := storage.NewDefaultChildInfo([]byte("sub2"))
+			contents := []change{
+				{StorageCollection: StorageCollection{StorageKeyValue{key, topTrieVal}}},
+				{ChildInfo: childInfo1, StorageCollection: StorageCollection{StorageKeyValue{key, childTrie1Val}}},
+				{ChildInfo: childInfo2, StorageCollection: StorageCollection{StorageKeyValue{key, childTrie2Val}}},
+			}
+
+			inMemory := NewMemoryDBTrieBackend[hash.H256, runtime.BlakeTwo256]()
+			inMemory = inMemory.update(contents, stateVersion)
+			childStorageKeys := []storage.ChildInfo{childInfo1, childInfo2}
+			var childDeltas []ChildDelta
+			for _, childStorageKey := range childStorageKeys {
+				childDeltas = append(childDeltas, ChildDelta{
+					ChildInfo: childStorageKey,
+					Deltas:    nil,
+				})
+			}
+			inMemoryRoot, _ := inMemory.FullStorageRoot(nil, childDeltas, stateVersion)
+			val, err := inMemory.Storage(key)
+			require.NoError(t, err)
+			require.Equal(t, topTrieVal, []byte(val))
+
+			val, err = inMemory.ChildStorage(childInfo1, key)
+			require.NoError(t, err)
+			require.Equal(t, childTrie1Val, []byte(val))
+
+			val, err = inMemory.ChildStorage(childInfo2, key)
+			require.NoError(t, err)
+			require.Equal(t, childTrie2Val, []byte(val))
+
+			for _, cache := range []*cache.SharedTrieCache[hash.H256]{cache.NewSharedTrieCache[hash.H256](1024 * 10), nil} {
+				// Run multiple times to have a different cache conditions.
+				for i := 0; i < 5; i++ {
+					if cache != nil {
+						if i == 2 {
+							cache.ResetNodeCache()
+						} else if i == 3 {
+							cache.ResetValueCache()
+						}
+					}
+
+					trie := inMemory.TrieBackend
+					trieRoot, _ := trie.StorageRoot(nil, stateVersion)
+					require.Equal(t, inMemoryRoot, trieRoot)
+
+					proving := NewWrappedTrieBackend(trie)
+					proving.essence.recorder = recorder.NewRecorder[hash.H256]()
+					if cache != nil {
+						local := cache.LocalTrieCache()
+						proving.essence.trieNodeCache = &local
+					}
+					val, err := proving.Storage(key)
+					require.NoError(t, err)
+					require.Equal(t, topTrieVal, []byte(val))
+					val, err = proving.ChildStorage(childInfo1, key)
+					require.NoError(t, err)
+					require.Equal(t, childTrie1Val, []byte(val))
+					val, err = proving.ChildStorage(childInfo2, key)
+					require.NoError(t, err)
+					require.Equal(t, childTrie2Val, []byte(val))
+
+					proof := proving.ExtractProof()
+					require.NotNil(t, proof)
+
+					proofCheck, err := NewProofCheckTrieBackend[hash.H256, runtime.BlakeTwo256](inMemoryRoot, *proof)
+					require.NoError(t, err)
+					val, err = proofCheck.Storage(key)
+					require.NoError(t, err)
+					require.Equal(t, topTrieVal, []byte(val))
+					val, err = proofCheck.ChildStorage(childInfo1, key)
+					require.NoError(t, err)
+					require.Equal(t, childTrie1Val, []byte(val))
+					val, err = proofCheck.ChildStorage(childInfo2, key)
+					require.NoError(t, err)
+					require.Equal(t, childTrie2Val, []byte(val))
+
+				}
+			}
+		}
+	})
+}

--- a/internal/primitives/storage/storage.go
+++ b/internal/primitives/storage/storage.go
@@ -1,0 +1,154 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package storage
+
+import (
+	"strings"
+
+	"github.com/ChainSafe/gossamer/pkg/trie"
+)
+
+// Storage key.
+type StorageKey []byte
+
+// Storage key of a child trie, it contains the prefix to the key.
+type PrefixedStorageKey []byte
+
+// Information related to a child state.
+type ChildInfo interface {
+	// Returns byte sequence (keyspace) that can be use by underlying db to isolate keys.
+	// This is a unique id of the child trie. The collision resistance of this value
+	// depends on the type of child info use. For `ChildInfo::Default` it is and need to be.
+	Keyspace() []byte
+	// Returns a reference to the location in the direct parent of
+	// this trie but without the common prefix for this kind of
+	// child trie.
+	StorageKey() StorageKey
+	// Return a the full location in the direct parent of
+	// this trie.
+	PrefixedStorageKey() PrefixedStorageKey
+	// Returns the type for this child info.
+	ChildType() ChildType
+}
+
+// This is the one used by default.
+type ChildInfoParentKeyID ChildTrieParentKeyID
+
+// Returns byte sequence (keyspace) that can be use by underlying db to isolate keys.
+// This is a unique id of the child trie. The collision resistance of this value
+// depends on the type of child info use.
+func (cipkid ChildInfoParentKeyID) Keyspace() []byte {
+	return cipkid.StorageKey()
+}
+
+// Returns a reference to the location in the direct parent of
+// this trie but without the common prefix for this kind of
+// child trie.
+func (cipkid ChildInfoParentKeyID) StorageKey() StorageKey {
+	return ChildTrieParentKeyID(cipkid).data
+}
+
+// Return a the full location in the direct parent of
+// this trie.
+func (cipkid ChildInfoParentKeyID) PrefixedStorageKey() PrefixedStorageKey {
+	return ChildTypeParentKeyID.NewPrefixedKey(cipkid.data)
+}
+
+// Returns the type for this child info.
+func (cipkid ChildInfoParentKeyID) ChildType() ChildType {
+	return ChildTypeParentKeyID
+}
+
+// Instantiates child information for a default child trie
+// of kind `ChildType::ParentKeyId`, using an unprefixed parent
+// storage key.
+func NewDefaultChildInfo(storageKey []byte) ChildInfo {
+	return ChildInfoParentKeyID{
+		data: storageKey,
+	}
+}
+
+// Type of child.
+// It does not strictly define different child type, it can also
+// be related to technical consideration or api variant.
+type ChildType uint32
+
+const (
+	// If runtime module ensures that the child key is a unique id that will
+	// only be used once, its parent key is used as a child trie unique id.
+	ChildTypeParentKeyID ChildType = iota + 1
+)
+
+// Transform a prefixed key into a tuple of the child type
+// and the unprefixed representation of the key.
+func NewChildTypeFromPrefixedKey(storageKey PrefixedStorageKey) *struct {
+	ChildType
+	Key []byte
+} {
+	childType := ChildTypeParentKeyID
+	prefix := childType.ParentPrefix()
+	if strings.Index(string(storageKey), string(prefix)) == 0 {
+		return &struct {
+			ChildType
+			Key []byte
+		}{childType, storageKey[len(prefix):]}
+	} else {
+		return nil
+	}
+}
+
+// Produce a prefixed key for a given child type.
+func (ct ChildType) NewPrefixedKey(key []byte) PrefixedStorageKey {
+	parentPrefix := ct.ParentPrefix()
+	result := append(parentPrefix, key...)
+	return PrefixedStorageKey(result)
+}
+
+// Prefix of the default child storage keys in the top trie.
+var DefaultChildStorageKeyPrefix = []byte(":child_storage:default:")
+
+// Returns the location reserved for this child trie in their parent trie if there
+// is one.
+func (ct ChildType) ParentPrefix() []byte {
+	switch ct {
+	case ChildTypeParentKeyID:
+		return DefaultChildStorageKeyPrefix
+	default:
+		panic("unreachable")
+	}
+}
+
+// A child trie of default type.
+//
+// It uses the same default implementation as the top trie, top trie being a child trie with no
+// keyspace and no storage key. Its keyspace is the variable (unprefixed) part of its storage key.
+// It shares its trie nodes backend storage with every other child trie, so its storage key needs
+// to be a unique id that will be use only once. Those unique id also required to be long enough to
+// avoid any unique id to be prefixed by an other unique id.
+type ChildTrieParentKeyID struct {
+	// Data is the storage key without prefix.
+	data []byte
+}
+
+// Different possible state version.
+//
+// V0 and V1 uses a same trie implementation, but V1 will write external value node in the trie for
+// value with size greater than 32 bytes.
+type StateVersion uint
+
+const (
+	StateVersionV0 StateVersion = iota
+	StateVersionV1
+)
+
+func (svv StateVersion) TrieLayout() trie.TrieLayout {
+	switch svv {
+	case StateVersionV0:
+		return trie.V0
+	case StateVersionV1:
+		return trie.V1
+	default:
+		panic("unreachable")
+	}
+}

--- a/internal/primitives/trie/cache/cache.go
+++ b/internal/primitives/trie/cache/cache.go
@@ -1,0 +1,368 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package cache
+
+import (
+	"log"
+	"sync"
+
+	costlru "github.com/ChainSafe/gossamer/internal/cost-lru"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/elastic/go-freelru"
+)
+
+// The maximum number of existing keys in the shared cache that a single local cache
+// can promote to the front of the LRU cache in one go.
+//
+// If we have a big shared cache and the local cache hits all of those keys we don't
+// want to spend forever bumping all of them.
+const sharedNodeCacheMaxPromotedKeys = uint(1792)
+
+// Same as sharedNodeCacheMaxPromotedKeys for value cache.
+const sharedValueCacheMaxPromotedKeys = uint(1792)
+
+// The maximum portion of the shared cache (in percent) that a single local
+// cache can replace in one go.
+//
+// We don't want a single local cache instance to have the ability to replace
+// everything in the shared cache.
+const sharedNodeCacheMaxReplacePercent = uint(33)
+
+// Same as sharedNodeCacheMaxReplacePercent for value cache.
+const sharedValueCacheMaxReplacePercent = uint(33)
+
+// The maximum size of the memory allocated on the heap by the local cache, in bytes.
+//
+// The size of the node cache should always be bigger than the value cache. The value
+// cache is only holding weak references to the actual values found in the nodes and
+// we account for the size of the node as part of the node cache.
+const localNodeCacheMaxSize = uint(8 * 1024 * 1024)
+
+// Same as localNodeCacheMaxSize for value cache.
+const localValueCacheMaxSize = uint(2 * 1024 * 1024)
+
+// An internal struct to store the cached trie nodes.
+type nodeCached[H runtime.Hash] struct {
+	// The cached node.
+	Node triedb.CachedNode[H]
+	// Whether this node was fetched from the shared cache or not.
+	FromSharedCache bool
+}
+
+// Returns the number of bytes allocated on the heap by this node.
+func (nc nodeCached[H]) ByteSize() uint {
+	return nc.Node.ByteSize()
+}
+
+// The local trie cache.
+//
+// This cache should be used per state instance created by the backend. One state instance is
+// referring to the state of one block. It will cache all the accesses that are done to the state
+// which could not be fullfilled by the [SharedTrieCache]. These locally cached items are merged
+// back to the shared trie cache when this instance is dropped.
+//
+// When using [LocalTrieCache.TrieCache] or [LocalTrieCache.TrieCacheMut] it will lock mutexes.
+// So, it is important that these methods are not called multiple times, because they otherwise
+// deadlock.
+type LocalTrieCache[H runtime.Hash] struct {
+	// The shared trie cache that created this instance.
+	shared *SharedTrieCache[H]
+
+	// The local cache for the trie nodes.
+	nodeCache    *costlru.LRU[H, nodeCached[H]]
+	nodeCacheMtx sync.Mutex
+
+	// The local cache for the values.
+	valueCache    *costlru.LRU[ValueCacheKeyComparable[H], triedb.CachedValue[H]]
+	valueCacheMtx sync.Mutex
+
+	// Keeps track of all values accessed in the shared cache.
+	//
+	// This will be used to ensure that these nodes are brought to the front of the LRU when this
+	// local instance is merged back to the shared cache. This can actually lead to collision when
+	// two [ValueCacheKey] instances with different storage roots and keys map to the same hash. However,
+	// as we only use this set to update the LRU position it is fine, even if we bring the wrong
+	// value to the top. The important part is that we always get the correct value from the value
+	// cache for a given key.
+	sharedValueCacheAccess    *freelru.LRU[ValueCacheKeyComparable[H], any]
+	sharedValueCacheAccessMtx sync.Mutex
+}
+
+func (ltc *LocalTrieCache[H]) Commit() {
+	ltc.shared.Lock()
+	defer ltc.shared.Unlock()
+
+	sharedInner := &ltc.shared.inner
+
+	updateItems := make([]updateItem[H], 0)
+	ltc.nodeCacheMtx.Lock()
+	for _, hash := range ltc.nodeCache.Keys() {
+		node, ok := ltc.nodeCache.Peek(hash)
+		if !ok {
+			panic("node should be found")
+		}
+		updateItems = append(updateItems, updateItem[H]{
+			Hash:       hash,
+			nodeCached: node,
+		})
+	}
+	ltc.nodeCache.Purge()
+	ltc.nodeCacheMtx.Unlock()
+	sharedInner.nodeCache.Update(updateItems)
+
+	added := make([]sharedValueCacheAdded[H], 0)
+	ltc.valueCacheMtx.Lock()
+	for _, key := range ltc.valueCache.Keys() {
+		value, ok := ltc.valueCache.Get(key)
+		if !ok {
+			panic("value should be found")
+		}
+		added = append(added, sharedValueCacheAdded[H]{
+			ValueCacheKey: key.ValueCacheKey(),
+			CachedValue:   value,
+		})
+	}
+	ltc.valueCache.Purge()
+	ltc.valueCacheMtx.Unlock()
+
+	ltc.sharedValueCacheAccessMtx.Lock()
+	accessed := ltc.sharedValueCacheAccess.Keys()
+	ltc.sharedValueCacheAccess.Purge()
+	ltc.sharedValueCacheAccessMtx.Unlock()
+
+	sharedInner.valueCache.Update(added, accessed)
+}
+
+// Returns a [triedb.TrieDB] compatible [triedb.TrieCache].
+//
+// The given storageRoot needs to be the storage root of the trie this cache is used for.
+func (ltc *LocalTrieCache[H]) TrieCache(storageRoot H) (cache *TrieCache[H], unlock func()) {
+	ltc.valueCacheMtx.Lock()
+	ltc.sharedValueCacheAccessMtx.Lock()
+	ltc.nodeCacheMtx.Lock()
+
+	unlock = func() {
+		ltc.valueCacheMtx.Unlock()
+		ltc.sharedValueCacheAccessMtx.Unlock()
+		ltc.nodeCacheMtx.Unlock()
+	}
+
+	return &TrieCache[H]{
+		sharedCache: ltc.shared,
+		localCache:  ltc.nodeCache,
+		valueCache: &forStorageRootValueCache[H]{
+			storageRoot:            storageRoot,
+			localValueCache:        ltc.valueCache,
+			sharedValueCacheAccess: ltc.sharedValueCacheAccess,
+		},
+	}, unlock
+}
+
+// Returns a [triedb.TrieDB] compatible [triedb.TrieCache].
+//
+// After finishing all operations with [triedb.TrieDB] and having obtained
+// the new storage root, [TrieCache.MergeInto] should be called to update this local
+// cache instance. If the function is not called, cached data is just thrown away and not
+// propagated to the shared cache.
+func (ltc *LocalTrieCache[H]) TrieCacheMut() (cache *TrieCache[H], unlock func()) {
+	ltc.nodeCacheMtx.Lock()
+	return &TrieCache[H]{
+		sharedCache: ltc.shared,
+		localCache:  ltc.nodeCache,
+		valueCache:  &freshValueCache[H]{},
+	}, ltc.nodeCacheMtx.Unlock
+}
+
+// Merge the cached data in other into self.
+//
+// This must be used for the cache returned by [LocalTrieCache.TrieCacheMut] as otherwise the
+// cached data is just thrown away.
+func (ltc *LocalTrieCache[H]) Merge(other *TrieCache[H], newRoot H) {
+	other.MergeInto(ltc, newRoot)
+}
+
+// The abstraction of the value cache for the [TrieCache].
+type valueCache[H runtime.Hash] interface {
+	get(key []byte, sharedCache *SharedTrieCache[H]) triedb.CachedValue[H]
+	insert(key []byte, value triedb.CachedValue[H])
+}
+
+// The value cache is fresh, aka not yet associated to any storage root.
+// This is used for example when a new trie is being build, to cache new values.
+type freshValueCache[H runtime.Hash] map[string]triedb.CachedValue[H]
+
+func (fvc *freshValueCache[H]) get(key []byte, sharedCache *SharedTrieCache[H]) triedb.CachedValue[H] {
+	val, ok := (*fvc)[string(key)]
+	if ok {
+		return val
+	} else {
+		return nil
+	}
+}
+func (fvc *freshValueCache[H]) insert(key []byte, value triedb.CachedValue[H]) {
+	(*fvc)[string(key)] = value
+}
+
+// The value cache is already bound to a specific storage root.
+type forStorageRootValueCache[H runtime.Hash] struct {
+	sharedValueCacheAccess *freelru.LRU[ValueCacheKeyComparable[H], any]
+	localValueCache        *costlru.LRU[ValueCacheKeyComparable[H], triedb.CachedValue[H]]
+	storageRoot            H
+}
+
+func (fsrvc forStorageRootValueCache[H]) get(key []byte, sharedCache *SharedTrieCache[H]) triedb.CachedValue[H] {
+	// We first need to look up in the local cache and then the shared cache.
+	// It can happen that some value is cached in the shared cache, but the
+	// weak reference of the data can not be upgraded anymore. This for example
+	// happens when the node is dropped that contains the strong reference to the data.
+	//
+	// So, the logic of the trie would lookup the data and the node and store both
+	// in our local caches.
+	vck := ValueCacheKey[H]{
+		StorageKey:  key,
+		StorageRoot: fsrvc.storageRoot,
+	}
+	val, ok := fsrvc.localValueCache.Peek(vck.ValueCacheKeyComparable())
+	if ok {
+		return val
+	}
+
+	sharedVal := sharedCache.PeekValueByHash(vck.ValueCacheKeyComparable(), fsrvc.storageRoot, key)
+	if sharedVal != nil {
+		fsrvc.sharedValueCacheAccess.Add(vck.ValueCacheKeyComparable(), any(nil))
+		return sharedVal
+	}
+
+	return nil
+}
+func (fsrvc forStorageRootValueCache[H]) insert(key []byte, value triedb.CachedValue[H]) {
+	vck := ValueCacheKey[H]{
+		StorageKey:  key,
+		StorageRoot: fsrvc.storageRoot,
+	}
+	fsrvc.localValueCache.Add(vck.ValueCacheKeyComparable(), value)
+}
+
+// The [triedb.TrieCache] implementation.
+//
+// If this instance was created using [LocalTrieCache.TrieCacheMut], it needs to
+// be merged back into the [LocalTrieCache] with [LocalTrieCache.MergeInto] after all operations are
+// done.
+type TrieCache[H runtime.Hash] struct {
+	sharedCache *SharedTrieCache[H]
+	localCache  *costlru.LRU[H, nodeCached[H]]
+	valueCache  valueCache[H]
+}
+
+// Merge this cache into the given [LocalTrieCache].
+//
+// This function is only required to be called when this instance was created through
+// [LocalTrieCache.TrieCacheMut], otherwise this method is a no-op. The given
+// storageRoot is the new storage root that was obtained after finishing all operations
+// using the [triedb.TrieDB].
+func (tc *TrieCache[H]) MergeInto(local *LocalTrieCache[H], storageRoot H) {
+	cache, ok := tc.valueCache.(*freshValueCache[H])
+	if !ok {
+		return
+	}
+
+	if len(*cache) != 0 {
+		local.valueCacheMtx.Lock()
+		defer local.valueCacheMtx.Unlock()
+
+		vck := ValueCacheKey[H]{
+			StorageRoot: storageRoot,
+		}
+		for k, v := range *cache {
+			vck.StorageKey = []byte(k)
+			ok, _ := local.valueCache.Add(vck.ValueCacheKeyComparable(), v)
+			if !ok {
+				panic("huh?")
+			}
+		}
+	}
+}
+
+func (tc *TrieCache[H]) GetOrInsertNode(hash H, fetchNode func() (triedb.CachedNode[H], error)) (triedb.CachedNode[H], error) {
+	var isLocalCacheHit bool = true
+
+	// First try to grab the node from the local cache.
+	var err error
+	var node *nodeCached[H]
+	local, ok := tc.localCache.Get(hash)
+	if !ok {
+		isLocalCacheHit = false
+
+		// It was not in the local cache; try the shared cache.
+		shared := tc.sharedCache.PeekNode(hash)
+		if shared != nil {
+			log.Printf("TRACE: Serving node from shared cache: %s\n", hash)
+			node = &nodeCached[H]{Node: shared, FromSharedCache: true}
+		} else {
+			// It was not in the shared cache; try fetching it from the database.
+			var fetched triedb.CachedNode[H]
+			fetched, err = fetchNode()
+			if err != nil {
+				log.Printf("TRACE: Serving node from database failed: %s\n", hash)
+				return nil, err
+			} else {
+				log.Printf("TRACE: Serving node from database: %s\n", hash)
+				node = &nodeCached[H]{Node: fetched, FromSharedCache: false}
+			}
+		}
+		tc.localCache.Add(hash, *node)
+	} else {
+		node = &local
+	}
+
+	if isLocalCacheHit {
+		log.Printf("TRACE: Serving node from local cache: %s\n", hash)
+	}
+
+	if node == nil {
+		panic("you can always insert at least one element into the local cache; qed")
+	}
+	return node.Node, nil
+}
+
+func (tc *TrieCache[H]) GetNode(hash H) triedb.CachedNode[H] {
+	var isLocalCacheHit bool = true
+
+	// First try to grab the node from the local cache.
+	var node *nodeCached[H]
+	nc, ok := tc.localCache.Get(hash)
+	if !ok {
+		isLocalCacheHit = false
+
+		// It was not in the local cache; try the shared cache.
+		peeked := tc.sharedCache.PeekNode(hash)
+		if peeked != nil {
+			log.Printf("TRACE: Serving node from shared cache: %s\n", hash)
+			node = &nodeCached[H]{Node: peeked, FromSharedCache: true}
+		} else {
+			log.Printf("TRACE: Serving node from cahe failed: %s\n", hash)
+			return nil
+		}
+	} else {
+		node = &nc
+	}
+
+	if isLocalCacheHit {
+		log.Printf("TRACE: Serving node from local cache: %s\n", hash)
+	}
+
+	return node.Node
+}
+
+func (tc *TrieCache[H]) GetValue(key []byte) triedb.CachedValue[H] {
+	cached := tc.valueCache.get(key, tc.sharedCache)
+	log.Printf("TRACE: Looked up value for key: %x\n", key)
+	return cached
+}
+
+func (tc *TrieCache[H]) SetValue(key []byte, value triedb.CachedValue[H]) {
+	log.Printf("TRACE: Caching value for key: %x\n", key)
+	tc.valueCache.insert(key, value)
+}

--- a/internal/primitives/trie/cache/cache_test.go
+++ b/internal/primitives/trie/cache/cache_test.go
@@ -1,0 +1,396 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie/recorder"
+	pkgtrie "github.com/ChainSafe/gossamer/pkg/trie"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/stretchr/testify/require"
+)
+
+var testData = []triedb.TrieItem{
+	{Key: []byte("key1"), Value: []byte("val1")},
+	{Key: []byte("key2"), Value: bytes.Repeat([]byte{2}, 64)},
+	{Key: []byte("key3"), Value: []byte("val3")},
+	{Key: []byte("key4"), Value: bytes.Repeat([]byte{4}, 64)},
+}
+
+const cacheSize uint = 1024 * 10
+
+func createTrie(t *testing.T) (*trie.MemoryDB[hash.H256, runtime.BlakeTwo256], hash.H256) {
+	t.Helper()
+
+	db := trie.NewMemoryDB[hash.H256, runtime.BlakeTwo256]()
+	trie := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](db)
+	trie.SetVersion(pkgtrie.V1)
+	for _, item := range testData {
+		err := trie.Set(item.Key, item.Value)
+		require.NoError(t, err)
+	}
+	hash := trie.MustHash()
+
+	return db, hash
+}
+
+func Test_SharedTrieCache(t *testing.T) {
+	t.Run("cache_works", func(t *testing.T) {
+		db, root := createTrie(t)
+		sharedCache := NewSharedTrieCache[hash.H256](cacheSize)
+		localCache := sharedCache.LocalTrieCache()
+
+		{
+			cache, unlock := localCache.TrieCache(root)
+			trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+				root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+			trie.SetVersion(pkgtrie.V1)
+
+			val, err := triedb.GetWith(trie, testData[0].Key, func(d []byte) []byte { return d })
+			require.NoError(t, err)
+			require.NotNil(t, val)
+			require.NotNil(t, *val)
+			require.Equal(t, testData[0].Value, *val)
+			unlock()
+		}
+
+		// Local cache wasn't committed yet, so there should nothing in the shared caches.
+		require.Equal(t, 0, sharedCache.inner.valueCache.lru.Len())
+		require.Equal(t, 0, sharedCache.inner.nodeCache.lru.Len())
+
+		localCache.Commit()
+
+		// Now we should have the cached items in the shared cache.
+		require.GreaterOrEqual(t, sharedCache.inner.nodeCache.lru.Len(), 1)
+
+		cachedVal, ok := sharedCache.inner.valueCache.lru.Peek(
+			ValueCacheKey[hash.H256]{
+				StorageRoot: root,
+				StorageKey:  testData[0].Key,
+			}.ValueCacheKeyComparable(),
+		)
+		require.True(t, ok)
+		existing, ok := cachedVal.(triedb.ExistingCachedValue[hash.H256])
+		require.True(t, ok)
+		require.Equal(t, testData[0].Value, existing.Data)
+
+		var fakeData = []byte("fake_data")
+
+		localCache = sharedCache.LocalTrieCache()
+		sharedCache.inner.valueCache.lru.Add(
+			ValueCacheKey[hash.H256]{
+				StorageRoot: root,
+				StorageKey:  testData[1].Key,
+			}.ValueCacheKeyComparable(),
+			triedb.ExistingCachedValue[hash.H256]{
+				Hash: hash.NewH256(),
+				Data: fakeData,
+			},
+		)
+
+		{
+			cache, unlock := localCache.TrieCache(root)
+			trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+				root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+			trie.SetVersion(pkgtrie.V1)
+
+			// We should now get the "fake_data", because we inserted this manually to the cache.
+			val, err := triedb.GetWith(trie, testData[1].Key, func(d []byte) []byte { return d })
+			require.NoError(t, err)
+			require.NotNil(t, val)
+			require.NotNil(t, *val)
+			require.Equal(t, fakeData, *val)
+			unlock()
+		}
+	})
+
+	t.Run("TrieCacheMut", func(t *testing.T) {
+		db, root := createTrie(t)
+		newKey := []byte("new_key")
+		// Use some long value to not have it inlined
+		newValue := bytes.Repeat([]byte{23}, 64)
+
+		sharedCache := NewSharedTrieCache[hash.H256](cacheSize)
+		var newRoot hash.H256
+
+		{
+			localCache := sharedCache.LocalTrieCache()
+			cache, unlock := localCache.TrieCacheMut()
+
+			{
+				trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+					root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+				trie.SetVersion(pkgtrie.V1)
+				require.NoError(t, trie.Set(newKey, newValue))
+				newRoot = trie.MustHash()
+			}
+
+			cache.MergeInto(&localCache, newRoot)
+			unlock()
+			localCache.Commit()
+
+		}
+
+		// After the local cache is dropped, all changes should have been merged back to the shared
+		// cache.
+		cachedVal, ok := sharedCache.inner.valueCache.lru.Peek(ValueCacheKey[hash.H256]{
+			StorageRoot: newRoot,
+			StorageKey:  newKey,
+		}.ValueCacheKeyComparable())
+		require.True(t, ok)
+		existing, ok := cachedVal.(triedb.ExistingCachedValue[hash.H256])
+		require.True(t, ok)
+		require.Equal(t, newValue, existing.Data)
+	})
+
+	t.Run("TrieCache_cache_and_recorder_work_together", func(t *testing.T) {
+		db, root := createTrie(t)
+		sharedCache := NewSharedTrieCache[hash.H256](cacheSize)
+
+		for i := 0; i < 5; i++ {
+			// Clear some of the caches.
+			if i == 2 {
+				sharedCache.ResetNodeCache()
+			} else if i == 3 {
+				sharedCache.ResetValueCache()
+			}
+
+			localCache := sharedCache.LocalTrieCache()
+			recorder := recorder.NewRecorder[hash.H256]()
+
+			{
+				cache, unlock := localCache.TrieCache(root)
+				recorder := recorder.TrieRecorder(root)
+				trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+					root, db,
+					triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache),
+					triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](recorder),
+				)
+
+				for _, item := range testData {
+					val, err := triedb.GetWith(trie, item.Key, func(d []byte) []byte { return d })
+					require.NoError(t, err)
+					require.NotNil(t, val)
+					require.NotNil(t, *val)
+					require.Equal(t, item.Value, *val)
+				}
+
+				root = trie.MustHash()
+				unlock()
+			}
+
+			storageProof := recorder.DrainStorageProof()
+			memoryDB := trie.NewMemoryDBFromStorageProof[hash.H256, runtime.BlakeTwo256](storageProof)
+
+			{
+				trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, memoryDB)
+				for _, item := range testData {
+					val, err := triedb.GetWith(trie, item.Key, func(d []byte) []byte { return d })
+					require.NoError(t, err)
+					require.NotNil(t, val)
+					require.NotNil(t, *val)
+					require.Equal(t, item.Value, *val)
+				}
+			}
+		}
+	})
+
+	t.Run("TrieCacheMut_cache_and_recorder_work_together", func(t *testing.T) {
+		var dataToAdd = []triedb.TrieItem{
+			{Key: []byte("key11"), Value: bytes.Repeat([]byte{45}, 78)},
+			{Key: []byte("key33"), Value: bytes.Repeat([]byte{78}, 89)},
+		}
+
+		db, root := createTrie(t)
+
+		sharedCache := NewSharedTrieCache[hash.H256](cacheSize)
+
+		// Run this twice so that we use the data cache in the second run.
+		for i := 0; i < 5; i++ {
+			// Clear some of the caches.
+			if i == 2 {
+				sharedCache.ResetNodeCache()
+			} else if i == 3 {
+				sharedCache.ResetValueCache()
+			}
+
+			localCache := sharedCache.LocalTrieCache()
+			recorder := recorder.NewRecorder[hash.H256]()
+			var newRoot hash.H256
+
+			{
+				db := db.Clone()
+				cache, unlock := localCache.TrieCache(root)
+				recorder := recorder.TrieRecorder(root)
+
+				trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+					root, &db,
+					triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache),
+					triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](recorder),
+				)
+
+				for _, item := range dataToAdd {
+					err := trie.Set(item.Key, item.Value)
+					require.NoError(t, err)
+				}
+
+				newRoot = trie.MustHash()
+				unlock()
+			}
+
+			storageProof := recorder.DrainStorageProof()
+			memoryDB := trie.NewMemoryDBFromStorageProof[hash.H256, runtime.BlakeTwo256](storageProof)
+			var proofRoot hash.H256
+			{
+				trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, memoryDB)
+				for _, item := range dataToAdd {
+					err := trie.Set(item.Key, item.Value)
+					require.NoError(t, err)
+				}
+				proofRoot = trie.MustHash()
+			}
+			require.Equal(t, newRoot, proofRoot)
+		}
+	})
+
+	t.Run("cache_lru_works", func(t *testing.T) {
+		db, root := createTrie(t)
+		sharedCache := NewSharedTrieCache[hash.H256](cacheSize)
+
+		{
+			localCache := sharedCache.LocalTrieCache()
+			cache, unlock := localCache.TrieCache(root)
+
+			trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+				root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+			trie.SetVersion(pkgtrie.V1)
+
+			for _, item := range testData {
+				val, err := triedb.GetWith(trie, item.Key, func(d []byte) []byte { return d })
+				require.NoError(t, err)
+				require.NotNil(t, val)
+				require.NotNil(t, *val)
+				require.Equal(t, item.Value, *val)
+			}
+
+			unlock()
+			localCache.Commit()
+		}
+
+		// Check that all items are there.
+		var allFound = true
+		for _, key := range sharedCache.inner.valueCache.lru.Keys() {
+			var found bool
+			for _, item := range testData {
+				if bytes.Equal([]byte(key.StorageKey), item.Key) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allFound = false
+				break
+			}
+		}
+		require.True(t, allFound)
+
+		// Run this in a loop. The first time we check that with the filled value cache,
+		// the expected values are at the top of the LRU.
+		// The second run is using an empty value cache to ensure that we access the nodes.
+		for i := 0; i < 2; i++ {
+			{
+				localCache := sharedCache.LocalTrieCache()
+				cache, unlock := localCache.TrieCache(root)
+				trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+					root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+				trie.SetVersion(pkgtrie.V1)
+
+				for _, item := range testData[:2] {
+					val, err := triedb.GetWith(trie, item.Key, func(d []byte) []byte { return d })
+					require.NoError(t, err)
+					require.NotNil(t, val)
+					require.NotNil(t, *val)
+					require.Equal(t, item.Value, *val)
+				}
+				unlock()
+				localCache.Commit()
+			}
+
+			// Ensure that the accessed items are part of the shared value
+			// cache.
+			for _, item := range testData[:2] {
+				_, ok := sharedCache.inner.valueCache.lru.Peek(ValueCacheKey[hash.H256]{
+					StorageRoot: root,
+					StorageKey:  item.Key,
+				}.ValueCacheKeyComparable())
+				require.True(t, ok)
+			}
+
+			// Delete the value cache, so that we access the nodes.
+			sharedCache.ResetValueCache()
+		}
+
+		mostRecentlyUsedNodes := sharedCache.inner.nodeCache.lru.Keys()
+
+		{
+			localCache := sharedCache.LocalTrieCache()
+			cache, unlock := localCache.TrieCache(root)
+			trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+				root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+			trie.SetVersion(pkgtrie.V1)
+
+			for _, item := range testData[2:] {
+				val, err := triedb.GetWith(trie, item.Key, func(d []byte) []byte { return d })
+				require.NoError(t, err)
+				require.NotNil(t, val)
+				require.NotNil(t, *val)
+				require.Equal(t, item.Value, *val)
+			}
+			unlock()
+			localCache.Commit()
+		}
+
+		// Ensure that the most recently used nodes changed as well.
+		cachedNodes := sharedCache.inner.nodeCache.lru.Keys()
+
+		require.NotEqual(t, mostRecentlyUsedNodes, cachedNodes)
+	})
+
+	t.Run("cache_respects_bounds", func(t *testing.T) {
+		db, root := createTrie(t)
+		sharedCache := NewSharedTrieCache[hash.H256](cacheSize)
+
+		{
+			localCache := sharedCache.LocalTrieCache()
+			var newRoot hash.H256
+
+			{
+				cache, unlock := localCache.TrieCache(root)
+				{
+					trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+						root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
+					trie.SetVersion(pkgtrie.V1)
+					value := bytes.Repeat([]byte{10}, 100)
+					// Ensure we add enough data that would overflow the cache.
+					for i := 0; i < (int(cacheSize) / 100 * 2); i++ {
+						require.NoError(t, trie.Set([]byte(fmt.Sprintf("key%d", i)), value))
+					}
+					newRoot = trie.MustHash()
+				}
+				unlock()
+				cache.MergeInto(&localCache, newRoot)
+			}
+
+			localCache.Commit()
+		}
+
+		require.Less(t, sharedCache.usedMemorySize(), cacheSize)
+	})
+}

--- a/internal/primitives/trie/cache/cache_test.go
+++ b/internal/primitives/trie/cache/cache_test.go
@@ -49,7 +49,7 @@ func Test_SharedTrieCache(t *testing.T) {
 
 		{
 			cache, unlock := localCache.TrieCache(root)
-			trie := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](
+			trie := triedb.NewTrieDB(
 				root, db, triedb.WithCache[hash.H256, runtime.BlakeTwo256](cache))
 			trie.SetVersion(pkgtrie.V1)
 
@@ -135,10 +135,9 @@ func Test_SharedTrieCache(t *testing.T) {
 			cache.MergeInto(&localCache, newRoot)
 			unlock()
 			localCache.Commit()
-
 		}
 
-		// After the local cache is dropped, all changes should have been merged back to the shared
+		// After the local cache is committed, all changes should have been merged back to the shared
 		// cache.
 		cachedVal, ok := sharedCache.inner.valueCache.lru.Peek(ValueCacheKey[hash.H256]{
 			StorageRoot: newRoot,

--- a/internal/primitives/trie/cache/shared_cache.go
+++ b/internal/primitives/trie/cache/shared_cache.go
@@ -1,0 +1,361 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package cache
+
+import (
+	"log"
+	"sync"
+
+	costlru "github.com/ChainSafe/gossamer/internal/cost-lru"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/dolthub/maphash"
+	"github.com/elastic/go-freelru"
+)
+
+// The shared node cache.
+//
+// Internally this stores all cached nodes in a [costlru.LRU]. It ensures that when updating the
+// cache, that the cache stays within its allowed bounds.
+type sharedNodeCache[H runtime.Hash] struct {
+	// The cached nodes, ordered by least recently used.
+	lru          *costlru.LRU[H, triedb.CachedNode[H]]
+	itemsEvicted uint
+}
+
+type hasher[K comparable] struct {
+	maphash.Hasher[K]
+}
+
+func (h hasher[K]) Hash(key K) uint32 {
+	return uint32(h.Hasher.Hash(key))
+}
+
+// Constructor for [sharedNodeCache] with fixed size in number of bytes.
+func newSharedNodeCache[H runtime.Hash](sizeBytes uint) *sharedNodeCache[H] {
+	snc := sharedNodeCache[H]{}
+	itemsEvictedPtr := &snc.itemsEvicted
+	h := hasher[H]{maphash.NewHasher[H]()}
+	var err error
+
+	snc.lru, err = costlru.New(sizeBytes, h.Hash, func(hash H, node triedb.CachedNode[H]) uint32 {
+		return uint32(node.ByteSize())
+	})
+	if err != nil {
+		panic(err)
+	}
+	snc.lru.SetOnEvict(func(h H, cn triedb.CachedNode[H]) {
+		(*itemsEvictedPtr)++
+	})
+	return &snc
+}
+
+// updateItem contains a hash and a [nodeCached] instance.
+type updateItem[H runtime.Hash] struct {
+	Hash H
+	nodeCached[H]
+}
+
+// Update the cache with the list of nodes which were either newly added or accessed.
+func (snc *sharedNodeCache[H]) Update(list []updateItem[H]) {
+	accessCount := uint(0)
+	addCount := uint(0)
+
+	snc.itemsEvicted = 0
+	maxItemsEvicted := uint(snc.lru.Len()*100) / sharedNodeCacheMaxReplacePercent
+	for _, ui := range list {
+		if ui.nodeCached.FromSharedCache {
+			_, ok := snc.lru.Get(ui.Hash)
+			if ok {
+				accessCount++
+				if accessCount >= sharedNodeCacheMaxPromotedKeys {
+					// Stop when we've promoted a large enough number of items.
+					break
+				}
+				continue
+			}
+		}
+
+		added, _ := snc.lru.Add(ui.Hash, ui.nodeCached.Node)
+		if added {
+			addCount++
+		}
+
+		if snc.itemsEvicted > maxItemsEvicted {
+			// Stop when we've evicted a big enough chunk of the shared cache.
+			break
+		}
+	}
+
+	log.Printf(
+		"DEBUG: Updated the shared node cache: %d accesses, %d new values, %d/%d evicted (length = %d, size=%d/%d)\n",
+		accessCount, addCount, snc.itemsEvicted, maxItemsEvicted, snc.lru.Len(), snc.lru.Cost(), snc.lru.MaxCost(),
+	)
+}
+
+// Reset clears the cache
+func (snc *sharedNodeCache[H]) Reset() {
+	snc.lru.Purge()
+}
+
+// The comparable type that identifies this instance of storage root and storage key, used in [sharedValueCache] LRU.
+type ValueCacheKeyComparable[H runtime.Hash] struct {
+	StorageRoot H
+	StorageKey  string
+}
+
+func (vckh ValueCacheKeyComparable[H]) ValueCacheKey() ValueCacheKey[H] {
+	return ValueCacheKey[H]{
+		StorageRoot: vckh.StorageRoot,
+		StorageKey:  []byte(vckh.StorageKey),
+	}
+}
+
+// The key type that is being used to address a [CachedValue].
+type ValueCacheKey[H runtime.Hash] struct {
+	// The storage root of the trie this key belongs to.
+	StorageRoot H
+	// The key to access the value in the storage.
+	StorageKey []byte
+}
+
+func (vck ValueCacheKey[H]) ValueCacheKeyComparable() ValueCacheKeyComparable[H] {
+	return ValueCacheKeyComparable[H]{
+		StorageRoot: vck.StorageRoot,
+		StorageKey:  string(vck.StorageKey),
+	}
+}
+
+// The shared value cache.
+//
+// The cache ensures that it stays in the configured size bounds.
+type sharedValueCache[H runtime.Hash] struct {
+	lru          *costlru.LRU[ValueCacheKeyComparable[H], triedb.CachedValue[H]]
+	itemsEvicted uint
+}
+
+// Constructor for [sharedValueCache].
+func newSharedValueCache[H runtime.Hash](size uint) *sharedValueCache[H] {
+	var svc sharedValueCache[H]
+	itemsEvictedPtr := &svc.itemsEvicted
+	var err error
+	h := hasher[ValueCacheKeyComparable[H]]{maphash.NewHasher[ValueCacheKeyComparable[H]]()}
+
+	svc.lru, err = costlru.New(size, h.Hash, func(key ValueCacheKeyComparable[H], value triedb.CachedValue[H]) uint32 {
+		keyCost := uint32(len(key.StorageKey))
+		switch value := value.(type) {
+		case triedb.NonExistingCachedValue[H]:
+			return keyCost + 1
+		case triedb.ExistingHashCachedValue[H]:
+			return keyCost + uint32(value.Hash.Length())
+		case triedb.ExistingCachedValue[H]:
+			return keyCost + uint32(value.Hash.Length()+len(value.Data))
+		default:
+			panic("unreachable")
+		}
+	})
+	if err != nil {
+		panic(err)
+	}
+	svc.lru.SetOnEvict(func(key ValueCacheKeyComparable[H], value triedb.CachedValue[H]) {
+		(*itemsEvictedPtr)++
+	})
+	return &svc
+}
+
+// sharedValueCacheAdded contains a [ValueCacheKey] and [triedb.CachedValue]. Used in [sharedValueCache.Update].
+type sharedValueCacheAdded[H runtime.Hash] struct {
+	ValueCacheKey[H]
+	triedb.CachedValue[H]
+}
+
+// Update the cache with the added values and the accessed values.
+//
+// The added values are the ones that have been collected by doing operations on the trie and
+// now should be stored in the shared cache. The accessed values are only referenced by the
+// [ValueCacheKeyComparable] and represent the values that were retrieved from this shared cache.
+// These accessed values are being put to the front of the internal LRU like the added ones.
+func (svc *sharedValueCache[H]) Update(added []sharedValueCacheAdded[H], accessed []ValueCacheKeyComparable[H]) {
+	accessCount := uint(0)
+	addCount := uint(0)
+
+	for _, hash := range accessed {
+		// Access every node in the map to put it to the front.
+		//
+		// Since we are only comparing the hashes here it may lead us to promoting the wrong
+		// values as the most recently accessed ones. However this is harmless as the only
+		// consequence is that we may accidentally prune a recently used value too early.
+		_, ok := svc.lru.Get(hash)
+		if ok {
+			accessCount++
+		}
+	}
+
+	// Insert all of the new items which were *not* found in the shared cache.
+	//
+	// Limit how many items we'll replace in the shared cache in one go so that
+	// we don't evict the whole shared cache nor we keep spinning our wheels
+	// evicting items which we've added ourselves in previous iterations of this loop.
+	svc.itemsEvicted = 0
+	maxItemsEvicted := uint(svc.lru.Len()) * 100 / sharedValueCacheMaxReplacePercent
+
+	for _, svca := range added {
+		added, _ := svc.lru.Add(svca.ValueCacheKey.ValueCacheKeyComparable(), svca.CachedValue)
+		if added {
+			addCount++
+		}
+
+		if svc.itemsEvicted > maxItemsEvicted {
+			// Stop when we've evicted a big enough chunk of the shared cache.
+			break
+		}
+	}
+
+	log.Printf(
+		"DEBUG: Updated the shared value cache: %d accesses, %d new values, %d/%d evicted (length = %d, size=%d/%d)\n",
+		accessCount, addCount, svc.itemsEvicted, maxItemsEvicted, svc.lru.Len(), svc.lru.Cost(), svc.lru.MaxCost(),
+	)
+}
+
+func (snc *sharedValueCache[H]) Reset() {
+	snc.lru.Purge()
+}
+
+// The inner of [SharedTrieCache].
+type sharedTrieCacheInner[H runtime.Hash] struct {
+	nodeCache  *sharedNodeCache[H]
+	valueCache *sharedValueCache[H]
+}
+
+// The shared trie cache.
+//
+// It should be instantiated once per node. It will hold the trie nodes and values of all
+// operations to the state. To not use all available memory it will ensure to stay in the
+// bounds given via the size in [NewSharedTrieCache].
+//
+// The instance of this object can be shared.
+type SharedTrieCache[H runtime.Hash] struct {
+	inner sharedTrieCacheInner[H]
+	mtx   sync.RWMutex
+}
+
+// Create a new [SharedTrieCache].
+func NewSharedTrieCache[H runtime.Hash](size uint) *SharedTrieCache[H] {
+	totalBudget := size
+
+	// Split our memory budget between the two types of caches.
+	valueCacheBudget := uint(float32(totalBudget) * 0.20) // 20% for the value cache
+	nodeCacheBudget := totalBudget - valueCacheBudget     // 80% for the node cache
+
+	return &SharedTrieCache[H]{
+		inner: sharedTrieCacheInner[H]{
+			nodeCache:  newSharedNodeCache[H](nodeCacheBudget),
+			valueCache: newSharedValueCache[H](valueCacheBudget),
+		},
+	}
+}
+
+// Create a new [LocalTrieCache] instance from this shared cache.
+func (stc *SharedTrieCache[H]) LocalTrieCache() LocalTrieCache[H] {
+	h := hasher[H]{maphash.NewHasher[H]()}
+	nodeCache, err := costlru.New(localNodeCacheMaxSize, h.Hash, func(hash H, node nodeCached[H]) uint32 {
+		return uint32(node.ByteSize())
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	valueCache, err := costlru.New(
+		localValueCacheMaxSize,
+		hasher[ValueCacheKeyComparable[H]]{maphash.NewHasher[ValueCacheKeyComparable[H]]()}.Hash,
+		func(key ValueCacheKeyComparable[H], value triedb.CachedValue[H]) uint32 {
+			keyCost := uint32(len(key.StorageKey))
+			switch value := value.(type) {
+			case triedb.NonExistingCachedValue[H]:
+				return keyCost + 1
+			case triedb.ExistingHashCachedValue[H]:
+				return keyCost + uint32(value.Hash.Length())
+			case triedb.ExistingCachedValue[H]:
+				return keyCost + uint32(value.Hash.Length()+len(value.Data))
+			default:
+				panic("unreachable")
+			}
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	sharedValueCacheAccess, err := freelru.New[ValueCacheKeyComparable[H], any](
+		uint32(sharedValueCacheMaxPromotedKeys),
+		hasher[ValueCacheKeyComparable[H]]{maphash.NewHasher[ValueCacheKeyComparable[H]]()}.Hash,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return LocalTrieCache[H]{
+		shared:                 stc,
+		nodeCache:              nodeCache,
+		valueCache:             valueCache,
+		sharedValueCacheAccess: sharedValueCacheAccess,
+	}
+}
+
+func (stc *SharedTrieCache[H]) Lock() {
+	stc.mtx.Lock()
+}
+
+func (stc *SharedTrieCache[H]) Unlock() {
+	stc.mtx.Unlock()
+}
+
+// Get a copy of the node for key.
+//
+// This will temporarily lock the shared cache for reading.
+//
+// This doesn't change the least recently order in the internal LRU.
+func (stc *SharedTrieCache[H]) PeekNode(key H) triedb.CachedNode[H] {
+	stc.mtx.RLock()
+	defer stc.mtx.RUnlock()
+	node, ok := stc.inner.nodeCache.lru.Peek(key)
+	if ok {
+		return node
+	}
+	return nil
+}
+
+// Get a copy of the [triedb.CachedValue] for key.
+//
+// This will temporarily lock the shared cache for reading.
+//
+// This doesn't reorder any of the elements in the internal LRU.
+func (stc *SharedTrieCache[H]) PeekValueByHash(hash ValueCacheKeyComparable[H], storageRoot H, storageKey []byte) triedb.CachedValue[H] {
+	stc.mtx.RLock()
+	defer stc.mtx.RUnlock()
+	val, ok := stc.inner.valueCache.lru.Peek(hash)
+	if ok {
+		return val
+	}
+	return nil
+}
+
+// Reset the node cache.
+func (stc *SharedTrieCache[H]) ResetNodeCache() {
+	stc.mtx.Lock()
+	defer stc.mtx.Unlock()
+	stc.inner.nodeCache.Reset()
+}
+
+// Reset the value cache.
+func (stc *SharedTrieCache[H]) ResetValueCache() {
+	stc.mtx.Lock()
+	defer stc.mtx.Unlock()
+	stc.inner.valueCache.Reset()
+}
+
+func (stc *SharedTrieCache[H]) usedMemorySize() uint {
+	stc.mtx.RLock()
+	defer stc.mtx.RUnlock()
+	return stc.inner.nodeCache.lru.Cost() + stc.inner.valueCache.lru.Cost()
+}

--- a/internal/primitives/trie/cache/shared_cache_test.go
+++ b/internal/primitives/trie/cache/shared_cache_test.go
@@ -1,0 +1,150 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package cache
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_sharedValueCache(t *testing.T) {
+	cache := newSharedValueCache[hash.H256](110)
+
+	key := bytes.Repeat([]byte{0}, 10)
+	root0 := hash.NewRandomH256()
+	root1 := hash.NewRandomH256()
+
+	vck0 := ValueCacheKey[hash.H256]{
+		StorageRoot: root0,
+		StorageKey:  key,
+	}
+	vck1 := ValueCacheKey[hash.H256]{
+		StorageRoot: root1,
+		StorageKey:  key,
+	}
+
+	cache.Update([]sharedValueCacheAdded[hash.H256]{
+		{
+			ValueCacheKey: vck0,
+			CachedValue:   triedb.NonExistingCachedValue[hash.H256]{},
+		},
+		{
+			ValueCacheKey: vck1,
+			CachedValue:   triedb.NonExistingCachedValue[hash.H256]{},
+		},
+	}, nil)
+
+	// Ensure that the basics are working
+	byStorageKey := slices.CompactFunc(cache.lru.Keys(), func(a, b ValueCacheKeyComparable[hash.H256]) bool {
+		return a.StorageKey == b.StorageKey
+	})
+	require.Len(t, byStorageKey, 1)
+	require.Equal(t, 2, cache.lru.Len())
+	keys := cache.lru.Keys()
+	newestKey := keys[len(keys)-1]
+	require.Equal(t, root1, newestKey.StorageRoot)
+	oldestKey := keys[0]
+	require.Equal(t, root0, oldestKey.StorageRoot)
+	require.Equal(t, uint(22), cache.lru.Cost())
+
+	// Just accessing a key should not change anything on the size and number of entries.
+	cache.Update(nil, []ValueCacheKeyComparable[hash.H256]{
+		vck0.ValueCacheKeyComparable(),
+	})
+	byStorageKey = slices.CompactFunc(cache.lru.Keys(), func(a, b ValueCacheKeyComparable[hash.H256]) bool {
+		return a.StorageKey == b.StorageKey
+	})
+	require.Len(t, byStorageKey, 1)
+	require.Equal(t, 2, cache.lru.Len())
+	keys = cache.lru.Keys()
+	newestKey = keys[len(keys)-1]
+	require.Equal(t, root0, newestKey.StorageRoot)
+	oldestKey = keys[0]
+	require.Equal(t, root1, oldestKey.StorageRoot)
+	require.Equal(t, uint(22), cache.lru.Cost())
+
+	// Updating the cache again with exactly the same data should not change anything.
+	cache.Update([]sharedValueCacheAdded[hash.H256]{
+		{
+			ValueCacheKey: vck1,
+			CachedValue:   triedb.NonExistingCachedValue[hash.H256]{},
+		},
+		{
+			ValueCacheKey: vck0,
+			CachedValue:   triedb.NonExistingCachedValue[hash.H256]{},
+		},
+	}, nil)
+	byStorageKey = slices.CompactFunc(cache.lru.Keys(), func(a, b ValueCacheKeyComparable[hash.H256]) bool {
+		return a.StorageKey == b.StorageKey
+	})
+	require.Len(t, byStorageKey, 1)
+	require.Equal(t, 2, cache.lru.Len())
+	keys = cache.lru.Keys()
+	newestKey = keys[len(keys)-1]
+	require.Equal(t, root0, newestKey.StorageRoot)
+	oldestKey = keys[0]
+	require.Equal(t, root1, oldestKey.StorageRoot)
+	require.Equal(t, uint(22), cache.lru.Cost())
+
+	var added []sharedValueCacheAdded[hash.H256]
+	// Add 10 other entries and this should move out two of the initial entries.
+	for i := 1; i < 11; i++ {
+		added = append(added, sharedValueCacheAdded[hash.H256]{
+			ValueCacheKey: ValueCacheKey[hash.H256]{
+				StorageRoot: root0,
+				StorageKey:  bytes.Repeat([]byte{uint8(i)}, 10),
+			},
+			CachedValue: triedb.NonExistingCachedValue[hash.H256]{},
+		})
+	}
+	cache.Update(added, nil)
+
+	require.Equal(t, uint64(2), cache.lru.Metrics().Removals) // removals instead of evictions
+	require.Equal(t, 10, cache.lru.Len())
+	byStorageKey = slices.CompactFunc(cache.lru.Keys(), func(a, b ValueCacheKeyComparable[hash.H256]) bool {
+		return a.StorageKey == b.StorageKey
+	})
+	require.Len(t, byStorageKey, 10)
+	require.False(t, slices.ContainsFunc(cache.lru.Keys(), func(a ValueCacheKeyComparable[hash.H256]) bool {
+		return a.StorageKey == string(key)
+	}))
+	require.Equal(t, uint(110), cache.lru.Cost())
+
+	val, ok := cache.lru.Peek(ValueCacheKey[hash.H256]{
+		StorageRoot: root0,
+		StorageKey:  bytes.Repeat([]byte{1}, 10),
+	}.ValueCacheKeyComparable())
+	require.True(t, ok)
+	require.Equal(t, triedb.NonExistingCachedValue[hash.H256]{}, val)
+
+	// this was never inserted
+	_, ok = cache.lru.Peek(ValueCacheKey[hash.H256]{
+		StorageRoot: root1,
+		StorageKey:  bytes.Repeat([]byte{1}, 10),
+	}.ValueCacheKeyComparable())
+	require.False(t, ok)
+
+	_, ok = cache.lru.Peek(vck0.ValueCacheKeyComparable())
+	require.False(t, ok)
+	_, ok = cache.lru.Peek(vck1.ValueCacheKeyComparable())
+	require.False(t, ok)
+
+	cache.Update([]sharedValueCacheAdded[hash.H256]{
+		{
+			ValueCacheKey: ValueCacheKey[hash.H256]{
+				StorageRoot: root0,
+				StorageKey:  bytes.Repeat([]byte{10}, 10),
+			},
+			CachedValue: triedb.NonExistingCachedValue[hash.H256]{},
+		},
+	}, nil)
+	require.False(t, slices.ContainsFunc(cache.lru.Keys(), func(a ValueCacheKeyComparable[hash.H256]) bool {
+		return a.StorageKey == string(key)
+	}))
+}

--- a/internal/primitives/trie/recorder/recorder.go
+++ b/internal/primitives/trie/recorder/recorder.go
@@ -1,0 +1,374 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package recorder
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/pkg/scale"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+)
+
+// Stores all the information per transaction.
+type transaction[H comparable] struct {
+	// Stores transaction information about recorder keys.
+	// For each transaction we only store the storage root and the old states per key.
+	// nil map entry means that the key wasn't recorded before.
+	recordedKeys map[H]map[string]*triedb.RecordedForKey
+	// Stores transaction information about accessed nodes.
+	// For each transaction we only store the hashes of added nodes.
+	accessedNodes map[H]bool
+}
+
+func newTransaction[H comparable]() transaction[H] {
+	return transaction[H]{
+		recordedKeys:  make(map[H]map[string]*triedb.RecordedForKey),
+		accessedNodes: make(map[H]bool),
+	}
+}
+
+// The internals of [Recorder].
+type recorderInner[H comparable] struct {
+	// The keys for that we have recorded the trie nodes and if we have recorded up to the value.
+	recordedKeys map[H]map[string]triedb.RecordedForKey
+	// Currently active transactions.
+	transactions []transaction[H]
+
+	// The encoded nodes we accessed while recording.
+	accessedNodes map[H][]byte
+}
+
+func newRecorderInner[H comparable]() recorderInner[H] {
+	return recorderInner[H]{
+		recordedKeys:  make(map[H]map[string]triedb.RecordedForKey),
+		transactions:  make([]transaction[H], 0),
+		accessedNodes: make(map[H][]byte),
+	}
+}
+
+// Recorder is be used to record accesses to the trie and then to convert them into a [StorageProof].
+type Recorder[H runtime.Hash] struct {
+	inner    recorderInner[H]
+	innerMtx sync.Mutex
+	// The estimated encoded size of the storage proof this recorder will produce.
+	encodedSizeEstimation    uint
+	encodedSizeEstimationMtx sync.Mutex
+}
+
+// Constructor for [Recorder].
+func NewRecorder[H runtime.Hash]() *Recorder[H] {
+	return &Recorder[H]{
+		inner: newRecorderInner[H](),
+	}
+}
+
+// Returns the recorder as an implementation of [triedb.TrieRecorder].
+//
+// The storage root supplied is of the trie for which accesses are recorded.
+// This is important when recording access to different tries at once (like top and child tries).
+func (r *Recorder[H]) TrieRecorder(storageRoot H) triedb.TrieRecorder {
+	return &trieRecorder[H]{
+		inner:                 &r.inner,
+		innerMtx:              &r.innerMtx,
+		storageRoot:           storageRoot,
+		encodedSizeEstimation: &r.encodedSizeEstimation,
+	}
+}
+
+// Drain the recording into a [StorageProof].
+//
+// While a recorder can be cloned, all share the same internal state. After calling this
+// function, all other instances will have their internal state reset as well.
+//
+// If you don't want to drain the recorded state, use [Recorder.StorageProof()].
+//
+// Returns a [StorageProof].
+func (r *Recorder[H]) DrainStorageProof() trie.StorageProof {
+	r.innerMtx.Lock()
+	defer r.innerMtx.Unlock()
+
+	proof := r.storageProof()
+	r.inner.accessedNodes = make(map[H][]byte)
+	return proof
+}
+
+func (r *Recorder[H]) storageProof() trie.StorageProof {
+	values := make([][]byte, len(r.inner.accessedNodes))
+	i := 0
+	for _, v := range r.inner.accessedNodes {
+		values[i] = v
+		i++
+	}
+	return trie.NewStorageProof(values)
+}
+
+// Convert the recording to a [StorageProof].
+//
+// In contrast to [Recorder.DrainStorageProof] this doesn't consume and clear the
+// recordings.
+//
+// Returns a [StorageProof].
+func (r *Recorder[H]) StorageProof() trie.StorageProof {
+	r.innerMtx.Lock()
+	defer r.innerMtx.Unlock()
+	return r.storageProof()
+}
+
+// Returns the estimated encoded size of the proof.
+//
+// The estimation is based on all the nodes that were accessed until now while
+// accessing the trie.
+func (r *Recorder[H]) EstimateEncodedSize() uint {
+	return r.encodedSizeEstimation
+}
+
+// Reset the state.
+//
+// This discards all recorded data.
+func (r *Recorder[H]) Reset() {
+	r.innerMtx.Lock()
+	defer r.innerMtx.Unlock()
+	r.inner = newRecorderInner[H]()
+}
+
+// Start a new transaction.
+func (r *Recorder[H]) StartTransaction() {
+	r.innerMtx.Lock()
+	defer r.innerMtx.Unlock()
+	r.inner.transactions = append(r.inner.transactions, newTransaction[H]())
+}
+
+// Rollback the latest transaction.
+//
+// Returns an error if there wasn't any active transaction.
+func (r *Recorder[H]) RollBackTransaction() error {
+	r.innerMtx.Lock()
+	defer r.innerMtx.Unlock()
+	r.encodedSizeEstimationMtx.Lock()
+	defer r.encodedSizeEstimationMtx.Unlock()
+	// We locked everything and can just update the encoded size locally and then store it back
+	newEncodedSizeEstimation := r.encodedSizeEstimation
+	if len(r.inner.transactions) == 0 {
+		return fmt.Errorf("no transactions to roll back")
+	}
+	tx := r.inner.transactions[len(r.inner.transactions)-1]
+	r.inner.transactions = r.inner.transactions[:len(r.inner.transactions)-1]
+
+	for n := range tx.accessedNodes {
+		old, ok := r.inner.accessedNodes[n]
+		if ok {
+			delete(r.inner.accessedNodes, n)
+			oldEncodedSize := uint(len(scale.MustMarshal(old)))
+			// saturating sub
+			if newEncodedSizeEstimation >= oldEncodedSize {
+				newEncodedSizeEstimation = newEncodedSizeEstimation - oldEncodedSize
+			} else {
+				newEncodedSizeEstimation = 0
+			}
+		}
+	}
+
+	for storageRoot, keys := range tx.recordedKeys {
+		for k, oldState := range keys {
+			if oldState != nil {
+				state := *oldState
+				_, ok := r.inner.recordedKeys[storageRoot]
+				if !ok {
+					r.inner.recordedKeys[storageRoot] = make(map[string]triedb.RecordedForKey)
+				}
+				r.inner.recordedKeys[storageRoot][k] = state
+			} else {
+				_, ok := r.inner.recordedKeys[storageRoot]
+				if !ok {
+					r.inner.recordedKeys[storageRoot] = make(map[string]triedb.RecordedForKey)
+				}
+				delete(r.inner.recordedKeys[storageRoot], k)
+			}
+		}
+	}
+
+	r.encodedSizeEstimation = newEncodedSizeEstimation
+	return nil
+}
+
+// Commit the latest transaction.
+//
+// Returns an error if there wasn't any active transaction.
+func (r *Recorder[H]) CommitTransaction() error {
+	r.innerMtx.Lock()
+	defer r.innerMtx.Unlock()
+
+	if len(r.inner.transactions) == 0 {
+		return fmt.Errorf("no transactions to roll back")
+	}
+	tx := r.inner.transactions[len(r.inner.transactions)-1]
+	r.inner.transactions = r.inner.transactions[:len(r.inner.transactions)-1]
+
+	if len(r.inner.transactions) != 0 {
+		parentTx := r.inner.transactions[len(r.inner.transactions)-1]
+		for h, v := range tx.accessedNodes {
+			parentTx.accessedNodes[h] = v
+		}
+
+		for storageRoot, keys := range tx.recordedKeys {
+			for k, oldState := range keys {
+				_, ok := parentTx.recordedKeys[storageRoot]
+				if !ok {
+					parentTx.recordedKeys[storageRoot] = make(map[string]*triedb.RecordedForKey)
+				}
+				_, ok = parentTx.recordedKeys[storageRoot][k]
+				if !ok {
+					parentTx.recordedKeys[storageRoot][k] = oldState
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// The [triedb.TrieRecorder] implementation.
+type trieRecorder[H runtime.Hash] struct {
+	inner                 *recorderInner[H]
+	innerMtx              *sync.Mutex
+	storageRoot           H
+	encodedSizeEstimation *uint
+}
+
+// Update the recorded keys entry for the given fullKey.
+func (tr *trieRecorder[H]) updateRecordedKeys(fullKey []byte, access triedb.RecordedForKey) {
+	_, ok := tr.inner.recordedKeys[tr.storageRoot]
+	if !ok {
+		tr.inner.recordedKeys[tr.storageRoot] = make(map[string]triedb.RecordedForKey)
+	}
+	key := string(fullKey)
+	old, ok := tr.inner.recordedKeys[tr.storageRoot][key]
+
+	// We don't need to update the record if we only accessed the hash for the given
+	// fullKey.
+	switch access {
+	case triedb.RecordedValue:
+		if ok {
+			if len(tr.inner.transactions) > 0 {
+				tx := &tr.inner.transactions[len(tr.inner.transactions)-1]
+				// Store the previous state only once per transaction.
+				_, ok := tx.recordedKeys[tr.storageRoot]
+				if !ok {
+					tx.recordedKeys[tr.storageRoot] = make(map[string]*triedb.RecordedForKey)
+				}
+				_, ok = tx.recordedKeys[tr.storageRoot][key]
+				if !ok {
+					tx.recordedKeys[tr.storageRoot][key] = &old
+				}
+			}
+			tr.inner.recordedKeys[tr.storageRoot][key] = access
+		}
+	default:
+	}
+
+	if !ok {
+		if len(tr.inner.transactions) > 0 {
+			tx := &tr.inner.transactions[len(tr.inner.transactions)-1]
+			// The key wasn't yet recorded, so there isn't any old state.
+			_, ok := tx.recordedKeys[tr.storageRoot]
+			if !ok {
+				tx.recordedKeys[tr.storageRoot] = make(map[string]*triedb.RecordedForKey)
+			}
+			_, ok = tx.recordedKeys[tr.storageRoot][key]
+			if !ok {
+				tx.recordedKeys[tr.storageRoot][key] = nil
+			}
+		}
+		tr.inner.recordedKeys[tr.storageRoot][key] = access
+	}
+}
+
+func (tr *trieRecorder[H]) Record(access triedb.TrieAccess) {
+	tr.innerMtx.Lock()
+	defer tr.innerMtx.Unlock()
+
+	var encodedSizeUpdate uint
+	switch access := access.(type) {
+	case triedb.CachedNodeAccess[H]:
+		log.Printf("TRACE: Recording node: %v", access.Hash)
+		_, ok := tr.inner.accessedNodes[access.Hash]
+		if !ok {
+			node := access.Node.Encoded()
+			encodedSizeUpdate += uint(len(scale.MustMarshal(node)))
+
+			if len(tr.inner.transactions) > 0 {
+				tx := tr.inner.transactions[len(tr.inner.transactions)-1]
+				tx.accessedNodes[access.Hash] = true
+				tr.inner.transactions[len(tr.inner.transactions)-1] = tx
+			}
+			tr.inner.accessedNodes[access.Hash] = node
+		}
+	case triedb.EncodedNodeAccess[H]:
+		log.Printf("TRACE: Recording node: %v", access.Hash)
+		_, ok := tr.inner.accessedNodes[access.Hash]
+		if !ok {
+			node := access.EncodedNode
+			encodedSizeUpdate += uint(len(scale.MustMarshal(node)))
+
+			if len(tr.inner.transactions) > 0 {
+				tx := tr.inner.transactions[len(tr.inner.transactions)-1]
+				tx.accessedNodes[access.Hash] = true
+				tr.inner.transactions[len(tr.inner.transactions)-1] = tx
+			}
+			tr.inner.accessedNodes[access.Hash] = node
+		}
+	case triedb.ValueAccess[H]:
+		log.Printf("TRACE: Recording value {hash:%v value:%v}", access.Hash, access.FullKey)
+		_, ok := tr.inner.accessedNodes[access.Hash]
+		if !ok {
+			value := access.Value
+			encodedSizeUpdate += uint(len(scale.MustMarshal(value)))
+			if len(tr.inner.transactions) > 0 {
+				tx := tr.inner.transactions[len(tr.inner.transactions)-1]
+				tx.accessedNodes[access.Hash] = true
+				tr.inner.transactions[len(tr.inner.transactions)-1] = tx
+			}
+			tr.inner.accessedNodes[access.Hash] = value
+		}
+		tr.updateRecordedKeys(access.FullKey, triedb.RecordedValue)
+	case triedb.HashAccess:
+		log.Printf("TRACE: Recorded hash access for key: %s", access.FullKey)
+		// We don't need to update the encodedSizeUpdate as the hash was already
+		// accounted for by the recorded node that holds the hash.
+		tr.updateRecordedKeys(access.FullKey, triedb.RecordedHash)
+	case triedb.NonExistingNodeAccess:
+		log.Printf("TRACE: Recorded non-existing value access for key for key: %s", access.FullKey)
+		// Non-existing access means we recorded all trie nodes up to the value.
+		// Not the actual value, as it doesn't exist, but all trie nodes to know
+		// that the value doesn't exist in the trie.
+		tr.updateRecordedKeys(access.FullKey, triedb.RecordedValue)
+	case triedb.InlineValueAccess:
+		log.Printf("TRACE: Recorded inline value access for key: %s", access.FullKey)
+		// A value was accessed that is stored inline a node and we recorded all trie nodes
+		// to access this value.
+		tr.updateRecordedKeys(access.FullKey, triedb.RecordedValue)
+	default:
+		panic("unreachable")
+	}
+
+	*tr.encodedSizeEstimation = *tr.encodedSizeEstimation + encodedSizeUpdate
+}
+
+func (tr *trieRecorder[H]) TrieNodesRecordedForKey(key []byte) triedb.RecordedForKey {
+	tr.innerMtx.Lock()
+	defer tr.innerMtx.Unlock()
+
+	_, ok := tr.inner.recordedKeys[tr.storageRoot]
+	if !ok {
+		return triedb.RecordedNone
+	}
+	recorded, ok := tr.inner.recordedKeys[tr.storageRoot][string(key)]
+	if !ok {
+		return triedb.RecordedNone
+	}
+	return recorded
+}

--- a/internal/primitives/trie/recorder/recorder_test.go
+++ b/internal/primitives/trie/recorder/recorder_test.go
@@ -290,7 +290,7 @@ func TestRecorder_TransactionAccessedKeys(t *testing.T) {
 		trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 		trieDB.SetVersion(trie.V1)
 
-		hash, err := trieDB.GetHash(testData[0].Key)
+		hash, err := trieDB.GetHash(key)
 		require.NoError(t, err)
 		require.NotNil(t, hash)
 		require.Equal(t, runtime.BlakeTwo256{}.Hash(testData[0].Value), *hash)

--- a/internal/primitives/trie/recorder/recorder_test.go
+++ b/internal/primitives/trie/recorder/recorder_test.go
@@ -20,7 +20,7 @@ import (
 func makeValue(i uint8) []byte {
 	val := make([]byte, 64)
 	for j := 0; j < len(val); j++ {
-		val[j] = byte(i)
+		val[j] = i
 	}
 	return val
 }
@@ -49,9 +49,9 @@ type MemoryDB = memorydb.MemoryDB[
 ]
 
 func newMemoryDB() *MemoryDB {
-	mdb := MemoryDB(memorydb.NewMemoryDB[
+	mdb := memorydb.NewMemoryDB[
 		hash.H256, runtime.BlakeTwo256, hash.H256, memorydb.HashKey[hash.H256],
-	]([]byte{0}))
+	]([]byte{0})
 	return &mdb
 }
 
@@ -77,7 +77,7 @@ func TestRecorder(t *testing.T) {
 
 	{
 		trieRecorder := rec.TrieRecorder(root)
-		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 		trieDB.SetVersion(trie.V1)
 		val, err := trieDB.Get(testData[0].Key)
 		require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestRecorder_TransactionsRollback(t *testing.T) {
 		rec.StartTransaction()
 		{
 			trieRecorder := rec.TrieRecorder(root)
-			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 			trieDB.SetVersion(trie.V1)
 			val, err := trieDB.Get(testData[i].Key)
 			require.NoError(t, err)
@@ -177,7 +177,7 @@ func TestRecorder_TransactionsCommit(t *testing.T) {
 		rec.StartTransaction()
 		{
 			trieRecorder := rec.TrieRecorder(root)
-			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 			trieDB.SetVersion(trie.V1)
 			val, err := trieDB.Get(testData[i].Key)
 			assert.NoError(t, err)
@@ -218,7 +218,7 @@ func TestRecorder_TransactionsCommitAndRollback(t *testing.T) {
 		rec.StartTransaction()
 		{
 			trieRecorder := rec.TrieRecorder(root)
-			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 			trieDB.SetVersion(trie.V1)
 			val, err := trieDB.Get(testData[i].Key)
 			assert.NoError(t, err)
@@ -233,7 +233,7 @@ func TestRecorder_TransactionsCommitAndRollback(t *testing.T) {
 		rec.StartTransaction()
 		{
 			trieRecorder := rec.TrieRecorder(root)
-			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 			trieDB.SetVersion(trie.V1)
 			val, err := trieDB.Get(testData[i].Key)
 			assert.NoError(t, err)
@@ -287,7 +287,7 @@ func TestRecorder_TransactionAccessedKeys(t *testing.T) {
 	rec.StartTransaction()
 	{
 		trieRecorder := rec.TrieRecorder(root)
-		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 		trieDB.SetVersion(trie.V1)
 
 		hash, err := trieDB.GetHash(testData[0].Key)
@@ -301,7 +301,7 @@ func TestRecorder_TransactionAccessedKeys(t *testing.T) {
 	rec.StartTransaction()
 	{
 		trieRecorder := rec.TrieRecorder(root)
-		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 		trieDB.SetVersion(trie.V1)
 
 		val, err := triedb.GetWith(trieDB, testData[0].Key, func(data []byte) []byte { return data })
@@ -329,7 +329,7 @@ func TestRecorder_TransactionAccessedKeys(t *testing.T) {
 	rec.StartTransaction()
 	{
 		trieRecorder := rec.TrieRecorder(root)
-		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 		trieDB.SetVersion(trie.V1)
 
 		val, err := triedb.GetWith(trieDB, testData[0].Key, func(data []byte) []byte { return data })
@@ -343,7 +343,7 @@ func TestRecorder_TransactionAccessedKeys(t *testing.T) {
 	rec.StartTransaction()
 	{
 		trieRecorder := rec.TrieRecorder(root)
-		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB := triedb.NewTrieDB(root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
 		trieDB.SetVersion(trie.V1)
 
 		hash, err := trieDB.GetHash(testData[0].Key)

--- a/internal/primitives/trie/recorder/recorder_test.go
+++ b/internal/primitives/trie/recorder/recorder_test.go
@@ -1,0 +1,370 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package recorder
+
+import (
+	"testing"
+
+	memorydb "github.com/ChainSafe/gossamer/internal/memory-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	ptrie "github.com/ChainSafe/gossamer/internal/primitives/trie"
+	"github.com/ChainSafe/gossamer/pkg/trie"
+	"github.com/ChainSafe/gossamer/pkg/trie/triedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func makeValue(i uint8) []byte {
+	val := make([]byte, 64)
+	for j := 0; j < len(val); j++ {
+		val[j] = byte(i)
+	}
+	return val
+}
+
+var testData []ptrie.KeyValue = []ptrie.KeyValue{
+	{
+		Key:   []byte("key1"),
+		Value: makeValue(1),
+	},
+	{
+		Key:   []byte("key2"),
+		Value: makeValue(2),
+	},
+	{
+		Key:   []byte("key3"),
+		Value: makeValue(3),
+	},
+	{
+		Key:   []byte("key4"),
+		Value: makeValue(4),
+	},
+}
+
+type MemoryDB = memorydb.MemoryDB[
+	hash.H256, runtime.BlakeTwo256, hash.H256, memorydb.HashKey[hash.H256],
+]
+
+func newMemoryDB() *MemoryDB {
+	mdb := MemoryDB(memorydb.NewMemoryDB[
+		hash.H256, runtime.BlakeTwo256, hash.H256, memorydb.HashKey[hash.H256],
+	]([]byte{0}))
+	return &mdb
+}
+
+func createTrie(t *testing.T) (db *MemoryDB, root hash.H256) {
+	t.Helper()
+	db = newMemoryDB()
+	trieDB := triedb.NewEmptyTrieDB[hash.H256, runtime.BlakeTwo256](db)
+	trieDB.SetVersion(trie.V1)
+
+	for _, td := range testData {
+		err := trieDB.Set(td.Key, td.Value)
+		require.NoError(t, err)
+	}
+
+	root, err := trieDB.Hash()
+	require.NoError(t, err)
+
+	return db, root
+}
+func TestRecorder(t *testing.T) {
+	db, root := createTrie(t)
+	rec := Recorder[hash.H256]{inner: newRecorderInner[hash.H256]()}
+
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB.SetVersion(trie.V1)
+		val, err := trieDB.Get(testData[0].Key)
+		require.NoError(t, err)
+		require.Equal(t, testData[0].Value, val)
+	}
+
+	storageProof := rec.DrainStorageProof()
+	memDB := ptrie.NewMemoryDBFromStorageProof[hash.H256, runtime.BlakeTwo256](storageProof)
+
+	// Check that we recorded the required data
+	trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, memDB)
+	trieDB.SetVersion(trie.V1)
+	val, err := trieDB.Get(testData[0].Key)
+	require.NoError(t, err)
+	require.Equal(t, testData[0].Value, val)
+}
+
+type recorderStats struct {
+	AccessedNodes int
+	RecordedKeys  int
+	EstimatedSize int
+}
+
+func newRecorderStats(recorder *Recorder[hash.H256]) (rs recorderStats) {
+	recorder.innerMtx.Lock()
+	defer recorder.innerMtx.Unlock()
+
+	var recordedKeys int
+	allKeys := maps.Values(recorder.inner.recordedKeys)
+	for _, keys := range allKeys {
+		recordedKeys = recordedKeys + len(maps.Keys(keys))
+	}
+
+	rs.RecordedKeys = recordedKeys
+	rs.AccessedNodes = len(recorder.inner.accessedNodes)
+	rs.EstimatedSize = int(recorder.EstimateEncodedSize())
+	return
+}
+
+func TestRecorder_TransactionsRollback(t *testing.T) {
+	db, root := createTrie(t)
+	rec := Recorder[hash.H256]{inner: newRecorderInner[hash.H256]()}
+	stats := make([]recorderStats, 0)
+	stats = append(stats, recorderStats{})
+
+	for i := 0; i < 4; i++ {
+		rec.StartTransaction()
+		{
+			trieRecorder := rec.TrieRecorder(root)
+			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB.SetVersion(trie.V1)
+			val, err := trieDB.Get(testData[i].Key)
+			require.NoError(t, err)
+			require.Equal(t, testData[i].Value, val)
+		}
+		stats = append(stats, newRecorderStats(&rec))
+	}
+
+	require.Equal(t, 4, len(rec.inner.transactions))
+
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, stats[4-i], newRecorderStats(&rec))
+
+		storageProof := rec.StorageProof()
+		memDB := ptrie.NewMemoryDBFromStorageProof[hash.H256, runtime.BlakeTwo256](storageProof)
+
+		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, memDB)
+		trieDB.SetVersion(trie.V1)
+
+		// Check that the required data is still present.
+		for a := 0; a < 4; a++ {
+			if a < 4-i {
+				val, err := trieDB.Get(testData[a].Key)
+				require.NoError(t, err)
+				assert.Equal(t, testData[a].Value, val)
+			} else {
+				// All the data that we already rolled back, should be gone!
+				val, err := trieDB.Get(testData[a].Key)
+				require.Error(t, err)
+				assert.Nil(t, val)
+			}
+		}
+
+		if i < 4 {
+			err := rec.RollBackTransaction()
+			assert.NoError(t, err)
+		}
+	}
+	assert.Equal(t, 0, len(rec.inner.transactions))
+}
+
+func TestRecorder_TransactionsCommit(t *testing.T) {
+	db, root := createTrie(t)
+	rec := Recorder[hash.H256]{inner: newRecorderInner[hash.H256]()}
+
+	for i := 0; i < 4; i++ {
+		rec.StartTransaction()
+		{
+			trieRecorder := rec.TrieRecorder(root)
+			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB.SetVersion(trie.V1)
+			val, err := trieDB.Get(testData[i].Key)
+			assert.NoError(t, err)
+			assert.Equal(t, testData[i].Value, val)
+		}
+	}
+
+	stats := newRecorderStats(&rec)
+	assert.Equal(t, 4, len(rec.inner.transactions))
+
+	for i := 0; i < 4; i++ {
+		err := rec.CommitTransaction()
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, 0, len(rec.inner.transactions))
+	assert.Equal(t, stats, newRecorderStats(&rec))
+
+	storageProof := rec.StorageProof()
+	memDB := ptrie.NewMemoryDBFromStorageProof[hash.H256, runtime.BlakeTwo256](storageProof)
+
+	// Check that we recorded the required data
+	trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, memDB)
+	trieDB.SetVersion(trie.V1)
+
+	// Check that the required data is still present.
+	for i := 0; i < 4; i++ {
+		val, err := trieDB.Get(testData[i].Key)
+		assert.NoError(t, err)
+		assert.Equal(t, testData[i].Value, val)
+	}
+}
+
+func TestRecorder_TransactionsCommitAndRollback(t *testing.T) {
+	db, root := createTrie(t)
+	rec := Recorder[hash.H256]{inner: newRecorderInner[hash.H256]()}
+
+	for i := 0; i < 2; i++ {
+		rec.StartTransaction()
+		{
+			trieRecorder := rec.TrieRecorder(root)
+			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB.SetVersion(trie.V1)
+			val, err := trieDB.Get(testData[i].Key)
+			assert.NoError(t, err)
+			assert.Equal(t, testData[i].Value, val)
+		}
+	}
+
+	err := rec.RollBackTransaction()
+	assert.NoError(t, err)
+
+	for i := 2; i < 4; i++ {
+		rec.StartTransaction()
+		{
+			trieRecorder := rec.TrieRecorder(root)
+			trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+			trieDB.SetVersion(trie.V1)
+			val, err := trieDB.Get(testData[i].Key)
+			assert.NoError(t, err)
+			assert.Equal(t, testData[i].Value, val)
+		}
+	}
+
+	err = rec.RollBackTransaction()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(rec.inner.transactions))
+
+	for i := 0; i < 2; i++ {
+		err := rec.CommitTransaction()
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, 0, len(rec.inner.transactions))
+
+	storageProof := rec.StorageProof()
+	memDB := ptrie.NewMemoryDBFromStorageProof[hash.H256, runtime.BlakeTwo256](storageProof)
+
+	// Check that we recorded the required data
+	trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, memDB)
+	trieDB.SetVersion(trie.V1)
+
+	// Check that the required data is still present.
+	for i := 0; i < 4; i++ {
+		if i%2 == 0 {
+			val, err := trieDB.Get(testData[i].Key)
+			assert.NoError(t, err)
+			assert.Equal(t, testData[i].Value, val)
+		} else {
+			val, err := trieDB.Get(testData[i].Key)
+			assert.Error(t, err)
+			assert.Nil(t, val)
+		}
+	}
+}
+
+func TestRecorder_TransactionAccessedKeys(t *testing.T) {
+	key := testData[0].Key
+	db, root := createTrie(t)
+	rec := Recorder[hash.H256]{inner: newRecorderInner[hash.H256]()}
+
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		assert.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedNone)
+	}
+
+	rec.StartTransaction()
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB.SetVersion(trie.V1)
+
+		hash, err := trieDB.GetHash(testData[0].Key)
+		require.NoError(t, err)
+		require.NotNil(t, hash)
+		require.Equal(t, runtime.BlakeTwo256{}.Hash(testData[0].Value), *hash)
+
+		assert.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedHash)
+	}
+
+	rec.StartTransaction()
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB.SetVersion(trie.V1)
+
+		val, err := triedb.GetWith(trieDB, testData[0].Key, func(data []byte) []byte { return data })
+		require.NoError(t, err)
+		require.NotNil(t, val)
+		require.Equal(t, testData[0].Value, *val)
+
+		require.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedValue)
+	}
+
+	err := rec.RollBackTransaction()
+	require.NoError(t, err)
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		require.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedHash)
+	}
+
+	err = rec.RollBackTransaction()
+	require.NoError(t, err)
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		require.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedNone)
+	}
+
+	rec.StartTransaction()
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB.SetVersion(trie.V1)
+
+		val, err := triedb.GetWith(trieDB, testData[0].Key, func(data []byte) []byte { return data })
+		require.NoError(t, err)
+		require.NotNil(t, val)
+		require.Equal(t, testData[0].Value, *val)
+
+		require.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedValue)
+	}
+
+	rec.StartTransaction()
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		trieDB := triedb.NewTrieDB[hash.H256, runtime.BlakeTwo256](root, db, triedb.WithRecorder[hash.H256, runtime.BlakeTwo256](trieRecorder))
+		trieDB.SetVersion(trie.V1)
+
+		hash, err := trieDB.GetHash(testData[0].Key)
+		require.NoError(t, err)
+		require.NotNil(t, hash)
+		require.Equal(t, runtime.BlakeTwo256{}.Hash(testData[0].Value), *hash)
+
+		assert.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedValue)
+	}
+
+	err = rec.RollBackTransaction()
+	require.NoError(t, err)
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		require.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedValue)
+	}
+
+	err = rec.RollBackTransaction()
+	require.NoError(t, err)
+	{
+		trieRecorder := rec.TrieRecorder(root)
+		require.Equal(t, trieRecorder.TrieNodesRecordedForKey(key), triedb.RecordedNone)
+	}
+}

--- a/internal/primitives/trie/storage_proof.go
+++ b/internal/primitives/trie/storage_proof.go
@@ -1,0 +1,57 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package trie
+
+import (
+	hashdb "github.com/ChainSafe/gossamer/internal/hash-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	"github.com/tidwall/btree"
+)
+
+// A proof that some set of key-value pairs are included in the storage trie. The proof contains
+// the storage values so that the partial storage backend can be reconstructed by a verifier that
+// does not already have access to the key-value pairs.
+//
+// The proof consists of the set of serialized nodes in the storage trie accessed when looking up
+// the keys covered by the proof. Verifying the proof requires constructing the partial trie from
+// the serialized nodes and performing the key lookups.
+type StorageProof struct {
+	trieNodes btree.Set[string]
+}
+
+// Constructs a [StorageProof] from a subset of encoded trie nodes.
+func NewStorageProof(trieNodes [][]byte) StorageProof {
+	set := btree.Set[string]{}
+	for _, trieNode := range trieNodes {
+		set.Insert(string(trieNode))
+	}
+	return StorageProof{
+		trieNodes: set,
+	}
+}
+
+// Returns whether this is an empty proof.
+func (sp *StorageProof) Empty() bool {
+	return sp.trieNodes.Len() == 0
+}
+
+// Returns all the encoded trie ndoes in lexigraphical order from the proof.
+func (sp *StorageProof) Nodes() [][]byte {
+	var ret [][]byte
+	sp.trieNodes.Scan(func(v string) bool {
+		ret = append(ret, []byte(v))
+		return true
+	})
+	return ret
+}
+
+// Constructs a [MemoryDB] from a [StorageProof]
+func NewMemoryDBFromStorageProof[H runtime.Hash, Hasher runtime.Hasher[H]](sp StorageProof) *MemoryDB[H, Hasher] {
+	db := NewMemoryDB[H, Hasher]()
+	sp.trieNodes.Scan(func(v string) bool {
+		db.Insert(hashdb.EmptyPrefix, []byte(v))
+		return true
+	})
+	return db
+}

--- a/internal/primitives/trie/storage_proof.go
+++ b/internal/primitives/trie/storage_proof.go
@@ -13,9 +13,9 @@ import (
 // the storage values so that the partial storage backend can be reconstructed by a verifier that
 // does not already have access to the key-value pairs.
 //
-// The proof consists of the set of serialized nodes in the storage trie accessed when looking up
+// The proof consists of the set of serialised nodes in the storage trie accessed when looking up
 // the keys covered by the proof. Verifying the proof requires constructing the partial trie from
-// the serialized nodes and performing the key lookups.
+// the serialised nodes and performing the key lookups.
 type StorageProof struct {
 	trieNodes btree.Set[string]
 }

--- a/internal/primitives/trie/trie.go
+++ b/internal/primitives/trie/trie.go
@@ -1,0 +1,282 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package trie
+
+import (
+	"slices"
+
+	hashdb "github.com/ChainSafe/gossamer/internal/hash-db"
+	memorydb "github.com/ChainSafe/gossamer/internal/memory-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/runtime"
+	triedb "github.com/ChainSafe/gossamer/pkg/trie/triedb"
+)
+
+// Reexport from [memorydb.MemoryDB] where supplied [memorydb.KeyFunction] is [memorydb.PrefixedKey] for prefixing
+// keys internally (avoiding key conflict for non random keys).
+type PrefixedMemoryDB[Hash runtime.Hash, Hasher hashdb.Hasher[Hash]] struct {
+	memorydb.MemoryDB[Hash, Hasher, string, memorydb.PrefixedKey[Hash]]
+}
+
+// Constructor for [PrefixedMemoryDB]
+func NewPrefixedMemoryDB[Hash runtime.Hash, Hasher hashdb.Hasher[Hash]]() *PrefixedMemoryDB[Hash, Hasher] {
+	return &PrefixedMemoryDB[Hash, Hasher]{
+		memorydb.NewMemoryDB[Hash, Hasher, string, memorydb.PrefixedKey[Hash]]([]byte{0}),
+	}
+}
+
+// Reexport from [memorydb.MemoryDB] where supplied [memorydb.KeyFunction] is [memorydb.HashKey] which is a noop
+// operation on the supplied prefix, and only uses the hash.
+type MemoryDB[Hash runtime.Hash, Hasher runtime.Hasher[Hash]] struct {
+	memorydb.MemoryDB[Hash, Hasher, Hash, memorydb.HashKey[Hash]]
+}
+
+// Constructor for [MemoryDB].
+func NewMemoryDB[Hash runtime.Hash, Hasher runtime.Hasher[Hash]]() *MemoryDB[Hash, Hasher] {
+	return &MemoryDB[Hash, Hasher]{
+		MemoryDB: memorydb.NewMemoryDB[Hash, Hasher, Hash, memorydb.HashKey[Hash]]([]byte{0}),
+	}
+}
+
+// KeyValue is a byte slice for key and value, where the value can be optional (nil).
+type KeyValue struct {
+	Key   []byte
+	Value []byte
+}
+
+// Determine a trie root given a hash DB and delta values.
+func DeltaTrieRoot[H runtime.Hash, Hasher runtime.Hasher[H]](
+	db hashdb.HashDB[H],
+	root H,
+	delta []KeyValue,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) (H, error) {
+	trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+
+	slices.SortStableFunc(delta, func(a KeyValue, b KeyValue) int {
+		if string(a.Key) < string(b.Key) {
+			return -1
+		} else if string(a.Key) == string(b.Key) {
+			return 0
+		} else {
+			return 1
+		}
+	})
+
+	for i, kv := range delta {
+		_ = i
+		if kv.Value != nil {
+			err := trieDB.Set(kv.Key, kv.Value)
+			if err != nil {
+				return *(new(H)), err
+			}
+		} else {
+			err := trieDB.Delete(kv.Key)
+			if err != nil {
+				return *(new(H)), err
+			}
+		}
+	}
+
+	hash, err := trieDB.Hash()
+	return hash, err
+}
+
+// Read a value from the trie.
+func ReadTrieValue[H runtime.Hash, Hasher runtime.Hasher[H]](
+	db hashdb.HashDB[H],
+	root H,
+	key []byte,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) ([]byte, error) {
+	trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+	b, err := triedb.GetWith(trieDB, key, func(data []byte) []byte { return data })
+	if err != nil {
+		return nil, err
+	}
+	if b != nil {
+		return *b, nil
+	}
+	return nil, nil
+}
+
+// Read a value from the trie with given [triedb.Query].
+func ReadTrieValueWith[H runtime.Hash, Hasher runtime.Hasher[H]](
+	db hashdb.HashDB[H],
+	root H,
+	key []byte,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+	query triedb.Query[[]byte],
+) ([]byte, error) {
+	trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+	b, err := triedb.GetWith[H, Hasher, []byte](trieDB, key, query)
+	if err != nil {
+		return nil, err
+	}
+	if b != nil {
+		return *b, nil
+	}
+	return nil, nil
+}
+
+// Read the [triedb.MerkleValue] of the node that is the closest descendant for
+// the provided key.
+func ReadTrieFirstDescendantValue[H runtime.Hash, Hasher runtime.Hasher[H]](
+	db hashdb.HashDB[H],
+	root H,
+	key []byte,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) (triedb.MerkleValue[H], error) {
+	trieDB := triedb.NewTrieDB(root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+
+	return trieDB.LookupFirstDescendant(key)
+}
+
+// EmptyTrieRoot returns the empty trie root.
+func EmptyTrieRoot[H runtime.Hash, Hasher runtime.Hasher[H]]() H {
+	hasher := *new(Hasher)
+	root := hasher.Hash([]byte{0})
+	return root
+}
+
+// EmptyChildTrieRoot returns the empty child trie root.
+func EmptyChildTrieRoot[H runtime.Hash, Hasher runtime.Hasher[H]]() H {
+	return EmptyTrieRoot[H, Hasher]()
+}
+
+// ChildDeltaTrieRoot determines a child trie root given a hash DB and delta values.
+func ChildDeltaTrieRoot[H runtime.Hash, Hasher runtime.Hasher[H]](
+	keyspace []byte,
+	db hashdb.HashDB[H],
+	root H,
+	delta []KeyValue,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) (H, error) {
+	ksdb := NewKeyspacedDB(db, keyspace)
+	return DeltaTrieRoot[H, Hasher](ksdb, root, delta, recorder, cache, stateVersion)
+}
+
+// Read a value from the child trie.
+func ReadChildTrieValue[H runtime.Hash, Hasher runtime.Hasher[H]](
+	keyspace []byte,
+	db hashdb.HashDB[H],
+	root H,
+	key []byte,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) ([]byte, error) {
+	ksdb := NewKeyspacedDB(db, keyspace)
+	trieDB := triedb.NewTrieDB(
+		root, ksdb, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+	val, err := triedb.GetWith(trieDB, key, func(data []byte) []byte { return data })
+	if err != nil {
+		return nil, err
+	}
+	if val != nil {
+		return *val, nil
+	}
+	return nil, nil
+}
+
+// Read a hash from the child trie.
+func ReadChildTrieHash[H runtime.Hash, Hasher runtime.Hasher[H]](
+	keyspace []byte,
+	db hashdb.HashDB[H],
+	root H,
+	key []byte,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) (*H, error) {
+	ksdb := NewKeyspacedDB(db, keyspace)
+	trieDB := triedb.NewTrieDB(
+		root, ksdb, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+	return trieDB.GetHash(key)
+}
+
+// Read the [triedb.MerkleValue] of the node that is the closest descendant for
+// the provided child key.
+func ReadChildTrieFirstDescendantValue[H runtime.Hash, Hasher runtime.Hasher[H]](
+	keyspace []byte,
+	db hashdb.HashDB[H],
+	root H,
+	key []byte,
+	recorder triedb.TrieRecorder,
+	cache triedb.TrieCache[H],
+	stateVersion triedb.TrieLayout,
+) (triedb.MerkleValue[H], error) {
+	ksdb := NewKeyspacedDB(db, keyspace)
+	trieDB := triedb.NewTrieDB(
+		root, ksdb, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB.SetVersion(stateVersion)
+	return trieDB.LookupFirstDescendant(key)
+}
+
+// KeyspacedDB is a [hashdb.HashDB] implementation that appends a keyspace (unique id bytes) in addition to the
+// prefix of every key value.
+type KeyspacedDB[Hash comparable] struct {
+	db       hashdb.HashDB[Hash]
+	keySpace []byte
+}
+
+// Constructor for [KeyspacedDB]
+func NewKeyspacedDB[Hash comparable](db hashdb.HashDB[Hash], ks []byte) *KeyspacedDB[Hash] {
+	return &KeyspacedDB[Hash]{
+		db:       db,
+		keySpace: ks,
+	}
+}
+
+// Utility function used to merge some byte data (keyspace) and prefix data
+// before calling key value database primitives.
+func keyspaceAsPrefix(ks []byte, prefix hashdb.Prefix) hashdb.Prefix {
+	result := ks
+	result = append(result, prefix.Key...)
+	return hashdb.Prefix{
+		Key:    result,
+		Padded: prefix.Padded,
+	}
+}
+
+func (tbe *KeyspacedDB[H]) Get(key H, prefix hashdb.Prefix) []byte {
+	derivedPrefix := keyspaceAsPrefix(tbe.keySpace, prefix)
+	return tbe.db.Get(key, derivedPrefix)
+}
+
+func (tbe *KeyspacedDB[H]) Contains(key H, prefix hashdb.Prefix) bool {
+	derivedPrefix := keyspaceAsPrefix(tbe.keySpace, prefix)
+	return tbe.db.Contains(key, derivedPrefix)
+}
+
+func (tbe *KeyspacedDB[H]) Insert(prefix hashdb.Prefix, value []byte) H {
+	derivedPrefix := keyspaceAsPrefix(tbe.keySpace, prefix)
+	h := tbe.db.Insert(derivedPrefix, value)
+	return h
+}
+
+func (tbe *KeyspacedDB[H]) Emplace(key H, prefix hashdb.Prefix, value []byte) {
+	derivedPrefix := keyspaceAsPrefix(tbe.keySpace, prefix)
+	tbe.db.Emplace(key, derivedPrefix, value)
+}
+
+func (tbe *KeyspacedDB[H]) Remove(key H, prefix hashdb.Prefix) {
+	derivedPrefix := keyspaceAsPrefix(tbe.keySpace, prefix)
+	tbe.db.Remove(key, derivedPrefix)
+}

--- a/internal/primitives/trie/trie.go
+++ b/internal/primitives/trie/trie.go
@@ -53,7 +53,7 @@ func DeltaTrieRoot[H runtime.Hash, Hasher runtime.Hasher[H]](
 	cache triedb.TrieCache[H],
 	stateVersion triedb.TrieLayout,
 ) (H, error) {
-	trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB := triedb.NewTrieDB(root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
 	trieDB.SetVersion(stateVersion)
 
 	slices.SortStableFunc(delta, func(a KeyValue, b KeyValue) int {
@@ -94,7 +94,7 @@ func ReadTrieValue[H runtime.Hash, Hasher runtime.Hasher[H]](
 	cache triedb.TrieCache[H],
 	stateVersion triedb.TrieLayout,
 ) ([]byte, error) {
-	trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB := triedb.NewTrieDB(root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
 	trieDB.SetVersion(stateVersion)
 	b, err := triedb.GetWith(trieDB, key, func(data []byte) []byte { return data })
 	if err != nil {
@@ -116,9 +116,9 @@ func ReadTrieValueWith[H runtime.Hash, Hasher runtime.Hasher[H]](
 	stateVersion triedb.TrieLayout,
 	query triedb.Query[[]byte],
 ) ([]byte, error) {
-	trieDB := triedb.NewTrieDB[H, Hasher](root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
+	trieDB := triedb.NewTrieDB(root, db, triedb.WithCache[H, Hasher](cache), triedb.WithRecorder[H, Hasher](recorder))
 	trieDB.SetVersion(stateVersion)
-	b, err := triedb.GetWith[H, Hasher, []byte](trieDB, key, query)
+	b, err := triedb.GetWith(trieDB, key, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/primitives/trie/trie_test.go
+++ b/internal/primitives/trie/trie_test.go
@@ -1,0 +1,13 @@
+// Copyright 2024 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package trie
+
+import (
+	hashdb "github.com/ChainSafe/gossamer/internal/hash-db"
+	"github.com/ChainSafe/gossamer/internal/primitives/core/hash"
+)
+
+var (
+	_ hashdb.HashDB[hash.H256] = &KeyspacedDB[hash.H256]{}
+)


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
### `statemachine.Backend`

`statemachine.Backend` is the interface that `statemachine.TrieBackend` implements.  It is used to read from state which is backed by `TrieDB`, as well as iteration through iterators, and calculate state roots.  

### `statemachine.TrieBackend`

`statemachine.TrieBackend` implements the `statemachine.Backend` interface.  The constructor `NewTrieBackend` takes as parameters an implementation of the `TrieCacheProvider` interface as well as an optional `recorder.Recorder` for node recording and eventual state proof generation. The storage that is read from is an implementation of `TrieBackendStorage` with an associated root hash to look up.

### `statemachine.ephemeral`

`ephemeral` is private type to facilitate overlayed changes provided by a `trie.PrefixedMemoryDB` as the overlay level, while fetching from the underlying `TrieBackendStorage` when the hash isn't found in the overlay.  This implements `HashDB` and is used as a n ephemeral storage layer for `TrieBackend`.

### `statemachine.MemoryDBTrieBackend`
`MemoryDBTrieBackend` is a helper type that creates a `TrieBackend` where a `trie.PrefixedMemoryDB` is used as underlying storage. Currently only used in tests but I've exported it for now since it will be used in future work.  

### `trie.SharedTrieCache`

`SharedTrieCache` is used to hold all the trie nodes and values for all operations to the state. Within `SharedTrieCache` consists of both `sharedNodeCache` and `sharedValueCache` instances. There should only be one instance of a `SharedTrieCache` for a node.  

### `trie.LocalTrieCache`

`SharedTrieCache.LocalTrieCache()` is used to create a `LocalTrieCache` instance which will get merged back to the parent `SharedTrieCache` after state changes are processed and `LocalTrieCache.Commit()` is called.  

### `trie.TrieCache`

`LocalTrieCache.TrieCache(storageRoot H)` is used to create a `TrieCache` instance which implements `triedb.TrieCache` interface.  `TrieCache.MergeInto(ltc *LocalTrieCache, storageRoot H)` is used to merge it back to the `LocalTrieCache`.

#### `costlru.LRU`

`costlru.LRU` is a wrapper around `freelru.LRU` to constrain the LRU based on the cost.  The cost used in the various caches is byte size.

### `recorder.Recorder`

`Recorder` is used to generate a compatible `triedb.TrieRecorder` using the private `trieRecorder` type.  The recorder supports transactions which can be rolled back.  

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->
closes #3901 #3836 