### PR TITLE
feat(dot/parachain/provisioner): handle `RequestInherentData` overseer message

### DIFF
--- a/dot/parachain/provisioner/provisioner.go
+++ b/dot/parachain/provisioner/provisioner.go
@@ -94,7 +94,7 @@ func (p *Provisioner) processMessage(msg any) error {
 			logger.Errorf("processing active leaves update signal: %s", err)
 		}
 	case provisionermessages.RequestInherentData:
-		// TODO #4159
+		return p.requestInherentData(msg)
 	case provisionermessages.ProvisionableData:
 		p.processProvisionableData(msg)
 	default:
@@ -102,7 +102,6 @@ func (p *Provisioner) processMessage(msg any) error {
 	}
 
 	return nil
-
 }
 
 func (*Provisioner) Name() parachaintypes.SubSystemName {
@@ -148,6 +147,21 @@ func (p *Provisioner) processProvisionableData(provisionableData provisionermess
 		// via reputation changes. Punitive actions here may become desirable
 		// enough to dedicate time to in the future.
 	}
+}
+
+func (p *Provisioner) requestInherentData(msg provisionermessages.RequestInherentData) error {
+	perRP, exists := p.perRelayParent[msg.RelayParent]
+	if !exists {
+		return nil
+	}
+
+	if !perRP.isInherentReady {
+		perRP.awaitingInherent = append(perRP.awaitingInherent, msg.ProvisionerInherentData)
+		return nil
+	}
+
+	responseSenders := []chan provisionermessages.ProvisionerInherentData{msg.ProvisionerInherentData}
+	return p.sendInherentData(perRP.leaf, perRP.signedBitfields, responseSenders)
 }
 
 func (p *Provisioner) sendInherentData(
@@ -447,6 +461,6 @@ func bitfieldsIndicateAvailability(
 type perRelayParent struct {
 	leaf             *parachaintypes.ActivatedLeaf
 	signedBitfields  []parachaintypes.CheckedSignedAvailabilityBitfield
-	isInherentReady  bool                                               //nolint:unused
-	awaitingInherent []chan provisionermessages.ProvisionerInherentData //nolint:unused
+	isInherentReady  bool
+	awaitingInherent []chan provisionermessages.ProvisionerInherentData
 }

--- a/dot/parachain/provisioner/provisioner_test.go
+++ b/dot/parachain/provisioner/provisioner_test.go
@@ -1554,7 +1554,6 @@ func TestRequestInherentData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
 			msg := provisionermessages.RequestInherentData{
 				RelayParent:             common.Hash{1},
 				ProvisionerInherentData: make(chan provisionermessages.ProvisionerInherentData),

--- a/dot/parachain/provisioner/provisioner_test.go
+++ b/dot/parachain/provisioner/provisioner_test.go
@@ -1495,3 +1495,94 @@ func hashFromU64BE(val uint64) common.Hash {
 	copy(h[common.HashLength-8:], b)
 	return h
 }
+
+func TestRequestInherentData(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		perRP map[common.Hash]*perRelayParent
+		//msg                provisionermessages.RequestInherentData
+		mockBlockState        func(*gomock.Controller) BlockState
+		expectErr             bool
+		expectAwaitInherit    bool
+		expectAwaitInheritLen int
+	}{
+		{
+			name:  "unknown_relay_parent",
+			perRP: map[common.Hash]*perRelayParent{},
+			mockBlockState: func(ctrl *gomock.Controller) BlockState {
+				return NewMockBlockState(ctrl)
+			},
+			expectErr: false,
+		},
+		{
+			name: "inherent_not_ready",
+			perRP: map[common.Hash]*perRelayParent{
+				{1}: {
+					leaf:            &parachaintypes.ActivatedLeaf{Hash: common.Hash{1}},
+					isInherentReady: false,
+				},
+			},
+			mockBlockState: func(ctrl *gomock.Controller) BlockState {
+				return NewMockBlockState(ctrl)
+			},
+			expectErr:          false,
+			expectAwaitInherit: true,
+		},
+		{
+			// This case triggers the sendInherentData method which has its own unit test.
+			// To avoid redundant testing, we simulate a GetRuntime error here.
+			name: "inherent_ready",
+			perRP: map[common.Hash]*perRelayParent{
+				{1}: {
+					leaf:            &parachaintypes.ActivatedLeaf{Hash: common.Hash{1}},
+					isInherentReady: true,
+					signedBitfields: []parachaintypes.CheckedSignedAvailabilityBitfield{},
+				},
+			},
+			mockBlockState: func(ctrl *gomock.Controller) BlockState {
+				bs := NewMockBlockState(ctrl)
+				bs.EXPECT().
+					GetRuntime(common.Hash{1}).
+					Return(nil, fmt.Errorf("mock runtime error")).
+					Times(1)
+				return bs
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := provisionermessages.RequestInherentData{
+				RelayParent:             common.Hash{1},
+				ProvisionerInherentData: make(chan provisionermessages.ProvisionerInherentData),
+			}
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			overseerChan := make(chan any)
+			bs := tc.mockBlockState(ctrl)
+			provisioner := New(overseerChan, bs)
+			provisioner.perRelayParent = tc.perRP
+
+			err := provisioner.requestInherentData(msg)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.expectAwaitInherit {
+				perRP := provisioner.perRelayParent[msg.RelayParent]
+				require.Len(t, perRP.awaitingInherent, 1)
+				require.Equal(t, msg.ProvisionerInherentData, perRP.awaitingInherent[0])
+			}
+		})
+	}
+}

--- a/dot/parachain/provisioner/provisioner_test.go
+++ b/dot/parachain/provisioner/provisioner_test.go
@@ -1500,13 +1500,11 @@ func TestRequestInherentData(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name  string
-		perRP map[common.Hash]*perRelayParent
-		//msg                provisionermessages.RequestInherentData
-		mockBlockState        func(*gomock.Controller) BlockState
-		expectErr             bool
-		expectAwaitInherit    bool
-		expectAwaitInheritLen int
+		name               string
+		perRP              map[common.Hash]*perRelayParent
+		mockBlockState     func(*gomock.Controller) BlockState
+		expectErr          bool
+		expectAwaitInherit bool
 	}{
 		{
 			name:  "unknown_relay_parent",
@@ -1554,7 +1552,6 @@ func TestRequestInherentData(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Changes
- Implement `requestInherentData` method of `provisioner` type.
- Write a Unit test for the same method.

## Tests
```sh
go test ./dot/parachain/provisioner/... -timeout 10s
```

## Issues
Closes #4159 