### PR TITLE
fix(dot/parachain/candidate-validation): avoid race condition in `TestHost_validate` test

### DIFF
--- a/dot/parachain/candidate-validation/host_test.go
+++ b/dot/parachain/candidate-validation/host_test.go
@@ -26,8 +26,6 @@ func TestHost_validate(t *testing.T) {
 	candidateReceiptCommitmentsMismatch.CommitmentsHash = common.MustHexToHash(
 		"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
 
-	pvfHost := newValidationHost()
-
 	bd, err := scale.Marshal(BlockDataInAdderParachain{
 		State: uint64(1),
 		Add:   uint64(1),
@@ -200,6 +198,7 @@ func TestHost_validate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
+			pvfHost := newValidationHost()
 			taskResult, err := pvfHost.validate(tt.validationTask)
 
 			require.NoError(t, err)


### PR DESCRIPTION
## Changes
create new `pvfHost` for each test case, instead of using shared `pvfHost` variable.

## Tests
```sh
 go test ./dot/parachain/candidate-validation -run TestHost_validate -race
```

## Issues
Fixes #4712 