### PR TITLE
feat(parachain/availability-distribution): handle `ChunkFetchingRequest`

### DIFF
--- a/dot/parachain/availability-distribution/availability_distribution.go
+++ b/dot/parachain/availability-distribution/availability_distribution.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"fmt"
 
+	availabilitystore "github.com/ChainSafe/gossamer/dot/parachain/availability-store"
+	"github.com/ChainSafe/gossamer/dot/parachain/network-bridge/messages"
+
 	"github.com/ChainSafe/gossamer/dot/network"
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
 	"github.com/ChainSafe/gossamer/dot/types"
@@ -43,11 +46,16 @@ func NewAvailabilityDistribution(
 	net Network,
 	blockState BlockState,
 ) *AvailabilityDistribution {
-	return &AvailabilityDistribution{
+	ad := &AvailabilityDistribution{
 		subSystemToOverseer: overseerChan,
 		net:                 net,
 		blockState:          blockState,
 	}
+
+	protoID := protocol.ID(messages.ChunkFetchingV2.String())
+	net.RegisterRequestHandler(protoID, ad.handleChunkFetchingRequest)
+
+	return ad
 }
 
 // Run starts the AvailabilityDistribution subsystem
@@ -113,12 +121,40 @@ func (ad *AvailabilityDistribution) processAvailabilityDistributionMessageFetchP
 	return nil // TODO: implement #4489
 }
 
-//nolint:unused
 func (ad *AvailabilityDistribution) handleChunkFetchingRequest(
-	who peer.ID,
+	_ peer.ID,
 	payload []byte,
 ) (network.ResponseMessage, error) {
-	return nil, nil // TODO: implement #4487
+	request := &messages.ChunkFetchingRequest{}
+
+	err := request.Decode(payload)
+	if err != nil {
+		return nil, fmt.Errorf("decoding chunk fetching request: %w", err)
+	}
+
+	query := availabilitystore.QueryChunk{
+		CandidateHash:  request.CandidateHash,
+		ValidatorIndex: request.Index,
+		Sender:         make(chan availabilitystore.ErasureChunk),
+	}
+
+	ad.subSystemToOverseer <- query
+	response := &messages.ChunkFetchingResponse{}
+
+	// Ideally availability store would close the channel instead of sending an empty ErasureChunk.
+	// This would allow using `chunk, ok := <-query.Sender` and read `ok == false` as "chunk not found".
+	chunk := <-query.Sender
+	if chunk.Chunk == nil {
+		_ = response.SetValue(messages.NoSuchChunk{})
+	} else {
+		_ = response.SetValue(messages.ChunkResponse{
+			Chunk: chunk.Chunk,
+			Index: chunk.Index,
+			// Proof: chunk.Proof,  // FIXME see #4597
+		})
+	}
+
+	return response, nil
 }
 
 //nolint:unused

--- a/dot/parachain/availability-distribution/availability_distribution.go
+++ b/dot/parachain/availability-distribution/availability_distribution.go
@@ -141,17 +141,23 @@ func (ad *AvailabilityDistribution) handleChunkFetchingRequest(
 	ad.subSystemToOverseer <- query
 	response := &messages.ChunkFetchingResponse{}
 
-	// Ideally availability store would close the channel instead of sending an empty ErasureChunk.
-	// This would allow using `chunk, ok := <-query.Sender` and read `ok == false` as "chunk not found".
-	chunk := <-query.Sender
-	if chunk.Chunk == nil {
-		_ = response.SetValue(messages.NoSuchChunk{})
+	// Conceptually, this is a "one shot" channel, so ideally availability store would always close the channel and not
+	// send anything in case the chunk is not found.
+	chunk, ok := <-query.Sender
+	if !ok || chunk.Chunk == nil {
+		err = response.SetValue(messages.NoSuchChunk{})
+		if err != nil {
+			return nil, fmt.Errorf("setting chunk response value: %w", err)
+		}
 	} else {
-		_ = response.SetValue(messages.ChunkResponse{
+		err = response.SetValue(messages.ChunkResponse{
 			Chunk: chunk.Chunk,
 			Index: chunk.Index,
 			// Proof: chunk.Proof,  // FIXME see #4597
 		})
+		if err != nil {
+			return nil, fmt.Errorf("setting chunk response value: %w", err)
+		}
 	}
 
 	return response, nil

--- a/dot/parachain/availability-distribution/availability_distribution_test.go
+++ b/dot/parachain/availability-distribution/availability_distribution_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/ChainSafe/gossamer/dot/network"
 	availabilitystore "github.com/ChainSafe/gossamer/dot/parachain/availability-store"
 	"github.com/ChainSafe/gossamer/dot/parachain/network-bridge/messages"
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
@@ -37,169 +38,99 @@ func TestHandleChunkFetchingRequest(t *testing.T) {
 		ad = NewAvailabilityDistribution(overseerCh, netMock, blockStateMock)
 	}
 
-	testCases := []struct {
-		description   string
-		createRequest func(t *testing.T) (*messages.ChunkFetchingRequest, []byte)
-		createChunk   func(t *testing.T) *availabilitystore.ErasureChunk
-		handleQuery   func(
-			t *testing.T,
-			overseerCh chan any,
-			request *messages.ChunkFetchingRequest,
-			chunk *availabilitystore.ErasureChunk,
-		)
-		validateResponse func(
-			t *testing.T,
-			response *messages.ChunkFetchingResponse,
-			err error,
-			chunk *availabilitystore.ErasureChunk,
-		)
-	}{
-		{
-			description: "invalid_request",
-			createRequest: func(t *testing.T) (*messages.ChunkFetchingRequest, []byte) {
-				return nil, []byte("0xDECAFBAD")
-			},
-			createChunk: func(t *testing.T) *availabilitystore.ErasureChunk {
-				return nil
-			},
-			handleQuery: func(
-				t *testing.T,
-				overseerCh chan any,
-				request *messages.ChunkFetchingRequest,
-				chunk *availabilitystore.ErasureChunk,
-			) {
-			},
-			validateResponse: func(
-				t *testing.T,
-				response *messages.ChunkFetchingResponse,
-				err error,
-				chunk *availabilitystore.ErasureChunk,
-			) {
-				assert.Error(t, err)
-				assert.Nil(t, response)
-			},
-		},
-		{
-			description: "chunk_not_found",
-			createRequest: func(t *testing.T) (*messages.ChunkFetchingRequest, []byte) {
-				request := messages.ChunkFetchingRequest{
-					CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
-					Index:         parachaintypes.ValidatorIndex(0),
-				}
+	t.Run("invalid_request", func(t *testing.T) {
+		setup(t)
 
-				encodedRequest, err := request.Encode()
-				assert.NoError(t, err)
-				return &request, encodedRequest
-			},
-			createChunk: func(t *testing.T) *availabilitystore.ErasureChunk {
-				return &availabilitystore.ErasureChunk{}
-			},
-			handleQuery: func(
-				t *testing.T,
-				overseerCh chan any,
-				request *messages.ChunkFetchingRequest,
-				chunk *availabilitystore.ErasureChunk,
-			) {
-				query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
-				assert.True(t, ok)
-				assert.Equal(t, request.CandidateHash, query.CandidateHash)
-				assert.Equal(t, request.Index, query.ValidatorIndex)
+		response, err := ad.handleChunkFetchingRequest("bob", []byte("0xDECAFBAD"))
 
-				query.Sender <- *chunk
-			},
-			validateResponse: func(
-				t *testing.T,
-				response *messages.ChunkFetchingResponse,
-				err error,
-				chunk *availabilitystore.ErasureChunk,
-			) {
-				assert.NoError(t, err)
-				assert.NotNil(t, response)
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
 
-				value, err := response.Value()
-				assert.NoError(t, err)
-				assert.Equal(t, messages.NoSuchChunk{}, value)
-			},
-		},
-		{
-			description: "chunk_found",
-			createRequest: func(t *testing.T) (*messages.ChunkFetchingRequest, []byte) {
-				request := messages.ChunkFetchingRequest{
-					CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
-					Index:         parachaintypes.ValidatorIndex(0),
-				}
+	t.Run("chunk_not_found", func(t *testing.T) {
+		setup(t)
 
-				encodedRequest, err := request.Encode()
-				assert.NoError(t, err)
-				return &request, encodedRequest
-			},
-			createChunk: func(t *testing.T) *availabilitystore.ErasureChunk {
-				return &availabilitystore.ErasureChunk{
-					Chunk: []byte{0x01, 0x02},
-					Index: 23,
-					Proof: []byte{0x03, 0x04},
-				}
-			},
-			handleQuery: func(
-				t *testing.T,
-				overseerCh chan any,
-				request *messages.ChunkFetchingRequest,
-				chunk *availabilitystore.ErasureChunk,
-			) {
-				query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
-				assert.True(t, ok)
-				assert.Equal(t, request.CandidateHash, query.CandidateHash)
-				assert.Equal(t, request.Index, query.ValidatorIndex)
+		request := messages.ChunkFetchingRequest{
+			CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
+			Index:         parachaintypes.ValidatorIndex(0),
+		}
 
-				query.Sender <- *chunk
-			},
-			validateResponse: func(
-				t *testing.T,
-				response *messages.ChunkFetchingResponse,
-				err error,
-				chunk *availabilitystore.ErasureChunk,
-			) {
-				assert.NoError(t, err)
-				assert.NotNil(t, response)
+		encodedRequest, err := request.Encode()
+		assert.NoError(t, err)
 
-				value, err := response.Value()
-				assert.NoError(t, err)
+		var response network.ResponseMessage
 
-				chunkRes, ok := value.(messages.ChunkResponse)
-				assert.True(t, ok)
-				assert.NotNil(t, chunkRes)
-				assert.Equal(t, chunk.Chunk, chunkRes.Chunk)
-				assert.Equal(t, chunk.Index, chunkRes.Index)
-				// assert.Equal(t, chunk.Proof, chunkRes.Proof) // FIXME see #4597
-			},
-		},
-	}
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			var err error
+			response, err = ad.handleChunkFetchingRequest("bob", encodedRequest)
+			assert.NoError(t, err)
+			assert.NotNil(t, response)
+			cfResponse, ok := response.(*messages.ChunkFetchingResponse)
+			assert.True(t, ok)
 
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			setup(t)
+			value, err := cfResponse.Value()
+			assert.NoError(t, err)
+			assert.Equal(t, messages.NoSuchChunk{}, value)
+			wg.Done()
+		}()
 
-			request, encodedRequest := tc.createRequest(t)
-			chunk := tc.createChunk(t)
+		query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
+		assert.True(t, ok)
+		assert.Equal(t, request.CandidateHash, query.CandidateHash)
+		assert.Equal(t, request.Index, query.ValidatorIndex)
 
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				response, err := ad.handleChunkFetchingRequest("bob", encodedRequest)
+		query.Sender <- availabilitystore.ErasureChunk{}
+		wg.Wait()
+	})
 
-				if response != nil {
-					cfResponse, ok := response.(*messages.ChunkFetchingResponse)
-					assert.True(t, ok)
-					tc.validateResponse(t, cfResponse, err, chunk)
-				} else {
-					tc.validateResponse(t, nil, err, chunk)
-				}
+	t.Run("chunk_found", func(t *testing.T) {
+		setup(t)
 
-				wg.Done()
-			}()
+		request := messages.ChunkFetchingRequest{
+			CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
+			Index:         parachaintypes.ValidatorIndex(0),
+		}
 
-			tc.handleQuery(t, overseerCh, request, chunk)
-			wg.Wait()
-		})
-	}
+		encodedRequest, err := request.Encode()
+		assert.NoError(t, err)
+
+		testChunk := availabilitystore.ErasureChunk{
+			Chunk: []byte{0x01, 0x02},
+			Index: 23,
+			Proof: []byte{0x03, 0x04},
+		}
+
+		var response network.ResponseMessage
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			var err error
+			response, err = ad.handleChunkFetchingRequest("bob", encodedRequest)
+			assert.NoError(t, err)
+			assert.NotNil(t, response)
+			cfResponse, ok := response.(*messages.ChunkFetchingResponse)
+			assert.True(t, ok)
+
+			value, err := cfResponse.Value()
+			assert.NoError(t, err)
+
+			chunkRes, ok := value.(messages.ChunkResponse)
+			assert.True(t, ok)
+			assert.Equal(t, testChunk.Chunk, chunkRes.Chunk)
+			assert.Equal(t, testChunk.Index, chunkRes.Index)
+			// assert.Equal(t, testChunk.Proof, chunkRes.Proof) // FIXME see #4597
+			wg.Done()
+		}()
+
+		query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
+		assert.True(t, ok)
+		assert.Equal(t, request.CandidateHash, query.CandidateHash)
+		assert.Equal(t, request.Index, query.ValidatorIndex)
+
+		query.Sender <- testChunk
+		wg.Wait()
+	})
 }

--- a/dot/parachain/availability-distribution/availability_distribution_test.go
+++ b/dot/parachain/availability-distribution/availability_distribution_test.go
@@ -4,20 +4,133 @@
 package availabilitydistribution
 
 import (
+	"sync"
 	"testing"
+
+	"github.com/ChainSafe/gossamer/dot/network"
+	availabilitystore "github.com/ChainSafe/gossamer/dot/parachain/availability-store"
+	"github.com/ChainSafe/gossamer/dot/parachain/network-bridge/messages"
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/libp2p/go-libp2p/core/protocol"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
-func TestNewAvailabilityDistribution(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	netMock := NewMockNetwork(ctrl)
-	blockStateMock := NewMockBlockState(ctrl)
+func TestHandleChunkFetchingRequest(t *testing.T) {
+	var (
+		ctrl           *gomock.Controller
+		netMock        *MockNetwork
+		blockStateMock *MockBlockState
+		overseerCh     chan any
+		ad             *AvailabilityDistribution
+	)
 
-	overseerCh := make(chan any)
+	setup := func(t *testing.T) {
+		ctrl = gomock.NewController(t)
+		netMock = NewMockNetwork(ctrl)
+		blockStateMock = NewMockBlockState(ctrl)
 
-	ad := NewAvailabilityDistribution(overseerCh, netMock, blockStateMock)
+		netMock.EXPECT().RegisterRequestHandler(protocol.ID("req_chunk/2"), gomock.Any())
 
-	assert.NotNil(t, ad)
+		overseerCh = make(chan any)
+		ad = NewAvailabilityDistribution(overseerCh, netMock, blockStateMock)
+	}
+
+	t.Run("invalid_request", func(t *testing.T) {
+		setup(t)
+
+		response, err := ad.handleChunkFetchingRequest("bob", []byte("0xDECAFBAD"))
+
+		assert.Error(t, err)
+		assert.Nil(t, response)
+	})
+
+	t.Run("chunk_not_found", func(t *testing.T) {
+		setup(t)
+
+		request := messages.ChunkFetchingRequest{
+			CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
+			Index:         parachaintypes.ValidatorIndex(0),
+		}
+
+		encodedRequest, err := request.Encode()
+		assert.NoError(t, err)
+
+		var response network.ResponseMessage
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			var err error
+			response, err = ad.handleChunkFetchingRequest("bob", encodedRequest)
+			assert.NoError(t, err)
+			assert.NotNil(t, response)
+			cfResponse, ok := response.(*messages.ChunkFetchingResponse)
+			assert.True(t, ok)
+
+			value, err := cfResponse.Value()
+			assert.NoError(t, err)
+			assert.Equal(t, messages.NoSuchChunk{}, value)
+			wg.Done()
+		}()
+
+		query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
+		assert.True(t, ok)
+		assert.Equal(t, request.CandidateHash, query.CandidateHash)
+		assert.Equal(t, request.Index, query.ValidatorIndex)
+
+		query.Sender <- availabilitystore.ErasureChunk{}
+		wg.Wait()
+	})
+
+	t.Run("chunk_found", func(t *testing.T) {
+		setup(t)
+
+		request := messages.ChunkFetchingRequest{
+			CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
+			Index:         parachaintypes.ValidatorIndex(0),
+		}
+
+		encodedRequest, err := request.Encode()
+		assert.NoError(t, err)
+
+		testChunk := availabilitystore.ErasureChunk{
+			Chunk: []byte{0x01, 0x02},
+			Index: 23,
+			Proof: []byte{0x03, 0x04},
+		}
+
+		var response network.ResponseMessage
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			var err error
+			response, err = ad.handleChunkFetchingRequest("bob", encodedRequest)
+			assert.NoError(t, err)
+			assert.NotNil(t, response)
+			cfResponse, ok := response.(*messages.ChunkFetchingResponse)
+			assert.True(t, ok)
+
+			value, err := cfResponse.Value()
+			assert.NoError(t, err)
+
+			chunkRes, ok := value.(messages.ChunkResponse)
+			assert.True(t, ok)
+			assert.Equal(t, testChunk.Chunk, chunkRes.Chunk)
+			assert.Equal(t, testChunk.Index, chunkRes.Index)
+			// assert.Equal(t, testChunk.Proof, chunkRes.Proof) // FIXME see #4597
+			wg.Done()
+		}()
+
+		query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
+		assert.True(t, ok)
+		assert.Equal(t, request.CandidateHash, query.CandidateHash)
+		assert.Equal(t, request.Index, query.ValidatorIndex)
+
+		query.Sender <- testChunk
+		wg.Wait()
+	})
 }

--- a/dot/parachain/availability-distribution/availability_distribution_test.go
+++ b/dot/parachain/availability-distribution/availability_distribution_test.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/ChainSafe/gossamer/dot/network"
 	availabilitystore "github.com/ChainSafe/gossamer/dot/parachain/availability-store"
 	"github.com/ChainSafe/gossamer/dot/parachain/network-bridge/messages"
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
@@ -38,99 +37,169 @@ func TestHandleChunkFetchingRequest(t *testing.T) {
 		ad = NewAvailabilityDistribution(overseerCh, netMock, blockStateMock)
 	}
 
-	t.Run("invalid_request", func(t *testing.T) {
-		setup(t)
+	testCases := []struct {
+		description   string
+		createRequest func(t *testing.T) (*messages.ChunkFetchingRequest, []byte)
+		createChunk   func(t *testing.T) *availabilitystore.ErasureChunk
+		handleQuery   func(
+			t *testing.T,
+			overseerCh chan any,
+			request *messages.ChunkFetchingRequest,
+			chunk *availabilitystore.ErasureChunk,
+		)
+		validateResponse func(
+			t *testing.T,
+			response *messages.ChunkFetchingResponse,
+			err error,
+			chunk *availabilitystore.ErasureChunk,
+		)
+	}{
+		{
+			description: "invalid_request",
+			createRequest: func(t *testing.T) (*messages.ChunkFetchingRequest, []byte) {
+				return nil, []byte("0xDECAFBAD")
+			},
+			createChunk: func(t *testing.T) *availabilitystore.ErasureChunk {
+				return nil
+			},
+			handleQuery: func(
+				t *testing.T,
+				overseerCh chan any,
+				request *messages.ChunkFetchingRequest,
+				chunk *availabilitystore.ErasureChunk,
+			) {
+			},
+			validateResponse: func(
+				t *testing.T,
+				response *messages.ChunkFetchingResponse,
+				err error,
+				chunk *availabilitystore.ErasureChunk,
+			) {
+				assert.Error(t, err)
+				assert.Nil(t, response)
+			},
+		},
+		{
+			description: "chunk_not_found",
+			createRequest: func(t *testing.T) (*messages.ChunkFetchingRequest, []byte) {
+				request := messages.ChunkFetchingRequest{
+					CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
+					Index:         parachaintypes.ValidatorIndex(0),
+				}
 
-		response, err := ad.handleChunkFetchingRequest("bob", []byte("0xDECAFBAD"))
+				encodedRequest, err := request.Encode()
+				assert.NoError(t, err)
+				return &request, encodedRequest
+			},
+			createChunk: func(t *testing.T) *availabilitystore.ErasureChunk {
+				return &availabilitystore.ErasureChunk{}
+			},
+			handleQuery: func(
+				t *testing.T,
+				overseerCh chan any,
+				request *messages.ChunkFetchingRequest,
+				chunk *availabilitystore.ErasureChunk,
+			) {
+				query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
+				assert.True(t, ok)
+				assert.Equal(t, request.CandidateHash, query.CandidateHash)
+				assert.Equal(t, request.Index, query.ValidatorIndex)
 
-		assert.Error(t, err)
-		assert.Nil(t, response)
-	})
+				query.Sender <- *chunk
+			},
+			validateResponse: func(
+				t *testing.T,
+				response *messages.ChunkFetchingResponse,
+				err error,
+				chunk *availabilitystore.ErasureChunk,
+			) {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
 
-	t.Run("chunk_not_found", func(t *testing.T) {
-		setup(t)
+				value, err := response.Value()
+				assert.NoError(t, err)
+				assert.Equal(t, messages.NoSuchChunk{}, value)
+			},
+		},
+		{
+			description: "chunk_found",
+			createRequest: func(t *testing.T) (*messages.ChunkFetchingRequest, []byte) {
+				request := messages.ChunkFetchingRequest{
+					CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
+					Index:         parachaintypes.ValidatorIndex(0),
+				}
 
-		request := messages.ChunkFetchingRequest{
-			CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
-			Index:         parachaintypes.ValidatorIndex(0),
-		}
+				encodedRequest, err := request.Encode()
+				assert.NoError(t, err)
+				return &request, encodedRequest
+			},
+			createChunk: func(t *testing.T) *availabilitystore.ErasureChunk {
+				return &availabilitystore.ErasureChunk{
+					Chunk: []byte{0x01, 0x02},
+					Index: 23,
+					Proof: []byte{0x03, 0x04},
+				}
+			},
+			handleQuery: func(
+				t *testing.T,
+				overseerCh chan any,
+				request *messages.ChunkFetchingRequest,
+				chunk *availabilitystore.ErasureChunk,
+			) {
+				query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
+				assert.True(t, ok)
+				assert.Equal(t, request.CandidateHash, query.CandidateHash)
+				assert.Equal(t, request.Index, query.ValidatorIndex)
 
-		encodedRequest, err := request.Encode()
-		assert.NoError(t, err)
+				query.Sender <- *chunk
+			},
+			validateResponse: func(
+				t *testing.T,
+				response *messages.ChunkFetchingResponse,
+				err error,
+				chunk *availabilitystore.ErasureChunk,
+			) {
+				assert.NoError(t, err)
+				assert.NotNil(t, response)
 
-		var response network.ResponseMessage
+				value, err := response.Value()
+				assert.NoError(t, err)
 
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			var err error
-			response, err = ad.handleChunkFetchingRequest("bob", encodedRequest)
-			assert.NoError(t, err)
-			assert.NotNil(t, response)
-			cfResponse, ok := response.(*messages.ChunkFetchingResponse)
-			assert.True(t, ok)
+				chunkRes, ok := value.(messages.ChunkResponse)
+				assert.True(t, ok)
+				assert.NotNil(t, chunkRes)
+				assert.Equal(t, chunk.Chunk, chunkRes.Chunk)
+				assert.Equal(t, chunk.Index, chunkRes.Index)
+				// assert.Equal(t, chunk.Proof, chunkRes.Proof) // FIXME see #4597
+			},
+		},
+	}
 
-			value, err := cfResponse.Value()
-			assert.NoError(t, err)
-			assert.Equal(t, messages.NoSuchChunk{}, value)
-			wg.Done()
-		}()
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			setup(t)
 
-		query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
-		assert.True(t, ok)
-		assert.Equal(t, request.CandidateHash, query.CandidateHash)
-		assert.Equal(t, request.Index, query.ValidatorIndex)
+			request, encodedRequest := tc.createRequest(t)
+			chunk := tc.createChunk(t)
 
-		query.Sender <- availabilitystore.ErasureChunk{}
-		wg.Wait()
-	})
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				response, err := ad.handleChunkFetchingRequest("bob", encodedRequest)
 
-	t.Run("chunk_found", func(t *testing.T) {
-		setup(t)
+				if response != nil {
+					cfResponse, ok := response.(*messages.ChunkFetchingResponse)
+					assert.True(t, ok)
+					tc.validateResponse(t, cfResponse, err, chunk)
+				} else {
+					tc.validateResponse(t, nil, err, chunk)
+				}
 
-		request := messages.ChunkFetchingRequest{
-			CandidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x01}},
-			Index:         parachaintypes.ValidatorIndex(0),
-		}
+				wg.Done()
+			}()
 
-		encodedRequest, err := request.Encode()
-		assert.NoError(t, err)
-
-		testChunk := availabilitystore.ErasureChunk{
-			Chunk: []byte{0x01, 0x02},
-			Index: 23,
-			Proof: []byte{0x03, 0x04},
-		}
-
-		var response network.ResponseMessage
-
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			var err error
-			response, err = ad.handleChunkFetchingRequest("bob", encodedRequest)
-			assert.NoError(t, err)
-			assert.NotNil(t, response)
-			cfResponse, ok := response.(*messages.ChunkFetchingResponse)
-			assert.True(t, ok)
-
-			value, err := cfResponse.Value()
-			assert.NoError(t, err)
-
-			chunkRes, ok := value.(messages.ChunkResponse)
-			assert.True(t, ok)
-			assert.Equal(t, testChunk.Chunk, chunkRes.Chunk)
-			assert.Equal(t, testChunk.Index, chunkRes.Index)
-			// assert.Equal(t, testChunk.Proof, chunkRes.Proof) // FIXME see #4597
-			wg.Done()
-		}()
-
-		query, ok := (<-overseerCh).(availabilitystore.QueryChunk)
-		assert.True(t, ok)
-		assert.Equal(t, request.CandidateHash, query.CandidateHash)
-		assert.Equal(t, request.Index, query.ValidatorIndex)
-
-		query.Sender <- testChunk
-		wg.Wait()
-	})
+			tc.handleQuery(t, overseerCh, request, chunk)
+			wg.Wait()
+		})
+	}
 }

--- a/dot/parachain/availability-store/availability_store.go
+++ b/dot/parachain/availability-store/availability_store.go
@@ -226,9 +226,12 @@ func (as *availabilityStore) loadMeta(candidate parachaintypes.CandidateHash) (*
 }
 
 // loadChunk loads a chunk from the availability store
-func (as *availabilityStore) loadChunk(candidate parachaintypes.CandidateHash, validatorIndex uint32) (*ErasureChunk,
+func (as *availabilityStore) loadChunk(
+	candidate parachaintypes.CandidateHash,
+	validatorIndex parachaintypes.ValidatorIndex,
+) (*ErasureChunk,
 	error) {
-	resultBytes, err := as.chunk.Get(append(candidate.Value[:], uint32ToBytes(validatorIndex)...))
+	resultBytes, err := as.chunk.Get(append(candidate.Value[:], uint32ToBytes(uint32(validatorIndex))...))
 	if err != nil {
 		return nil, fmt.Errorf("getting candidate %v, index %d from chunk table: %w", candidate.Value, validatorIndex, err)
 	}
@@ -746,10 +749,10 @@ func (av *AvailabilityStoreSubsystem) handleQueryChunkSize(msg QueryChunkSize) e
 	if err != nil {
 		return fmt.Errorf("load metadata: %w", err)
 	}
-	var validatorIndex uint32
+	var validatorIndex parachaintypes.ValidatorIndex
 	for i, v := range meta.ChunksStored {
 		if v {
-			validatorIndex = uint32(i)
+			validatorIndex = parachaintypes.ValidatorIndex(i)
 			break
 		}
 	}
@@ -771,7 +774,7 @@ func (av *AvailabilityStoreSubsystem) handleQueryAllChunks(msg QueryAllChunks) e
 	chunks := []ErasureChunk{}
 	for i, v := range meta.ChunksStored {
 		if v {
-			chunk, err := av.availabilityStore.loadChunk(msg.CandidateHash, uint32(i))
+			chunk, err := av.availabilityStore.loadChunk(msg.CandidateHash, parachaintypes.ValidatorIndex(i))
 			if err != nil {
 				logger.Errorf("load chunk: %w", err)
 			}

--- a/dot/parachain/availability-store/availability_store.go
+++ b/dot/parachain/availability-store/availability_store.go
@@ -229,8 +229,7 @@ func (as *availabilityStore) loadMeta(candidate parachaintypes.CandidateHash) (*
 func (as *availabilityStore) loadChunk(
 	candidate parachaintypes.CandidateHash,
 	validatorIndex parachaintypes.ValidatorIndex,
-) (*ErasureChunk,
-	error) {
+) (*ErasureChunk, error) {
 	resultBytes, err := as.chunk.Get(append(candidate.Value[:], uint32ToBytes(uint32(validatorIndex))...))
 	if err != nil {
 		return nil, fmt.Errorf("getting candidate %v, index %d from chunk table: %w", candidate.Value, validatorIndex, err)
@@ -496,7 +495,7 @@ func (av *AvailabilityStoreSubsystem) processMessage(msg any) {
 }
 
 func (av *AvailabilityStoreSubsystem) ProcessActiveLeavesUpdateSignal(signal parachaintypes.
-	ActiveLeavesUpdateSignal) error {
+ActiveLeavesUpdateSignal) error {
 	now := timeNow()
 	logger.Infof("ProcessActiveLeavesUpdateSignal %s", signal)
 

--- a/dot/parachain/availability-store/availability_store.go
+++ b/dot/parachain/availability-store/availability_store.go
@@ -494,8 +494,9 @@ func (av *AvailabilityStoreSubsystem) processMessage(msg any) {
 	}
 }
 
-func (av *AvailabilityStoreSubsystem) ProcessActiveLeavesUpdateSignal(signal parachaintypes.
-ActiveLeavesUpdateSignal) error {
+func (av *AvailabilityStoreSubsystem) ProcessActiveLeavesUpdateSignal(
+	signal parachaintypes.ActiveLeavesUpdateSignal,
+) error {
 	now := timeNow()
 	logger.Infof("ProcessActiveLeavesUpdateSignal %s", signal)
 

--- a/dot/parachain/availability-store/availability_store_test.go
+++ b/dot/parachain/availability-store/availability_store_test.go
@@ -1067,7 +1067,7 @@ func (h *testHarness) hasAllChunks(candidateHash parachaintypes.CandidateHash, n
 		msgQueryChan := make(chan ErasureChunk)
 		queryChunk := QueryChunk{
 			CandidateHash:  candidateHash,
-			ValidatorIndex: i,
+			ValidatorIndex: parachaintypes.ValidatorIndex(i),
 			Sender:         msgQueryChan,
 		}
 		h.broadcastMessages = append(h.broadcastMessages, queryChunk)
@@ -1393,7 +1393,7 @@ func TestStorePOVandQueryChunkWorks(t *testing.T) {
 		msgSenderQueryChan := make(chan ErasureChunk)
 		harness.broadcastMessages = append(harness.broadcastMessages, QueryChunk{
 			CandidateHash:  candidateHash,
-			ValidatorIndex: i,
+			ValidatorIndex: parachaintypes.ValidatorIndex(i),
 			Sender:         msgSenderQueryChan,
 		})
 		harness.triggerBroadcast()

--- a/dot/parachain/availability-store/messages.go
+++ b/dot/parachain/availability-store/messages.go
@@ -41,7 +41,7 @@ type ErasureChunk struct {
 // QueryChunk query an `ErasureChunk` from the AV store by candidate hash and validator index
 type QueryChunk struct {
 	CandidateHash  parachaintypes.CandidateHash
-	ValidatorIndex uint32
+	ValidatorIndex parachaintypes.ValidatorIndex
 	Sender         chan ErasureChunk
 }
 

--- a/dot/parachain/network-bridge/messages/chunk_fetching.go
+++ b/dot/parachain/network-bridge/messages/chunk_fetching.go
@@ -26,6 +26,11 @@ func (c ChunkFetchingRequest) Encode() ([]byte, error) {
 	return scale.Marshal(c)
 }
 
+// Decode returns the SCALE decoding of the ChunkFetchingRequest.
+func (c *ChunkFetchingRequest) Decode(in []byte) (err error) {
+	return scale.Unmarshal(in, c)
+}
+
 // Protocol returns the sub-protocol ID for this message
 func (c ChunkFetchingRequest) Protocol() ReqProtocolName {
 	return ChunkFetchingV1
@@ -97,13 +102,16 @@ func NewChunkFetchingResponse() ChunkFetchingResponse {
 	return ChunkFetchingResponse{}
 }
 
-// ChunkResponse represents the requested chunk data
+// ChunkResponse represents the requested chunk data. This is the response format for v2 of the chunk fetching protocol.
 type ChunkResponse struct {
 	// The erasure-encoded chunk of data belonging to the candidate block
 	Chunk []byte `scale:"1"`
 
+	// The index of this erasure-coded chunk
+	Index uint32 `scale:"2"`
+
 	// Proof for this chunk's branch in the Merkle tree
-	Proof [][]byte `scale:"2"`
+	Proof [][]byte `scale:"3"`
 }
 
 // NoSuchChunk indicates that the requested chunk was not found

--- a/dot/parachain/network-bridge/messages/chunk_fetching_test.go
+++ b/dot/parachain/network-bridge/messages/chunk_fetching_test.go
@@ -26,6 +26,22 @@ func TestEncodeChunkFetchingRequest(t *testing.T) {
 	require.Equal(t, expextedEncode, actualEncode)
 }
 
+func TestDecodeChunkFetchingRequest(t *testing.T) {
+	encodedRequest := common.MustHexToBytes("0x677811d2f3ded2489685468dbdb2e4fa280a249fba9356acceb2e823820e2c1908000000")
+
+	request := ChunkFetchingRequest{}
+	err := request.Decode(encodedRequest)
+	require.NoError(t, err)
+
+	expectedDecode := ChunkFetchingRequest{
+		CandidateHash: parachaintypes.CandidateHash{
+			Value: common.MustHexToHash("0x677811d2f3ded2489685468dbdb2e4fa280a249fba9356acceb2e823820e2c19"),
+		},
+		Index: parachaintypes.ValidatorIndex(8),
+	}
+	require.Equal(t, expectedDecode, request)
+}
+
 func TestChunkFetchingResponse(t *testing.T) {
 	t.Parallel()
 
@@ -39,9 +55,10 @@ func TestChunkFetchingResponse(t *testing.T) {
 			name: "chunkResponse",
 			value: ChunkResponse{
 				Chunk: testBytes,
+				Index: 5,
 				Proof: [][]byte{testBytes},
 			},
-			encodeValue: common.MustHexToBytes("0x0080677811d2f3ded2489685468dbdb2e4fa280a249fba9356acceb2e823820e2c190480677811d2f3ded2489685468dbdb2e4fa280a249fba9356acceb2e823820e2c19"), //nolint:lll
+			encodeValue: common.MustHexToBytes("0x0080677811d2f3ded2489685468dbdb2e4fa280a249fba9356acceb2e823820e2c19050000000480677811d2f3ded2489685468dbdb2e4fa280a249fba9356acceb2e823820e2c19"), //nolint:lll
 		},
 		{
 			name:        "NoSuchChunk",

--- a/dot/parachain/network-bridge/messages/request_response_protocols.go
+++ b/dot/parachain/network-bridge/messages/request_response_protocols.go
@@ -14,6 +14,7 @@ type ReqProtocolName uint
 
 const (
 	ChunkFetchingV1 ReqProtocolName = iota
+	ChunkFetchingV2
 	CollationFetchingV1
 	PoVFetchingV1
 	AvailableDataFetchingV1
@@ -25,6 +26,8 @@ func (n ReqProtocolName) String() string {
 	switch n {
 	case ChunkFetchingV1:
 		return "req_chunk/1"
+	case ChunkFetchingV2:
+		return "req_chunk/2"
 	case CollationFetchingV1:
 		return "req_collation/1"
 	case PoVFetchingV1:


### PR DESCRIPTION
## Changes

This PR implements handling of `ChunkFetchingRequest` network messages in the availability distribution subsystem.

The PR builds on #4591, which should be reviewed first.

## Tests

```sh
go test ./dot/parachain/availability-distribution
```

## Issues

#4487