### PR TITLE
Chore: Upgrade Ristretto

### DIFF
--- a/dot/network/host.go
+++ b/dot/network/host.go
@@ -235,11 +235,11 @@ func newHost(ctx context.Context, cfg *Config) (*host, error) {
 	}
 
 	cacheSize := 64 << 20 // 64 MB
-	config := ristretto.Config[[]byte, string]{
+	config := ristretto.Config{
 		NumCounters: int64(float64(cacheSize) * 0.05 * 2),
 		MaxCost:     int64(float64(cacheSize) * 0.95),
 		BufferItems: 64,
-		Cost: func(_ string) int64 {
+		Cost: func(_ interface{}) int64 {
 			return int64(1)
 		},
 	}

--- a/dot/network/message_cache.go
+++ b/dot/network/message_cache.go
@@ -17,12 +17,12 @@ var msgCacheTTL = 5 * time.Minute
 
 // messageCache is used to detect duplicated messages per peer.
 type messageCache struct {
-	cache *ristretto.Cache[[]byte, string]
+	cache *ristretto.Cache
 	ttl   time.Duration
 }
 
 // newMessageCache creates a new messageCache which takes config and TTL duration.
-func newMessageCache(config ristretto.Config[[]byte, string], ttl time.Duration) (*messageCache, error) {
+func newMessageCache(config ristretto.Config, ttl time.Duration) (*messageCache, error) {
 	cache, err := ristretto.NewCache(&config)
 	if err != nil {
 		return nil, err

--- a/dot/network/message_cache_integration_test.go
+++ b/dot/network/message_cache_integration_test.go
@@ -20,11 +20,11 @@ func TestMessageCache(t *testing.T) {
 	t.Parallel()
 
 	cacheSize := 64 << 20 // 64 MB
-	msgCache, err := newMessageCache(ristretto.Config[[]byte, string]{
+	msgCache, err := newMessageCache(ristretto.Config{
 		NumCounters: int64(float64(cacheSize) * 0.05 * 2),
 		MaxCost:     int64(float64(cacheSize) * 0.95),
 		BufferItems: 64,
-		Cost: func(value string) int64 {
+		Cost: func(value interface{}) int64 {
 			return int64(1)
 		},
 	}, 800*time.Millisecond)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cockroachdb/pebble v1.1.2
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/dgraph-io/badger/v4 v4.4.0
-	github.com/dgraph-io/ristretto v1.0.0
+	github.com/dgraph-io/ristretto v0.2.0
 	github.com/disiqueira/gotree v1.0.0
 	github.com/ethereum/go-ethereum v1.14.11
 	github.com/fatih/color v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/dgraph-io/badger/v4 v4.4.0 h1:rA48XiDynZLyMdlaJl67p9+lqfqwxlgKtCpYLAio7Zk=
 github.com/dgraph-io/badger/v4 v4.4.0/go.mod h1:sONMmPPfbnj9FPwS/etCqky/ULth6CQJuAZSuWCmixE=
+github.com/dgraph-io/ristretto v0.2.0 h1:XAfl+7cmoUDWW/2Lx8TGZQjjxIQ2Ley9DSf52dru4WE=
+github.com/dgraph-io/ristretto v0.2.0/go.mod h1:8uBHCU/PBV4Ag0CJrP47b9Ofby5dqWNh4FicAdoqFNU=
 github.com/dgraph-io/ristretto v1.0.0 h1:SYG07bONKMlFDUYu5pEu3DGAh8c2OFNzKm6G9J4Si84=
 github.com/dgraph-io/ristretto v1.0.0/go.mod h1:jTi2FiYEhQ1NsMmA7DeBykizjOuY88NhKBkepyu1jPc=
 github.com/dgraph-io/ristretto/v2 v2.0.0 h1:l0yiSOtlJvc0otkqyMaDNysg8E9/F/TYZwMbxscNOAQ=


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
We were receiving this output when building
`
#9 29.99 go: warning: github.com/dgraph-io/ristretto@v1.0.0: retracted by module author: we retract v1.0.0 because v0.2.0 is not backwards compatible with v1.0.0.
#9 29.99 go: to switch to the latest unretracted version, run:
#9 29.99 	go get github.com/dgraph-io/ristretto@latest
`

however, so this PR upgrades to the latest nonretracted version and makes it compatible with the new version
## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->