### PR TITLE
chore(dot/parachain): make validator sign method generic to support signing any datatype

### DIFF
--- a/dot/parachain/backing/active_leaves_update.go
+++ b/dot/parachain/backing/active_leaves_update.go
@@ -309,14 +309,14 @@ func constructPerRelayParentState(
 		ParentHash:   relayParent,
 	}
 
-	var localValidator *validator
+	var localValidator *parachaintypes.Validator
 	validatorID, validatorIndex := parachainutil.SigningKeyAndIndex(validators, *keystore)
 	if validatorID != nil {
 		//  local node is a validator
-		localValidator = &validator{
-			signingContext: signingContext,
-			key:            *validatorID,
-			index:          validatorIndex,
+		localValidator = &parachaintypes.Validator{
+			SigningContext: signingContext,
+			Key:            *validatorID,
+			Index:          validatorIndex,
 		}
 	}
 
@@ -352,7 +352,7 @@ func constructPerRelayParentState(
 		validatorIndexes := validatorGroups.Validators[groupIndex]
 
 		if validatorIndexes != nil {
-			if localValidator != nil && slices.Contains(validatorIndexes, localValidator.index) {
+			if localValidator != nil && slices.Contains(validatorIndexes, localValidator.Index) {
 				assignment = &coreParaID
 			}
 			groups[coreParaID] = validatorIndexes

--- a/dot/parachain/backing/candidate_backing.go
+++ b/dot/parachain/backing/candidate_backing.go
@@ -113,7 +113,7 @@ type attestingData struct {
 // tableContext represents the contextual information associated with a validator and groups
 // for a table under a relay-parent.
 type tableContext struct {
-	validator  *validator
+	validator  *parachaintypes.Validator
 	groups     map[parachaintypes.ParaID][]parachaintypes.ValidatorIndex
 	validators []parachaintypes.ValidatorID
 }
@@ -126,29 +126,6 @@ func (tc *tableContext) isMemberOf(validatorIndex parachaintypes.ValidatorIndex,
 	}
 
 	return slices.Contains(indexes, validatorIndex)
-}
-
-// validator represents local validator information.
-// It can be created if the local node is a validator in the context of a particular relay chain block.
-type validator struct {
-	signingContext parachaintypes.SigningContext
-	key            parachaintypes.ValidatorID
-	index          parachaintypes.ValidatorIndex
-}
-
-// sign method signs a given payload with the validator and returns a SignedFullStatement.
-func (v validator) sign(keystore keystore.Keystore, payload parachaintypes.StatementVDT,
-) (*parachaintypes.SignedFullStatement, error) {
-	valSign, err := payload.Sign(keystore, v.signingContext, v.key)
-	if err != nil {
-		return nil, fmt.Errorf("signing statement: %w", err)
-	}
-
-	return &parachaintypes.SignedFullStatement{
-		Payload:        payload,
-		ValidatorIndex: v.index,
-		Signature:      *valSign,
-	}, nil
 }
 
 // GetBackableCandidatesMessage is a message received from overseer that requests a set of backable
@@ -321,7 +298,7 @@ func (cb *CandidateBacking) handleStatementMessage(
 			return errFallbackNotAvailable
 		}
 
-		ourIndex := rpState.tableContext.validator.index
+		ourIndex := rpState.tableContext.validator.Index
 		if signedStatementWithPVD.SignedFullStatement.ValidatorIndex == ourIndex {
 			return nil
 		}

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -334,8 +334,8 @@ func dummyTableContext(t *testing.T) tableContext {
 	t.Helper()
 
 	return tableContext{
-		validator: &validator{
-			index: 1,
+		validator: &parachaintypes.Validator{
+			Index: 1,
 		},
 		groups: map[parachaintypes.ParaID][]parachaintypes.ValidatorIndex{
 			1: {1, 2, 3},

--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -516,15 +516,17 @@ func TestCandidateReachesQuorum(t *testing.T) {
 	err = statementSeconded.SetValue(parachaintypes.Seconded(candidate))
 	require.NoError(t, err)
 
-	statementSecondedSign, err := statementSeconded.Sign(candidateBacking.Keystore, signingContext, paraValidators[2])
+	val := parachaintypes.Validator{
+		SigningContext: signingContext,
+		Key:            paraValidators[2],
+		Index:          2,
+	}
+
+	signedStatement, err := statementSeconded.Sign(val, candidateBacking.Keystore)
 	require.NoError(t, err)
 
-	signedStatementSeconded := parachaintypes.SignedFullStatementWithPVD{
-		SignedFullStatement: parachaintypes.SignedFullStatement{
-			Payload:        statementSeconded,
-			ValidatorIndex: 2,
-			Signature:      *statementSecondedSign,
-		},
+	signedStatementWithPVD := parachaintypes.SignedFullStatementWithPVD{
+		SignedFullStatement:     *signedStatement,
 		PersistedValidationData: &pvd,
 	}
 
@@ -556,7 +558,7 @@ func TestCandidateReachesQuorum(t *testing.T) {
 	// receive statement message from overseer to candidate backing subsystem containing seconded statement
 	overseer.ReceiveMessage(backing.StatementMessage{
 		RelayParent:         relayParent,
-		SignedFullStatement: signedStatementSeconded,
+		SignedFullStatement: signedStatementWithPVD,
 	})
 
 	time.Sleep(1 * time.Second)
@@ -587,15 +589,17 @@ func TestCandidateReachesQuorum(t *testing.T) {
 	err = statementValid.SetValue(parachaintypes.Valid(candidateHash))
 	require.NoError(t, err)
 
-	statementValidSign, err := statementValid.Sign(candidateBacking.Keystore, signingContext, paraValidators[5])
+	val = parachaintypes.Validator{
+		SigningContext: signingContext,
+		Key:            paraValidators[5],
+		Index:          5,
+	}
+
+	signedStatement, err = statementValid.Sign(val, candidateBacking.Keystore)
 	require.NoError(t, err)
 
 	signedStatementValid := parachaintypes.SignedFullStatementWithPVD{
-		SignedFullStatement: parachaintypes.SignedFullStatement{
-			Payload:        statementValid,
-			ValidatorIndex: 5,
-			Signature:      *statementValidSign,
-		},
+		SignedFullStatement: *signedStatement,
 	}
 
 	// receive statement message from overseer to candidate backing subsystem containing valid statement
@@ -705,15 +709,17 @@ func TestValidationFailDoesNotStopSubsystem(t *testing.T) {
 	err = statementSeconded.SetValue(parachaintypes.Seconded(candidate))
 	require.NoError(t, err)
 
-	statementSecondedSign, err := statementSeconded.Sign(candidateBacking.Keystore, signingContext, paraValidators[2])
+	val := parachaintypes.Validator{
+		SigningContext: signingContext,
+		Key:            paraValidators[2],
+		Index:          2,
+	}
+
+	signedStatement, err := statementSeconded.Sign(val, candidateBacking.Keystore)
 	require.NoError(t, err)
 
-	signedStatementSeconded := parachaintypes.SignedFullStatementWithPVD{
-		SignedFullStatement: parachaintypes.SignedFullStatement{
-			Payload:        statementSeconded,
-			ValidatorIndex: 2,
-			Signature:      *statementSecondedSign,
-		},
+	statementWithPVD := parachaintypes.SignedFullStatementWithPVD{
+		SignedFullStatement:     *signedStatement,
 		PersistedValidationData: &pvd,
 	}
 
@@ -744,7 +750,7 @@ func TestValidationFailDoesNotStopSubsystem(t *testing.T) {
 	// receive statement message from overseer to candidate backing subsystem containing seconded statement
 	overseer.ReceiveMessage(backing.StatementMessage{
 		RelayParent:         relayParent,
-		SignedFullStatement: signedStatementSeconded,
+		SignedFullStatement: statementWithPVD,
 	})
 
 	time.Sleep(1 * time.Second)
@@ -1114,15 +1120,17 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 	err = statementSeconded.SetValue(parachaintypes.Seconded(candidate))
 	require.NoError(t, err)
 
-	statementSecondedSign, err := statementSeconded.Sign(candidateBacking.Keystore, signingContext, paraValidators[2])
+	val := parachaintypes.Validator{
+		SigningContext: signingContext,
+		Key:            paraValidators[2],
+		Index:          2,
+	}
+
+	signedStatement, err := statementSeconded.Sign(val, candidateBacking.Keystore)
 	require.NoError(t, err)
 
 	signedStatementSeconded := parachaintypes.SignedFullStatementWithPVD{
-		SignedFullStatement: parachaintypes.SignedFullStatement{
-			Payload:        statementSeconded,
-			ValidatorIndex: 2,
-			Signature:      *statementSecondedSign,
-		},
+		SignedFullStatement:     *signedStatement,
 		PersistedValidationData: &pvd,
 	}
 
@@ -1165,15 +1173,11 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 	err = statementValid.SetValue(parachaintypes.Valid(candidateHash))
 	require.NoError(t, err)
 
-	statementValidSign, err := statementValid.Sign(candidateBacking.Keystore, signingContext, paraValidators[2])
+	signedStatement, err = statementValid.Sign(val, candidateBacking.Keystore)
 	require.NoError(t, err)
 
-	signedStatementValid := parachaintypes.SignedFullStatementWithPVD{
-		SignedFullStatement: parachaintypes.SignedFullStatement{
-			Payload:        statementValid,
-			ValidatorIndex: 2,
-			Signature:      *statementValidSign,
-		},
+	statementWithPVD := parachaintypes.SignedFullStatementWithPVD{
+		SignedFullStatement: *signedStatement,
 	}
 
 	reportMisbehavior := func(msg any) bool {
@@ -1196,7 +1200,13 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 			parachaintypes.Seconded(doubleVote.CommittedCandidateReceiptAndSign.CommittedCandidateReceipt))
 		require.NoError(t, err)
 
-		ok, err = statementSeconded.VerifySignature(paraValidators[2], signingContext, signForSeconded)
+		validator := parachaintypes.Validator{
+			SigningContext: signingContext,
+			Key:            paraValidators[2],
+			Index:          2,
+		}
+
+		ok, err = statementSeconded.VerifySignature(validator, signForSeconded)
 		require.NoError(t, err)
 		require.True(t, ok)
 
@@ -1205,7 +1215,7 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 		err = statementValid.SetValue(parachaintypes.Valid(doubleVote.CandidateHashAndSign.CandidateHash))
 		require.NoError(t, err)
 
-		ok, err = statementValid.VerifySignature(paraValidators[2], signingContext, signForValid)
+		ok, err = statementValid.VerifySignature(validator, signForValid)
 		require.NoError(t, err)
 		require.True(t, ok)
 
@@ -1218,7 +1228,7 @@ func TestConflictingStatementIsMisbehavior(t *testing.T) {
 	// this candidate is already seconded by the same validator So, it is a misbehaviour for conflicting statements.
 	overseer.ReceiveMessage(backing.StatementMessage{
 		RelayParent:         relayParent,
-		SignedFullStatement: signedStatementValid,
+		SignedFullStatement: statementWithPVD,
 	})
 	time.Sleep(1 * time.Second)
 }

--- a/dot/parachain/backing/validated_candidate_command.go
+++ b/dot/parachain/backing/validated_candidate_command.go
@@ -330,7 +330,7 @@ func signImportAndDistributeStatement(
 	pvd *parachaintypes.PersistedValidationData,
 	keystore keystore.Keystore,
 ) (parachaintypes.SignedFullStatementWithPVD, error) {
-	signedStatement, err := rpState.tableContext.validator.sign(keystore, statementVDT)
+	signedStatement, err := statementVDT.Sign(*rpState.tableContext.validator, keystore)
 	if err != nil {
 		return parachaintypes.SignedFullStatementWithPVD{}, fmt.Errorf("signing statement: %w", err)
 	}

--- a/dot/parachain/prospective-parachains/fragment_chain_test.go
+++ b/dot/parachain/prospective-parachains/fragment_chain_test.go
@@ -911,25 +911,33 @@ func TestCandidateStorageMethods(t *testing.T) {
 
 					// here we should have 1 possible backed candidate since
 					// the other candidate is seconded
-					possibleBackedCandidateHashes := make([]parachaintypes.CandidateHash, 0)
+					possibleBackedCandidateHashes := make(map[parachaintypes.CandidateHash]struct{})
 					for entry := range storage.possibleBackedParaChildren(parentHeadHash) {
-						possibleBackedCandidateHashes = append(possibleBackedCandidateHashes, entry.candidateHash)
+						possibleBackedCandidateHashes[entry.candidateHash] = struct{}{}
 					}
 
-					require.Equal(t, []parachaintypes.CandidateHash{candidateHash}, possibleBackedCandidateHashes)
+					expectedCandidates := map[parachaintypes.CandidateHash]struct{}{
+						candidateHash: {},
+					}
+
+					require.Equal(t, expectedCandidates, possibleBackedCandidateHashes)
 
 					// now mark it as backed
 					storage.markBacked(candidateHash2)
 
 					// here we should have 1 possible backed candidate since
 					// the other candidate is seconded
-					possibleBackedCandidateHashes = make([]parachaintypes.CandidateHash, 0)
+					possibleBackedCandidateHashes = make(map[parachaintypes.CandidateHash]struct{})
 					for entry := range storage.possibleBackedParaChildren(parentHeadHash) {
-						possibleBackedCandidateHashes = append(possibleBackedCandidateHashes, entry.candidateHash)
+						possibleBackedCandidateHashes[entry.candidateHash] = struct{}{}
 					}
 
-					require.Equal(t, []parachaintypes.CandidateHash{
-						candidateHash, candidateHash2}, possibleBackedCandidateHashes)
+					expectedCandidates = map[parachaintypes.CandidateHash]struct{}{
+						candidateHash:  {},
+						candidateHash2: {},
+					}
+
+					require.Equal(t, expectedCandidates, possibleBackedCandidateHashes)
 
 				})
 			},

--- a/dot/parachain/prospective-parachains/prospective_parachains_test.go
+++ b/dot/parachain/prospective-parachains/prospective_parachains_test.go
@@ -3,6 +3,7 @@ package prospectiveparachains
 import (
 	"bytes"
 	"context"
+	"sort"
 	"testing"
 
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
@@ -364,6 +365,12 @@ func TestGetMinimumRelayParents(t *testing.T) {
 	// Validate the results
 	result := <-sender
 	assert.Len(t, result, 2)
+
+	// orders might be different, so sort the result to compare
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ParaId < result[j].ParaId
+	})
+
 	assert.Equal(t, expected, result)
 }
 

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -9,7 +9,6 @@ import (
 	"io"
 
 	"github.com/ChainSafe/gossamer/lib/common"
-	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
 	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
@@ -84,29 +83,6 @@ type Seconded CommittedCandidateReceipt
 // Valid represents a statement that a validator has deemed a candidate valid.
 type Valid CandidateHash
 
-// encodeSignData encodes the statement and signing context into a byte slice.
-func encodeSignData(statement StatementVDT, signingContext SigningContext) ([]byte, error) {
-	buffer := bytes.NewBuffer(nil)
-	encoder := scale.NewEncoder(buffer)
-
-	compact, err := statement.CompactStatement()
-	if err != nil {
-		return nil, fmt.Errorf("getting compact statement: %w", err)
-	}
-
-	err = encoder.Encode(compact)
-	if err != nil {
-		return nil, fmt.Errorf("encoding compact statement: %w", err)
-	}
-
-	err = encoder.Encode(signingContext)
-	if err != nil {
-		return nil, fmt.Errorf("encoding signing context: %w", err)
-	}
-
-	return buffer.Bytes(), nil
-}
-
 // CompactStatement returns a compact representation of the statement.
 func (s StatementVDT) CompactStatement() (any, error) {
 	switch s := s.inner.(type) {
@@ -123,48 +99,47 @@ func (s StatementVDT) CompactStatement() (any, error) {
 }
 
 func (s *StatementVDT) Sign(
+	validator Validator,
 	keystore keystore.Keystore,
-	signingContext SigningContext,
-	key ValidatorID,
-) (*ValidatorSignature, error) {
-	data, err := encodeSignData(*s, signingContext)
+) (*SignedFullStatement, error) {
+	compact, err := s.CompactStatement()
 	if err != nil {
-		return nil, fmt.Errorf("encoding data to sign: %w", err)
+		return nil, fmt.Errorf("getting compact statement: %w", err)
 	}
 
-	validatorPublicKey, err := sr25519.NewPublicKey(key[:])
+	bytes, err := scale.Marshal(compact)
 	if err != nil {
-		return nil, fmt.Errorf("getting public key: %w", err)
+		return nil, fmt.Errorf("marshalling statementVDT: %w", err)
 	}
 
-	signatureBytes, err := keystore.GetKeypair(validatorPublicKey).Sign(data)
+	valSign, err := validator.Sign(keystore, bytes)
 	if err != nil {
-		return nil, fmt.Errorf("signing data: %w", err)
+		return nil, fmt.Errorf("signing encoded statementVDT: %w", err)
 	}
 
-	var signature Signature
-	copy(signature[:], signatureBytes)
-	valSign := ValidatorSignature(signature)
-	return &valSign, nil
+	return &SignedFullStatement{
+		Payload:        *s,
+		ValidatorIndex: validator.Index,
+		Signature:      *valSign,
+	}, nil
 }
 
 // VerifySignature verifies the validator signature for the statement.
 func (s *StatementVDT) VerifySignature(
-	validator ValidatorID,
-	signingContext SigningContext,
+	validator Validator,
 	validatorSignature ValidatorSignature,
 ) (bool, error) {
-	data, err := encodeSignData(*s, signingContext)
+	compact, err := s.CompactStatement()
 	if err != nil {
-		return false, fmt.Errorf("encoding signed data: %w", err)
+		return false, fmt.Errorf("getting compact statement: %w", err)
 	}
 
-	publicKey, err := sr25519.NewPublicKey(validator[:])
+	bytes, err := scale.Marshal(compact)
 	if err != nil {
-		return false, fmt.Errorf("getting public key: %w", err)
+		return false, fmt.Errorf("marshalling statementVDT: %w", err)
 	}
 
-	return publicKey.Verify(data, validatorSignature[:])
+	return validator.VerifySignature(bytes, validatorSignature)
 }
 
 // UncheckedSignedFullStatement is a Variant of `SignedFullStatement` where the signature has not yet been verified.

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -141,7 +141,7 @@ func TestStatementVDT(t *testing.T) {
 	}
 }
 
-func TestStatementVDT_Sign(t *testing.T) {
+func TestStatementVDT_SignAndVerify(t *testing.T) {
 	statement := NewStatementVDT()
 	err := statement.SetValue(Seconded{})
 	require.NoError(t, err)
@@ -162,10 +162,15 @@ func TestStatementVDT_Sign(t *testing.T) {
 	publicKeyBytes := keyPair.Public().Encode()
 	validatorID := ValidatorID(publicKeyBytes)
 
-	valSign, err := statement.Sign(ks, signingContext, validatorID)
+	validator := Validator{
+		SigningContext: signingContext,
+		Key:            validatorID,
+	}
+
+	signedStatement, err := statement.Sign(validator, ks)
 	require.NoError(t, err)
 
-	ok, err := statement.VerifySignature(validatorID, signingContext, *valSign)
+	ok, err := statement.VerifySignature(validator, signedStatement.Signature)
 	require.NoError(t, err)
 	require.True(t, ok)
 }

--- a/dot/parachain/types/types.go
+++ b/dot/parachain/types/types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/ChainSafe/gossamer/lib/crypto/sr25519"
+	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 )
 
@@ -834,4 +835,64 @@ func (mvdt UpgradeRestriction) ValueAt(index uint) (value any, err error) {
 type CandidateHashAndRelayParent struct {
 	CandidateHash        CandidateHash
 	CandidateRelayParent common.Hash
+}
+
+// validator represents local validator information.
+// It can be created if the local node is a validator in the context of a particular relay chain block.
+type Validator struct {
+	SigningContext SigningContext
+	Key            ValidatorID
+	Index          ValidatorIndex
+}
+
+// Sign signs the encoded payload with the validator's key.
+func (v Validator) Sign(keystore keystore.Keystore, encodedPayload []byte) (*ValidatorSignature, error) {
+	buf := bytes.NewBuffer(encodedPayload)
+	encoder := scale.NewEncoder(buf)
+
+	err := encoder.Encode(v.SigningContext)
+	if err != nil {
+		return nil, fmt.Errorf("encoding signing context: %w", err)
+	}
+
+	encodedData := buf.Bytes()
+
+	validatorPublicKey, err := sr25519.NewPublicKey(v.Key[:])
+	if err != nil {
+		return nil, fmt.Errorf("getting public key: %w", err)
+	}
+
+	signatureBytes, err := keystore.GetKeypair(validatorPublicKey).Sign(encodedData)
+	if err != nil {
+		return nil, fmt.Errorf("signing data: %w", err)
+	}
+
+	var signature Signature
+	copy(signature[:], signatureBytes)
+	valSign := ValidatorSignature(signature)
+
+	return &valSign, nil
+}
+
+// VerifySignature verifies the validator signature for the encoded payload.
+func (v Validator) VerifySignature(
+	encodedPayload []byte,
+	validatorSignature ValidatorSignature,
+) (bool, error) {
+	buf := bytes.NewBuffer(encodedPayload)
+	encoder := scale.NewEncoder(buf)
+
+	err := encoder.Encode(v.SigningContext)
+	if err != nil {
+		return false, fmt.Errorf("encoding signing context: %w", err)
+	}
+
+	encodedData := buf.Bytes()
+
+	publicKey, err := sr25519.NewPublicKey(v.Key[:])
+	if err != nil {
+		return false, fmt.Errorf("getting public key: %w", err)
+	}
+
+	return publicKey.Verify(encodedData, validatorSignature[:])
 }

--- a/dot/parachain/types/types_test.go
+++ b/dot/parachain/types/types_test.go
@@ -11,6 +11,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/ChainSafe/gossamer/lib/crypto"
+	"github.com/ChainSafe/gossamer/lib/keystore"
 	"github.com/ChainSafe/gossamer/pkg/scale"
 	"github.com/stretchr/testify/require"
 )
@@ -437,4 +439,37 @@ func TestUpgradeRestrictionEncodingDecoding(t *testing.T) {
 	require.NoError(t, expectedRestriction.SetValue(Present{}))
 
 	require.Equal(t, expectedRestriction, &restriction)
+}
+
+func TestValidator_SignAndVerify(t *testing.T) {
+	signingContext := SigningContext{
+		SessionIndex: 1,
+		ParentHash:   getDummyHash(1),
+	}
+
+	ks := keystore.NewBasicKeystore("test", crypto.Sr25519Type)
+	keyring, err := keystore.NewSr25519Keyring()
+	require.NoError(t, err)
+
+	keyPair := keyring.Alice()
+	err = ks.Insert(keyPair)
+	require.NoError(t, err)
+
+	publicKeyBytes := keyPair.Public().Encode()
+	validatorID := ValidatorID(publicKeyBytes)
+
+	validator := Validator{
+		SigningContext: signingContext,
+		Key:            validatorID,
+		Index:          50,
+	}
+
+	payloadBytes := []byte("test payload")
+
+	valSign, err := validator.Sign(ks, payloadBytes)
+	require.NoError(t, err)
+
+	ok, err := validator.VerifySignature(payloadBytes, *valSign)
+	require.NoError(t, err)
+	require.True(t, ok)
 }


### PR DESCRIPTION
## Changes
- Moved Validator struct and it's methods from `dot/parachain/backing` package to `dot/parachain/types` package
- modified Sign method to accept `[]byte` as an argument which is encoded value of the data we want to sign.
- modified sign method of `statementVDT` in `backing` package to use `validator.Sign` method to reuse the code.
- unit tests for `validator` sign and verify, `statementVDT` sign and verify.
- **Also**, some tests were failing continuously in CI. so fixed those flaky tests.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
 go test ./dot/parachain/...
```

## Issues
Closes #4562