### PR TITLE
chore(pkg/finality-grandpa): Close all channels  on `Voter.Stop()`

### DIFF
--- a/pkg/finality-grandpa/environment_test.go
+++ b/pkg/finality-grandpa/environment_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/exp/rand"
+	rand "math/rand/v2"
 )
 
 type ID uint32
@@ -134,7 +134,7 @@ func (e *environment) RoundData(
 }
 
 func (*environment) RoundCommitTimer() Timer {
-	inner := time.NewTimer(time.Duration(rand.Int63n(1000)) * time.Millisecond).C
+	inner := time.NewTimer(time.Duration(rand.Int64N(1000)) * time.Millisecond).C
 	timer := newTimer(inner)
 	return timer
 }

--- a/pkg/finality-grandpa/environment_test.go
+++ b/pkg/finality-grandpa/environment_test.go
@@ -24,12 +24,17 @@ func newTimer(in <-chan time.Time) *timer {
 	inErr := make(chan error)
 	wc := newWakerChan(inErr)
 	t := timer{wakerChan: wc}
-	go func() {
-		<-in
-		inErr <- nil
-		t.expired = true
-	}()
+	go t.poll(in)
 	return &t
+}
+
+func (t *timer) poll(in <-chan time.Time) {
+	<-in
+	if t.wakerChan.in != nil {
+		t.wakerChan.in <- nil
+		close(t.wakerChan.in)
+	}
+	t.expired = true
 }
 
 func (t *timer) SetWaker(waker *waker) {
@@ -38,6 +43,13 @@ func (t *timer) SetWaker(waker *waker) {
 
 func (t *timer) Elapsed() (bool, error) {
 	return t.expired, nil
+}
+
+func (t *timer) Close() {
+	if t.wakerChan.in != nil {
+		close(t.wakerChan.in)
+		t.wakerChan.in = nil
+	}
 }
 
 type listenerItem struct {
@@ -97,6 +109,7 @@ func (e *environment) BestChainContaining(base string) BestChain[string, uint32]
 
 	ch := make(chan BestChainOutput[string, uint32], 1)
 	ch <- BestChainOutput[string, uint32]{Value: e.chain.BestChainContaining(base)}
+	close(ch)
 	return ch
 }
 
@@ -260,6 +273,9 @@ func (bm *BroadcastNetwork[M, N]) Stop() {
 		close(ch)
 	}
 	bm.wg.Wait()
+	for _, sender := range bm.senders {
+		close(sender)
+	}
 }
 
 type RoundNetwork struct {

--- a/pkg/finality-grandpa/environment_test.go
+++ b/pkg/finality-grandpa/environment_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"math/rand"
+	"golang.org/x/exp/rand"
 )
 
 type ID uint32
@@ -17,6 +17,7 @@ type Signature uint32
 
 type timer struct {
 	wakerChan *wakerChan[error]
+	mtx       sync.Mutex
 	expired   bool
 }
 
@@ -30,6 +31,8 @@ func newTimer(in <-chan time.Time) *timer {
 
 func (t *timer) poll(in <-chan time.Time) {
 	<-in
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	if t.wakerChan.in != nil {
 		t.wakerChan.in <- nil
 		close(t.wakerChan.in)
@@ -46,6 +49,8 @@ func (t *timer) Elapsed() (bool, error) {
 }
 
 func (t *timer) Close() {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	if t.wakerChan.in != nil {
 		close(t.wakerChan.in)
 		t.wakerChan.in = nil
@@ -269,9 +274,6 @@ func (bm *BroadcastNetwork[M, N]) route() {
 
 func (bm *BroadcastNetwork[M, N]) Stop() {
 	close(bm.receiver)
-	for _, ch := range bm.senders {
-		close(ch)
-	}
 	bm.wg.Wait()
 	for _, sender := range bm.senders {
 		close(sender)

--- a/pkg/finality-grandpa/voter.go
+++ b/pkg/finality-grandpa/voter.go
@@ -30,6 +30,9 @@ func newWakerChan[Item any](in chan Item) *wakerChan[Item] {
 
 func (wc *wakerChan[Item]) start() {
 	defer close(wc.out)
+	if wc.in == nil {
+		return
+	}
 	for item := range wc.in {
 		if wc.waker != nil {
 			wc.waker.wake()
@@ -51,6 +54,7 @@ func (wc *wakerChan[Item]) channel() chan Item {
 type Timer interface {
 	SetWaker(waker *waker)
 	Elapsed() (bool, error)
+	Close()
 }
 
 // Output is the output stream used to communicate with the outside world.
@@ -926,6 +930,46 @@ func (v *Voter[Hash, Number, Signature, ID]) Stop() error {
 		return fmt.Errorf("timeout for Voter.Stop()")
 	case <-wgDone:
 	}
+
+	close(v.finalizedNotifications.in)
+	close(v.inner.bestRound.outgoing.inner)
+	switch state := v.inner.bestRound.state.(type) {
+	case statePrecommitted:
+	case statePrevoted[Timer]:
+		state[0].Close()
+	case statePrevoting[Timer, hashBestChain[Hash, Number]]:
+		state.T.Close()
+	case stateProposed[Timer]:
+		state[0].Close()
+		state[1].Close()
+	case stateStart[Timer]:
+		state[0].Close()
+		state[1].Close()
+	}
+
+	for _, round := range v.inner.pastRounds.pastRounds {
+		close(round.inner.outgoing.inner)
+
+		switch state := round.inner.state.(type) {
+		case statePrecommitted:
+		case statePrevoted[Timer]:
+			state[0].Close()
+		case statePrevoting[Timer, hashBestChain[Hash, Number]]:
+			state.T.Close()
+		case stateProposed[Timer]:
+			state[0].Close()
+			state[1].Close()
+		case stateStart[Timer]:
+			state[0].Close()
+			state[1].Close()
+		}
+
+		if round.roundCommitter != nil {
+			round.roundCommitter.commitTimer.Close()
+			close(round.roundCommitter.importCommits.in)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/finality-grandpa/voter_test.go
+++ b/pkg/finality-grandpa/voter_test.go
@@ -33,7 +33,7 @@ func TestVoter_TalkingToMyself(t *testing.T) {
 	voter, globalOut := NewVoter[string, uint32, Signature, ID](
 		&env,
 		*voters,
-		make(chan globalInItem),
+		nil,
 		0,
 		nil,
 		lastFinalized,


### PR DESCRIPTION
## Changes

<!-- Brief list of functional changes -->
- Noticed some failing unit tests on PR #4604 and determined it was due to too many leaked goroutines in `pkg/finality-grandpa` tests.
- Closes all stale channels within `Voter.Stop()`
- Closes all test network channel when calling `Network.Stop()`.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```