### PR TITLE
feat(parachain/statement-distribution): Implement `groups`

### DIFF
--- a/dot/parachain/backing/statement_table.go
+++ b/dot/parachain/backing/statement_table.go
@@ -336,7 +336,7 @@ func (table *statementTable) attestedCandidate(
 
 	var validityThreshold uint
 	if group, ok := tableCtx.groups[parachaintypes.CoreIndex{Index: uint32(data.groupID)}]; ok {
-		validityThreshold = effectiveMinimumBackingVotes(uint(len(group)), minimumBackingVotes)
+		validityThreshold = EffectiveMinimumBackingVotes(uint(len(group)), minimumBackingVotes)
 	} else {
 		validityThreshold = math.MaxUint
 	}
@@ -344,10 +344,10 @@ func (table *statementTable) attestedCandidate(
 	return data.attested(validityThreshold)
 }
 
-// effectiveMinimumBackingVotes adjusts the configured needed backing votes with the size of the backing group.
+// EffectiveMinimumBackingVotes adjusts the configured needed backing votes with the size of the backing group.
 //
 // groupLen is the size of the backing group.
-func effectiveMinimumBackingVotes(groupLen uint, configuredMinimumBackingVotes uint32) uint {
+func EffectiveMinimumBackingVotes(groupLen uint, configuredMinimumBackingVotes uint32) uint {
 	return min(groupLen, uint(configuredMinimumBackingVotes))
 }
 

--- a/dot/parachain/statement-distribution/groups.go
+++ b/dot/parachain/statement-distribution/groups.go
@@ -1,0 +1,69 @@
+// Copyright 2025 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statementdistribution
+
+import (
+	"github.com/ChainSafe/gossamer/dot/parachain/backing"
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+)
+
+// groups tracks Validator groups within a session, plus some helpful indexing
+// for looking up groups by validator indices or authority discovery ID.
+type groups struct {
+	groups           [][]parachaintypes.ValidatorIndex
+	byValidatorIdx   map[parachaintypes.ValidatorIndex]parachaintypes.GroupIndex
+	backingThreshold uint32
+}
+
+func newGroups(initGroups [][]parachaintypes.ValidatorIndex, backingThreshold uint32) *groups {
+	if initGroups == nil {
+		initGroups = [][]parachaintypes.ValidatorIndex{}
+	}
+
+	bvi := make(map[parachaintypes.ValidatorIndex]parachaintypes.GroupIndex)
+
+	for groupIdx, group := range initGroups {
+		for _, validatorIdx := range group {
+			bvi[validatorIdx] = parachaintypes.GroupIndex(groupIdx)
+		}
+	}
+
+	return &groups{
+		groups:           initGroups,
+		byValidatorIdx:   bvi,
+		backingThreshold: backingThreshold,
+	}
+}
+
+func (g *groups) all() [][]parachaintypes.ValidatorIndex {
+	return g.groups
+}
+
+func (g *groups) group(groupIndex parachaintypes.GroupIndex) []parachaintypes.ValidatorIndex {
+	if int(groupIndex) > len(g.groups)-1 {
+		return nil
+	}
+
+	return g.groups[groupIndex]
+}
+
+func (g *groups) getSizeAndBackingThreshold(groupIndex parachaintypes.GroupIndex) (*uint32, *uint32) {
+	group := g.group(groupIndex)
+	if group == nil {
+		return nil, nil
+	}
+
+	size := uint32(len(group))
+	threshold := uint32(backing.EffectiveMinimumBackingVotes(uint(size), g.backingThreshold))
+	return &size, &threshold
+}
+
+func (g *groups) byValidatorIndex(validatorIndex parachaintypes.ValidatorIndex) *parachaintypes.GroupIndex {
+	groupIndex, ok := g.byValidatorIdx[validatorIndex]
+	if !ok {
+		return nil
+	}
+
+	return &groupIndex
+}

--- a/dot/parachain/statement-distribution/groups.go
+++ b/dot/parachain/statement-distribution/groups.go
@@ -40,7 +40,7 @@ func (g *groups) all() [][]parachaintypes.ValidatorIndex {
 	return g.groups
 }
 
-func (g *groups) group(groupIndex parachaintypes.GroupIndex) []parachaintypes.ValidatorIndex {
+func (g *groups) get(groupIndex parachaintypes.GroupIndex) []parachaintypes.ValidatorIndex {
 	if int(groupIndex) > len(g.groups)-1 {
 		return nil
 	}
@@ -49,7 +49,7 @@ func (g *groups) group(groupIndex parachaintypes.GroupIndex) []parachaintypes.Va
 }
 
 func (g *groups) getSizeAndBackingThreshold(groupIndex parachaintypes.GroupIndex) (*uint32, *uint32) {
-	group := g.group(groupIndex)
+	group := g.get(groupIndex)
 	if group == nil {
 		return nil, nil
 	}

--- a/dot/parachain/statement-distribution/groups_test.go
+++ b/dot/parachain/statement-distribution/groups_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package statementdistribution
+
+import (
+	"testing"
+
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGroups(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_groups", func(t *testing.T) {
+		t.Parallel()
+
+		emptyGroups := [][]parachaintypes.ValidatorIndex{}
+
+		g := newGroups(emptyGroups, 2)
+
+		assert.NotNil(t, g)
+		assert.Empty(t, g.groups)
+		assert.Empty(t, g.byValidatorIdx)
+		assert.Equal(t, uint32(2), g.backingThreshold)
+	})
+
+	t.Run("nil_groups", func(t *testing.T) {
+		t.Parallel()
+
+		g := newGroups(nil, 2)
+
+		assert.NotNil(t, g)
+		assert.NotNil(t, g.groups)
+		assert.Empty(t, g.groups)
+		assert.Empty(t, g.byValidatorIdx)
+		assert.Equal(t, uint32(2), g.backingThreshold)
+	})
+
+	t.Run("non_empty_groups", func(t *testing.T) {
+		t.Parallel()
+
+		initGroups := [][]parachaintypes.ValidatorIndex{
+			{0, 1, 2},
+			{3, 4, 5},
+		}
+
+		g := newGroups(initGroups, 3)
+
+		assert.NotNil(t, g)
+		assert.Equal(t, initGroups, g.groups)
+		assert.Len(t, g.byValidatorIdx, 6)
+		assert.Equal(t, uint32(3), g.backingThreshold)
+	})
+}
+
+func TestGroups_All(t *testing.T) {
+	t.Parallel()
+
+	initGroups := [][]parachaintypes.ValidatorIndex{
+		{0, 1, 2},
+		{3, 4, 5},
+	}
+	g := newGroups(initGroups, 2)
+
+	result := g.all()
+
+	assert.Equal(t, initGroups, result)
+}
+
+func TestGroups_Group(t *testing.T) {
+	t.Parallel()
+
+	initGroups := [][]parachaintypes.ValidatorIndex{
+		{0, 1, 2},
+		{3, 4, 5},
+	}
+	g := newGroups(initGroups, 2)
+
+	t.Run("valid_group_indices", func(t *testing.T) {
+		t.Parallel()
+
+		group0 := g.group(0)
+
+		assert.Equal(t, initGroups[0], group0)
+
+		group1 := g.group(1)
+
+		assert.Equal(t, initGroups[1], group1)
+	})
+
+	t.Run("invalid_group_index", func(t *testing.T) {
+		t.Parallel()
+
+		invalidGroup := g.group(2)
+
+		assert.Nil(t, invalidGroup)
+	})
+}
+
+func TestGroups_GetSizeAndBackingThreshold(t *testing.T) {
+	t.Parallel()
+
+	initGroups := [][]parachaintypes.ValidatorIndex{
+		{0, 1, 2},
+	}
+	g := newGroups(initGroups, 2)
+
+	t.Run("valid_group_index", func(t *testing.T) {
+		t.Parallel()
+
+		size, threshold := g.getSizeAndBackingThreshold(0)
+
+		assert.NotNil(t, size)
+		assert.NotNil(t, threshold)
+		assert.Equal(t, uint32(3), *size)
+		assert.NotNil(t, threshold)
+	})
+
+	t.Run("invalid_group_index", func(t *testing.T) {
+		t.Parallel()
+
+		size, threshold := g.getSizeAndBackingThreshold(3)
+
+		assert.Nil(t, size)
+		assert.Nil(t, threshold)
+	})
+}
+
+func TestGroups_ByValidatorIndex(t *testing.T) {
+	t.Parallel()
+
+	initGroups := [][]parachaintypes.ValidatorIndex{
+		{0, 1, 2},
+		{3, 4, 5},
+	}
+	g := newGroups(initGroups, 2)
+
+	t.Run("valid_validator_index", func(t *testing.T) {
+		t.Parallel()
+
+		groupIndex := g.byValidatorIndex(4)
+
+		assert.NotNil(t, groupIndex)
+		expectedGroupIdx := parachaintypes.GroupIndex(1)
+		assert.Equal(t, expectedGroupIdx, *groupIndex)
+	})
+
+	t.Run("invalid_validator_index", func(t *testing.T) {
+		t.Parallel()
+
+		groupIndex := g.byValidatorIndex(6)
+
+		assert.Nil(t, groupIndex)
+	})
+}

--- a/dot/parachain/statement-distribution/groups_test.go
+++ b/dot/parachain/statement-distribution/groups_test.go
@@ -55,7 +55,7 @@ func TestNewGroups(t *testing.T) {
 	})
 }
 
-func TestGroups_All(t *testing.T) {
+func TestGroups_all(t *testing.T) {
 	t.Parallel()
 
 	initGroups := [][]parachaintypes.ValidatorIndex{
@@ -69,7 +69,7 @@ func TestGroups_All(t *testing.T) {
 	assert.Equal(t, initGroups, result)
 }
 
-func TestGroups_Group(t *testing.T) {
+func TestGroups_get(t *testing.T) {
 	t.Parallel()
 
 	initGroups := [][]parachaintypes.ValidatorIndex{
@@ -81,11 +81,11 @@ func TestGroups_Group(t *testing.T) {
 	t.Run("valid_group_indices", func(t *testing.T) {
 		t.Parallel()
 
-		group0 := g.group(0)
+		group0 := g.get(0)
 
 		assert.Equal(t, initGroups[0], group0)
 
-		group1 := g.group(1)
+		group1 := g.get(1)
 
 		assert.Equal(t, initGroups[1], group1)
 	})
@@ -93,13 +93,13 @@ func TestGroups_Group(t *testing.T) {
 	t.Run("invalid_group_index", func(t *testing.T) {
 		t.Parallel()
 
-		invalidGroup := g.group(2)
+		invalidGroup := g.get(2)
 
 		assert.Nil(t, invalidGroup)
 	})
 }
 
-func TestGroups_GetSizeAndBackingThreshold(t *testing.T) {
+func TestGroups_getSizeAndBackingThreshold(t *testing.T) {
 	t.Parallel()
 
 	initGroups := [][]parachaintypes.ValidatorIndex{
@@ -128,7 +128,7 @@ func TestGroups_GetSizeAndBackingThreshold(t *testing.T) {
 	})
 }
 
-func TestGroups_ByValidatorIndex(t *testing.T) {
+func TestGroups_byValidatorIndex(t *testing.T) {
 	t.Parallel()
 
 	initGroups := [][]parachaintypes.ValidatorIndex{

--- a/dot/parachain/statement-distribution/groups_test.go
+++ b/dot/parachain/statement-distribution/groups_test.go
@@ -16,7 +16,7 @@ func TestNewGroups(t *testing.T) {
 	t.Run("empty_groups", func(t *testing.T) {
 		t.Parallel()
 
-		emptyGroups := [][]parachaintypes.ValidatorIndex{}
+		var emptyGroups [][]parachaintypes.ValidatorIndex
 
 		g := newGroups(emptyGroups, 2)
 


### PR DESCRIPTION
## Changes

This PR adds an implementation of the `groups` utility used in the statement distribution subsystem.

## Tests

```sh
go test github.com/ChainSafe/gossamer/dot/parachain/statement-distribution
```

## Issues

#4615 