### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/dot/network/authoritydiscovery/service.go
+++ b/dot/network/authoritydiscovery/service.go
@@ -6,6 +6,7 @@ package authoritydiscovery
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -293,10 +294,8 @@ func appendUniqueAuthorityID(slice []AuthorityID, auth AuthorityID) []AuthorityI
 }
 
 func appendUniquePeerID(slice []peer.ID, peerID peer.ID) []peer.ID {
-	for _, existing := range slice {
-		if existing == peerID {
-			return slice
-		}
+	if slices.Contains(slice, peerID) {
+		return slice
 	}
 	return append(slice, peerID)
 }

--- a/dot/rpc/modules/rpc.go
+++ b/dot/rpc/modules/rpc.go
@@ -5,6 +5,7 @@ package modules
 
 import (
 	"net/http"
+	"slices"
 )
 
 var (
@@ -55,11 +56,5 @@ func (rm *RPCModule) Methods(r *http.Request, req *EmptyRequest, res *MethodsRes
 
 // IsUnsafe returns true if the `name` has the  suffix
 func IsUnsafe(name string) bool {
-	for _, unsafe := range UnsafeMethods {
-		if name == unsafe {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(UnsafeMethods, name)
 }

--- a/dot/state/block_test.go
+++ b/dot/state/block_test.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -460,22 +461,13 @@ func TestFinalization_DeleteBlock(t *testing.T) {
 
 	after := bs.bt.GetAllBlocks()
 
-	isIn := func(arr []common.Hash, b common.Hash) bool {
-		for _, a := range arr {
-			if b == a {
-				return true
-			}
-		}
-		return false
-	}
-
 	// assert that every block except finalised has been deleted
 	for _, b := range before {
 		if b == fin {
 			continue
 		}
 
-		if isIn(after, b) {
+		if slices.Contains(after, b) {
 			continue
 		}
 


### PR DESCRIPTION
## Changes

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.



## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test -tags integration github.com/ChainSafe/gossamer
```

## Issues

<!-- Write the issue number(s), for example: #123 -->