### PR TITLE
feat(statement-distribution): Implement `handleIncomingManifestCommon()`

### DIFF
--- a/dot/parachain/statement-distribution/grid_tracker.go
+++ b/dot/parachain/statement-distribution/grid_tracker.go
@@ -23,6 +23,17 @@ const (
 	acknowledgement
 )
 
+func (mk manifestKind) String() string {
+	switch mk {
+	case full:
+		return "full"
+	case acknowledgement:
+		return "acknowledgement"
+	default:
+		panic("unreachable")
+	}
+}
+
 type validatorGroupPair struct {
 	validator parachaintypes.ValidatorIndex
 	group     parachaintypes.GroupIndex
@@ -95,7 +106,7 @@ func (g *gridTracker) importManifest( //skipcq: GO-R1005
 	sessionTopology *sessionTopologyView,
 	groups groups,
 	candidateHash parachaintypes.CandidateHash,
-	secondingLimit uint, //nolint:unparam
+	secondingLimit uint,
 	manifest manifestSummary,
 	kind manifestKind,
 	sender parachaintypes.ValidatorIndex,

--- a/dot/parachain/statement-distribution/mocks_generate_test.go
+++ b/dot/parachain/statement-distribution/mocks_generate_test.go
@@ -4,5 +4,4 @@
 package statementdistribution
 
 //go:generate mockgen -destination=mocks_implicitview_test.go -package=$GOPACKAGE github.com/ChainSafe/gossamer/dot/parachain/util ImplicitView
-//go:generate mockgen -destination=mocks_statement_store_test.go -package=$GOPACKAGE . statementStore
 //go:generate mockgen -destination=mocks_candidates_store_test.go -package=$GOPACKAGE . candidatesStore

--- a/dot/parachain/statement-distribution/mocks_statement_store_test.go
+++ b/dot/parachain/statement-distribution/mocks_statement_store_test.go
@@ -53,10 +53,10 @@ func (mr *MockstatementStoreMockRecorder) fillStatementFilter(arg0, arg1, arg2 a
 }
 
 // freshStatementsForBacking mocks base method.
-func (m *MockstatementStore) freshStatementsForBacking(validators []parachaintypes.ValidatorIndex, candidateHash parachaintypes.CandidateHash) []parachaintypes.SignedStatement {
+func (m *MockstatementStore) freshStatementsForBacking(validators []parachaintypes.ValidatorIndex, candidateHash parachaintypes.CandidateHash) []*parachaintypes.SignedStatement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "freshStatementsForBacking", validators, candidateHash)
-	ret0, _ := ret[0].([]parachaintypes.SignedStatement)
+	ret0, _ := ret[0].([]*parachaintypes.SignedStatement)
 	return ret0
 }
 
@@ -67,10 +67,10 @@ func (mr *MockstatementStoreMockRecorder) freshStatementsForBacking(validators, 
 }
 
 // groupStatements mocks base method.
-func (m *MockstatementStore) groupStatements(arg0 *groups, arg1 parachaintypes.GroupIndex, arg2 parachaintypes.CandidateHash, arg3 *parachaintypes.StatementFilter) []parachaintypes.SignedStatement {
+func (m *MockstatementStore) groupStatements(arg0 *groups, arg1 parachaintypes.GroupIndex, arg2 parachaintypes.CandidateHash, arg3 *parachaintypes.StatementFilter) []*parachaintypes.SignedStatement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "groupStatements", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].([]parachaintypes.SignedStatement)
+	ret0, _ := ret[0].([]*parachaintypes.SignedStatement)
 	return ret0
 }
 
@@ -93,15 +93,16 @@ func (mr *MockstatementStoreMockRecorder) noteKnownByBacking(arg0, arg1 any) *go
 }
 
 // validatorStatement mocks base method.
-func (m *MockstatementStore) validatorStatement(stmt originatorStatementPair) *parachaintypes.SignedStatement {
+func (m *MockstatementStore) validatorStatement(validatorIndex parachaintypes.ValidatorIndex, statement parachaintypes.CompactStatement) (*parachaintypes.SignedStatement, bool) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "validatorStatement", stmt)
+	ret := m.ctrl.Call(m, "validatorStatement", validatorIndex, statement)
 	ret0, _ := ret[0].(*parachaintypes.SignedStatement)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 // validatorStatement indicates an expected call of validatorStatement.
-func (mr *MockstatementStoreMockRecorder) validatorStatement(stmt any) *gomock.Call {
+func (mr *MockstatementStoreMockRecorder) validatorStatement(validatorIndex, statement any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "validatorStatement", reflect.TypeOf((*MockstatementStore)(nil).validatorStatement), stmt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "validatorStatement", reflect.TypeOf((*MockstatementStore)(nil).validatorStatement), validatorIndex, statement)
 }

--- a/dot/parachain/statement-distribution/session_topology_view.go
+++ b/dot/parachain/statement-distribution/session_topology_view.go
@@ -4,6 +4,7 @@
 package statementdistribution
 
 import (
+	"iter"
 	"maps"
 	"slices"
 
@@ -48,6 +49,31 @@ type sessionTopologyView struct {
 func newSessionTopologyView() *sessionTopologyView {
 	return &sessionTopologyView{
 		groupViews: make(map[parachaintypes.GroupIndex]groupSubView),
+	}
+}
+
+// iterSendingForGroup returns an iterator over all validator indices from the group who are allowed to
+// send us manifests of the given kind.
+func (stv *sessionTopologyView) iterSendingForGroup(
+	group parachaintypes.GroupIndex,
+	kind manifestKind,
+) iter.Seq[parachaintypes.ValidatorIndex] {
+	return func(yield func(parachaintypes.ValidatorIndex) bool) {
+		groupView, ok := stv.groupViews[group]
+		if !ok {
+			return
+		}
+
+		validators := groupView.receiving
+		if kind == acknowledgement {
+			validators = groupView.sending
+		}
+
+		for validatorIndex := range validators {
+			if !yield(validatorIndex) {
+				return
+			}
+		}
 	}
 }
 

--- a/dot/parachain/statement-distribution/session_topology_view_test.go
+++ b/dot/parachain/statement-distribution/session_topology_view_test.go
@@ -149,3 +149,77 @@ func TestBuildSessionTopology(t *testing.T) {
 		)
 	})
 }
+
+func TestSessionTopologyView_IterSendingForGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non_existent_group", func(t *testing.T) {
+		t.Parallel()
+
+		view := newSessionTopologyView()
+
+		var results []parachaintypes.ValidatorIndex
+		for i := range view.iterSendingForGroup(42, full) {
+			results = append(results, i)
+		}
+
+		// Should be empty since group doesn't exist
+		require.Empty(t, results)
+	})
+
+	t.Run("manifestKind_full", func(t *testing.T) {
+		t.Parallel()
+
+		view := newSessionTopologyView()
+
+		groupIdx := parachaintypes.GroupIndex(1)
+		view.groupViews[groupIdx] = groupSubView{
+			sending: map[parachaintypes.ValidatorIndex]struct{}{
+				5: {},
+				7: {},
+			},
+			receiving: map[parachaintypes.ValidatorIndex]struct{}{
+				1: {},
+				2: {},
+				3: {},
+			},
+		}
+
+		var results []parachaintypes.ValidatorIndex
+		for i := range view.iterSendingForGroup(groupIdx, full) {
+			results = append(results, i)
+		}
+
+		// For full manifest kind, should return indices from receiving map
+		require.Len(t, results, 3)
+		require.ElementsMatch(t, []parachaintypes.ValidatorIndex{1, 2, 3}, results)
+	})
+
+	t.Run("manifestKind_acknowledgement", func(t *testing.T) {
+		t.Parallel()
+
+		view := newSessionTopologyView()
+
+		groupIdx := parachaintypes.GroupIndex(1)
+		view.groupViews[groupIdx] = groupSubView{
+			sending: map[parachaintypes.ValidatorIndex]struct{}{
+				5: {},
+				7: {},
+			},
+			receiving: map[parachaintypes.ValidatorIndex]struct{}{
+				1: {},
+				2: {},
+				3: {},
+			},
+		}
+
+		var results []parachaintypes.ValidatorIndex
+		for i := range view.iterSendingForGroup(groupIdx, acknowledgement) {
+			results = append(results, i)
+		}
+
+		// For acknowledgement kind, should return indices from sending map
+		require.Len(t, results, 2)
+		require.ElementsMatch(t, []parachaintypes.ValidatorIndex{5, 7}, results)
+	})
+}

--- a/dot/parachain/statement-distribution/state_v2.go
+++ b/dot/parachain/statement-distribution/state_v2.go
@@ -114,7 +114,7 @@ func (s *perSessionState) supplyTopology(topology *grid.SessionGridTopology, loc
 		localIdx,
 	)
 	if err != nil {
-		logger.Errorf("Failed to build sessionTopologyView for validator index %d: %s", localIdx, err)
+		logger.Errorf("building sessionTopologyView for validator index %d: %s", localIdx, err)
 		return
 	}
 
@@ -128,7 +128,7 @@ func (s *perSessionState) supplyTopology(topology *grid.SessionGridTopology, loc
 
 // isNotValidator returns `true` if local is neither active or inactive validator node.
 //
-// `false` is also returned if session topology is not known yet.
+// returns `false` if session topology is not known yet.
 func (s *perSessionState) isNotValidator() bool {
 	return s.gridView != nil && s.localValidator == nil
 }

--- a/dot/parachain/statement-distribution/state_v2.go
+++ b/dot/parachain/statement-distribution/state_v2.go
@@ -37,12 +37,13 @@ type statementStore interface {
 // skipcq:SCC-U1000
 type perRelayParentState struct {
 	localValidator       *localValidatorStore
-	statementStore       statementStore // TODO #4719: Create statement store
+	statementStore       statementStore // TODO: Use statement store impl
 	secondingLimit       uint
 	session              parachaintypes.SessionIndex
 	transposedClaimQueue parachaintypes.TransposedClaimQueue
 	groupsPerPara        map[parachaintypes.ParaID][]parachaintypes.GroupIndex
 	disabledValidators   map[parachaintypes.ValidatorIndex]struct{}
+	assignmentsPerGroup  map[parachaintypes.GroupIndex][]parachaintypes.ParaID
 }
 
 // isDisabled returns `true` if the given validator is disabled in the context of the relay parent.
@@ -51,7 +52,7 @@ func (p *perRelayParentState) isDisabled(vIdx parachaintypes.ValidatorIndex) boo
 	return ok
 }
 
-func (p *perRelayParentState) disableBitmask(group []parachaintypes.ValidatorIndex) (parachaintypes.BitVec, error) {
+func (p *perRelayParentState) disabledBitmask(group []parachaintypes.ValidatorIndex) (parachaintypes.BitVec, error) {
 	disableBm := make([]bool, len(group))
 	for idx, v := range group {
 		disableBm[idx] = p.isDisabled(v)
@@ -83,7 +84,7 @@ type perSessionState struct {
 	sessionInfo parachaintypes.SessionInfo
 	groups      *groups
 	authLookup  map[parachaintypes.AuthorityDiscoveryID]parachaintypes.ValidatorIndex
-	gridView    any // TODO: use SessionTopologyView from statement-distribution grid (#4576)
+	gridView    *sessionTopologyView
 
 	// when localValidator is nil means it is inactive
 	localValidator     *parachaintypes.ValidatorIndex
@@ -123,19 +124,29 @@ func newPerSessionState(sessionInfo parachaintypes.SessionInfo,
 // discovery being a superset of the active validators for consensus.
 // skipcq:SCC-U1000
 func (s *perSessionState) supplyTopology(topology *grid.SessionGridTopology, localIdx *parachaintypes.ValidatorIndex) {
-	// TODO #4373: implement once buildSessionTopology is done
-	// gridView := buildSessionTopology(
-	// 	s.sessionInfo.ValidatorGroups,
-	// 	topology,
-	// 	localIdx,
-	// )
+	gridView, err := buildSessionTopology(
+		s.sessionInfo.ValidatorGroups,
+		topology,
+		localIdx,
+	)
+	if err != nil {
+		logger.Errorf("Failed to build sessionTopologyView for validator index %d: %s", localIdx, err)
+		return
+	}
 
-	// s.gridView = gridView
+	s.gridView = gridView
 
 	logger.Infof(
 		"Node uses the following topology indices: "+
 			"index_in_gossip_topology: %d, index_in_parachain_auths: %d",
 		localIdx, s.localValidator)
+}
+
+// isNotValidator returns `true` if local is neither active or inactive validator node.
+//
+// `false` is also returned if session topology is not known yet.
+func (s *perSessionState) isNotValidator() bool {
+	return s.gridView != nil && s.localValidator == nil
 }
 
 // skipcq:SCC-U1000

--- a/dot/parachain/statement-distribution/state_v2.go
+++ b/dot/parachain/statement-distribution/state_v2.go
@@ -18,26 +18,10 @@ type candidatesStore interface {
 	getConfirmed(candidateHash parachaintypes.CandidateHash) (*confirmedCandidate, bool)
 }
 
-type statementStore interface {
-	validatorStatement(stmt originatorStatementPair) *parachaintypes.SignedStatement
-
-	// freshStatementsForBacking provides a list of all statements marked as being
-	// unknown by the backing subsystem. This provides `Seconded` statements prior to `Valid` statements.
-	freshStatementsForBacking(validators []parachaintypes.ValidatorIndex,
-		candidateHash parachaintypes.CandidateHash) []parachaintypes.SignedStatement
-	noteKnownByBacking(parachaintypes.ValidatorIndex, parachaintypes.CompactStatement)
-	fillStatementFilter(parachaintypes.GroupIndex, parachaintypes.CandidateHash, *parachaintypes.StatementFilter)
-	// Get an iterator over stored signed statements by the group conforming to the
-	// given filter.
-	// Seconded statements are provided first.
-	groupStatements(*groups, parachaintypes.GroupIndex, parachaintypes.CandidateHash,
-		*parachaintypes.StatementFilter) []parachaintypes.SignedStatement
-}
-
 // skipcq:SCC-U1000
 type perRelayParentState struct {
 	localValidator       *localValidatorStore
-	statementStore       statementStore // TODO: Use statement store impl
+	statementStore       *statementStore
 	secondingLimit       uint
 	session              parachaintypes.SessionIndex
 	transposedClaimQueue parachaintypes.TransposedClaimQueue

--- a/dot/parachain/statement-distribution/statement_distribution.go
+++ b/dot/parachain/statement-distribution/statement_distribution.go
@@ -312,7 +312,7 @@ func (s *StatementDistribution) sendBackingFreshStatements(
 			panic(fmt.Sprintf("unexpected error setting Statement VDT: %s", err.Error()))
 		}
 
-		signed, err := compareAndConvert(freshStmt, convertedStmt, withPVD)
+		signed, err := compareAndConvert(*freshStmt, convertedStmt, withPVD)
 		if err != nil {
 			return fmt.Errorf("comparing and converting stmt: %w", err)
 		}
@@ -544,7 +544,7 @@ func localKnowledgeFilter(
 	groupSize int,
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
-	statementStore statementStore,
+	statementStore *statementStore, // Store,
 ) (*parachaintypes.StatementFilter, error) {
 	f, err := parachaintypes.NewStatementFilter(uint(groupSize), false)
 	if err != nil {
@@ -622,7 +622,7 @@ func postAcknowledgementStatementMessages(
 	recipient parachaintypes.ValidatorIndex,
 	rp common.Hash,
 	gridTracker *gridTracker,
-	stmtStore statementStore,
+	stmtStore *statementStore,
 	groups *groups,
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
@@ -648,7 +648,7 @@ func postAcknowledgementStatementMessages(
 			stmtMessage := validationprotocol.NewStatementDistributionMessage()
 			err := stmtMessage.SetValue(validationprotocol.Statement{
 				RelayParent: rp,
-				Compact:     parachaintypes.UncheckedSignedCompactStatement(stmt),
+				Compact:     parachaintypes.UncheckedSignedCompactStatement(*stmt),
 			})
 			if err != nil {
 				panic(fmt.Sprintf("failed while defining enum variant: %s", err.Error()))
@@ -671,14 +671,14 @@ func postAcknowledgementStatementMessages(
 }
 
 func pendingStatementNetworkMessage(
-	stmtStore statementStore,
+	stmtStore *statementStore,
 	rp common.Hash,
 	peerID peer.ID, validationVersion validationprotocol.ValidationVersion,
 	pending originatorStatementPair,
 ) *networkbridgemessages.SendValidationMessage {
 	if validationVersion == validationprotocol.ValidationVersionV3 {
-		signed := stmtStore.validatorStatement(pending)
-		if signed == nil {
+		signed, known := stmtStore.validatorStatement(pending.validatorIndex, pending.statement)
+		if !known || signed == nil {
 			return nil
 		}
 

--- a/dot/parachain/statement-distribution/statement_distribution.go
+++ b/dot/parachain/statement-distribution/statement_distribution.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ChainSafe/gossamer/dot/parachain/backing"
@@ -24,6 +25,48 @@ var (
 	errEncodedStatementsDoNotMatch = errors.New("encoded statements do not match")
 	errUnkownLocalValidator        = errors.New("unknown local validator")
 	errEmptyGroup                  = errors.New("group of validators empty")
+)
+
+var (
+	costConflictingManifest = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMajor,
+		Reason: "Manifest conflicts with previous",
+	}
+
+	costMalformedManifest = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMajor,
+		Reason: "Manifest is malformed",
+	}
+
+	costInsufficientManifest = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMajor,
+		Reason: "Manifest statements insufficient to back candidate",
+	}
+
+	costUnexpectedManifestDisallowed = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMinor,
+		Reason: "Unexpected Manifest, Peer Disallowed",
+	}
+
+	costUnexpectedManifestMissingKnowledge = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMinor,
+		Reason: "Unexpected Manifest, missing knowledge for relay parent",
+	}
+
+	costUnexpectedManifestPeerUnknown = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMinor,
+		Reason: "Unexpected Manifest, Peer Unknown",
+	}
+
+	costExcessiveSeconded = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMinor,
+		Reason: "Sent Excessive `Seconded` Statements",
+	}
+
+	costInaccurateAdvertisement = parachainutil.UnifiedReputationChange{ //nolint:unused
+		Type:   parachainutil.CostMajor,
+		Reason: "Peer advertised a candidate inaccurately",
+	}
 )
 
 var logger = log.NewFromGlobal(log.AddContext("pkg", "parachain-statement-distribution"))
@@ -292,6 +335,172 @@ func (s *StatementDistribution) sendBackingFreshStatements(
 	return nil
 }
 
+type manifestImportSuccess struct { //nolint:unused
+	relayParentState perRelayParentState
+	perSession       perSessionState
+	acknowledge      bool
+	senderIndex      parachaintypes.ValidatorIndex
+}
+
+// handleIncomingManifestCommon handles the common part of incoming manifests of both types (full & acknowledgement)
+//
+// Basic sanity checks around data, importing the manifest into the grid tracker, finding the
+// sending peer's validator index, reporting the peer for any misbehaviour, etc.
+func (s *StatementDistribution) handleIncomingManifestCommon( //nolint:unused
+	peer peer.ID,
+	peers map[peer.ID]peerState,
+	perRelayParent map[common.Hash]perRelayParentState,
+	perSession map[parachaintypes.SessionIndex]perSessionState,
+	candidates candidates,
+	candidateHash parachaintypes.CandidateHash,
+	relayParent common.Hash,
+	paraID parachaintypes.ParaID,
+	manifestSummary manifestSummary,
+	manifestKind manifestKind,
+	reputation *parachainutil.ReputationAggregator,
+) *manifestImportSuccess {
+	// 1. sanity checks: peer is connected, relay-parent in state, para ID matches group index.
+	peerState, ok := peers[peer]
+	if !ok {
+		return nil
+	}
+
+	relayParentState, ok := perRelayParent[relayParent]
+	if !ok {
+		reputation.Modify(s.SubSystemToOverseer, peer, costUnexpectedManifestMissingKnowledge)
+		return nil
+	}
+
+	perSessionEntry, ok := perSession[relayParentState.session]
+	if !ok {
+		return nil
+	}
+
+	if relayParentState.localValidator == nil {
+		if perSessionEntry.isNotValidator() {
+			reputation.Modify(s.SubSystemToOverseer, peer, costUnexpectedManifestMissingKnowledge)
+		}
+		return nil
+	}
+
+	expectedGroups, ok := relayParentState.groupsPerPara[paraID]
+	if !ok {
+		reputation.Modify(s.SubSystemToOverseer, peer, costMalformedManifest)
+		return nil
+	}
+
+	if !slices.Contains(expectedGroups, manifestSummary.claimedGroupIndex) {
+		reputation.Modify(s.SubSystemToOverseer, peer, costMalformedManifest)
+		return nil
+	}
+
+	gridTopology := perSessionEntry.gridView
+	if gridTopology == nil {
+		return nil
+	}
+
+	var senderIndex *parachaintypes.ValidatorIndex
+	for idx := range gridTopology.iterSendingForGroup(manifestSummary.claimedGroupIndex, manifestKind) {
+		if int(idx) >= len(perSessionEntry.sessionInfo.DiscoveryKeys) {
+			continue
+		}
+
+		ad := perSessionEntry.sessionInfo.DiscoveryKeys[idx]
+		if peerState.isAuthority(ad) {
+			senderIndex = &idx
+			break
+		}
+	}
+
+	if senderIndex == nil {
+		reputation.Modify(s.SubSystemToOverseer, peer, costUnexpectedManifestPeerUnknown)
+		return nil
+	}
+
+	// 2. sanity checks: peer is validator, bitvec size, import into grid tracker
+
+	// Ignore votes from disabled validators when counting towards the threshold.
+	groupIndex := manifestSummary.claimedGroupIndex
+	group := perSessionEntry.groups.get(groupIndex)
+	disabledMask, err := relayParentState.disabledBitmask(group)
+	if err != nil {
+		logger.Criticalf("perRelayParentState.disabledBitmask() failed in handleIncomingManifestCommon(): %s", err)
+		return nil
+	}
+
+	manifestSummary.statementKnowledge.MaskSeconded(disabledMask)
+	manifestSummary.statementKnowledge.MaskValid(disabledMask)
+
+	assignments, ok := relayParentState.assignmentsPerGroup[groupIndex]
+	if !ok {
+		return nil
+	}
+
+	var secondingLimit uint
+	for _, pID := range assignments {
+		if pID == paraID {
+			secondingLimit += 1
+		}
+	}
+
+	localValidator := *relayParentState.localValidator // non-nil check already done above
+	acknowledge, err := localValidator.gridTracker.importManifest(
+		gridTopology,
+		*perSessionEntry.groups,
+		candidateHash,
+		secondingLimit,
+		manifestSummary,
+		manifestKind,
+		*senderIndex,
+	)
+	switch err {
+	case errManifestImportConflicting:
+		reputation.Modify(s.SubSystemToOverseer, peer, costConflictingManifest)
+		return nil
+	case errManifestImportOverflow:
+		reputation.Modify(s.SubSystemToOverseer, peer, costExcessiveSeconded)
+		return nil
+	case errManifestImportInsufficient:
+		reputation.Modify(s.SubSystemToOverseer, peer, costInsufficientManifest)
+		return nil
+	case errManifestImportMalformed:
+		reputation.Modify(s.SubSystemToOverseer, peer, costMalformedManifest)
+		return nil
+	case errManifestImportDisallowed:
+		reputation.Modify(s.SubSystemToOverseer, peer, costUnexpectedManifestDisallowed)
+		return nil
+	default:
+	}
+
+	// 3. if accepted by grid, insert as unconfirmed.
+	if err = candidates.insertUnconfirmed(
+		peer,
+		candidateHash,
+		relayParent,
+		groupIndex,
+		&hashAndParaID{manifestSummary.claimedParentHash, paraID},
+	); errors.Is(err, errBadAdvertisement) {
+		reputation.Modify(s.SubSystemToOverseer, peer, costInaccurateAdvertisement)
+		return nil
+	}
+
+	if acknowledge {
+		logger.Tracef(
+			"immediate ack, known candidate: candidateHash=%s, from=%d, localIndex=%d, manifestKind=%s",
+			candidateHash.String(),
+			*senderIndex,
+			*perSessionEntry.localValidator,
+			manifestKind.String(),
+		)
+	}
+	return &manifestImportSuccess{
+		relayParentState: relayParentState,
+		perSession:       perSessionEntry,
+		acknowledge:      acknowledge,
+		senderIndex:      *senderIndex,
+	}
+}
+
 // compareAndConvert ensure the original compact statement matches
 // the same encoding as the converted statement and transforms the
 // converted statement into a SignedFullStatementWithPVD with the
@@ -417,7 +626,8 @@ func postAcknowledgementStatementMessages(
 	groups *groups,
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
-	peerID peer.ID, validationVersion validationprotocol.ValidationVersion,
+	peerID peer.ID,
+	validationVersion validationprotocol.ValidationVersion,
 ) []*networkbridgemessages.SendValidationMessage {
 	sendingFilter := gridTracker.pendingStatementsFor(recipient, candidateHash)
 	if sendingFilter == nil {

--- a/dot/parachain/statement-distribution/statement_distribution.go
+++ b/dot/parachain/statement-distribution/statement_distribution.go
@@ -28,42 +28,42 @@ var (
 )
 
 var (
-	costConflictingManifest = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costConflictingManifest = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMajor,
 		Reason: "Manifest conflicts with previous",
 	}
 
-	costMalformedManifest = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costMalformedManifest = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMajor,
 		Reason: "Manifest is malformed",
 	}
 
-	costInsufficientManifest = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costInsufficientManifest = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMajor,
 		Reason: "Manifest statements insufficient to back candidate",
 	}
 
-	costUnexpectedManifestDisallowed = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costUnexpectedManifestDisallowed = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMinor,
 		Reason: "Unexpected Manifest, Peer Disallowed",
 	}
 
-	costUnexpectedManifestMissingKnowledge = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costUnexpectedManifestMissingKnowledge = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMinor,
 		Reason: "Unexpected Manifest, missing knowledge for relay parent",
 	}
 
-	costUnexpectedManifestPeerUnknown = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costUnexpectedManifestPeerUnknown = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMinor,
 		Reason: "Unexpected Manifest, Peer Unknown",
 	}
 
-	costExcessiveSeconded = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costExcessiveSeconded = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMinor,
 		Reason: "Sent Excessive `Seconded` Statements",
 	}
 
-	costInaccurateAdvertisement = parachainutil.UnifiedReputationChange{ //nolint:unused
+	costInaccurateAdvertisement = parachainutil.UnifiedReputationChange{
 		Type:   parachainutil.CostMajor,
 		Reason: "Peer advertised a candidate inaccurately",
 	}
@@ -335,7 +335,7 @@ func (s *StatementDistribution) sendBackingFreshStatements(
 	return nil
 }
 
-type manifestImportSuccess struct { //nolint:unused
+type manifestImportSuccess struct {
 	relayParentState perRelayParentState
 	perSession       perSessionState
 	acknowledge      bool
@@ -346,7 +346,7 @@ type manifestImportSuccess struct { //nolint:unused
 //
 // Basic sanity checks around data, importing the manifest into the grid tracker, finding the
 // sending peer's validator index, reporting the peer for any misbehaviour, etc.
-func (s *StatementDistribution) handleIncomingManifestCommon( //nolint:unused
+func (s *StatementDistribution) handleIncomingManifestCommon(
 	peer peer.ID,
 	peers map[peer.ID]peerState,
 	perRelayParent map[common.Hash]perRelayParentState,

--- a/dot/parachain/statement-distribution/statement_distribution_test.go
+++ b/dot/parachain/statement-distribution/statement_distribution_test.go
@@ -19,8 +19,6 @@ import (
 
 func TestSendBackingFreshStatements(t *testing.T) {
 	t.Run("should_send_3_statements_to_backing", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
 		relayParent := common.Hash{0x01}
 		groupIndex := parachaintypes.GroupIndex(0)
 
@@ -35,14 +33,16 @@ func TestSendBackingFreshStatements(t *testing.T) {
 			validators,
 			{3, 4, 5},
 		}
+
+		groups := newGroups(initGroups, 1)
+
 		sessionState := &perSessionState{
-			groups: newGroups(initGroups, 1),
+			groups: groups,
 		}
 
-		stmtStore := NewMockstatementStore(ctrl)
-		stmtStore.EXPECT().
-			freshStatementsForBacking(validators, candidateHash).
-			Return([]parachaintypes.SignedStatement{
+		stmtStore := newStatementStore(groups)
+		{
+			stmts := []parachaintypes.SignedStatement{
 				parachaintypes.SignedStatement(
 					parachaintypes.UncheckedSignedCompactStatement{
 						ValidatorIndex: parachaintypes.ValidatorIndex(0),
@@ -64,17 +64,14 @@ func TestSendBackingFreshStatements(t *testing.T) {
 						Signature:      parachaintypes.ValidatorSignature{0x05, 0x05, 0x05},
 					},
 				),
-			})
+			}
 
-		stmtStore.EXPECT().
-			noteKnownByBacking(parachaintypes.ValidatorIndex(0),
-				parachaintypes.NewCompactSeconded(candidateHash))
-		stmtStore.EXPECT().
-			noteKnownByBacking(parachaintypes.ValidatorIndex(1),
-				parachaintypes.NewCompactValid(candidateHash))
-		stmtStore.EXPECT().
-			noteKnownByBacking(parachaintypes.ValidatorIndex(2),
-				parachaintypes.NewCompactValid(candidateHash))
+			for _, stmt := range stmts {
+				newStmt, err := stmtStore.insert(groups, &stmt, statementOriginRemote)
+				require.NoError(t, err)
+				require.True(t, newStmt)
+			}
+		}
 
 		relayParentState := &perRelayParentState{
 			statementStore: stmtStore,
@@ -152,8 +149,6 @@ func TestSendBackingFreshStatements(t *testing.T) {
 	})
 
 	t.Run("should_fail_when_confirmed_candidate_does_not_match", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-
 		relayParent := common.Hash{0x01}
 		groupIndex := parachaintypes.GroupIndex(0)
 
@@ -162,25 +157,33 @@ func TestSendBackingFreshStatements(t *testing.T) {
 		require.NoError(t, err)
 
 		candidateHash := parachaintypes.CandidateHash{Value: h}
+		groups := newGroups([][]parachaintypes.ValidatorIndex{{0, 1, 2}}, 1)
+
 		sessionState := &perSessionState{
-			groups: newGroups([][]parachaintypes.ValidatorIndex{{0, 1, 2}}, 1),
+			groups: groups,
 		}
 
-		stmtStore := NewMockstatementStore(ctrl)
+		stmtStore := newStatementStore(groups)
 		// returning a compact statement with a candidate hash
 		// that when encoded generates a different encoding from the
 		// confirmed candidate we passed to sendBackingFreshStatements
-		stmtStore.EXPECT().
-			freshStatementsForBacking([]parachaintypes.ValidatorIndex{0, 1, 2}, candidateHash).
-			Return([]parachaintypes.SignedStatement{
-				parachaintypes.SignedStatement(
-					parachaintypes.UncheckedSignedCompactStatement{
-						ValidatorIndex: parachaintypes.ValidatorIndex(0),
-						Payload: *parachaintypes.NewCompactSeconded(
-							parachaintypes.CandidateHash{Value: common.Hash{0xab, 0xab}}).ToEncodable(),
-					},
-				),
-			})
+		freshStmt := parachaintypes.SignedStatement(
+			parachaintypes.UncheckedSignedCompactStatement{
+				ValidatorIndex: parachaintypes.ValidatorIndex(0),
+				Payload: *parachaintypes.NewCompactSeconded(
+					parachaintypes.CandidateHash{Value: common.Hash{0xab, 0xab}}).ToEncodable(),
+			},
+		)
+
+		fp := fingerprint{
+			validator:     parachaintypes.ValidatorIndex(1),
+			kind:          fingerprintKindCompactSeconded,
+			candidateHash: candidateHash,
+		}
+		stmtStore.knownStmts[fp] = &storedStatement{
+			stmt:           &freshStmt,
+			knownByBacking: false,
+		}
 
 		relayParentState := &perRelayParentState{
 			statementStore: stmtStore,
@@ -316,24 +319,27 @@ func TestSendPendingGridMessages(t *testing.T) {
 		peerID := peer.ID("peer-ex")
 		v3 := validationprotocol.ValidationVersionV3
 
-		var f *parachaintypes.StatementFilter
-		stmtStoreMock := NewMockstatementStore(ctrl)
-		stmtStoreMock.EXPECT().
-			fillStatementFilter(
-				parachaintypes.GroupIndex(1),
-				parachaintypes.CandidateHash{Value: common.Hash{0x12}},
-				gomock.AssignableToTypeOf((*parachaintypes.StatementFilter)(nil)),
-			).
-			Do(func(_ parachaintypes.GroupIndex, _ parachaintypes.CandidateHash, filter *parachaintypes.StatementFilter) {
-				require.NoError(t, filter.SecondedInGroup.Set(1, true))
-				f = filter
-			})
+		stmtStore := newStatementStore(gps)
+
+		seconded, err := parachaintypes.NewBitVec([]bool{false, true, false})
+		require.NoError(t, err)
+
+		valid, err := parachaintypes.NewBitVec([]bool{false, false, false})
+		require.NoError(t, err)
+
+		stmtStore.groupStmts[groupAndCandidateHash{
+			groupIdx:      parachaintypes.GroupIndex(1),
+			candidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x12}},
+		}] = &groupStatements{
+			seconded,
+			valid,
+		}
 
 		rpState := &perRelayParentState{
 			localValidator: &localValidatorStore{
 				gridTracker: gt,
 			},
-			statementStore: stmtStoreMock,
+			statementStore: stmtStore,
 		}
 
 		overseer := make(chan any, 1)
@@ -341,7 +347,7 @@ func TestSendPendingGridMessages(t *testing.T) {
 			SubSystemToOverseer: overseer,
 		}
 
-		err := sd.sendPendingGridMessages(rpHash, peerID,
+		err = sd.sendPendingGridMessages(rpHash, peerID,
 			v3, peerValidatorID, gps,
 			rpState, candidatesMock,
 		)
@@ -350,31 +356,27 @@ func TestSendPendingGridMessages(t *testing.T) {
 		require.Len(t, overseer, 1)
 		outgoingMessage := <-overseer
 
-		// building the validation protocol exepected message
-		manifest := validationprotocol.BackedCandidateManifest{
-			RelayParent:        rpHash,
-			CandidateHash:      parachaintypes.CandidateHash{Value: common.Hash{0x12}},
-			GroupIndex:         parachaintypes.GroupIndex(1),
-			ParaID:             parachaintypes.ParaID(10),
-			ParentHeadDataHash: common.Hash(bytes.Repeat([]byte{0xbc}, 32)),
-			StatementKnowledge: *f,
-		}
+		svm, ok := outgoingMessage.(networkbridgemessages.SendValidationMessages)
+		require.True(t, ok)
+		require.Len(t, svm.Messages, 1)
 
-		sdm := validationprotocol.NewStatementDistributionMessage()
-		require.NoError(t, sdm.SetValue(manifest))
+		svmVal, err := svm.Messages[0].ValidationProtocolMessage.Value()
+		require.NoError(t, err)
 
-		expectedMessage := validationprotocol.NewValidationProtocolVDT()
-		require.NoError(t, expectedMessage.SetValue(
-			validationprotocol.StatementDistribution{StatementDistributionMessage: sdm}))
+		sdm, ok := svmVal.(validationprotocol.StatementDistribution)
+		require.True(t, ok)
 
-		require.Equal(t, networkbridgemessages.SendValidationMessages{
-			Messages: []*networkbridgemessages.SendValidationMessage{
-				{
-					To:                        []peer.ID{peerID},
-					ValidationProtocolMessage: expectedMessage,
-				},
-			},
-		}, outgoingMessage)
+		sdmVal, err := sdm.StatementDistributionMessage.Value()
+		require.NoError(t, err)
+
+		bcm, ok := sdmVal.(validationprotocol.BackedCandidateManifest)
+		require.True(t, ok)
+
+		require.Equal(t, rpHash, bcm.RelayParent)
+		require.Equal(t, parachaintypes.CandidateHash{Value: common.Hash{0x12}}, bcm.CandidateHash)
+		require.Equal(t, parachaintypes.GroupIndex(1), bcm.GroupIndex)
+		require.Equal(t, parachaintypes.ParaID(10), bcm.ParaID)
+		require.Equal(t, common.Hash(bytes.Repeat([]byte{0xbc}, 32)), bcm.ParentHeadDataHash)
 	})
 
 	t.Run("pending_full_and_ack_manifest_confirmed", func(t *testing.T) {
@@ -422,37 +424,38 @@ func TestSendPendingGridMessages(t *testing.T) {
 		peerID := peer.ID("peer-ex")
 		v3 := validationprotocol.ValidationVersionV3
 
-		var fstKnowledge *parachaintypes.StatementFilter
-		var sndKnowledge *parachaintypes.StatementFilter
+		stmtStore := newStatementStore(gps)
 
-		stmtStoreMock := NewMockstatementStore(ctrl)
-		stmtStoreMock.EXPECT().
-			fillStatementFilter(
-				parachaintypes.GroupIndex(1),
-				parachaintypes.CandidateHash{Value: common.Hash{0x12}},
-				gomock.AssignableToTypeOf((*parachaintypes.StatementFilter)(nil)),
-			).
-			Do(func(_ parachaintypes.GroupIndex, _ parachaintypes.CandidateHash, filter *parachaintypes.StatementFilter) {
-				require.NoError(t, filter.SecondedInGroup.Set(1, true))
-				fstKnowledge = filter
-			})
+		seconded, err := parachaintypes.NewBitVec([]bool{false, true, false})
+		require.NoError(t, err)
 
-		stmtStoreMock.EXPECT().
-			fillStatementFilter(
-				parachaintypes.GroupIndex(0),
-				parachaintypes.CandidateHash{Value: common.Hash{0xab}},
-				gomock.AssignableToTypeOf((*parachaintypes.StatementFilter)(nil)),
-			).
-			Do(func(_ parachaintypes.GroupIndex, _ parachaintypes.CandidateHash, filter *parachaintypes.StatementFilter) {
-				require.NoError(t, filter.SecondedInGroup.Set(0, true))
-				sndKnowledge = filter
-			})
+		valid, err := parachaintypes.NewBitVec([]bool{false, false, false})
+		require.NoError(t, err)
+
+		stmtStore.groupStmts[groupAndCandidateHash{
+			groupIdx:      parachaintypes.GroupIndex(1),
+			candidateHash: parachaintypes.CandidateHash{Value: common.Hash{0x12}},
+		}] = &groupStatements{
+			seconded,
+			valid,
+		}
+
+		seconded, err = parachaintypes.NewBitVec([]bool{true, false, false})
+		require.NoError(t, err)
+
+		stmtStore.groupStmts[groupAndCandidateHash{
+			groupIdx:      parachaintypes.GroupIndex(0),
+			candidateHash: parachaintypes.CandidateHash{Value: common.Hash{0xab}},
+		}] = &groupStatements{
+			seconded,
+			valid,
+		}
 
 		rpState := &perRelayParentState{
 			localValidator: &localValidatorStore{
 				gridTracker: gt,
 			},
-			statementStore: stmtStoreMock,
+			statementStore: stmtStore,
 		}
 
 		overseer := make(chan any, 1)
@@ -460,7 +463,7 @@ func TestSendPendingGridMessages(t *testing.T) {
 			SubSystemToOverseer: overseer,
 		}
 
-		err := sd.sendPendingGridMessages(rpHash, peerID,
+		err = sd.sendPendingGridMessages(rpHash, peerID,
 			v3, peerValidatorID, gps,
 			rpState, candidatesMock,
 		)
@@ -469,47 +472,51 @@ func TestSendPendingGridMessages(t *testing.T) {
 		require.Equal(t, 1, len(overseer))
 		outgoingMessage := <-overseer
 
-		// building the validation protocol exepected message
-		manifest := validationprotocol.BackedCandidateManifest{
-			RelayParent:        rpHash,
-			CandidateHash:      parachaintypes.CandidateHash{Value: common.Hash{0x12}},
-			GroupIndex:         parachaintypes.GroupIndex(1),
-			ParaID:             parachaintypes.ParaID(10),
-			ParentHeadDataHash: common.Hash(bytes.Repeat([]byte{0xbc}, 32)),
-			StatementKnowledge: *fstKnowledge,
+		svm, ok := outgoingMessage.(networkbridgemessages.SendValidationMessages)
+		require.True(t, ok)
+		require.Len(t, svm.Messages, 2)
+
+		firstSvm, err := svm.Messages[0].ValidationProtocolMessage.Value()
+		require.NoError(t, err)
+
+		firstSdm, ok := firstSvm.(validationprotocol.StatementDistribution)
+		require.True(t, ok)
+
+		firstSdmVal, err := firstSdm.StatementDistributionMessage.Value()
+		require.NoError(t, err)
+
+		secondSvm, err := svm.Messages[1].ValidationProtocolMessage.Value()
+		require.NoError(t, err)
+
+		secondSdm, ok := secondSvm.(validationprotocol.StatementDistribution)
+		require.True(t, ok)
+
+		secondSdmVal, err := secondSdm.StatementDistributionMessage.Value()
+		require.NoError(t, err)
+
+		var bcm validationprotocol.BackedCandidateManifest
+		var bck validationprotocol.BackedCandidateKnown
+
+		// order in svm.Messages is random
+		bcm, ok = firstSdmVal.(validationprotocol.BackedCandidateManifest)
+		if ok {
+			bck, ok = secondSdmVal.(validationprotocol.BackedCandidateKnown)
+			require.True(t, ok)
+		} else {
+			bck, ok = firstSdmVal.(validationprotocol.BackedCandidateKnown)
+			require.True(t, ok)
+
+			bcm, ok = secondSdmVal.(validationprotocol.BackedCandidateManifest)
+			require.True(t, ok)
 		}
 
-		ack := validationprotocol.BackedCandidateKnown{
-			CandidateHash:      parachaintypes.CandidateHash{Value: common.Hash{0xab}},
-			StatementKnowledge: *sndKnowledge,
-		}
+		require.Equal(t, rpHash, bcm.RelayParent)
+		require.Equal(t, parachaintypes.CandidateHash{Value: common.Hash{0x12}}, bcm.CandidateHash)
+		require.Equal(t, parachaintypes.GroupIndex(1), bcm.GroupIndex)
+		require.Equal(t, parachaintypes.ParaID(10), bcm.ParaID)
+		require.Equal(t, common.Hash(bytes.Repeat([]byte{0xbc}, 32)), bcm.ParentHeadDataHash)
 
-		manifestSDM := validationprotocol.NewStatementDistributionMessage()
-		require.NoError(t, manifestSDM.SetValue(manifest))
-
-		ackSDM := validationprotocol.NewStatementDistributionMessage()
-		require.NoError(t, ackSDM.SetValue(ack))
-
-		manifestVPMessage := validationprotocol.NewValidationProtocolVDT()
-		require.NoError(t, manifestVPMessage.SetValue(
-			validationprotocol.StatementDistribution{StatementDistributionMessage: manifestSDM}))
-
-		ackVPMessage := validationprotocol.NewValidationProtocolVDT()
-		require.NoError(t, ackVPMessage.SetValue(
-			validationprotocol.StatementDistribution{StatementDistributionMessage: ackSDM}))
-
-		require.Equal(t, networkbridgemessages.SendValidationMessages{
-			Messages: []*networkbridgemessages.SendValidationMessage{
-				{
-					To:                        []peer.ID{peerID},
-					ValidationProtocolMessage: manifestVPMessage,
-				},
-				{
-					To:                        []peer.ID{peerID},
-					ValidationProtocolMessage: ackVPMessage,
-				},
-			},
-		}, outgoingMessage)
+		require.Equal(t, parachaintypes.CandidateHash{Value: common.Hash{0xab}}, bck.CandidateHash)
 	})
 
 	// TODO: include tests for postAcknowledgementStatementMessages that

--- a/dot/parachain/statement-distribution/statement_distribution_test.go
+++ b/dot/parachain/statement-distribution/statement_distribution_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/ChainSafe/gossamer/dot/parachain/backing"
 	networkbridgemessages "github.com/ChainSafe/gossamer/dot/parachain/network-bridge/messages"
 	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+	"github.com/ChainSafe/gossamer/dot/parachain/util"
 	validationprotocol "github.com/ChainSafe/gossamer/dot/parachain/validation-protocol"
+	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/lib/common"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
@@ -521,4 +523,197 @@ func TestSendPendingGridMessages(t *testing.T) {
 
 	// TODO: include tests for postAcknowledgementStatementMessages that
 	// integrates grid tracker pending statements and statement store
+}
+
+func TestHandleIncomingManifestCommon(t *testing.T) {
+	pierre := peer.ID("pierre")
+	candidateHash := parachaintypes.CandidateHash{Value: common.Hash{0x12}}
+	relayParent := common.Hash{0xab}
+	paraID := parachaintypes.ParaID(10)
+
+	t.Run("peer_not_connected", func(t *testing.T) {
+		sd := StatementDistribution{}
+
+		importSuccess := sd.handleIncomingManifestCommon(
+			pierre,
+			make(map[peer.ID]peerState),
+			make(map[common.Hash]perRelayParentState),
+			make(map[parachaintypes.SessionIndex]perSessionState),
+			candidates{},
+			candidateHash,
+			relayParent,
+			paraID,
+			manifestSummary{},
+			full,
+			nil,
+		)
+
+		require.Nil(t, importSuccess)
+	})
+
+	t.Run("not_in_relay_parent_state", func(t *testing.T) {
+		peers := map[peer.ID]peerState{
+			pierre: {},
+		}
+
+		repAgg := util.NewReputationAggregator(func(rep util.UnifiedReputationChange) bool { return false })
+
+		overseer := make(chan any, 1)
+		sd := StatementDistribution{
+			SubSystemToOverseer: overseer,
+		}
+
+		importSuccess := sd.handleIncomingManifestCommon(
+			pierre,
+			peers,
+			make(map[common.Hash]perRelayParentState),
+			make(map[parachaintypes.SessionIndex]perSessionState),
+			candidates{},
+			candidateHash,
+			relayParent,
+			paraID,
+			manifestSummary{},
+			full,
+			repAgg,
+		)
+
+		require.Nil(t, importSuccess)
+
+		repAgg.Send(overseer)
+		require.Len(t, overseer, 1)
+
+		msg := <-overseer
+
+		repMsg, ok := msg.(networkbridgemessages.ReportPeer)
+		require.True(t, ok)
+		require.Equal(t, pierre, repMsg.PeerID)
+
+		require.Equal(
+			t,
+			peerset.Reputation(costUnexpectedManifestMissingKnowledge.CostOrBenefit()),
+			repMsg.ReputationChange.Value,
+		)
+
+		require.Equal(t, costUnexpectedManifestMissingKnowledge.Reason, repMsg.ReputationChange.Reason)
+	})
+
+	t.Run("happy_path", func(t *testing.T) {
+		groupIndex := parachaintypes.GroupIndex(0)
+
+		manifestSummary := manifestSummary{
+			claimedGroupIndex: groupIndex,
+			claimedParentHash: common.Hash{0x03},
+		}
+
+		seconded, err := parachaintypes.NewBitVec([]bool{true, false, false})
+		require.NoError(t, err)
+		valid, err := parachaintypes.NewBitVec([]bool{false, true, false})
+		require.NoError(t, err)
+
+		manifestSummary.statementKnowledge = parachaintypes.StatementFilter{
+			SecondedInGroup:  seconded,
+			ValidatedInGroup: valid,
+		}
+
+		authKey := [32]byte{0x04}
+		peerStateEntry := peerState{
+			discoveryIds: &map[parachaintypes.AuthorityDiscoveryID]struct{}{authKey: {}},
+		}
+		peers := map[peer.ID]peerState{
+			pierre: peerStateEntry,
+		}
+
+		gt := newGridTracker()
+		localValidator := &localValidatorStore{
+			gridTracker: gt,
+		}
+
+		initGroups := [][]parachaintypes.ValidatorIndex{
+			{0, 1, 2},
+			{3, 4, 5},
+		}
+		groups := newGroups(initGroups, 2)
+
+		relayParentState := perRelayParentState{
+			session:        1,
+			localValidator: localValidator,
+			groupsPerPara:  map[parachaintypes.ParaID][]parachaintypes.GroupIndex{paraID: {groupIndex}},
+			assignmentsPerGroup: map[parachaintypes.GroupIndex][]parachaintypes.ParaID{
+				groupIndex: {paraID},
+			},
+		}
+		perRelayParent := map[common.Hash]perRelayParentState{
+			relayParent: relayParentState,
+		}
+
+		validatorIndex := parachaintypes.ValidatorIndex(1)
+		gridTopology := &sessionTopologyView{
+			groupViews: map[parachaintypes.GroupIndex]groupSubView{
+				groupIndex: {
+					sending:   make(map[parachaintypes.ValidatorIndex]struct{}),
+					receiving: map[parachaintypes.ValidatorIndex]struct{}{validatorIndex: {}},
+				},
+			},
+		}
+
+		sessionInfo := parachaintypes.SessionInfo{
+			DiscoveryKeys: []parachaintypes.AuthorityDiscoveryID{
+				{0x0a},  // Validator 0
+				authKey, // Validator 1 - matches our peer's authority key
+				{0x0c},  // Validator 2
+			},
+		}
+
+		sessionState := perSessionState{
+			gridView:       gridTopology,
+			groups:         groups,
+			sessionInfo:    sessionInfo,
+			localValidator: &validatorIndex,
+		}
+		perSession := map[parachaintypes.SessionIndex]perSessionState{
+			1: sessionState,
+		}
+
+		candidates := candidates{
+			candidates: make(map[parachaintypes.CandidateHash]candidateState),
+			byParent:   make(map[hashAndParaID]map[parachaintypes.CandidateHash]struct{}),
+		}
+
+		reputation := util.NewReputationAggregator(func(rep util.UnifiedReputationChange) bool { return false })
+
+		overseerCh := make(chan any, 1)
+		sd := &StatementDistribution{
+			SubSystemToOverseer: overseerCh,
+		}
+
+		importSuccess := sd.handleIncomingManifestCommon(
+			pierre,
+			peers,
+			perRelayParent,
+			perSession,
+			candidates,
+			candidateHash,
+			relayParent,
+			paraID,
+			manifestSummary,
+			full,
+			reputation,
+		)
+
+		require.NotNil(t, importSuccess)
+		require.Equal(t, relayParentState, importSuccess.relayParentState)
+		require.Equal(t, sessionState, importSuccess.perSession)
+		require.Equal(t, validatorIndex, importSuccess.senderIndex)
+
+		// Verify the candidate was added as unconfirmed in candidate store and grid tracker
+
+		_, ok := candidates.candidates[candidateHash]
+		require.True(t, ok)
+
+		validatorAndGroups, ok := gt.unconfirmed[candidateHash]
+		require.True(t, ok)
+		require.Len(t, validatorAndGroups, 1)
+		require.Equal(t, validatorIndex, validatorAndGroups[0].validator)
+		require.Equal(t, groupIndex, validatorAndGroups[0].group)
+	})
 }

--- a/dot/parachain/statement-distribution/statement_distribution_test.go
+++ b/dot/parachain/statement-distribution/statement_distribution_test.go
@@ -20,7 +20,11 @@ import (
 )
 
 func TestSendBackingFreshStatements(t *testing.T) {
+	t.Parallel()
+
 	t.Run("should_send_3_statements_to_backing", func(t *testing.T) {
+		t.Parallel()
+
 		relayParent := common.Hash{0x01}
 		groupIndex := parachaintypes.GroupIndex(0)
 
@@ -151,6 +155,8 @@ func TestSendBackingFreshStatements(t *testing.T) {
 	})
 
 	t.Run("should_fail_when_confirmed_candidate_does_not_match", func(t *testing.T) {
+		t.Parallel()
+
 		relayParent := common.Hash{0x01}
 		groupIndex := parachaintypes.GroupIndex(0)
 
@@ -206,7 +212,11 @@ func TestSendBackingFreshStatements(t *testing.T) {
 }
 
 func TestSendPendingGridMessages(t *testing.T) {
+	t.Parallel()
+
 	t.Run("nil_local_validator", func(t *testing.T) {
+		t.Parallel()
+
 		rpHash := common.Hash{0xab}
 		peerID := peer.ID("peer-ex")
 		validationVersion := validationprotocol.ValidationVersionV3
@@ -225,6 +235,8 @@ func TestSendPendingGridMessages(t *testing.T) {
 	})
 
 	t.Run("empty_pending_manifests_for_validator_id", func(t *testing.T) {
+		t.Parallel()
+
 		gt := newGridTracker()
 
 		rpHash := common.Hash{0xab}
@@ -247,6 +259,8 @@ func TestSendPendingGridMessages(t *testing.T) {
 	})
 
 	t.Run("pending_stmts_but_none_confirmed", func(t *testing.T) {
+		t.Parallel()
+
 		ctrl := gomock.NewController(t)
 		peerValidatorID := parachaintypes.ValidatorIndex(0)
 
@@ -285,6 +299,8 @@ func TestSendPendingGridMessages(t *testing.T) {
 	})
 
 	t.Run("pending_full_manifest_confirmed", func(t *testing.T) {
+		t.Parallel()
+
 		ctrl := gomock.NewController(t)
 		peerValidatorID := parachaintypes.ValidatorIndex(4)
 
@@ -382,6 +398,8 @@ func TestSendPendingGridMessages(t *testing.T) {
 	})
 
 	t.Run("pending_full_and_ack_manifest_confirmed", func(t *testing.T) {
+		t.Parallel()
+
 		ctrl := gomock.NewController(t)
 		peerValidatorID := parachaintypes.ValidatorIndex(4)
 
@@ -526,12 +544,16 @@ func TestSendPendingGridMessages(t *testing.T) {
 }
 
 func TestHandleIncomingManifestCommon(t *testing.T) {
+	t.Parallel()
+
 	pierre := peer.ID("pierre")
 	candidateHash := parachaintypes.CandidateHash{Value: common.Hash{0x12}}
 	relayParent := common.Hash{0xab}
 	paraID := parachaintypes.ParaID(10)
 
 	t.Run("peer_not_connected", func(t *testing.T) {
+		t.Parallel()
+
 		sd := StatementDistribution{}
 
 		importSuccess := sd.handleIncomingManifestCommon(
@@ -552,6 +574,8 @@ func TestHandleIncomingManifestCommon(t *testing.T) {
 	})
 
 	t.Run("not_in_relay_parent_state", func(t *testing.T) {
+		t.Parallel()
+
 		peers := map[peer.ID]peerState{
 			pierre: {},
 		}
@@ -598,6 +622,8 @@ func TestHandleIncomingManifestCommon(t *testing.T) {
 	})
 
 	t.Run("happy_path", func(t *testing.T) {
+		t.Parallel()
+
 		groupIndex := parachaintypes.GroupIndex(0)
 
 		manifestSummary := manifestSummary{

--- a/dot/parachain/statement-distribution/statement_store.go
+++ b/dot/parachain/statement-distribution/statement_store.go
@@ -82,7 +82,7 @@ type groupAndCandidateHash struct {
 
 // Storage for statements. Intended to be used for statements signed under
 // the same relay-parent.
-type statements struct {
+type statementStore struct {
 	validatorMeta map[parachaintypes.ValidatorIndex]*validatorMeta
 
 	// we keep statements per-group because even though only one group _should_ be
@@ -92,7 +92,7 @@ type statements struct {
 	knownStmts map[fingerprint]*storedStatement
 }
 
-func newStatementStore(groups *groups) *statements {
+func newStatementStore(groups *groups) *statementStore {
 	meta := map[parachaintypes.ValidatorIndex]*validatorMeta{}
 
 	for gIdx, validators := range groups.all() {
@@ -105,7 +105,7 @@ func newStatementStore(groups *groups) *statements {
 		}
 	}
 
-	return &statements{
+	return &statementStore{
 		validatorMeta: meta,
 		groupStmts:    make(map[groupAndCandidateHash]*groupStatements),
 		knownStmts:    make(map[fingerprint]*storedStatement),
@@ -114,11 +114,11 @@ func newStatementStore(groups *groups) *statements {
 
 // Insert adds a statement. Returns true if it was not known already, false if it was.
 // Ignores statements by unknown validators and returns an error.
-func (s *statements) insert(
+func (s *statementStore) insert(
 	groups *groups,
 	statement *parachaintypes.SignedStatement,
 	origin statementOrigin,
-) (bool, error) { //nolint:unparam
+) (bool, error) {
 	validatorIndex := statement.ValidatorIndex
 	validatorMeta, ok := s.validatorMeta[validatorIndex]
 	if !ok {
@@ -195,7 +195,7 @@ func (s *statements) insert(
 }
 
 // fillStatementFilter fills a StatementFilter with all statements already known for the given group and candidate hash.
-func (s *statements) fillStatementFilter( //nolint:unused
+func (s *statementStore) fillStatementFilter(
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
 	statementFilter *parachaintypes.StatementFilter,
@@ -212,7 +212,7 @@ func (s *statements) fillStatementFilter( //nolint:unused
 
 // groupStatements returns all stored signed statements by the group conforming to the given filter.
 // Seconded statements are provided first.
-func (s *statements) groupStatements( //nolint:unused
+func (s *statementStore) groupStatements(
 	groups *groups,
 	groupIndex parachaintypes.GroupIndex,
 	candidateHash parachaintypes.CandidateHash,
@@ -256,7 +256,7 @@ func (s *statements) groupStatements( //nolint:unused
 }
 
 // validatorStatement returns the full statement of this kind issued by this validator, if it is known.
-func (s *statements) validatorStatement( //nolint:unused
+func (s *statementStore) validatorStatement(
 	validatorIndex parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
 ) (*parachaintypes.SignedStatement, bool) {
@@ -277,7 +277,7 @@ func (s *statements) validatorStatement( //nolint:unused
 // freshStatementsForBacking returns all statements for the given candidate hash
 // and validators that are not yet known by backing.
 // Seconded statements are provided before Valid statements.
-func (s *statements) freshStatementsForBacking(
+func (s *statementStore) freshStatementsForBacking(
 	validators []parachaintypes.ValidatorIndex,
 	candidateHash parachaintypes.CandidateHash,
 ) []*parachaintypes.SignedStatement {
@@ -303,7 +303,7 @@ func (s *statements) freshStatementsForBacking(
 }
 
 // secondedCount returns the amount of known Seconded statements by the given validator index.
-func (s *statements) secondedCount( //nolint:unused
+func (s *statementStore) secondedCount( //nolint:unused
 	validatorIndex parachaintypes.ValidatorIndex,
 ) uint {
 	if meta, ok := s.validatorMeta[validatorIndex]; ok {
@@ -313,7 +313,7 @@ func (s *statements) secondedCount( //nolint:unused
 }
 
 // noteKnownByBacking marks a statement as known by the backing subsystem.
-func (s *statements) noteKnownByBacking( //nolint:unused
+func (s *statementStore) noteKnownByBacking(
 	validatorIndex parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
 ) {


### PR DESCRIPTION
## Changes

This PR adds an implementation of `StatementDistribution.handleIncomingManifestCommon()`, which performs various checks used in `StatementDistribution.handleIncomingManifest()` and `StatementDistribution.handleIncomingAcknowledgement()`.

The issue also covers `acknowledgementAndStatementMessages()` but that was already done.

## Tests

```sh
go test ./dot/parachain/statement-distribution
```

## Issues

#4394 