### PR TITLE
update `CompactStatement` to not use generics

### DIFF
--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -87,15 +87,13 @@ type Valid CandidateHash
 func (s StatementVDT) CompactStatement() (any, error) {
 	switch s := s.inner.(type) {
 	case Valid:
-		v := Valid(s)
-		return &v, nil
+		return &CompactValid{inner: s}, nil
 	case Seconded:
 		hash, err := GetCandidateHash(CommittedCandidateReceiptV2(s))
 		if err != nil {
 			return nil, fmt.Errorf("getting candidate hash: %w", err)
 		}
-		sch := SecondedCandidateHash(hash)
-		return &sch, nil
+		return &CompactSeconded{inner: SecondedCandidateHash(hash)}, nil
 	}
 	return nil, fmt.Errorf("unsupported type")
 }
@@ -242,35 +240,44 @@ type CompactStatement interface {
 }
 
 var (
-	_ CompactStatement = (*Valid)(nil)
-	_ CompactStatement = (*SecondedCandidateHash)(nil)
+	_ CompactStatement = (*CompactValid)(nil)
+	_ CompactStatement = (*CompactSeconded)(nil)
 )
 
-func (v *Valid) MarshalSCALE() ([]byte, error) {
-	return compactMarshalSCALE[Valid](*v)
+type CompactValid struct {
+	inner Valid
 }
 
-func (v *Valid) UnmarshalSCALE(reader io.Reader) error {
+type CompactSeconded struct {
+	inner SecondedCandidateHash
+}
+
+func (v *CompactValid) MarshalSCALE() ([]byte, error) {
+	return compactMarshalSCALE(v.inner)
+}
+
+func (v *CompactValid) UnmarshalSCALE(reader io.Reader) error {
 	decoded, err := compactUnmarshalSCALE[Valid](reader)
 	if err != nil {
 		return err
 	}
 
-	*v = decoded
+	v.inner = decoded
 	return nil
 }
 
-func (v *SecondedCandidateHash) MarshalSCALE() ([]byte, error) {
-	return compactMarshalSCALE[SecondedCandidateHash](*v)
+func (sch *CompactSeconded) MarshalSCALE() ([]byte, error) {
+	return compactMarshalSCALE(sch.inner)
 }
 
-func (v *SecondedCandidateHash) UnmarshalSCALE(reader io.Reader) error {
+func (sch *CompactSeconded) UnmarshalSCALE(reader io.Reader) error {
+	fmt.Printf("seconded unmarshal\n")
 	decoded, err := compactUnmarshalSCALE[SecondedCandidateHash](reader)
 	if err != nil {
 		return err
 	}
 
-	*v = decoded
+	sch.inner = decoded
 	return nil
 }
 
@@ -293,18 +300,22 @@ func compactMarshalSCALE[T CompactStatementValues](v T) ([]byte, error) {
 }
 
 func compactUnmarshalSCALE[T CompactStatementValues](reader io.Reader) (T, error) {
+	decoder := scale.NewDecoder(reader)
+
 	var magicBytes [4]byte
-	_, err := io.ReadFull(reader, magicBytes[:])
+	err := decoder.Decode(&magicBytes)
 	if err != nil {
-		return *new(T), fmt.Errorf("reading magic bytes: %w", err)
+		return *new(T), err
 	}
+
+	fmt.Println("magic bytes:", magicBytes)
 
 	if !bytes.Equal(magicBytes[:], backingStatementMagic[:]) {
 		return *new(T), fmt.Errorf("invalid magic bytes")
 	}
 
 	var inner compactStatementInner
-	err = scale.NewDecoder(reader).Decode(&inner)
+	err = decoder.Decode(&inner)
 	if err != nil {
 		return *new(T), fmt.Errorf("decoding compactStatementInner: %w", err)
 	}

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -87,13 +87,15 @@ type Valid CandidateHash
 func (s StatementVDT) CompactStatement() (any, error) {
 	switch s := s.inner.(type) {
 	case Valid:
-		return CompactStatement[Valid]{Value: s}, nil
+		v := Valid(s)
+		return &v, nil
 	case Seconded:
 		hash, err := GetCandidateHash(CommittedCandidateReceiptV2(s))
 		if err != nil {
 			return nil, fmt.Errorf("getting candidate hash: %w", err)
 		}
-		return CompactStatement[SecondedCandidateHash]{Value: SecondedCandidateHash(hash)}, nil
+		sch := SecondedCandidateHash(hash)
+		return &sch, nil
 	}
 	return nil, fmt.Errorf("unsupported type")
 }
@@ -234,13 +236,47 @@ func (mvdt compactStatementInner) ValueAt(index uint) (value any, err error) {
 
 // CompactStatement is a compact representation of a statement that can be made about parachain candidates.
 // this is the actual value that is signed.
-type CompactStatement[T CompactStatementValues] struct {
-	Value T
+type CompactStatement interface {
+	MarshalSCALE() ([]byte, error)
+	UnmarshalSCALE(reader io.Reader) error
 }
 
-func (c CompactStatement[CompactStatementValues]) MarshalSCALE() ([]byte, error) {
+var (
+	_ CompactStatement = (*Valid)(nil)
+	_ CompactStatement = (*SecondedCandidateHash)(nil)
+)
+
+func (v *Valid) MarshalSCALE() ([]byte, error) {
+	return compactMarshalSCALE[Valid](*v)
+}
+
+func (v *Valid) UnmarshalSCALE(reader io.Reader) error {
+	decoded, err := compactUnmarshalSCALE[Valid](reader)
+	if err != nil {
+		return err
+	}
+
+	*v = decoded
+	return nil
+}
+
+func (v *SecondedCandidateHash) MarshalSCALE() ([]byte, error) {
+	return compactMarshalSCALE[SecondedCandidateHash](*v)
+}
+
+func (v *SecondedCandidateHash) UnmarshalSCALE(reader io.Reader) error {
+	decoded, err := compactUnmarshalSCALE[SecondedCandidateHash](reader)
+	if err != nil {
+		return err
+	}
+
+	*v = decoded
+	return nil
+}
+
+func compactMarshalSCALE[T CompactStatementValues](v T) ([]byte, error) {
 	inner := compactStatementInner{}
-	err := inner.SetValue(c.Value)
+	err := inner.SetValue(v)
 	if err != nil {
 		return nil, fmt.Errorf("setting value: %w", err)
 	}
@@ -256,30 +292,27 @@ func (c CompactStatement[CompactStatementValues]) MarshalSCALE() ([]byte, error)
 	return buffer.Bytes(), nil
 }
 
-func (c *CompactStatement[CompactStatementValues]) UnmarshalSCALE(reader io.Reader) error {
-	decoder := scale.NewDecoder(reader)
-
+func compactUnmarshalSCALE[T CompactStatementValues](reader io.Reader) (T, error) {
 	var magicBytes [4]byte
-	err := decoder.Decode(&magicBytes)
+	_, err := io.ReadFull(reader, magicBytes[:])
 	if err != nil {
-		return err
+		return *new(T), fmt.Errorf("reading magic bytes: %w", err)
 	}
 
 	if !bytes.Equal(magicBytes[:], backingStatementMagic[:]) {
-		return fmt.Errorf("invalid magic bytes")
+		return *new(T), fmt.Errorf("invalid magic bytes")
 	}
 
 	var inner compactStatementInner
-	err = decoder.Decode(&inner)
+	err = scale.NewDecoder(reader).Decode(&inner)
 	if err != nil {
-		return fmt.Errorf("decoding compactStatementInner: %w", err)
+		return *new(T), fmt.Errorf("decoding compactStatementInner: %w", err)
 	}
 
 	value, err := inner.Value()
 	if err != nil {
-		return fmt.Errorf("getting value: %w", err)
+		return *new(T), fmt.Errorf("getting value: %w", err)
 	}
 
-	c.Value = value.(CompactStatementValues)
-	return nil
+	return value.(T), nil
 }

--- a/dot/parachain/types/statement.go
+++ b/dot/parachain/types/statement.go
@@ -271,7 +271,6 @@ func (sch *CompactSeconded) MarshalSCALE() ([]byte, error) {
 }
 
 func (sch *CompactSeconded) UnmarshalSCALE(reader io.Reader) error {
-	fmt.Printf("seconded unmarshal\n")
 	decoded, err := compactUnmarshalSCALE[SecondedCandidateHash](reader)
 	if err != nil {
 		return err
@@ -307,8 +306,6 @@ func compactUnmarshalSCALE[T CompactStatementValues](reader io.Reader) (T, error
 	if err != nil {
 		return *new(T), err
 	}
-
-	fmt.Println("magic bytes:", magicBytes)
 
 	if !bytes.Equal(magicBytes[:], backingStatementMagic[:]) {
 		return *new(T), fmt.Errorf("invalid magic bytes")

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -199,8 +199,6 @@ func TestCompactStatement(t *testing.T) {
 
 	for _, c := range testCases {
 		c := c
-		fmt.Println("spawning test for", c.name)
-
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -222,7 +220,6 @@ func TestCompactStatement(t *testing.T) {
 					require.NoError(t, err)
 					require.EqualValues(t, *expectedSatetement, actualStatement)
 				case *CompactSeconded:
-					fmt.Println("testing sch...")
 					var actualStatement CompactSeconded
 					err := scale.Unmarshal(c.encodingValue, &actualStatement)
 					require.NoError(t, err)

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -180,31 +180,27 @@ func TestCompactStatement(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		compactStatement any
+		compactStatement CompactStatement
 		encodingValue    []byte
-		expectedErr      error
 	}{
 		{
-			name: "SecondedCandidateHash",
-			compactStatement: CompactStatement[SecondedCandidateHash]{
-				Value: SecondedCandidateHash{Value: getDummyHash(6)},
-			},
+			name:             "SecondedCandidateHash",
+			compactStatement: &CompactSeconded{SecondedCandidateHash{Value: getDummyHash(6)}},
 			encodingValue: []byte{66, 75, 78, 71, 1,
 				6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6},
 		},
 		{
-			name: "Valid",
-			compactStatement: CompactStatement[Valid]{
-				Value: Valid{Value: getDummyHash(7)},
-			},
-			encodingValue: []byte{
-				66, 75, 78, 71, 2,
+			name:             "Valid",
+			compactStatement: &CompactValid{Valid{Value: getDummyHash(7)}},
+			encodingValue: []byte{66, 75, 78, 71, 2,
 				7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7},
 		},
 	}
 
 	for _, c := range testCases {
 		c := c
+		fmt.Println("spawning test for", c.name)
+
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -220,19 +216,19 @@ func TestCompactStatement(t *testing.T) {
 				t.Parallel()
 
 				switch expectedSatetement := c.compactStatement.(type) {
-				case CompactStatement[Valid]:
-					var actualStatement CompactStatement[Valid]
+				case *CompactValid:
+					var actualStatement CompactValid
 					err := scale.Unmarshal(c.encodingValue, &actualStatement)
 					require.NoError(t, err)
-					require.EqualValues(t, expectedSatetement, actualStatement)
-				case CompactStatement[SecondedCandidateHash]:
-					var actualStatement CompactStatement[SecondedCandidateHash]
+					require.EqualValues(t, *expectedSatetement, actualStatement)
+				case *CompactSeconded:
+					fmt.Println("testing sch...")
+					var actualStatement CompactSeconded
 					err := scale.Unmarshal(c.encodingValue, &actualStatement)
 					require.NoError(t, err)
-					require.EqualValues(t, expectedSatetement, actualStatement)
+					require.EqualValues(t, *expectedSatetement, actualStatement)
 				}
 			})
-
 		})
 	}
 }


### PR DESCRIPTION
## Changes

- Update the type `CompactStatement` to not use generics but to be an interface that is implement by `Valid` and `SecondedCandidateHash`, its only two variants.
- Theses changes enables the usage of `CompactStatement` inside the `StatementDistribution` subsystem w/o bringing the generics overhead.

## Tests

<!-- Detail how to run relevant tests to the changes -->

N/A

## Issues

N/A