### PR TITLE
Feat(dot/parachain): Add `CompactStatement` type

### DIFF
--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -177,3 +177,67 @@ type SignedFullStatementWithPVD struct {
 	// otherwise, it should be nil.
 	PersistedValidationData *PersistedValidationData
 }
+
+type SecondedCandidateHash CandidateHash
+
+type CompactStatementValues interface {
+	Valid | SecondedCandidateHash
+}
+
+// Statements that can be made about parachain candidates.
+// These are the actual values that are signed.
+type CompactStatement struct {
+	inner any
+}
+
+func setCompactStatement[Value CompactStatementValues](mvdt *CompactStatement, value Value) {
+	mvdt.inner = value
+}
+
+func (mvdt *CompactStatement) SetValue(value any) (err error) {
+	switch value := value.(type) {
+	case Valid:
+		setCompactStatement(mvdt, value)
+		return
+	case SecondedCandidateHash:
+		setCompactStatement(mvdt, value)
+		return
+	default:
+		return fmt.Errorf("unsupported type")
+	}
+}
+
+func (mvdt CompactStatement) IndexValue() (index uint, value any, err error) {
+	switch mvdt.inner.(type) {
+	case Valid:
+		return 2, mvdt.inner, nil
+	case SecondedCandidateHash:
+		return 1, mvdt.inner, nil
+	}
+	return 0, nil, scale.ErrUnsupportedVaryingDataTypeValue
+}
+
+func (mvdt CompactStatement) Value() (value any, err error) {
+	_, value, err = mvdt.IndexValue()
+	return
+}
+
+func (mvdt CompactStatement) ValueAt(index uint) (value any, err error) {
+	switch index {
+	case 2:
+		return Valid{}, nil
+	case 1:
+		return SecondedCandidateHash{}, nil
+	}
+	return nil, scale.ErrUnknownVaryingDataTypeValue
+}
+
+func (c *CompactStatement) Encode() ([]byte, error) {
+	// TODO: implement this
+	return nil, nil
+}
+
+func (c *CompactStatement) Decode(in []byte) error {
+	// TODO: implement this
+	return nil
+}

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -84,10 +84,42 @@ type Seconded CommittedCandidateReceipt
 // Valid represents a statement that a validator has deemed a candidate valid.
 type Valid CandidateHash
 
-// statementVDTAndSigningContext is just a wrapper struct to hold both the statement and the signing context.
-type statementVDTAndSigningContext struct {
-	Statement StatementVDT
-	Context   SigningContext
+// encodeSignData encodes the statement and signing context into a byte slice.
+func encodeSignData(statement StatementVDT, signingContext SigningContext) ([]byte, error) {
+	buffer := bytes.NewBuffer(nil)
+	encoder := scale.NewEncoder(buffer)
+
+	compact, err := statement.CompactStatement()
+	if err != nil {
+		return nil, fmt.Errorf("getting compact statement: %w", err)
+	}
+
+	err = encoder.Encode(compact)
+	if err != nil {
+		return nil, fmt.Errorf("encoding compact statement: %w", err)
+	}
+
+	err = encoder.Encode(signingContext)
+	if err != nil {
+		return nil, fmt.Errorf("encoding signing context: %w", err)
+	}
+
+	return buffer.Bytes(), nil
+}
+
+// CompactStatement returns a compact representation of the statement.
+func (s StatementVDT) CompactStatement() (any, error) {
+	switch s := s.inner.(type) {
+	case Valid:
+		return CompactStatement[Valid]{Value: s}, nil
+	case Seconded:
+		hash, err := GetCandidateHash(CommittedCandidateReceipt(s))
+		if err != nil {
+			return nil, fmt.Errorf("getting candidate hash: %w", err)
+		}
+		return CompactStatement[SecondedCandidateHash]{Value: SecondedCandidateHash(hash)}, nil
+	}
+	return nil, fmt.Errorf("unsupported type")
 }
 
 func (s *StatementVDT) Sign(
@@ -95,14 +127,9 @@ func (s *StatementVDT) Sign(
 	signingContext SigningContext,
 	key ValidatorID,
 ) (*ValidatorSignature, error) {
-	statementAndSigningCtx := statementVDTAndSigningContext{
-		Statement: *s,
-		Context:   signingContext,
-	}
-
-	encodedData, err := scale.Marshal(statementAndSigningCtx)
+	data, err := encodeSignData(*s, signingContext)
 	if err != nil {
-		return nil, fmt.Errorf("marshalling statement and signing-context: %w", err)
+		return nil, fmt.Errorf("encoding data to sign: %w", err)
 	}
 
 	validatorPublicKey, err := sr25519.NewPublicKey(key[:])
@@ -110,7 +137,7 @@ func (s *StatementVDT) Sign(
 		return nil, fmt.Errorf("getting public key: %w", err)
 	}
 
-	signatureBytes, err := keystore.GetKeypair(validatorPublicKey).Sign(encodedData)
+	signatureBytes, err := keystore.GetKeypair(validatorPublicKey).Sign(data)
 	if err != nil {
 		return nil, fmt.Errorf("signing data: %w", err)
 	}
@@ -127,14 +154,9 @@ func (s *StatementVDT) VerifySignature(
 	signingContext SigningContext,
 	validatorSignature ValidatorSignature,
 ) (bool, error) {
-	statementAndSigningCtx := statementVDTAndSigningContext{
-		Statement: *s,
-		Context:   signingContext,
-	}
-
-	encodedMsg, err := scale.Marshal(statementAndSigningCtx)
+	data, err := encodeSignData(*s, signingContext)
 	if err != nil {
-		return false, fmt.Errorf("marshalling statement and signing-context: %w", err)
+		return false, fmt.Errorf("encoding signed data: %w", err)
 	}
 
 	publicKey, err := sr25519.NewPublicKey(validator[:])
@@ -142,7 +164,7 @@ func (s *StatementVDT) VerifySignature(
 		return false, fmt.Errorf("getting public key: %w", err)
 	}
 
-	return publicKey.Verify(encodedMsg, validatorSignature[:])
+	return publicKey.Verify(data, validatorSignature[:])
 }
 
 // UncheckedSignedFullStatement is a Variant of `SignedFullStatement` where the signature has not yet been verified.

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -235,8 +235,8 @@ func (mvdt compactStatementInner) ValueAt(index uint) (value any, err error) {
 	return nil, scale.ErrUnknownVaryingDataTypeValue
 }
 
-// Statements that can be made about parachain candidates.
-// These are the actual values that are signed.
+// CompactStatement is a compact representation of a statement that can be made about parachain candidates.
+// this is the actual value that is signed.
 type CompactStatement[T CompactStatementValues] struct {
 	Value T
 }

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -4,13 +4,17 @@
 package parachaintypes
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
+
+var BACKING_STATEMENT_MAGIC = [4]byte{'B', 'K', 'N', 'G'}
 
 // Statement is a result of candidate validation. It could be either `Valid` or `Seconded`.
 type StatementVDTValues interface {
@@ -184,17 +188,16 @@ type CompactStatementValues interface {
 	Valid | SecondedCandidateHash
 }
 
-// Statements that can be made about parachain candidates.
-// These are the actual values that are signed.
-type CompactStatement struct {
+// compactStatementInner is a helper struct that is used to encode/decode CompactStatement.
+type compactStatementInner struct {
 	inner any
 }
 
-func setCompactStatement[Value CompactStatementValues](mvdt *CompactStatement, value Value) {
+func setCompactStatement[Value CompactStatementValues](mvdt *compactStatementInner, value Value) {
 	mvdt.inner = value
 }
 
-func (mvdt *CompactStatement) SetValue(value any) (err error) {
+func (mvdt *compactStatementInner) SetValue(value any) (err error) {
 	switch value := value.(type) {
 	case Valid:
 		setCompactStatement(mvdt, value)
@@ -207,7 +210,7 @@ func (mvdt *CompactStatement) SetValue(value any) (err error) {
 	}
 }
 
-func (mvdt CompactStatement) IndexValue() (index uint, value any, err error) {
+func (mvdt compactStatementInner) IndexValue() (index uint, value any, err error) {
 	switch mvdt.inner.(type) {
 	case Valid:
 		return 2, mvdt.inner, nil
@@ -217,12 +220,12 @@ func (mvdt CompactStatement) IndexValue() (index uint, value any, err error) {
 	return 0, nil, scale.ErrUnsupportedVaryingDataTypeValue
 }
 
-func (mvdt CompactStatement) Value() (value any, err error) {
+func (mvdt compactStatementInner) Value() (value any, err error) {
 	_, value, err = mvdt.IndexValue()
 	return
 }
 
-func (mvdt CompactStatement) ValueAt(index uint) (value any, err error) {
+func (mvdt compactStatementInner) ValueAt(index uint) (value any, err error) {
 	switch index {
 	case 2:
 		return Valid{}, nil
@@ -232,12 +235,54 @@ func (mvdt CompactStatement) ValueAt(index uint) (value any, err error) {
 	return nil, scale.ErrUnknownVaryingDataTypeValue
 }
 
-func (c *CompactStatement) Encode() ([]byte, error) {
-	// TODO: implement this
-	return nil, nil
+// Statements that can be made about parachain candidates.
+// These are the actual values that are signed.
+type CompactStatement[T CompactStatementValues] struct {
+	Value T
 }
 
-func (c *CompactStatement) Decode(in []byte) error {
-	// TODO: implement this
+func (c CompactStatement[CompactStatementValues]) MarshalSCALE() ([]byte, error) {
+	inner := compactStatementInner{}
+	err := inner.SetValue(c.Value)
+	if err != nil {
+		return nil, fmt.Errorf("setting value: %w", err)
+	}
+
+	buffer := bytes.NewBuffer(BACKING_STATEMENT_MAGIC[:])
+	encoder := scale.NewEncoder(buffer)
+
+	err = encoder.Encode(inner)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (c *CompactStatement[CompactStatementValues]) UnmarshalSCALE(reader io.Reader) error {
+	decoder := scale.NewDecoder(reader)
+
+	var magicBytes [4]byte
+	err := decoder.Decode(&magicBytes)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(magicBytes[:], BACKING_STATEMENT_MAGIC[:]) {
+		return fmt.Errorf("invalid magic bytes")
+	}
+
+	var inner compactStatementInner
+	err = decoder.Decode(&inner)
+	if err != nil {
+		return fmt.Errorf("decoding compactStatementInner: %w", err)
+	}
+
+	value, err := inner.Value()
+	if err != nil {
+		return fmt.Errorf("getting value: %w", err)
+	}
+
+	c.Value = value.(CompactStatementValues)
 	return nil
 }

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
 
-var BACKING_STATEMENT_MAGIC = [4]byte{'B', 'K', 'N', 'G'}
+var backingStatementMagic = [4]byte{'B', 'K', 'N', 'G'}
 
 // Statement is a result of candidate validation. It could be either `Valid` or `Seconded`.
 type StatementVDTValues interface {
@@ -270,7 +270,7 @@ func (c CompactStatement[CompactStatementValues]) MarshalSCALE() ([]byte, error)
 		return nil, fmt.Errorf("setting value: %w", err)
 	}
 
-	buffer := bytes.NewBuffer(BACKING_STATEMENT_MAGIC[:])
+	buffer := bytes.NewBuffer(backingStatementMagic[:])
 	encoder := scale.NewEncoder(buffer)
 
 	err = encoder.Encode(inner)
@@ -290,7 +290,7 @@ func (c *CompactStatement[CompactStatementValues]) UnmarshalSCALE(reader io.Read
 		return err
 	}
 
-	if !bytes.Equal(magicBytes[:], BACKING_STATEMENT_MAGIC[:]) {
+	if !bytes.Equal(magicBytes[:], backingStatementMagic[:]) {
 		return fmt.Errorf("invalid magic bytes")
 	}
 

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -169,3 +169,65 @@ func TestStatementVDT_Sign(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 }
+
+func TestCompactStatement(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		compactStatement any
+		encodingValue    []byte
+		expectedErr      error
+	}{
+		{
+			name: "SecondedCandidateHash",
+			compactStatement: CompactStatement[SecondedCandidateHash]{
+				Value: SecondedCandidateHash{Value: getDummyHash(6)},
+			},
+			encodingValue: []byte{66, 75, 78, 71, 1,
+				6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6},
+		},
+		{
+			name: "Valid",
+			compactStatement: CompactStatement[Valid]{
+				Value: Valid{Value: getDummyHash(7)},
+			},
+			encodingValue: []byte{
+				66, 75, 78, 71, 2,
+				7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
+		},
+	}
+
+	for _, c := range testCases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("marshal", func(t *testing.T) {
+				t.Parallel()
+
+				bytes, err := scale.Marshal(c.compactStatement)
+				require.NoError(t, err)
+				require.Equal(t, c.encodingValue, bytes)
+			})
+
+			t.Run("unmarshal", func(t *testing.T) {
+				t.Parallel()
+
+				switch value := c.compactStatement.(type) {
+				case CompactStatement[Valid]:
+					var statement CompactStatement[Valid]
+					err := scale.Unmarshal(c.encodingValue, &statement)
+					require.NoError(t, err)
+					require.EqualValues(t, value, statement)
+				case CompactStatement[SecondedCandidateHash]:
+					var statement CompactStatement[SecondedCandidateHash]
+					err := scale.Unmarshal(c.encodingValue, &statement)
+					require.NoError(t, err)
+					require.EqualValues(t, value, statement)
+				}
+			})
+
+		})
+	}
+}

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -206,25 +206,25 @@ func TestCompactStatement(t *testing.T) {
 			t.Run("marshal", func(t *testing.T) {
 				t.Parallel()
 
-				bytes, err := scale.Marshal(c.compactStatement)
+				compactStatementBytes, err := scale.Marshal(c.compactStatement)
 				require.NoError(t, err)
-				require.Equal(t, c.encodingValue, bytes)
+				require.Equal(t, c.encodingValue, compactStatementBytes)
 			})
 
 			t.Run("unmarshal", func(t *testing.T) {
 				t.Parallel()
 
-				switch value := c.compactStatement.(type) {
+				switch expectedSatetement := c.compactStatement.(type) {
 				case CompactStatement[Valid]:
-					var statement CompactStatement[Valid]
-					err := scale.Unmarshal(c.encodingValue, &statement)
+					var actualStatement CompactStatement[Valid]
+					err := scale.Unmarshal(c.encodingValue, &actualStatement)
 					require.NoError(t, err)
-					require.EqualValues(t, value, statement)
+					require.EqualValues(t, expectedSatetement, actualStatement)
 				case CompactStatement[SecondedCandidateHash]:
-					var statement CompactStatement[SecondedCandidateHash]
-					err := scale.Unmarshal(c.encodingValue, &statement)
+					var actualStatement CompactStatement[SecondedCandidateHash]
+					err := scale.Unmarshal(c.encodingValue, &actualStatement)
 					require.NoError(t, err)
-					require.EqualValues(t, value, statement)
+					require.EqualValues(t, expectedSatetement, actualStatement)
 				}
 			})
 


### PR DESCRIPTION
## Changes
- introduced `CompactStatement` and `compactStatementInner` types. We will only deal with `CompactStatement` in other codebases. `compactStatementInner` is only used for encoding/decoding of `CompactStatement`, which is why it's not exported.
- implemented `MarshalSCALE` and `UnmarshalSCALE` methods to have custom encoding/decoding logic for `CompactStatement`.
- also updated the sign logic of statementVDT to encode the data properly before signing.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./dot/parachain/types/... -v
```

## Issues
Closes #4422 