### PR TITLE
feat(statement-distribution): Finish `clusterTracker` implementation

### DIFF
--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -56,25 +56,25 @@ type rejectOutgoing interface { //nolint:unused
 }
 
 // candidateUnknownOutgoing means the candidate was unknown. Only applies to `Valid` statements.
-type candidateUnknownOutgoing struct{} //nolint:unused
+type candidateUnknownOutgoing struct{}
 
-func (candidateUnknownOutgoing) isRejectOutgoing() {} //nolint:unused
+func (candidateUnknownOutgoing) isRejectOutgoing() {}
 
 // excessiveSecondedOutgoing means we attempted to send excessive `Seconded` statements.
 // Indicates a bug on the local node's code.
-type excessiveSecondedOutgoing struct{} //nolint:unused
+type excessiveSecondedOutgoing struct{}
 
-func (excessiveSecondedOutgoing) isRejectOutgoing() {} //nolint:unused
+func (excessiveSecondedOutgoing) isRejectOutgoing() {}
 
 // knownOutgoing means the statement was already known to the peer.
-type knownOutgoing struct{} //nolint:unused
+type knownOutgoing struct{}
 
-func (knownOutgoing) isRejectOutgoing() {} //nolint:unused
+func (knownOutgoing) isRejectOutgoing() {}
 
 // notInGroupOutgoing means the target or originator are not in the group.
-type notInGroupOutgoing struct{} //nolint:unused
+type notInGroupOutgoing struct{}
 
-func (notInGroupOutgoing) isRejectOutgoing() {} //nolint:unused
+func (notInGroupOutgoing) isRejectOutgoing() {}
 
 type acceptOrRejectIncoming interface {
 	isAcceptOrRejectIncoming()
@@ -87,16 +87,16 @@ func (notInGroupIncoming) isAcceptOrRejectIncoming()        {}
 func (candidateUnknownIncoming) isAcceptOrRejectIncoming()  {}
 func (duplicateIncoming) isAcceptOrRejectIncoming()         {}
 
-type acceptOrRejectOutgoing interface { //nolint:unused
+type acceptOrRejectOutgoing interface {
 	isAcceptOrRejectOutgoing()
 }
 
 func (ok) isAcceptOrRejectOutgoing()                        {}
 func (withPrejudice) isAcceptOrRejectOutgoing()             {}
-func (candidateUnknownOutgoing) isAcceptOrRejectOutgoing()  {} //nolint:unused
-func (excessiveSecondedOutgoing) isAcceptOrRejectOutgoing() {} //nolint:unused
-func (knownOutgoing) isAcceptOrRejectOutgoing()             {} //nolint:unused
-func (notInGroupOutgoing) isAcceptOrRejectOutgoing()        {} //nolint:unused
+func (candidateUnknownOutgoing) isAcceptOrRejectOutgoing()  {}
+func (excessiveSecondedOutgoing) isAcceptOrRejectOutgoing() {}
+func (knownOutgoing) isAcceptOrRejectOutgoing()             {}
+func (notInGroupOutgoing) isAcceptOrRejectOutgoing()        {}
 
 // knowledge about a candidate
 type knowledge interface {
@@ -272,7 +272,7 @@ func (c *clusterTracker) canReceive(
 //
 // Should only be called after a successful [canReceive] call.
 func (c *clusterTracker) noteReceived(
-	sender parachaintypes.ValidatorIndex, //nolint:unparam
+	sender parachaintypes.ValidatorIndex,
 	originator parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
 ) {
@@ -407,4 +407,68 @@ func (c *clusterTracker) validatorSeconded(
 		}
 	}
 	return false
+}
+
+// canSend queries whether we can send a statement to a given validator.
+func (c *clusterTracker) canSend(
+	target parachaintypes.ValidatorIndex,
+	originator parachaintypes.ValidatorIndex, //nolint:unparam
+	statement parachaintypes.CompactStatement,
+) acceptOrRejectOutgoing {
+	if !c.isInGroup(target) || !c.isInGroup(originator) {
+		return notInGroupOutgoing{}
+	}
+
+	if c.theyKnowStatement(target, originator, statement) {
+		return knownOutgoing{}
+	}
+
+	switch statement.(type) {
+	case *parachaintypes.CompactSeconded:
+		// we send the same `Seconded` statements to all our peers, and only the first `k`
+		// from each originator.
+		if !c.secondedAlreadyOrWithinLimit(originator, statement.CandidateHash()) {
+			return excessiveSecondedOutgoing{}
+		}
+		return ok{}
+	case *parachaintypes.CompactValid:
+		if !c.knowsCandidate(target, statement.CandidateHash()) {
+			return candidateUnknownOutgoing{}
+		}
+		return ok{}
+	default:
+		panic("unreachable")
+	}
+}
+
+// noteSent notes that we sent an outgoing statement to a peer in the group.
+// This must be preceded by a successful `can_send` call.
+func (c *clusterTracker) noteSent(
+	target parachaintypes.ValidatorIndex,
+	originator parachaintypes.ValidatorIndex,
+	statement parachaintypes.CompactStatement,
+) {
+	targetKnowledge, ok := c.knowledge[target]
+	if !ok {
+		targetKnowledge = map[taggedKnowledge]struct{}{
+			outgoingP2P{specific{statement, originator}}: {},
+		}
+		c.knowledge[target] = targetKnowledge
+	}
+
+	if _, ok := statement.(*parachaintypes.CompactSeconded); ok {
+		targetKnowledge[outgoingP2P{general{statement.CandidateHash()}}] = struct{}{}
+
+		originatorKnowledge, ok := c.knowledge[originator]
+		if !ok {
+			originatorKnowledge = make(map[taggedKnowledge]struct{})
+		}
+
+		originatorKnowledge[seconded{statement.CandidateHash()}] = struct{}{}
+		c.knowledge[originator] = originatorKnowledge
+	}
+
+	if pending, ok := c.pending[target]; ok {
+		pending.remove(originator, statement)
+	}
 }

--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+	"github.com/ChainSafe/gossamer/lib/common"
 )
 
 // accept signifies that an incoming statement was accepted.
@@ -470,5 +471,58 @@ func (c *clusterTracker) noteSent(
 
 	if pending, ok := c.pending[target]; ok {
 		pending.remove(originator, statement)
+	}
+}
+
+// pendingStatementsFor returns a slice of pending statements to be sent to a particular validator.
+// `Seconded` statements are sorted to the front of the slice.
+func (c *clusterTracker) pendingStatementsFor(target parachaintypes.ValidatorIndex) []originatorStatementPair {
+	var seconded, valid []originatorStatementPair
+
+	pending, ok := c.pending[target]
+	if !ok {
+		return nil
+	}
+
+	for pair, _ := range pending {
+		switch pair.statement.(type) {
+		case *parachaintypes.CompactSeconded:
+			seconded = append(seconded, pair)
+		case *parachaintypes.CompactValid:
+			valid = append(valid, pair)
+		default:
+			panic("unreachable")
+		}
+	}
+
+	return append(seconded, valid...)
+}
+
+// warnIfTooManyStatements dumps pending statement for this cluster.
+//
+// Normally we should not have pending statements to validators in our cluster,
+// but if we do for all validators in our cluster, then we don't participate
+// in backing. Occasional pending statements are expected if two authorities
+// can't detect each other or after restart, where it takes a while to discover
+// the whole network.
+func (c *clusterTracker) warnIfTooManyStatements(parentHash common.Hash) {
+	count := 0
+	for _, set := range c.pending {
+		if len(set) > 0 {
+			count += 1
+		}
+	}
+
+	numValidators := len(c.validators)
+	if count >= numValidators &&
+		// No reason to warn if we are the only node in the cluster.
+		numValidators > 1 {
+		logger.Warnf(
+			"Cluster has too many pending statements, something wrong with our connection to our group peers "+
+				"Restart might be needed if validator gets 0 backing rewards for more than 3-4 consecutive sessions "+
+				"count=%d parentHash=%s",
+			count,
+			parentHash.String(),
+		)
 	}
 }

--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -373,6 +373,27 @@ func (c *clusterTracker) secondedAlreadyOrWithinLimit(
 	return secondedOtherCandidates < c.secondingLimit
 }
 
+// targets returns all targets as validator-indices. This doesn't attempt to filter
+// out the local validator index.
+func (c *clusterTracker) targets() []parachaintypes.ValidatorIndex {
+	return slices.Clone(c.validators)
+}
+
+// sendersForOriginator returns all possible senders for the given originator.
+// Returns the empty slice in the case that the originator
+// is not part of the cluster.
+// note: this API is future-proofing for a case where we may
+// extend clusters beyond just the assigned group, for optimization
+// purposes.
+func (c *clusterTracker) sendersForOriginator(
+	originator parachaintypes.ValidatorIndex,
+) []parachaintypes.ValidatorIndex {
+	if slices.Contains(c.validators, originator) {
+		return slices.Clone(c.validators)
+	}
+	return nil
+}
+
 // knowsCandidate queries whether a validator knows the candidate is `Seconded`.
 func (c *clusterTracker) knowsCandidate(
 	validator parachaintypes.ValidatorIndex,

--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -373,12 +373,6 @@ func (c *clusterTracker) secondedAlreadyOrWithinLimit(
 	return secondedOtherCandidates < c.secondingLimit
 }
 
-// targets returns all targets as validator-indices. This doesn't attempt to filter
-// out the local validator index.
-func (c *clusterTracker) targets() []parachaintypes.ValidatorIndex { //nolint:unused
-	return slices.Clone(c.validators)
-}
-
 // sendersForOriginator returns all possible senders for the given originator.
 // Returns the empty slice in the case that the originator
 // is not part of the cluster.

--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -375,7 +375,7 @@ func (c *clusterTracker) secondedAlreadyOrWithinLimit(
 
 // targets returns all targets as validator-indices. This doesn't attempt to filter
 // out the local validator index.
-func (c *clusterTracker) targets() []parachaintypes.ValidatorIndex {
+func (c *clusterTracker) targets() []parachaintypes.ValidatorIndex { //nolint:unused
 	return slices.Clone(c.validators)
 }
 
@@ -385,7 +385,7 @@ func (c *clusterTracker) targets() []parachaintypes.ValidatorIndex {
 // note: this API is future-proofing for a case where we may
 // extend clusters beyond just the assigned group, for optimization
 // purposes.
-func (c *clusterTracker) sendersForOriginator(
+func (c *clusterTracker) sendersForOriginator( //nolint:unused
 	originator parachaintypes.ValidatorIndex,
 ) []parachaintypes.ValidatorIndex {
 	if slices.Contains(c.validators, originator) {
@@ -403,6 +403,35 @@ func (c *clusterTracker) knowsCandidate(
 
 	return c.weSentSeconded(validator, candidateHash) || c.theySentSeconded(validator, candidateHash) ||
 		c.validatorSeconded(validator, candidateHash)
+}
+
+// canRequest queries whether a validator can request a candidate from us.
+func (c *clusterTracker) canRequest( //nolint:unused
+	target parachaintypes.ValidatorIndex,
+	candidateHash parachaintypes.CandidateHash,
+) bool {
+	return slices.Contains(c.validators, target) &&
+		c.weSentSeconded(target, candidateHash) &&
+		!c.theySentSeconded(target, candidateHash)
+}
+
+// noteIssued notes that we issued a statement. This updates internal structures.
+func (c *clusterTracker) noteIssued(
+	originator parachaintypes.ValidatorIndex,
+	statement parachaintypes.CompactStatement,
+) {
+	for _, clusterMember := range c.validators {
+		if !c.theyKnowStatement(clusterMember, originator, statement) {
+			// add the statement to pending knowledge for all peers
+			// which don't know the statement.
+			pending, ok := c.pending[clusterMember]
+			if !ok {
+				pending = make(originatorStatementPairSet)
+				c.pending[clusterMember] = pending
+			}
+			pending.insert(originator, statement)
+		}
+	}
 }
 
 func (c *clusterTracker) weSentSeconded(
@@ -434,7 +463,7 @@ func (c *clusterTracker) validatorSeconded(
 // canSend queries whether we can send a statement to a given validator.
 func (c *clusterTracker) canSend(
 	target parachaintypes.ValidatorIndex,
-	originator parachaintypes.ValidatorIndex, //nolint:unparam
+	originator parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
 ) acceptOrRejectOutgoing {
 	if !c.isInGroup(target) || !c.isInGroup(originator) {
@@ -505,7 +534,7 @@ func (c *clusterTracker) pendingStatementsFor(target parachaintypes.ValidatorInd
 		return nil
 	}
 
-	for pair, _ := range pending {
+	for pair := range pending {
 		switch pair.statement.(type) {
 		case *parachaintypes.CompactSeconded:
 			seconded = append(seconded, pair)
@@ -526,7 +555,7 @@ func (c *clusterTracker) pendingStatementsFor(target parachaintypes.ValidatorInd
 // in backing. Occasional pending statements are expected if two authorities
 // can't detect each other or after restart, where it takes a while to discover
 // the whole network.
-func (c *clusterTracker) warnIfTooManyStatements(parentHash common.Hash) {
+func (c *clusterTracker) warnIfTooManyStatements(parentHash common.Hash) { //nolint:unused
 	count := 0
 	for _, set := range c.pending {
 		if len(set) > 0 {

--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -379,11 +379,13 @@ func (c *clusterTracker) secondedAlreadyOrWithinLimit(
 // note: this API is future-proofing for a case where we may
 // extend clusters beyond just the assigned group, for optimization
 // purposes.
+// The method returns an internal datastructure of the object which
+// should be copied before mutating it.
 func (c *clusterTracker) sendersForOriginator( //nolint:unused
 	originator parachaintypes.ValidatorIndex,
 ) []parachaintypes.ValidatorIndex {
 	if slices.Contains(c.validators, originator) {
-		return slices.Clone(c.validators)
+		return c.validators
 	}
 	return nil
 }

--- a/dot/parachain/statement-distribution/cluster_tracker_test.go
+++ b/dot/parachain/statement-distribution/cluster_tracker_test.go
@@ -4,6 +4,8 @@
 package statementdistribution
 
 import (
+	"cmp"
+	"slices"
 	"testing"
 
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
@@ -360,6 +362,340 @@ func TestClusterTracker_send_statements(t *testing.T) {
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.NewCompactSeconded(hashA),
 			),
+		)
+	})
+}
+
+func TestClusterTracker_pendingStatementsFor(t *testing.T) {
+	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
+	secondingLimit := uint(1)
+	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
+	hashB := parachaintypes.CandidateHash{Value: common.Hash{0x2}}
+
+	// Test that the `pending_statements` are set whenever we receive a fresh statement.
+	//
+	// Also test that pending statements are sorted, with `Seconded` statements in the front.
+	t.Run("pending_statements_set_when_receiving_fresh_statements", func(t *testing.T) {
+		tracker := newClusterTracker(group, secondingLimit)
+
+		// Receive a 'Seconded' statement for candidate A.
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(5)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair(nil),
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(200)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(146)),
+		)
+
+		// Receive a 'Valid' statement for candidate A.
+
+		// First, send a `Seconded` statement for the candidate.
+		require.Equal(
+			t,
+			ok{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+
+		tracker.noteSent(
+			parachaintypes.ValidatorIndex(24),
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		// We have to see that the candidate is known by the sender, e.g. we sent them
+		// 'Seconded' above.
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.NewCompactValid(hashA),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(24),
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.NewCompactValid(hashA),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(5)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(200)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(146)),
+		)
+
+		// Receive a 'Seconded' statement for candidate B.
+
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.ValidatorIndex(146),
+				parachaintypes.NewCompactSeconded(hashB),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.ValidatorIndex(146),
+			parachaintypes.NewCompactSeconded(hashB),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(5)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(146), parachaintypes.NewCompactSeconded(hashB)},
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(200)),
+		)
+
+		sorter := func(a, b originatorStatementPair) int { return cmp.Compare(a.validatorIndex, b.validatorIndex) }
+		{
+			pendingStatements := tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24))
+			slices.SortFunc(pendingStatements, sorter)
+
+			require.Equal(
+				t,
+				[]originatorStatementPair{
+					{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+					{parachaintypes.ValidatorIndex(146), parachaintypes.NewCompactSeconded(hashB)},
+				},
+				pendingStatements,
+			)
+		}
+
+		{
+			pendingStatements := tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(146))
+			slices.SortFunc(pendingStatements, sorter)
+
+			require.Equal(
+				t,
+				[]originatorStatementPair{
+					{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+					{parachaintypes.ValidatorIndex(146), parachaintypes.NewCompactSeconded(hashB)},
+					{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashA)},
+				},
+				pendingStatements,
+			)
+		}
+	})
+
+	// Test that the `pending_statements` are updated when we send or receive statements from others
+	// in the cluster.
+	t.Run("pending_statements_updated_when_sending_statements", func(t *testing.T) {
+		tracker := newClusterTracker(group, secondingLimit)
+
+		// Receive a 'Seconded' statement for candidate A.
+
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		// Pending statements should be updated.
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(5)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair(nil),
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(200)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(146)),
+		)
+
+		// Receive a 'Valid' statement for candidate B.
+
+		// First, send a `Seconded` statement for the candidate.
+		require.Equal(
+			t,
+			ok{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.NewCompactSeconded(hashB),
+			),
+		)
+
+		tracker.noteSent(
+			parachaintypes.ValidatorIndex(24),
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.NewCompactSeconded(hashB),
+		)
+
+		// We have to see the candidate is known by the sender, e.g. we sent them 'Seconded'.
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.NewCompactValid(hashB),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(24),
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.NewCompactValid(hashB),
+		)
+
+		// Pending statements should be updated.
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashB)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(5)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashB)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(200)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24)),
+		)
+
+		require.Equal(
+			t,
+			[]originatorStatementPair{
+				{parachaintypes.ValidatorIndex(5), parachaintypes.NewCompactSeconded(hashA)},
+				{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactValid(hashB)},
+			},
+			tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(146)),
 		)
 	})
 }

--- a/dot/parachain/statement-distribution/cluster_tracker_test.go
+++ b/dot/parachain/statement-distribution/cluster_tracker_test.go
@@ -699,3 +699,52 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 		)
 	})
 }
+
+func TestClusterTracker_noteIssued(t *testing.T) {
+	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
+	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
+	tracker := newClusterTracker(group, 2)
+
+	// validator 24 knows the seconded statement from validator 200 about hashA
+	tracker.knowledge[parachaintypes.ValidatorIndex(24)] = map[taggedKnowledge]struct{}{
+		incomingP2P{
+			specific{
+				statement: parachaintypes.NewCompactSeconded(hashA),
+				validator: parachaintypes.ValidatorIndex(200),
+			},
+		}: {},
+	}
+
+	tracker.noteIssued(parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactSeconded(hashA))
+
+	require.Equal(
+		t,
+		[]originatorStatementPair{
+			{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactSeconded(hashA)},
+		},
+		tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(5)),
+	)
+
+	require.Equal(
+		t,
+		[]originatorStatementPair{
+			{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactSeconded(hashA)},
+		},
+		tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(200)),
+	)
+
+	// pending statement for validator 24 was not added because of preexisting knowledge
+	require.Equal(
+		t,
+		[]originatorStatementPair(nil),
+		tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(24)),
+	)
+
+	require.Equal(
+		t,
+		[]originatorStatementPair{
+			{parachaintypes.ValidatorIndex(200), parachaintypes.NewCompactSeconded(hashA)},
+		},
+		tracker.pendingStatementsFor(parachaintypes.ValidatorIndex(146)),
+	)
+}

--- a/dot/parachain/statement-distribution/cluster_tracker_test.go
+++ b/dot/parachain/statement-distribution/cluster_tracker_test.go
@@ -14,12 +14,16 @@ import (
 )
 
 func TestNewClusterTracker(t *testing.T) {
+	t.Parallel()
+
 	clusterTracker := newClusterTracker([]parachaintypes.ValidatorIndex{4, 6, 3, 9}, 3)
 	require.NotNil(t, clusterTracker)
 }
 
 // tests that cover clusterTracker.canReceive() and clusterTracker.noteReceived()
 func TestClusterTracker_receive_statements(t *testing.T) {
+	t.Parallel()
+
 	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
 	secondingLimit := uint(2)
 	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
@@ -27,6 +31,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 	hashC := parachaintypes.CandidateHash{Value: common.Hash{0x3}}
 
 	t.Run("rejects_incoming_outside_of_group", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		require.Equal(
@@ -51,6 +57,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 	})
 
 	t.Run("begrudgingly_accepts_too_many_seconded_from_multiple_peers", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		require.Equal(
@@ -97,6 +105,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 	})
 
 	t.Run("rejects_too_many_seconded_from_sender", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		require.Equal(
@@ -143,6 +153,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 	})
 
 	t.Run("rejects_duplicates", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		tracker.noteReceived(
@@ -179,6 +191,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 	})
 
 	t.Run("rejects_incoming_valid_without_seconded", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		require.Equal(
@@ -193,6 +207,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 	})
 
 	t.Run("accepts_incoming_valid_after_receiving_seconded", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		tracker.noteReceived(
@@ -215,6 +231,8 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 // tests that cover clusterTracker.canSend() and clusterTracker.noteSent()
 func TestClusterTracker_send_statements(t *testing.T) {
+	t.Parallel()
+
 	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
 	secondingLimit := uint(2)
 	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
@@ -222,6 +240,8 @@ func TestClusterTracker_send_statements(t *testing.T) {
 	hashC := parachaintypes.CandidateHash{Value: common.Hash{0x3}}
 
 	t.Run("accepts_incoming_valid_after_outgoing_seconded", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		tracker.noteSent(
@@ -242,6 +262,8 @@ func TestClusterTracker_send_statements(t *testing.T) {
 	})
 
 	t.Run("cannot_send_too_many_seconded_even_to_multiple_peers", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		tracker.noteSent(
@@ -278,6 +300,8 @@ func TestClusterTracker_send_statements(t *testing.T) {
 	})
 
 	t.Run("cannot_send_duplicate", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		tracker.noteSent(
@@ -298,6 +322,8 @@ func TestClusterTracker_send_statements(t *testing.T) {
 	})
 
 	t.Run("cannot_send_what_was_received", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		tracker.noteReceived(
@@ -319,6 +345,8 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 	// Ensure statements received with prejudice don't prevent sending later.
 	t.Run("can_send_statements_received_with_prejudice", func(t *testing.T) {
+		t.Parallel()
+
 		secondingLimit := uint(1)
 		tracker := newClusterTracker(group, secondingLimit)
 
@@ -367,6 +395,8 @@ func TestClusterTracker_send_statements(t *testing.T) {
 }
 
 func TestClusterTracker_pendingStatementsFor(t *testing.T) {
+	t.Parallel()
+
 	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
 	secondingLimit := uint(1)
 	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
@@ -376,6 +406,8 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 	//
 	// Also test that pending statements are sorted, with `Seconded` statements in the front.
 	t.Run("pending_statements_set_when_receiving_fresh_statements", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		// Receive a 'Seconded' statement for candidate A.
@@ -574,6 +606,8 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 	// Test that the `pending_statements` are updated when we send or receive statements from others
 	// in the cluster.
 	t.Run("pending_statements_updated_when_sending_statements", func(t *testing.T) {
+		t.Parallel()
+
 		tracker := newClusterTracker(group, secondingLimit)
 
 		// Receive a 'Seconded' statement for candidate A.
@@ -701,6 +735,8 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 }
 
 func TestClusterTracker_noteIssued(t *testing.T) {
+	t.Parallel()
+
 	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
 	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
 	tracker := newClusterTracker(group, 2)

--- a/dot/parachain/statement-distribution/cluster_tracker_test.go
+++ b/dot/parachain/statement-distribution/cluster_tracker_test.go
@@ -210,3 +210,156 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 		)
 	})
 }
+
+// tests that cover clusterTracker.canSend() and clusterTracker.noteSent()
+func TestClusterTracker_send_statements(t *testing.T) {
+	group := []parachaintypes.ValidatorIndex{5, 200, 24, 146}
+	secondingLimit := uint(2)
+	hashA := parachaintypes.CandidateHash{Value: common.Hash{0x1}}
+	hashB := parachaintypes.CandidateHash{Value: common.Hash{0x2}}
+	hashC := parachaintypes.CandidateHash{Value: common.Hash{0x3}}
+
+	t.Run("accepts_incoming_valid_after_outgoing_seconded", func(t *testing.T) {
+		tracker := newClusterTracker(group, secondingLimit)
+
+		tracker.noteSent(
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+	})
+
+	t.Run("cannot_send_too_many_seconded_even_to_multiple_peers", func(t *testing.T) {
+		tracker := newClusterTracker(group, secondingLimit)
+
+		tracker.noteSent(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		tracker.noteSent(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashB),
+		)
+
+		require.Equal(
+			t,
+			excessiveSecondedOutgoing{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashC),
+			),
+		)
+
+		require.Equal(
+			t,
+			excessiveSecondedOutgoing{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashC),
+			),
+		)
+	})
+
+	t.Run("cannot_send_duplicate", func(t *testing.T) {
+		tracker := newClusterTracker(group, secondingLimit)
+
+		tracker.noteSent(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		require.Equal(
+			t,
+			knownOutgoing{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+	})
+
+	t.Run("cannot_send_what_was_received", func(t *testing.T) {
+		tracker := newClusterTracker(group, secondingLimit)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		require.Equal(
+			t,
+			knownOutgoing{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+	})
+
+	// Ensure statements received with prejudice don't prevent sending later.
+	t.Run("can_send_statements_received_with_prejudice", func(t *testing.T) {
+		secondingLimit := uint(1)
+		tracker := newClusterTracker(group, secondingLimit)
+
+		require.Equal(
+			t,
+			ok{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(200),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(200),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashA),
+		)
+
+		require.Equal(
+			t,
+			withPrejudice{},
+			tracker.canReceive(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashB),
+			),
+		)
+
+		tracker.noteReceived(
+			parachaintypes.ValidatorIndex(24),
+			parachaintypes.ValidatorIndex(5),
+			parachaintypes.NewCompactSeconded(hashB),
+		)
+
+		require.Equal(
+			t,
+			ok{},
+			tracker.canSend(
+				parachaintypes.ValidatorIndex(24),
+				parachaintypes.ValidatorIndex(5),
+				parachaintypes.NewCompactSeconded(hashA),
+			),
+		)
+	})
+}

--- a/dot/parachain/statement-distribution/grid_tracker.go
+++ b/dot/parachain/statement-distribution/grid_tracker.go
@@ -47,7 +47,7 @@ func (o originatorStatementPairSet) insert(
 func (o originatorStatementPairSet) remove(
 	validatorIndex parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
-) bool {
+) bool { //nolint:unparam
 	for pair := range o {
 		if pair.validatorIndex == validatorIndex && pair.statement.Equals(statement) {
 			delete(o, pair)


### PR DESCRIPTION
## Changes

This PR contains the remaining functionality of `clusterTracker`, a utility type used in the statement distribution subsystem. It is based on #4772.

## Tests

```sh
go test ./dot/parachain/statement-distribution
```

## Issues

#4707 #4708 #4709 