### PR TITLE
feat(parachain/candidate-validation): ensure session-index and core-index are valid

### DIFF
--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -643,10 +643,9 @@ func TestValidateAndMakeAvailable(t *testing.T) {
 				for data := range ch {
 					switch data := data.(type) {
 					case candidatevalidation.ValidateFromExhaustive:
-						ci := candidatevalidation.ExecutionError
 						data.Ch <- parachaintypes.OverseerFuncRes[candidatevalidation.ValidationResult]{
 							Data: candidatevalidation.ValidationResult{
-								Invalid: &ci,
+								Invalid: candidatevalidation.ExecutionError.Ptr(),
 							},
 						}
 					default:

--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -377,10 +377,9 @@ func TestSecondsValidCandidate(t *testing.T) {
 			return false
 		}
 
-		badReturn := candidatevalidation.BadReturn
 		validateFromExhaustive.Ch <- parachaintypes.OverseerFuncRes[candidatevalidation.ValidationResult]{
 			Data: candidatevalidation.ValidationResult{
-				Invalid: &badReturn,
+				Invalid: candidatevalidation.BadReturn.Ptr(),
 			},
 		}
 		return true

--- a/dot/parachain/candidate-validation/candidate_validation.go
+++ b/dot/parachain/candidate-validation/candidate_validation.go
@@ -149,12 +149,7 @@ func (cv *CandidateValidation) validateFromExhaustive(msg ValidateFromExhaustive
 		ClaimQueue:              claimQueue,
 	}
 
-	result, err := cv.pvfHost.validate(validationTask)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return cv.pvfHost.validate(validationTask)
 }
 
 // PoVRequestor gets proof of validity by issuing network requests to validators of the current backing group.

--- a/dot/parachain/candidate-validation/candidate_validation.go
+++ b/dot/parachain/candidate-validation/candidate_validation.go
@@ -20,7 +20,8 @@ import (
 type CandidateValidation struct {
 	SubsystemToOverseer chan<- any
 	BlockState          BlockState
-	pvfHost             *host // pvfHost is the host for the parachain validation function
+	pvfHost             *host
+	claimQueueCache     map[common.Hash]parachaintypes.ClaimQueue // Cache of claim queues per relay parent
 }
 
 type BlockState interface {
@@ -33,6 +34,9 @@ func NewCandidateValidation(overseerChan chan<- any, blockState BlockState) *Can
 		SubsystemToOverseer: overseerChan,
 		pvfHost:             newValidationHost(),
 		BlockState:          blockState,
+
+		// Cache of claim queues per relay parent
+		claimQueueCache: make(map[common.Hash]parachaintypes.ClaimQueue),
 	}
 	return &candidateValidation
 }
@@ -58,8 +62,9 @@ func (*CandidateValidation) Name() parachaintypes.SubSystemName {
 }
 
 // ProcessActiveLeavesUpdateSignal processes active leaves update signal
-func (*CandidateValidation) ProcessActiveLeavesUpdateSignal(parachaintypes.ActiveLeavesUpdateSignal) error {
-	// NOTE: this subsystem does not process active leaves update signal
+func (cv *CandidateValidation) ProcessActiveLeavesUpdateSignal(signal parachaintypes.ActiveLeavesUpdateSignal) error {
+	// Clear cache for deactivated leaves
+	cv.clearOldCache(signal)
 	return nil
 }
 
@@ -125,16 +130,15 @@ func (cv *CandidateValidation) validateFromExhaustive(msg ValidateFromExhaustive
 		return nil, fmt.Errorf("getting execution kind: %w", err)
 	}
 
-	// check if the execution kind is backing
-	_, isBackingExecKind := execKind.(parachaintypes.Backing)
-
 	// We only check the session index for backing.
+	_, isBackingExecKind := execKind.(parachaintypes.Backing)
 	if isBackingExecKind && expectedSessionIndex != msg.CandidateReceipt.Descriptor.SessionIndex {
 		invalidSessionIndex := InvalidSessionIndex
 		return &ValidationResult{Invalid: &invalidSessionIndex}, nil
 	}
 
-	claimQueue, err := runtimeInstance.ParachainHostClaimQueue()
+	// Get claim queue from cache or fetch from runtime
+	claimQueue, err := cv.getOrFetchClaimQueue(runtimeInstance, msg.CandidateReceipt.Descriptor.RelayParent)
 	if err != nil {
 		return nil, fmt.Errorf("getting claim queue: %w", err)
 	}
@@ -338,5 +342,32 @@ func pvfPrepTimeout(params parachaintypes.ExecutorParams, kind parachaintypes.Pv
 		return time.Second * 10
 	default:
 		return time.Second * 2
+	}
+}
+
+// getOrFetchClaimQueue gets the claim queue from cache or fetches it from runtime
+func (cv *CandidateValidation) getOrFetchClaimQueue(
+	runtimeInstance runtime.Instance, relayParent common.Hash) (parachaintypes.ClaimQueue, error) {
+	// Check cache first
+	if claimQueue, ok := cv.claimQueueCache[relayParent]; ok {
+		return claimQueue, nil
+	}
+
+	// Fetch from runtime if not in cache
+	claimQueue, err := runtimeInstance.ParachainHostClaimQueue()
+	if err != nil {
+		return nil, fmt.Errorf("getting claim queue: %w", err)
+	}
+
+	// Store in cache
+	cv.claimQueueCache[relayParent] = claimQueue
+	return claimQueue, nil
+}
+
+// clearOldCache clears claim queues for old relay parents
+func (cv *CandidateValidation) clearOldCache(activeLeavesUpdate parachaintypes.ActiveLeavesUpdateSignal) {
+	// Remove deactivated leaves from cache
+	for _, deactivated := range activeLeavesUpdate.Deactivated {
+		delete(cv.claimQueueCache, deactivated)
 	}
 }

--- a/dot/parachain/candidate-validation/candidate_validation.go
+++ b/dot/parachain/candidate-validation/candidate_validation.go
@@ -135,8 +135,7 @@ func (cv *CandidateValidation) validateFromExhaustive(msg ValidateFromExhaustive
 	// We only check the session index for backing.
 	_, isBackingExecKind := execKind.(parachaintypes.Backing)
 	if isBackingExecKind && expectedSessionIndex != msg.CandidateReceipt.Descriptor.SessionIndex {
-		invalidSessionIndex := InvalidSessionIndex
-		return &ValidationResult{Invalid: &invalidSessionIndex}, nil
+		return &ValidationResult{Invalid: InvalidSessionIndex.Ptr()}, nil
 	}
 
 	// Get claim queue from cache or fetch from runtime
@@ -219,9 +218,8 @@ func (cv *CandidateValidation) validateFromChainState(msg ValidateFromChainState
 	}
 
 	if persistedValidationData == nil {
-		badParent := BadParent
 		reason := ValidationResult{
-			Invalid: &badParent,
+			Invalid: BadParent.Ptr(),
 		}
 		msg.Ch <- parachaintypes.OverseerFuncRes[ValidationResult]{
 			Data: reason,
@@ -260,9 +258,8 @@ func (cv *CandidateValidation) validateFromChainState(msg ValidateFromChainState
 		return
 	}
 	if !valid {
-		invalidOutput := InvalidOutputs
 		reason := &ValidationResult{
-			Invalid: &invalidOutput,
+			Invalid: InvalidOutputs.Ptr(),
 		}
 		msg.Ch <- parachaintypes.OverseerFuncRes[ValidationResult]{
 			Data: *reason,

--- a/dot/parachain/candidate-validation/candidate_validation.go
+++ b/dot/parachain/candidate-validation/candidate_validation.go
@@ -20,8 +20,10 @@ import (
 type CandidateValidation struct {
 	SubsystemToOverseer chan<- any
 	BlockState          BlockState
-	pvfHost             *host
-	claimQueueCache     map[common.Hash]parachaintypes.ClaimQueue // Cache of claim queues per relay parent
+	// pvfHost is the host for the parachain validation function
+	pvfHost *host
+	// Cache of claim queues per relay parent
+	claimQueueCache map[common.Hash]parachaintypes.ClaimQueue
 }
 
 type BlockState interface {

--- a/dot/parachain/candidate-validation/candidate_validation.go
+++ b/dot/parachain/candidate-validation/candidate_validation.go
@@ -79,24 +79,14 @@ func (cv *CandidateValidation) processMessage(msg any) {
 	case ValidateFromChainState:
 		cv.validateFromChainState(msg)
 	case ValidateFromExhaustive:
-		validationTask := &ValidationTask{
-			PersistedValidationData: msg.PersistedValidationData,
-			ValidationCode:          &msg.ValidationCode,
-			CandidateReceipt:        &msg.CandidateReceipt,
-			PoV:                     msg.PoV,
-			ExecutorParams:          msg.ExecutorParams,
-			PvfExecTimeoutKind:      msg.PvfExecTimeoutKind,
-		}
-
-		result, err := cv.pvfHost.validate(validationTask)
+		validationResult, err := cv.validateFromExhaustive(msg)
 		if err != nil {
-			logger.Errorf("failed to validate from exhaustive: %w", err)
 			msg.Ch <- parachaintypes.OverseerFuncRes[ValidationResult]{
 				Err: err,
 			}
 		} else {
 			msg.Ch <- parachaintypes.OverseerFuncRes[ValidationResult]{
-				Data: *result,
+				Data: *validationResult,
 			}
 		}
 
@@ -117,6 +107,54 @@ func (cv *CandidateValidation) processMessage(msg any) {
 	default:
 		logger.Errorf("%w: %T", parachaintypes.ErrUnknownOverseerMessage, msg)
 	}
+}
+
+func (cv *CandidateValidation) validateFromExhaustive(msg ValidateFromExhaustive) (*ValidationResult, error) {
+	runtimeInstance, err := cv.BlockState.GetRuntime(msg.CandidateReceipt.Descriptor.RelayParent)
+	if err != nil {
+		return nil, fmt.Errorf("getting runtime instance: %w", err)
+	}
+
+	expectedSessionIndex, err := runtimeInstance.ParachainHostSessionIndexForChild()
+	if err != nil {
+		return nil, fmt.Errorf("getting session index: %w", err)
+	}
+
+	execKind, err := msg.PvfExecTimeoutKind.Value()
+	if err != nil {
+		return nil, fmt.Errorf("getting execution kind: %w", err)
+	}
+
+	// check if the execution kind is backing
+	_, isBackingExecKind := execKind.(parachaintypes.Backing)
+
+	// We only check the session index for backing.
+	if isBackingExecKind && expectedSessionIndex != msg.CandidateReceipt.Descriptor.SessionIndex {
+		invalidSessionIndex := InvalidSessionIndex
+		return &ValidationResult{Invalid: &invalidSessionIndex}, nil
+	}
+
+	claimQueue, err := runtimeInstance.ParachainHostClaimQueue()
+	if err != nil {
+		return nil, fmt.Errorf("getting claim queue: %w", err)
+	}
+
+	validationTask := &ValidationTask{
+		PersistedValidationData: msg.PersistedValidationData,
+		ValidationCode:          &msg.ValidationCode,
+		CandidateReceipt:        &msg.CandidateReceipt,
+		PoV:                     msg.PoV,
+		ExecutorParams:          msg.ExecutorParams,
+		PvfExecTimeoutKind:      msg.PvfExecTimeoutKind,
+		ClaimQueue:              claimQueue,
+	}
+
+	result, err := cv.pvfHost.validate(validationTask)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 // PoVRequestor gets proof of validity by issuing network requests to validators of the current backing group.

--- a/dot/parachain/candidate-validation/candidate_validation_test.go
+++ b/dot/parachain/candidate-validation/candidate_validation_test.go
@@ -19,12 +19,14 @@ import (
 )
 
 var (
-	povHashMismatch  = PoVHashMismatch
-	paramsTooLarge   = ParamsTooLarge
-	codeHashMismatch = CodeHashMismatch
-	badSignature     = BadSignature
-	invalidOutputs   = InvalidOutputs
-	badParent        = BadParent
+	povHashMismatch     = PoVHashMismatch
+	paramsTooLarge      = ParamsTooLarge
+	codeHashMismatch    = CodeHashMismatch
+	badSignature        = BadSignature
+	invalidOutputs      = InvalidOutputs
+	badParent           = BadParent
+	invalidSessionIndex = InvalidSessionIndex
+	invalidCoreIndex    = InvalidCoreIndex
 )
 
 func createTestCandidateReceiptAndValidationCodeWParaId(t *testing.T, id parachaintypes.ParaID) (
@@ -138,21 +140,52 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 	})
 	require.NoError(t, err)
 
-	overseerToSubsystem := make(chan any)
-	sender := make(chan parachaintypes.OverseerFuncRes[ValidationResult])
-	candidateValidationSubsystem := CandidateValidation{
-		pvfHost: newValidationHost(),
+	execKindBacking := parachaintypes.PvfExecTimeoutKind{}
+	err = execKindBacking.SetValue(parachaintypes.Backing{})
+	require.NoError(t, err)
+
+	setup := func(
+		t *testing.T,
+		configMockInstance func(*MockInstance),
+	) *CandidateValidation {
+		ctrl := gomock.NewController(t)
+		mockInstance := NewMockInstance(ctrl)
+		configMockInstance(mockInstance)
+
+		mockBlockState := NewMockBlockState(ctrl)
+		mockBlockState.EXPECT().GetRuntime(gomock.AssignableToTypeOf(common.Hash{})).Return(mockInstance, nil)
+
+		cv := CandidateValidation{
+			pvfHost:    newValidationHost(),
+			BlockState: mockBlockState,
+		}
+
+		t.Cleanup(cv.Stop)
+		return &cv
 	}
 
-	t.Cleanup(candidateValidationSubsystem.Stop)
-
-	ctx := context.Background()
-	go candidateValidationSubsystem.Run(ctx, overseerToSubsystem)
-
 	tests := map[string]struct {
-		msg  ValidateFromExhaustive
-		want parachaintypes.OverseerFuncRes[ValidationResult]
+		msg                ValidateFromExhaustive
+		configMockInstance func(*MockInstance)
+		expectedResult     ValidationResult
 	}{
+		"invalid_session_index": {
+			msg: ValidateFromExhaustive{
+				CandidateReceipt: parachaintypes.CandidateReceiptV2{
+					Descriptor: parachaintypes.CandidateDescriptorV2{
+						SessionIndex: parachaintypes.SessionIndex(10),
+					},
+				},
+				PvfExecTimeoutKind: execKindBacking,
+			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().ParachainHostSessionIndexForChild().
+					Return(parachaintypes.SessionIndex(5), nil) // different session index than the one in receipt
+			},
+			expectedResult: ValidationResult{
+				Invalid: &invalidSessionIndex,
+			},
+		},
 		"invalid_pov_hash": {
 			msg: ValidateFromExhaustive{
 				PersistedValidationData: parachaintypes.PersistedValidationData{
@@ -161,16 +194,18 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					RelayParentStorageRoot: common.MustHexToHash("0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
 					MaxPovSize:             uint32(2048),
 				},
-				ValidationCode:   validationCode,
-				CandidateReceipt: candidateReceipt2,
-				PoV:              pov,
-				Ch:               sender,
+				ValidationCode:     validationCode,
+				CandidateReceipt:   candidateReceipt2,
+				PoV:                pov,
+				PvfExecTimeoutKind: execKindBacking,
 			},
-			want: parachaintypes.OverseerFuncRes[ValidationResult]{
-				Data: ValidationResult{
-					Invalid: &povHashMismatch,
-				},
-				Err: nil,
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().ParachainHostClaimQueue().Return(make(parachaintypes.ClaimQueue), nil)
+				mi.EXPECT().ParachainHostSessionIndexForChild().
+					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
+			},
+			expectedResult: ValidationResult{
+				Invalid: &povHashMismatch,
 			},
 		},
 		"invalid_pov_size": {
@@ -181,15 +216,18 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					RelayParentStorageRoot: common.MustHexToHash("0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
 					MaxPovSize:             uint32(10),
 				},
-				ValidationCode:   validationCode,
-				CandidateReceipt: candidateReceipt,
-				PoV:              pov,
-				Ch:               sender,
+				ValidationCode:     validationCode,
+				CandidateReceipt:   candidateReceipt,
+				PoV:                pov,
+				PvfExecTimeoutKind: execKindBacking,
 			},
-			want: parachaintypes.OverseerFuncRes[ValidationResult]{
-				Data: ValidationResult{
-					Invalid: &paramsTooLarge,
-				},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().ParachainHostClaimQueue().Return(make(parachaintypes.ClaimQueue), nil)
+				mi.EXPECT().ParachainHostSessionIndexForChild().
+					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
+			},
+			expectedResult: ValidationResult{
+				Invalid: &paramsTooLarge,
 			},
 		},
 		"code_mismatch": {
@@ -200,18 +238,21 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					RelayParentStorageRoot: common.MustHexToHash("0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
 					MaxPovSize:             uint32(2048),
 				},
-				ValidationCode:   []byte{1, 2, 3, 4, 5, 6, 7, 8},
-				CandidateReceipt: candidateReceipt,
-				PoV:              pov,
-				Ch:               sender,
+				ValidationCode:     []byte{1, 2, 3, 4, 5, 6, 7, 8},
+				CandidateReceipt:   candidateReceipt,
+				PoV:                pov,
+				PvfExecTimeoutKind: execKindBacking,
 			},
-			want: parachaintypes.OverseerFuncRes[ValidationResult]{
-				Data: ValidationResult{
-					Invalid: &codeHashMismatch,
-				},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().ParachainHostClaimQueue().Return(make(parachaintypes.ClaimQueue), nil)
+				mi.EXPECT().ParachainHostSessionIndexForChild().
+					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
+			},
+			expectedResult: ValidationResult{
+				Invalid: &codeHashMismatch,
 			},
 		},
-		"happy_path": {
+		"happy_path_descriptor_v1": {
 			msg: ValidateFromExhaustive{
 				PersistedValidationData: parachaintypes.PersistedValidationData{
 					ParentHead:             parachaintypes.HeadData{Data: hd},
@@ -219,33 +260,100 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					RelayParentStorageRoot: common.MustHexToHash("0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
 					MaxPovSize:             uint32(2048),
 				},
-				ValidationCode:   validationCode,
-				CandidateReceipt: candidateReceipt,
-				PoV:              pov,
-				Ch:               sender,
+				ValidationCode:     validationCode,
+				CandidateReceipt:   candidateReceipt,
+				PoV:                pov,
+				PvfExecTimeoutKind: execKindBacking,
 			},
-			want: parachaintypes.OverseerFuncRes[ValidationResult]{
-				Data: ValidationResult{
-					Valid: &Valid{
-						CandidateCommitments: parachaintypes.CandidateCommitments{
-							HeadData: parachaintypes.HeadData{Data: []byte{2, 0, 0, 0, 0, 0, 0, 0, 123,
-								207, 206, 8, 219, 227, 136, 82, 236, 169, 14, 100, 45, 100, 31, 177, 154, 160, 220, 245,
-								59, 106, 76, 168, 122, 109, 164, 169, 22, 46, 144, 39, 103, 92, 31, 78, 66, 72, 252, 64,
-								24, 194, 129, 162, 128, 1, 77, 147, 200, 229, 189, 242, 111, 198, 236, 139, 16, 143, 19,
-								245, 113, 233, 138, 210}},
-							HrmpWatermark: 1,
-						},
-						PersistedValidationData: parachaintypes.PersistedValidationData{
-							ParentHead: parachaintypes.HeadData{Data: []byte{1, 0, 0, 0, 0, 0, 0, 0, 1,
-								2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7,
-								8, 9, 0, 1, 2, 48, 246, 146, 178, 86, 226, 64, 9,
-								188, 179, 77, 14, 232, 77, 167, 60, 41, 138, 250, 204, 9, 36, 224, 17, 5, 226, 235,
-								15, 1, 168, 127, 226}},
-							RelayParentNumber: 1,
-							RelayParentStorageRoot: common.MustHexToHash(
-								"0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
-							MaxPovSize: 2048,
-						},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().ParachainHostClaimQueue().Return(make(parachaintypes.ClaimQueue), nil)
+				mi.EXPECT().ParachainHostSessionIndexForChild().
+					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
+			},
+			expectedResult: ValidationResult{
+				Valid: &Valid{
+					CandidateCommitments: parachaintypes.CandidateCommitments{
+						HeadData: parachaintypes.HeadData{Data: []byte{2, 0, 0, 0, 0, 0, 0, 0, 123,
+							207, 206, 8, 219, 227, 136, 82, 236, 169, 14, 100, 45, 100, 31, 177, 154, 160, 220, 245,
+							59, 106, 76, 168, 122, 109, 164, 169, 22, 46, 144, 39, 103, 92, 31, 78, 66, 72, 252, 64,
+							24, 194, 129, 162, 128, 1, 77, 147, 200, 229, 189, 242, 111, 198, 236, 139, 16, 143, 19,
+							245, 113, 233, 138, 210}},
+						HrmpWatermark: 1,
+					},
+					PersistedValidationData: parachaintypes.PersistedValidationData{
+						ParentHead: parachaintypes.HeadData{Data: []byte{1, 0, 0, 0, 0, 0, 0, 0, 1,
+							2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7,
+							8, 9, 0, 1, 2, 48, 246, 146, 178, 86, 226, 64, 9,
+							188, 179, 77, 14, 232, 77, 167, 60, 41, 138, 250, 204, 9, 36, 224, 17, 5, 226, 235,
+							15, 1, 168, 127, 226}},
+						RelayParentNumber: 1,
+						RelayParentStorageRoot: common.MustHexToHash(
+							"0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
+						MaxPovSize: 2048,
+					},
+				},
+			},
+		},
+		"invalida_core_index_descriptor_v2": {
+			msg: ValidateFromExhaustive{
+				PersistedValidationData: parachaintypes.PersistedValidationData{
+					ParentHead:             parachaintypes.HeadData{Data: hd},
+					RelayParentNumber:      uint32(1),
+					RelayParentStorageRoot: common.MustHexToHash("0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
+					MaxPovSize:             uint32(2048),
+				},
+				ValidationCode:     validationCode,
+				CandidateReceipt:   dummyCandidateReceiptV2(t),
+				PoV:                pov,
+				PvfExecTimeoutKind: execKindBacking,
+			},
+			configMockInstance: func(mi *MockInstance) {
+				mi.EXPECT().ParachainHostClaimQueue().Return(make(parachaintypes.ClaimQueue), nil)
+				mi.EXPECT().ParachainHostSessionIndexForChild().Return(parachaintypes.SessionIndex(2), nil)
+			},
+			expectedResult: ValidationResult{
+				Invalid: &invalidCoreIndex,
+			},
+		},
+		"happy_path_descriptor_v2": {
+			msg: ValidateFromExhaustive{
+				PersistedValidationData: parachaintypes.PersistedValidationData{
+					ParentHead:             parachaintypes.HeadData{Data: hd},
+					RelayParentNumber:      uint32(1),
+					RelayParentStorageRoot: common.MustHexToHash("0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
+					MaxPovSize:             uint32(2048),
+				},
+				ValidationCode:     validationCode,
+				CandidateReceipt:   dummyCandidateReceiptV2(t),
+				PoV:                pov,
+				PvfExecTimeoutKind: execKindBacking,
+			},
+			configMockInstance: func(mi *MockInstance) {
+				claimQueue := make(parachaintypes.ClaimQueue)
+				claimQueue[parachaintypes.CoreIndex{Index: 2}] = []parachaintypes.ParaID{1000} // Core 2 is valid
+				mi.EXPECT().ParachainHostClaimQueue().Return(claimQueue, nil)
+				mi.EXPECT().ParachainHostSessionIndexForChild().Return(parachaintypes.SessionIndex(2), nil)
+			},
+			expectedResult: ValidationResult{
+				Valid: &Valid{
+					CandidateCommitments: parachaintypes.CandidateCommitments{
+						HeadData: parachaintypes.HeadData{Data: []byte{2, 0, 0, 0, 0, 0, 0, 0, 123,
+							207, 206, 8, 219, 227, 136, 82, 236, 169, 14, 100, 45, 100, 31, 177, 154, 160, 220, 245,
+							59, 106, 76, 168, 122, 109, 164, 169, 22, 46, 144, 39, 103, 92, 31, 78, 66, 72, 252, 64,
+							24, 194, 129, 162, 128, 1, 77, 147, 200, 229, 189, 242, 111, 198, 236, 139, 16, 143, 19,
+							245, 113, 233, 138, 210}},
+						HrmpWatermark: 1,
+					},
+					PersistedValidationData: parachaintypes.PersistedValidationData{
+						ParentHead: parachaintypes.HeadData{Data: []byte{1, 0, 0, 0, 0, 0, 0, 0, 1,
+							2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7,
+							8, 9, 0, 1, 2, 48, 246, 146, 178, 86, 226, 64, 9,
+							188, 179, 77, 14, 232, 77, 167, 60, 41, 138, 250, 204, 9, 36, 224, 17, 5, 226, 235,
+							15, 1, 168, 127, 226}},
+						RelayParentNumber: 1,
+						RelayParentStorageRoot: common.MustHexToHash(
+							"0x50c969706800c0e9c3c4565dc2babb25e4a73d1db0dee1bcf7745535a32e7ca1"),
+						MaxPovSize: 2048,
 					},
 				},
 			},
@@ -255,9 +363,13 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			overseerToSubsystem <- tt.msg
-			result := <-sender
-			require.Equal(t, tt.want, result)
+
+			candidateValidationSubsystem := setup(t, tt.configMockInstance)
+
+			validationResult, err := candidateValidationSubsystem.validateFromExhaustive(tt.msg)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedResult, *validationResult)
+
 		})
 	}
 }
@@ -657,5 +769,34 @@ func Test_precheckPvF(t *testing.T) {
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+// dummyCandidateReceiptV2 creates a dummy CandidateReceiptV2 for testing purposes.
+func dummyCandidateReceiptV2(t *testing.T) parachaintypes.CandidateReceiptV2 {
+	t.Helper()
+
+	descriptor := parachaintypes.CandidateDescriptorV2{
+		ParaID:         1000,
+		RelayParent:    common.MustHexToHash("0xded542bacb3ca6c033a57676f94ae7c8f36834511deb44e3164256fd3b1c0de0"),
+		CurrentVersion: 0, // Version 2 indicator
+		CoreIndex:      2,
+		SessionIndex:   2,
+		PersistedValidationDataHash: common.MustHexToHash(
+			"0x690d8f252ef66ab0f969c3f518f90012b849aa5ac94e1752c5e5ae5a8996de37"),
+		PovHash: common.MustHexToHash(
+			"0xb608991ffc48dd405fd4b10e92eaebe2b5a2eedf44d0c3efb8997fdee8bebed9"),
+		ErasureRoot: common.MustHexToHash(
+			"0xc07f658163e93c45a6f0288d229698f09c1252e41076f4caa71c8cbc12f118a1"),
+		ParaHead: common.MustHexToHash(
+			"0x657a011336002a7f2acd5db97d34b9b703c04cadcb63ad82c7658b04fb42f3de"),
+		ValidationCodeHash: parachaintypes.ValidationCodeHash(common.MustHexToHash(
+			"0xd7d82e716d8ca4366ab441c2625878dd148ed961d0ae8bf9f71af2b2f6583f24")),
+		// Reserved1 and Reserved2 are zero by default = Version 2
+	}
+
+	return parachaintypes.CandidateReceiptV2{
+		Descriptor:      descriptor,
+		CommitmentsHash: common.MustHexToHash("0x4ddce2e9ed80f386cdbba4b42f5de76957d5fbf9f093258d6048e9218d1fe98d"),
 	}
 }

--- a/dot/parachain/candidate-validation/candidate_validation_test.go
+++ b/dot/parachain/candidate-validation/candidate_validation_test.go
@@ -18,17 +18,6 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var (
-	povHashMismatch     = PoVHashMismatch
-	paramsTooLarge      = ParamsTooLarge
-	codeHashMismatch    = CodeHashMismatch
-	badSignature        = BadSignature
-	invalidOutputs      = InvalidOutputs
-	badParent           = BadParent
-	invalidSessionIndex = InvalidSessionIndex
-	invalidCoreIndex    = InvalidCoreIndex
-)
-
 func createTestCandidateReceiptAndValidationCodeWParaId(t *testing.T, id parachaintypes.ParaID) (
 	parachaintypes.CandidateReceiptV2, parachaintypes.ValidationCode) {
 	t.Helper()
@@ -180,7 +169,7 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					Return(parachaintypes.SessionIndex(5), nil) // different session index than the one in receipt
 			},
 			expectedResult: ValidationResult{
-				Invalid: &invalidSessionIndex,
+				Invalid: InvalidSessionIndex.Ptr(),
 			},
 		},
 		"invalid_pov_hash": {
@@ -202,7 +191,7 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
 			},
 			expectedResult: ValidationResult{
-				Invalid: &povHashMismatch,
+				Invalid: PoVHashMismatch.Ptr(),
 			},
 		},
 		"invalid_pov_size": {
@@ -224,7 +213,7 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
 			},
 			expectedResult: ValidationResult{
-				Invalid: &paramsTooLarge,
+				Invalid: ParamsTooLarge.Ptr(),
 			},
 		},
 		"code_mismatch": {
@@ -246,7 +235,7 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 					Return(candidateReceipt2.Descriptor.SessionIndex, nil)
 			},
 			expectedResult: ValidationResult{
-				Invalid: &codeHashMismatch,
+				Invalid: CodeHashMismatch.Ptr(),
 			},
 		},
 		"happy_path_descriptor_v1": {
@@ -291,7 +280,7 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 				},
 			},
 		},
-		"invalida_core_index_descriptor_v2": {
+		"invalid_core_index_descriptor_v2": {
 			msg: ValidateFromExhaustive{
 				PersistedValidationData: parachaintypes.PersistedValidationData{
 					ParentHead:             parachaintypes.HeadData{Data: hd},
@@ -309,7 +298,7 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 				mi.EXPECT().ParachainHostSessionIndexForChild().Return(parachaintypes.SessionIndex(2), nil)
 			},
 			expectedResult: ValidationResult{
-				Invalid: &invalidCoreIndex,
+				Invalid: InvalidCoreIndex.Ptr(),
 			},
 		},
 		"happy_path_descriptor_v2": {
@@ -480,7 +469,7 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 				Pov:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &povHashMismatch,
+				Invalid: PoVHashMismatch.Ptr(),
 			},
 			configMockInstance: func(mi *MockInstance) {
 				mi.EXPECT().
@@ -500,7 +489,7 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 				Pov:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &paramsTooLarge,
+				Invalid: ParamsTooLarge.Ptr(),
 			},
 			configMockInstance: func(mi *MockInstance) {
 				mi.EXPECT().
@@ -520,7 +509,7 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 				Pov:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &codeHashMismatch,
+				Invalid: CodeHashMismatch.Ptr(),
 			},
 			configMockInstance: func(mi *MockInstance) {
 				mi.EXPECT().
@@ -540,7 +529,7 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 				Pov:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &badSignature,
+				Invalid: BadSignature.Ptr(),
 			},
 			configMockInstance: func(mi *MockInstance) {
 				mi.EXPECT().
@@ -560,7 +549,7 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 				Pov:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &invalidOutputs,
+				Invalid: InvalidOutputs.Ptr(),
 			},
 			configMockInstance: func(mi *MockInstance) {
 				mi.EXPECT().
@@ -581,7 +570,7 @@ func TestCandidateValidation_processMessageValidateFromChainState(t *testing.T) 
 				Pov:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &badParent,
+				Invalid: BadParent.Ptr(),
 			},
 			configMockInstance: func(mi *MockInstance) {
 				mi.EXPECT().

--- a/dot/parachain/candidate-validation/candidate_validation_test.go
+++ b/dot/parachain/candidate-validation/candidate_validation_test.go
@@ -155,13 +155,10 @@ func TestCandidateValidation_processMessageValidateFromExhaustive(t *testing.T) 
 		mockBlockState := NewMockBlockState(ctrl)
 		mockBlockState.EXPECT().GetRuntime(gomock.AssignableToTypeOf(common.Hash{})).Return(mockInstance, nil)
 
-		cv := CandidateValidation{
-			pvfHost:    newValidationHost(),
-			BlockState: mockBlockState,
-		}
+		cv := NewCandidateValidation(nil, mockBlockState)
 
 		t.Cleanup(cv.Stop)
-		return &cv
+		return cv
 	}
 
 	tests := map[string]struct {

--- a/dot/parachain/candidate-validation/host.go
+++ b/dot/parachain/candidate-validation/host.go
@@ -62,25 +62,21 @@ func performBasicChecks(candidate *parachaintypes.CandidateDescriptorV2, maxPoVS
 	encodedPoVSize := uint32(len(encodedPoV))
 
 	if encodedPoVSize > maxPoVSize {
-		ci := ParamsTooLarge
-		return &ci, nil
+		return ParamsTooLarge.Ptr(), nil
 	}
 
 	if povHash != candidate.PovHash {
-		ci := PoVHashMismatch
-		return &ci, nil
+		return PoVHashMismatch.Ptr(), nil
 	}
 
 	if validationCodeHash != candidate.ValidationCodeHash {
-		ci := CodeHashMismatch
-		return &ci, nil
+		return CodeHashMismatch.Ptr(), nil
 	}
 
 	// No-op for descriptor v2.
 	err = candidate.CheckCollatorSignature()
 	if err != nil {
-		ci := BadSignature
-		return &ci, nil
+		return BadSignature.Ptr(), nil
 	}
 
 	return nil, nil

--- a/dot/parachain/candidate-validation/host_test.go
+++ b/dot/parachain/candidate-validation/host_test.go
@@ -26,13 +26,6 @@ func TestHost_validate(t *testing.T) {
 	candidateReceiptCommitmentsMismatch.CommitmentsHash = common.MustHexToHash(
 		"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
 
-	povHashMismatch := PoVHashMismatch
-	paramsTooLarge := ParamsTooLarge
-	codeHashMismatch := CodeHashMismatch
-	paraHedHashMismatch := ParaHeadHashMismatch
-	commitmentsHashMismatch := CommitmentsHashMismatch
-	executionError := ExecutionError
-
 	pvfHost := newValidationHost()
 
 	bd, err := scale.Marshal(BlockDataInAdderParachain{
@@ -77,7 +70,7 @@ func TestHost_validate(t *testing.T) {
 				ValidationCode:     &validationCode,
 			},
 			want: &ValidationResult{
-				Invalid: &povHashMismatch,
+				Invalid: PoVHashMismatch.Ptr(),
 			},
 			isValid: false,
 		},
@@ -94,7 +87,7 @@ func TestHost_validate(t *testing.T) {
 				PoV:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &paramsTooLarge,
+				Invalid: ParamsTooLarge.Ptr(),
 			},
 		},
 		"code_mismatch": {
@@ -110,7 +103,7 @@ func TestHost_validate(t *testing.T) {
 				PoV:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &codeHashMismatch,
+				Invalid: CodeHashMismatch.Ptr(),
 			},
 			isValid: false,
 		},
@@ -124,7 +117,7 @@ func TestHost_validate(t *testing.T) {
 				PoV:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &executionError,
+				Invalid: ExecutionError.Ptr(),
 			},
 		},
 		"para_head_hash_mismatch": {
@@ -140,7 +133,7 @@ func TestHost_validate(t *testing.T) {
 				PoV:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &paraHedHashMismatch,
+				Invalid: ParaHeadHashMismatch.Ptr(),
 			},
 			isValid: false,
 		},
@@ -157,7 +150,7 @@ func TestHost_validate(t *testing.T) {
 				PoV:              pov,
 			},
 			want: &ValidationResult{
-				Invalid: &commitmentsHashMismatch,
+				Invalid: CommitmentsHashMismatch.Ptr(),
 			},
 			isValid: false,
 		},
@@ -218,10 +211,6 @@ func TestHost_validate(t *testing.T) {
 
 func TestHost_performBasicChecks(t *testing.T) {
 	t.Parallel()
-	paramsTooLarge := ParamsTooLarge
-	povHashMismatch := PoVHashMismatch
-	codeHashMismatch := CodeHashMismatch
-	badSignature := BadSignature
 
 	pov := parachaintypes.PoV{
 		BlockData: []byte{1, 2, 3, 4, 5, 6, 7, 8},
@@ -283,7 +272,7 @@ func TestHost_performBasicChecks(t *testing.T) {
 				maxPoVSize: 2,
 				pov:        pov,
 			},
-			expectedError: &paramsTooLarge,
+			expectedError: ParamsTooLarge.Ptr(),
 		},
 		"invalid_pov_hash": {
 			args: args{
@@ -291,7 +280,7 @@ func TestHost_performBasicChecks(t *testing.T) {
 				maxPoVSize: 1024,
 				pov:        pov2,
 			},
-			expectedError: &povHashMismatch,
+			expectedError: PoVHashMismatch.Ptr(),
 		},
 		"invalid_code_hash": {
 			args: args{
@@ -300,7 +289,7 @@ func TestHost_performBasicChecks(t *testing.T) {
 				pov:                pov,
 				validationCodeHash: parachaintypes.ValidationCodeHash{1, 2, 3},
 			},
-			expectedError: &codeHashMismatch,
+			expectedError: CodeHashMismatch.Ptr(),
 		},
 		"invalid_signature": {
 			args: args{
@@ -309,7 +298,7 @@ func TestHost_performBasicChecks(t *testing.T) {
 				pov:                pov,
 				validationCodeHash: validationCodeHash,
 			},
-			expectedError: &badSignature,
+			expectedError: BadSignature.Ptr(),
 		},
 		"happy_path": {
 			args: args{

--- a/dot/parachain/candidate-validation/worker.go
+++ b/dot/parachain/candidate-validation/worker.go
@@ -107,27 +107,23 @@ func (w *worker) executeRequest(task *workerTask) (*ValidationResult, error) {
 	case validationResultWErr := <-validationResultCh:
 		if validationResultWErr.err != nil {
 			logger.Errorf("executing validate_block: %w", err)
-			reasonForInvalidity := ExecutionError
-			return &ValidationResult{Invalid: &reasonForInvalidity}, nil //nolint
+			return &ValidationResult{Invalid: ExecutionError.Ptr()}, nil //nolint
 		}
 		validationResult = validationResultWErr.result.(*parachainruntime.ValidationResult)
 
 	case <-time.After(timeoutDuration):
 		logger.Errorf("validation timed out")
-		reasonForInvalidity := Timeout
-		return &ValidationResult{Invalid: &reasonForInvalidity}, nil
+		return &ValidationResult{Invalid: Timeout.Ptr()}, nil
 	}
 
 	headDataHash, err := validationResult.HeadData.Hash()
 	if err != nil {
 		logger.Errorf("hashing head data: %w", err)
-		reasonForInvalidity := ExecutionError
-		return &ValidationResult{Invalid: &reasonForInvalidity}, nil
+		return &ValidationResult{Invalid: ExecutionError.Ptr()}, nil
 	}
 
 	if headDataHash != task.candidateReceipt.Descriptor.ParaHead {
-		reasonForInvalidity := ParaHeadHashMismatch
-		return &ValidationResult{Invalid: &reasonForInvalidity}, nil
+		return &ValidationResult{Invalid: ParaHeadHashMismatch.Ptr()}, nil
 	}
 	candidateCommitments := parachaintypes.CandidateCommitments{
 		UpwardMessages:            validationResult.UpwardMessages,
@@ -140,8 +136,7 @@ func (w *worker) executeRequest(task *workerTask) (*ValidationResult, error) {
 
 	// if validation produced a new set of commitments, we treat the candidate as invalid
 	if task.candidateReceipt.CommitmentsHash != candidateCommitments.Hash() {
-		reasonForInvalidity := CommitmentsHashMismatch
-		return &ValidationResult{Invalid: &reasonForInvalidity}, nil
+		return &ValidationResult{Invalid: CommitmentsHashMismatch.Ptr()}, nil
 	}
 
 	committedCandidateReceipt := parachaintypes.CommittedCandidateReceiptV2{
@@ -153,9 +148,7 @@ func (w *worker) executeRequest(task *workerTask) (*ValidationResult, error) {
 	err = committedCandidateReceipt.CheckCoreIndex(task.ClaimQueue.ToTransposed())
 	if err != nil {
 		logger.Warnf("checking core index: %s", err)
-
-		invalidCoreIndex := InvalidCoreIndex
-		return &ValidationResult{Invalid: &invalidCoreIndex}, nil
+		return &ValidationResult{Invalid: InvalidCoreIndex.Ptr()}, nil
 	}
 
 	pvd := parachaintypes.PersistedValidationData{

--- a/dot/parachain/candidate-validation/worker.go
+++ b/dot/parachain/candidate-validation/worker.go
@@ -24,6 +24,7 @@ type workerTask struct {
 	maxPoVSize       uint32
 	candidateReceipt *parachaintypes.CandidateReceiptV2
 	timeoutKind      parachaintypes.PvfExecTimeoutKind
+	ClaimQueue       parachaintypes.ClaimQueue
 }
 
 var ErrorPreCheckTimeout = errors.New("precheck timed out")
@@ -142,6 +143,21 @@ func (w *worker) executeRequest(task *workerTask) (*ValidationResult, error) {
 		reasonForInvalidity := CommitmentsHashMismatch
 		return &ValidationResult{Invalid: &reasonForInvalidity}, nil
 	}
+
+	committedCandidateReceipt := parachaintypes.CommittedCandidateReceiptV2{
+		Descriptor:  task.candidateReceipt.Descriptor,
+		Commitments: candidateCommitments,
+	}
+
+	// check if the core index is valid
+	err = committedCandidateReceipt.CheckCoreIndex(task.ClaimQueue.ToTransposed())
+	if err != nil {
+		logger.Warnf("checking core index: %s", err)
+
+		invalidCoreIndex := InvalidCoreIndex
+		return &ValidationResult{Invalid: &invalidCoreIndex}, nil
+	}
+
 	pvd := parachaintypes.PersistedValidationData{
 		ParentHead:             task.work.ParentHeadData,
 		RelayParentNumber:      task.work.RelayParentNumber,

--- a/dot/parachain/candidate-validation/worker_pool.go
+++ b/dot/parachain/candidate-validation/worker_pool.go
@@ -56,6 +56,12 @@ type Valid struct {
 
 type ReasonForInvalidity byte
 
+// Ptr returns a pointer to the ReasonForInvalidity value.
+func (ri ReasonForInvalidity) Ptr() *ReasonForInvalidity {
+	reason := ri
+	return &reason
+}
+
 const (
 	// ExecutionError Failed to execute `validate_block`. This includes function panicking.
 	ExecutionError ReasonForInvalidity = iota

--- a/dot/parachain/candidate-validation/worker_pool.go
+++ b/dot/parachain/candidate-validation/worker_pool.go
@@ -31,6 +31,7 @@ type ValidationTask struct {
 	ExecutorParams          parachaintypes.ExecutorParams
 	PvfExecTimeoutKind      parachaintypes.PvfExecTimeoutKind
 	ValidationCode          *parachaintypes.ValidationCode
+	ClaimQueue              parachaintypes.ClaimQueue
 }
 
 // ValidationResult represents the result coming from the candidate validation subsystem.
@@ -82,6 +83,10 @@ const (
 	CodeHashMismatch
 	// CommitmentsHashMismatch Validation has generated different candidate commitments.
 	CommitmentsHashMismatch
+	// InvalidSessionIndex The candidate receipt contains an invalid session index.
+	InvalidSessionIndex
+	// The candidate receipt contains an invalid core index.
+	InvalidCoreIndex
 )
 
 func (ci ReasonForInvalidity) Error() string {
@@ -112,6 +117,10 @@ func (ci ReasonForInvalidity) Error() string {
 		return "validation code hash does not match"
 	case CommitmentsHashMismatch:
 		return "validation has generated different candidate commitments"
+	case InvalidSessionIndex:
+		return "candidate receipt contains an invalid session index"
+	case InvalidCoreIndex:
+		return "candidate receipt contains an invalid core index"
 	default:
 		return "unknown invalidity reason"
 	}
@@ -173,6 +182,7 @@ func (v *workerPool) executeRequest(msg *ValidationTask) (*ValidationResult, err
 		maxPoVSize:       msg.PersistedValidationData.MaxPovSize,
 		candidateReceipt: msg.CandidateReceipt,
 		timeoutKind:      msg.PvfExecTimeoutKind,
+		ClaimQueue:       msg.ClaimQueue,
 	}
 	return worker.executeRequest(workTask)
 

--- a/dot/parachain/candidate-validation/worker_test.go
+++ b/dot/parachain/candidate-validation/worker_test.go
@@ -90,9 +90,6 @@ func Test_worker_executeRequest(t *testing.T) {
 	err = timeoutKind.SetValue(parachaintypes.Approval{})
 	require.NoError(t, err)
 
-	commitmentsHashMismatch := CommitmentsHashMismatch
-	timeout := Timeout
-
 	tests := map[string]struct {
 		instance parachain.ValidatorInstance
 		task     *workerTask
@@ -111,7 +108,7 @@ func Test_worker_executeRequest(t *testing.T) {
 				candidateReceipt: &candidateReceiptCommitmentsMismatch,
 			},
 			want: &ValidationResult{
-				Invalid: &commitmentsHashMismatch,
+				Invalid: CommitmentsHashMismatch.Ptr(),
 			},
 		},
 		"execution_timeout": {
@@ -120,7 +117,7 @@ func Test_worker_executeRequest(t *testing.T) {
 				candidateReceipt: &candidateReceipt,
 			},
 			want: &ValidationResult{
-				Invalid: &timeout,
+				Invalid: Timeout.Ptr(),
 			},
 		},
 		"long_timeout_ok": {

--- a/dot/parachain/types/types.go
+++ b/dot/parachain/types/types.go
@@ -1004,7 +1004,7 @@ func (c ClaimQueue) ToTransposed() TransposedClaimQueue {
 			coresPerDepth, exists := transposedClaimQueue[para]
 			if !exists {
 				coresPerDepth = make(map[uint8]map[CoreIndex]struct{})
-				transposedClaimQueue[para] = make(map[uint8]map[CoreIndex]struct{})
+				transposedClaimQueue[para] = coresPerDepth
 			}
 
 			// Get or initialize the core index set for this depth


### PR DESCRIPTION
## Changes
- ensure the session index in the candidate receipt is same as we get from the runtime.
- ensure the descriptor core index is equal to the committed core index.
- added test cases to test new logic.

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./dot/parachain/candidate-validation/... -timeout 2m
```

## Issues
Closes #4472 