### PR TITLE
chore: increase linter timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ help: Makefile
 .PHONY: lint
 lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62
-	golangci-lint run
+	golangci-lint run --timeout 3m
 
 clean:
 	rm -fr ./bin


### PR DESCRIPTION
The `lint` job in CI has been timing out occasionally. This change sets a timeout of three minutes for `golangci-lint` (default is 1 min).