### PR TITLE
feat(dot/parachain/provisioner): process available inherent

### DIFF
--- a/dot/parachain/provisioner/provisioner.go
+++ b/dot/parachain/provisioner/provisioner.go
@@ -59,11 +59,7 @@ type Provisioner struct {
 	subSystemToOverseer chan<- any
 	blockState          BlockState
 	perRelayParent      map[common.Hash]*perRelayParent
-
-	// TODO #4162
-	// This doesn't have to be a channel with buffer.
-	// The idea is to send a relay parent hash on this channel after INHERENT_TIMEOUT, open to design changes
-	availableInherent chan common.Hash
+	availableInherent   chan common.Hash
 }
 
 func (p *Provisioner) Run(ctx context.Context, overseerToSubSystem <-chan any) {
@@ -79,9 +75,12 @@ func (p *Provisioner) Run(ctx context.Context, overseerToSubSystem <-chan any) {
 			if err != nil {
 				logger.Errorf("processing overseer message: %s", err)
 			}
-		case <-p.availableInherent:
-			// This inherentAfterDelay gets populated while handling active leaves update signal
-			// TODO #4162
+		case activatedLeafHash := <-p.availableInherent:
+			// we receive this hash from ProcessActiveLeavesUpdateSignal method.
+			err := p.processAvailableInherent(activatedLeafHash)
+			if err != nil {
+				logger.Errorf("processing available inherent for leaf %s: %s", activatedLeafHash, err)
+			}
 		}
 	}
 }
@@ -130,6 +129,22 @@ func (*Provisioner) ProcessBlockFinalizedSignal(parachaintypes.BlockFinalizedSig
 }
 
 func (*Provisioner) Stop() {}
+
+func (p *Provisioner) processAvailableInherent(relayParent common.Hash) error {
+	perRP, exists := p.perRelayParent[relayParent]
+	if !exists {
+		return nil
+	}
+
+	perRP.isInherentReady = true
+	responseSenders := perRP.awaitingInherent
+	perRP.awaitingInherent = nil
+
+	if len(responseSenders) > 0 {
+		return p.sendInherentData(perRP.leaf, perRP.signedBitfields, responseSenders)
+	}
+	return nil
+}
 
 func (p *Provisioner) processProvisionableData(provisionableData provisionermessages.ProvisionableData) {
 	state, exists := p.perRelayParent[provisionableData.RelayParent]

--- a/dot/parachain/provisioner/provisioner_test.go
+++ b/dot/parachain/provisioner/provisioner_test.go
@@ -1582,3 +1582,101 @@ func TestRequestInherentData(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessAvailableInherent(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		relayParent    common.Hash
+		perRP          map[common.Hash]*perRelayParent
+		mockBlockState func(*gomock.Controller) BlockState
+		expectErr      bool
+		validateState  func(*testing.T, *perRelayParent)
+	}{
+		{
+			name:        "relay_parent_not_exists",
+			relayParent: common.Hash{1},
+			perRP:       make(map[common.Hash]*perRelayParent),
+			mockBlockState: func(ctrl *gomock.Controller) BlockState {
+				return NewMockBlockState(ctrl)
+			},
+			expectErr: false,
+		},
+		{
+			name:        "no_awaiting_inherent",
+			relayParent: common.Hash{1},
+			perRP: map[common.Hash]*perRelayParent{
+				{1}: {
+					leaf:             &parachaintypes.ActivatedLeaf{Hash: common.Hash{1}},
+					signedBitfields:  []parachaintypes.CheckedSignedAvailabilityBitfield{},
+					isInherentReady:  false,
+					awaitingInherent: nil,
+				},
+			},
+			mockBlockState: func(ctrl *gomock.Controller) BlockState {
+				return NewMockBlockState(ctrl)
+			},
+			expectErr: false,
+			validateState: func(t *testing.T, perRP *perRelayParent) {
+				require.True(t, perRP.isInherentReady)
+				require.Empty(t, perRP.awaitingInherent)
+			},
+		},
+		{
+			// This case triggers the sendInherentData method which has its own unit test.
+			// To avoid redundant testing, we simulate a GetRuntime error here.
+			name:        "with_awaiting_inherent_get_runtime_error",
+			relayParent: common.Hash{1},
+			perRP: map[common.Hash]*perRelayParent{
+				{1}: {
+					leaf:            &parachaintypes.ActivatedLeaf{Hash: common.Hash{1}},
+					signedBitfields: []parachaintypes.CheckedSignedAvailabilityBitfield{},
+					isInherentReady: false,
+					awaitingInherent: []chan provisionermessages.ProvisionerInherentData{
+						make(chan provisionermessages.ProvisionerInherentData),
+					},
+				},
+			},
+			mockBlockState: func(ctrl *gomock.Controller) BlockState {
+				bs := NewMockBlockState(ctrl)
+				bs.EXPECT().
+					GetRuntime(gomock.Any()).
+					Return(nil, fmt.Errorf("mock runtime error"))
+				return bs
+			},
+			expectErr: true,
+			validateState: func(t *testing.T, perRP *perRelayParent) {
+				require.True(t, perRP.isInherentReady)
+				require.Empty(t, perRP.awaitingInherent)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			overseerChan := make(chan any)
+			bs := tc.mockBlockState(ctrl)
+			provisioner := New(overseerChan, bs)
+			provisioner.perRelayParent = tc.perRP
+
+			err := provisioner.processAvailableInherent(tc.relayParent)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tc.validateState != nil {
+				perRP := provisioner.perRelayParent[tc.relayParent]
+				tc.validateState(t, perRP)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes
- Write a method to process the available inherent, after the 2-second delay that we already perform by having a sleep in the other method, which is to process active leaves updates.
- Write the unit test for the same method.

## Tests
```sh
go test ./dot/parachain/provisioner/... -v -timeout 10s 
```

## Issues
Closes #4162 