### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/dot/node_test.go
+++ b/dot/node_test.go
@@ -32,11 +32,7 @@ func DefaultTestWestendDevConfig(t *testing.T) *cfg.Config {
 
 	config.BasePath = t.TempDir()
 	if os.Getenv("CI") == "buildjet" {
-		tmpdir, err := os.MkdirTemp("..", "*_wnd_dev_cfg")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, os.RemoveAll(tmpdir))
-		})
+		tmpdir := t.TempDir()
 		config.BasePath = tmpdir
 	}
 

--- a/dot/test_utils.go
+++ b/dot/test_utils.go
@@ -20,11 +20,7 @@ import (
 func NewTestGenesisRawFile(t *testing.T, config *cfg.Config) (filename string) {
 	filename = filepath.Join(t.TempDir(), "genesis.json")
 	if os.Getenv("CI") == "buildjet" {
-		tmpdir, err := os.MkdirTemp("..", "*_gen_raw_file")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, os.RemoveAll(tmpdir))
-		})
+		tmpdir := t.TempDir()
 		filename = filepath.Join(tmpdir, "genesis.json")
 	}
 


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->

 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir


## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->