### PR TITLE
feat(statement-distribution): implement `statement-store`

### DIFF
--- a/dot/parachain/statement-distribution/statement_store.go
+++ b/dot/parachain/statement-distribution/statement_store.go
@@ -2,7 +2,6 @@ package statementdistribution
 
 import (
 	"errors"
-	"slices"
 
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
 )
@@ -30,9 +29,7 @@ type storedStatement struct {
 type fingerprintKind byte
 
 const (
-	// CompactSeconded is a fingerprint for a Seconded statement.
 	fingerprintKindCompactSeconded fingerprintKind = iota
-	// CompactValid is a fingerprint for a Valid statement.
 	fingerprintKindCompactValid
 )
 
@@ -54,12 +51,12 @@ type groupStatements struct {
 }
 
 func newGroupStatements(size int) (*groupStatements, error) {
-	seconded, err := parachaintypes.NewBitVec(slices.Repeat([]bool{false}, size))
+	seconded, err := parachaintypes.NewBitVec(make([]bool, size))
 	if err != nil {
 		return nil, err
 	}
 
-	valid, err := parachaintypes.NewBitVec(slices.Repeat([]bool{false}, size))
+	valid, err := parachaintypes.NewBitVec(make([]bool, size))
 	if err != nil {
 		return nil, err
 	}
@@ -158,13 +155,10 @@ func (s *statements) insert(
 
 	candidateHash := compact.CandidateHash()
 
-	_, seconded := compact.(*parachaintypes.CompactSeconded)
-
 	// cross-reference updates
 	groupIndex := validatorMeta.groupIdx
 	group := groups.get(groupIndex)
 	if len(group) == 0 {
-		// log error: groups passed into insert differ from those used at store creation
 		logger.Errorf("groups passed into `insert` differ "+
 			"from those used at store creation, group index: %d", groupIndex)
 		return false, errValidatorUnknown
@@ -184,7 +178,7 @@ func (s *statements) insert(
 		s.groupStmts[key] = groupStmts
 	}
 
-	if seconded {
+	if _, ok := compact.(*parachaintypes.CompactSeconded); ok {
 		validatorMeta.secondedCount++
 		err = groupStmts.noteSeconded(validatorMeta.withinGroupIdx)
 		if err != nil {

--- a/dot/parachain/statement-distribution/statement_store.go
+++ b/dot/parachain/statement-distribution/statement_store.go
@@ -121,7 +121,7 @@ func (s *statements) insert(
 	groups *groups,
 	statement *parachaintypes.SignedStatement,
 	origin statementOrigin,
-) (bool, error) {
+) (bool, error) { //nolint:unparam
 	validatorIndex := statement.ValidatorIndex
 	validatorMeta, ok := s.validatorMeta[validatorIndex]
 	if !ok {
@@ -201,7 +201,7 @@ func (s *statements) insert(
 }
 
 // fillStatementFilter fills a StatementFilter with all statements already known for the given group and candidate hash.
-func (s *statements) fillStatementFilter(
+func (s *statements) fillStatementFilter( //nolint:unused
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
 	statementFilter *parachaintypes.StatementFilter,
@@ -218,7 +218,7 @@ func (s *statements) fillStatementFilter(
 
 // groupStatements returns all stored signed statements by the group conforming to the given filter.
 // Seconded statements are provided first.
-func (s *statements) groupStatements(
+func (s *statements) groupStatements( //nolint:unused
 	groups *groups,
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
@@ -230,7 +230,7 @@ func (s *statements) groupStatements(
 
 	// Seconded statements first
 	for _, i := range filter.SecondedInGroup.Ones() {
-		if int(i) < len(groupValidators) {
+		if i < len(groupValidators) {
 			v := groupValidators[i]
 			fp := fingerprint{
 				validator:     v,
@@ -245,7 +245,7 @@ func (s *statements) groupStatements(
 
 	// Then validated statements
 	for _, i := range filter.ValidatedInGroup.Ones() {
-		if int(i) < len(groupValidators) {
+		if i < len(groupValidators) {
 			v := groupValidators[i]
 			fp := fingerprint{
 				validator:     v,
@@ -262,7 +262,7 @@ func (s *statements) groupStatements(
 }
 
 // validatorStatement returns the full statement of this kind issued by this validator, if it is known.
-func (s *statements) validatorStatement(
+func (s *statements) validatorStatement( //nolint:unused
 	validatorIndex parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
 ) (*parachaintypes.SignedStatement, bool) {
@@ -280,7 +280,8 @@ func (s *statements) validatorStatement(
 	return sst.stmt, ok
 }
 
-// freshStatementsForBacking returns all statements for the given candidate hash and validators that are not yet known by backing.
+// freshStatementsForBacking returns all statements for the given candidate hash
+// and validators that are not yet known by backing.
 // Seconded statements are provided before Valid statements.
 func (s *statements) freshStatementsForBacking(
 	validators []parachaintypes.ValidatorIndex,
@@ -308,7 +309,9 @@ func (s *statements) freshStatementsForBacking(
 }
 
 // secondedCount returns the amount of known Seconded statements by the given validator index.
-func (s *statements) secondedCount(validatorIndex parachaintypes.ValidatorIndex) uint {
+func (s *statements) secondedCount( //nolint:unused
+	validatorIndex parachaintypes.ValidatorIndex,
+) uint {
 	if meta, ok := s.validatorMeta[validatorIndex]; ok {
 		return meta.secondedCount
 	}
@@ -316,7 +319,7 @@ func (s *statements) secondedCount(validatorIndex parachaintypes.ValidatorIndex)
 }
 
 // noteKnownByBacking marks a statement as known by the backing subsystem.
-func (s *statements) noteKnownByBacking(
+func (s *statements) noteKnownByBacking( //nolint:unused
 	validatorIndex parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
 ) {

--- a/dot/parachain/statement-distribution/statement_store.go
+++ b/dot/parachain/statement-distribution/statement_store.go
@@ -1,0 +1,337 @@
+package statementdistribution
+
+import (
+	"errors"
+	"slices"
+
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+)
+
+var errValidatorUnknown = errors.New("validator unknown")
+
+type statementOrigin byte
+
+func (o statementOrigin) isLocal() bool {
+	return o == statementOriginLocal
+}
+
+const (
+	// The statement originated locally.
+	statementOriginLocal statementOrigin = iota
+	// The statement originated from a remote peer.
+	statementOriginRemote
+)
+
+type storedStatement struct {
+	stmt           *parachaintypes.SignedStatement
+	knownByBacking bool
+}
+
+type fingerprintKind byte
+
+const (
+	// CompactSeconded is a fingerprint for a Seconded statement.
+	fingerprintKindCompactSeconded fingerprintKind = iota
+	// CompactValid is a fingerprint for a Valid statement.
+	fingerprintKindCompactValid
+)
+
+type fingerprint struct {
+	validator     parachaintypes.ValidatorIndex
+	kind          fingerprintKind
+	candidateHash parachaintypes.CandidateHash
+}
+
+type validatorMeta struct {
+	groupIdx       parachaintypes.GroupIndex
+	withinGroupIdx uint
+	secondedCount  uint
+}
+
+type groupStatements struct {
+	seconded parachaintypes.BitVec
+	valid    parachaintypes.BitVec
+}
+
+func newGroupStatements(size int) (*groupStatements, error) {
+	seconded, err := parachaintypes.NewBitVec(slices.Repeat([]bool{false}, size))
+	if err != nil {
+		return nil, err
+	}
+
+	valid, err := parachaintypes.NewBitVec(slices.Repeat([]bool{false}, size))
+	if err != nil {
+		return nil, err
+	}
+
+	return &groupStatements{
+		seconded: seconded,
+		valid:    valid,
+	}, nil
+}
+
+func (g *groupStatements) noteSeconded(index uint) error {
+	return g.seconded.Set(index, true)
+}
+
+func (g *groupStatements) noteValidated(index uint) error {
+	return g.valid.Set(index, true)
+}
+
+type groupAndCandidateHash struct {
+	groupIdx      parachaintypes.GroupIndex
+	candidateHash parachaintypes.CandidateHash
+}
+
+// Storage for statements. Intended to be used for statements signed under
+// the same relay-parent.
+type statements struct {
+	validatorMeta map[parachaintypes.ValidatorIndex]*validatorMeta
+
+	// we keep statements per-group because even though only one group _should_ be
+	// producing statements about a candidate, until we have the candidate receipt
+	// itself, we can't tell which group that is.
+	groupStmts map[groupAndCandidateHash]*groupStatements
+	knownStmts map[fingerprint]*storedStatement
+}
+
+func newStatementStore(groups *groups) *statements {
+	meta := map[parachaintypes.ValidatorIndex]*validatorMeta{}
+
+	for gIdx, validators := range groups.all() {
+		for vIdx, v := range validators {
+			meta[v] = &validatorMeta{
+				groupIdx:       parachaintypes.GroupIndex(gIdx),
+				withinGroupIdx: uint(vIdx),
+				secondedCount:  0,
+			}
+		}
+	}
+
+	return &statements{
+		validatorMeta: meta,
+		groupStmts:    make(map[groupAndCandidateHash]*groupStatements),
+		knownStmts:    make(map[fingerprint]*storedStatement),
+	}
+}
+
+// Insert adds a statement. Returns true if it was not known already, false if it was.
+// Ignores statements by unknown validators and returns an error.
+func (s *statements) insert(
+	groups *groups,
+	statement *parachaintypes.SignedStatement,
+	origin statementOrigin,
+) (bool, error) {
+	validatorIndex := statement.ValidatorIndex
+	validatorMeta, ok := s.validatorMeta[validatorIndex]
+	if !ok {
+		return false, errValidatorUnknown
+	}
+
+	compact, err := statement.Payload.ToCompact()
+	if err != nil {
+		return false, err
+	}
+
+	kind := fingerprintKindCompactSeconded // default to Seconded
+	if _, ok := compact.(*parachaintypes.CompactValid); ok {
+		kind = fingerprintKindCompactValid
+	}
+
+	fp := fingerprint{
+		validator:     validatorIndex,
+		kind:          kind,
+		candidateHash: compact.CandidateHash(),
+	}
+
+	if stored, exists := s.knownStmts[fp]; exists {
+		if origin.isLocal() {
+			stored.knownByBacking = true
+		}
+		return false, nil
+	} else {
+		s.knownStmts[fp] = &storedStatement{
+			stmt:           statement,
+			knownByBacking: origin.isLocal(),
+		}
+	}
+
+	candidateHash := compact.CandidateHash()
+
+	_, seconded := compact.(*parachaintypes.CompactSeconded)
+
+	// cross-reference updates
+	groupIndex := validatorMeta.groupIdx
+	group := groups.get(groupIndex)
+	if len(group) == 0 {
+		// log error: groups passed into insert differ from those used at store creation
+		logger.Errorf("groups passed into `insert` differ "+
+			"from those used at store creation, group index: %d", groupIndex)
+		return false, errValidatorUnknown
+	}
+
+	key := groupAndCandidateHash{
+		groupIdx:      groupIndex,
+		candidateHash: candidateHash,
+	}
+	groupStmts, ok := s.groupStmts[key]
+	if !ok {
+		gs, err := newGroupStatements(len(group))
+		if err != nil {
+			return false, err
+		}
+		groupStmts = gs
+		s.groupStmts[key] = groupStmts
+	}
+
+	if seconded {
+		validatorMeta.secondedCount++
+		err = groupStmts.noteSeconded(validatorMeta.withinGroupIdx)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		err = groupStmts.noteValidated(validatorMeta.withinGroupIdx)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+// fillStatementFilter fills a StatementFilter with all statements already known for the given group and candidate hash.
+func (s *statements) fillStatementFilter(
+	groupIndex parachaintypes.GroupIndex,
+	candidateHash parachaintypes.CandidateHash,
+	statementFilter *parachaintypes.StatementFilter,
+) {
+	key := groupAndCandidateHash{
+		groupIdx:      groupIndex,
+		candidateHash: candidateHash,
+	}
+	if statements, ok := s.groupStmts[key]; ok {
+		statementFilter.SecondedInGroup = statementFilter.SecondedInGroup.Or(statements.seconded)
+		statementFilter.ValidatedInGroup = statementFilter.ValidatedInGroup.Or(statements.valid)
+	}
+}
+
+// groupStatements returns all stored signed statements by the group conforming to the given filter.
+// Seconded statements are provided first.
+func (s *statements) groupStatements(
+	groups *groups,
+	groupIndex parachaintypes.GroupIndex,
+	candidateHash parachaintypes.CandidateHash,
+	filter *parachaintypes.StatementFilter,
+) []*parachaintypes.SignedStatement {
+	var result []*parachaintypes.SignedStatement
+
+	groupValidators := groups.get(groupIndex)
+
+	// Seconded statements first
+	for _, i := range filter.SecondedInGroup.Ones() {
+		if int(i) < len(groupValidators) {
+			v := groupValidators[i]
+			fp := fingerprint{
+				validator:     v,
+				kind:          fingerprintKindCompactSeconded,
+				candidateHash: candidateHash,
+			}
+			if sst, ok := s.knownStmts[fp]; ok {
+				result = append(result, sst.stmt)
+			}
+		}
+	}
+
+	// Then validated statements
+	for _, i := range filter.ValidatedInGroup.Ones() {
+		if int(i) < len(groupValidators) {
+			v := groupValidators[i]
+			fp := fingerprint{
+				validator:     v,
+				kind:          fingerprintKindCompactValid,
+				candidateHash: candidateHash,
+			}
+			if sst, ok := s.knownStmts[fp]; ok {
+				result = append(result, sst.stmt)
+			}
+		}
+	}
+
+	return result
+}
+
+// validatorStatement returns the full statement of this kind issued by this validator, if it is known.
+func (s *statements) validatorStatement(
+	validatorIndex parachaintypes.ValidatorIndex,
+	statement parachaintypes.CompactStatement,
+) (*parachaintypes.SignedStatement, bool) {
+	kind := fingerprintKindCompactSeconded // default to Seconded
+	if _, ok := statement.(*parachaintypes.CompactValid); ok {
+		kind = fingerprintKindCompactValid
+	}
+
+	fp := fingerprint{
+		validator:     validatorIndex,
+		kind:          kind,
+		candidateHash: statement.CandidateHash(),
+	}
+	sst, ok := s.knownStmts[fp]
+	return sst.stmt, ok
+}
+
+// freshStatementsForBacking returns all statements for the given candidate hash and validators that are not yet known by backing.
+// Seconded statements are provided before Valid statements.
+func (s *statements) freshStatementsForBacking(
+	validators []parachaintypes.ValidatorIndex,
+	candidateHash parachaintypes.CandidateHash,
+) []*parachaintypes.SignedStatement {
+	var result []*parachaintypes.SignedStatement
+
+	// First, fresh seconded
+	for _, v := range validators {
+		fp := fingerprint{validator: v, kind: fingerprintKindCompactSeconded, candidateHash: candidateHash}
+		if stored, ok := s.knownStmts[fp]; ok && !stored.knownByBacking {
+			result = append(result, stored.stmt)
+		}
+	}
+
+	// Then, fresh valid
+	for _, v := range validators {
+		fp := fingerprint{validator: v, kind: fingerprintKindCompactValid, candidateHash: candidateHash}
+		if stored, ok := s.knownStmts[fp]; ok && !stored.knownByBacking {
+			result = append(result, stored.stmt)
+		}
+	}
+
+	return result
+}
+
+// secondedCount returns the amount of known Seconded statements by the given validator index.
+func (s *statements) secondedCount(validatorIndex parachaintypes.ValidatorIndex) uint {
+	if meta, ok := s.validatorMeta[validatorIndex]; ok {
+		return meta.secondedCount
+	}
+	return 0
+}
+
+// noteKnownByBacking marks a statement as known by the backing subsystem.
+func (s *statements) noteKnownByBacking(
+	validatorIndex parachaintypes.ValidatorIndex,
+	statement parachaintypes.CompactStatement,
+) {
+	kind := fingerprintKindCompactSeconded // default to Seconded
+	if _, ok := statement.(*parachaintypes.CompactValid); ok {
+		kind = fingerprintKindCompactValid
+	}
+
+	fp := fingerprint{
+		validator:     validatorIndex,
+		kind:          kind,
+		candidateHash: statement.CandidateHash(),
+	}
+
+	if stored, ok := s.knownStmts[fp]; ok {
+		stored.knownByBacking = true
+	}
+}

--- a/dot/parachain/statement-distribution/statement_store_test.go
+++ b/dot/parachain/statement-distribution/statement_store_test.go
@@ -1,0 +1,69 @@
+package statementdistribution
+
+import (
+	"bytes"
+	"testing"
+
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlwaysProvidesFreshStatementsInOrder(t *testing.T) {
+	validatorA := parachaintypes.ValidatorIndex(1)
+	validatorB := parachaintypes.ValidatorIndex(2)
+	candidateHash := parachaintypes.CandidateHash{Value: common.Hash(bytes.Repeat([]byte{0x42}, 32))}
+
+	validStatement := parachaintypes.NewCompactValid(candidateHash)
+	secondedStatement := parachaintypes.NewCompactSeconded(candidateHash)
+
+	groups := newGroups([][]parachaintypes.ValidatorIndex{{validatorA, validatorB}}, 2)
+	store := newStatementStore(groups)
+
+	// Signed Valid by A
+	var sigA [64]byte
+	copy(sigA[:], bytes.Repeat([]byte{1}, 64))
+
+	signedValidByA := &parachaintypes.SignedStatement{
+		Payload:        *validStatement.ToEncodable(),
+		ValidatorIndex: validatorA,
+		Signature:      parachaintypes.ValidatorSignature(sigA),
+	}
+	_, err := store.insert(groups, signedValidByA, statementOriginRemote)
+	require.NoError(t, err)
+
+	// Signed Seconded by B
+	var sigB [64]byte
+	copy(sigB[:], bytes.Repeat([]byte{2}, 64))
+
+	signedSecondedByB := &parachaintypes.SignedStatement{
+		Payload:        *secondedStatement.ToEncodable(),
+		ValidatorIndex: validatorB,
+		Signature:      parachaintypes.ValidatorSignature(sigB),
+	}
+	_, err = store.insert(groups, signedSecondedByB, statementOriginRemote)
+	require.NoError(t, err)
+
+	// Regardless of the order statements are requested, we will get them in the order [B, A] because seconded statements must be first.
+	vals := []parachaintypes.ValidatorIndex{validatorA, validatorB}
+	statements := store.freshStatementsForBacking(vals, candidateHash)
+	require.Len(t, statements, 2)
+	cmp, err := statements[0].Payload.ToCompact()
+	require.NoError(t, err)
+	require.Equal(t, secondedStatement, cmp)
+
+	cmp, err = statements[1].Payload.ToCompact()
+	require.NoError(t, err)
+	require.Equal(t, validStatement, cmp)
+
+	vals = []parachaintypes.ValidatorIndex{validatorB, validatorA}
+	statements = store.freshStatementsForBacking(vals, candidateHash)
+	require.Len(t, statements, 2)
+	cmp, err = statements[0].Payload.ToCompact()
+	require.NoError(t, err)
+	require.Equal(t, secondedStatement, cmp)
+
+	cmp, err = statements[1].Payload.ToCompact()
+	require.NoError(t, err)
+	require.Equal(t, validStatement, cmp)
+}

--- a/dot/parachain/statement-distribution/statement_store_test.go
+++ b/dot/parachain/statement-distribution/statement_store_test.go
@@ -44,7 +44,8 @@ func TestAlwaysProvidesFreshStatementsInOrder(t *testing.T) {
 	_, err = store.insert(groups, signedSecondedByB, statementOriginRemote)
 	require.NoError(t, err)
 
-	// Regardless of the order statements are requested, we will get them in the order [B, A] because seconded statements must be first.
+	// Regardless of the order statements are requested, we will get them
+	// in the order [B, A] because seconded statements must be first.
 	vals := []parachaintypes.ValidatorIndex{validatorA, validatorB}
 	statements := store.freshStatementsForBacking(vals, candidateHash)
 	require.Len(t, statements, 2)

--- a/dot/parachain/types/bitvec.go
+++ b/dot/parachain/types/bitvec.go
@@ -238,6 +238,17 @@ func (bv *BitVec) CountOnes() int { // skipcq:GO-W1029
 	return count
 }
 
+// Ones returns the indices of all set bits (1s) in the BitVec following LSB0 ordering
+func (bv *BitVec) Ones() []int {
+	var ones []int
+	for i := 0; i < bv.len; i++ {
+		if bit, _ := bv.Get(uint(i)); bit {
+			ones = append(ones, i)
+		}
+	}
+	return ones
+}
+
 // Mask masks out bits according to the provided mask BitVec.
 // For each position, the bit is kept only if it was set and the mask bit is not set.
 // This implements the logic: (x, mask) => x && !mask

--- a/dot/parachain/types/bitvec_test.go
+++ b/dot/parachain/types/bitvec_test.go
@@ -4,6 +4,7 @@
 package parachaintypes
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/ChainSafe/gossamer/pkg/scale"
@@ -824,5 +825,36 @@ func TestBitVec_Or(t *testing.T) {
 
 		expected := []bool{true, true, false, true, true, true, false}
 		require.Equal(t, expected, result.Bits())
+	})
+}
+
+func TestBitVec_Ones(t *testing.T) {
+	t.Run("no_ones", func(t *testing.T) {
+		bv, err := NewBitVec(make([]bool, 16))
+		require.NoError(t, err)
+		require.Empty(t, bv.Ones())
+	})
+
+	t.Run("upper_half_ones", func(t *testing.T) {
+		bits := make([]bool, 16)
+		for i := 8; i < 16; i++ {
+			bits[i] = true
+		}
+
+		bv, err := NewBitVec(bits)
+		require.NoError(t, err)
+		require.Equal(t, []int{8, 9, 10, 11, 12, 13, 14, 15}, bv.Ones())
+	})
+
+	t.Run("all_ones", func(t *testing.T) {
+		bits := slices.Repeat([]bool{true}, 16)
+		bv, err := NewBitVec(bits)
+		require.NoError(t, err)
+
+		expected := make([]int, 16)
+		for i := 0; i < 16; i++ {
+			expected[i] = i
+		}
+		require.Equal(t, expected, bv.Ones())
 	})
 }


### PR DESCRIPTION
## Changes

- Implements the polkadot-sdk `statement-store` which is a store of all statements under a given relay-parent.
- Unblocks active leaves update

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -timeout 30s github.com/ChainSafe/gossamer/dot/parachain/statement-distribution -v
```

## Issues

- Closes https://github.com/ChainSafe/gossamer/issues/4719