### PR TITLE
(feat/parachain): provide parachain inherent data

### DIFF
--- a/dot/parachain/inherent.go
+++ b/dot/parachain/inherent.go
@@ -33,27 +33,25 @@ type blockState interface {
 	GetHeader(common.Hash) (*types.Header, error)
 }
 
+// ProvideInherentData creates the inherent data for the parachain block authoring process
+// and returns it as a types.InherentData object with the parachain inherent data.
 func ProvideInherentData(
 	blockState blockState,
 	overseerCh chan<- any,
 	relayParent common.Hash,
-	inherentData *types.InherentData,
-) error {
+) (*types.InherentData, error) {
 	parachainInherentData, err := createInherentData(blockState, overseerCh, relayParent)
 	if err != nil {
-		return fmt.Errorf("creating parachain inherent data: %w", err)
+		return nil, fmt.Errorf("creating parachain inherent data: %w", err)
 	}
 
-	if inherentData == nil {
-		inherentData = types.NewInherentData()
-	}
-
+	inherentData := types.NewInherentData()
 	err = inherentData.SetInherent(types.Parachn0, parachainInherentData)
 	if err != nil {
-		return fmt.Errorf("setting parachain inherent data: %w", err)
+		return nil, fmt.Errorf("setting parachain inherent data: %w", err)
 	}
 
-	return nil
+	return inherentData, nil
 }
 
 func createInherentData(

--- a/dot/parachain/inherent.go
+++ b/dot/parachain/inherent.go
@@ -1,0 +1,157 @@
+package parachain
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ChainSafe/gossamer/internal/log"
+
+	provisioner "github.com/ChainSafe/gossamer/dot/parachain/provisioner/messages"
+	parachaintypes "github.com/ChainSafe/gossamer/dot/parachain/types"
+	"github.com/ChainSafe/gossamer/dot/types"
+	"github.com/ChainSafe/gossamer/lib/common"
+)
+
+var logger = log.NewFromGlobal(log.AddContext("pkg", "parachain"))
+
+var errResponseChannelClosed = fmt.Errorf("response channel is closed")
+
+// InherentData represents parachains inherent-data passed into the runtime by a block author
+type InherentData struct {
+	// Bitfields represents signed bitfields by validators about availability.
+	Bitfields []parachaintypes.UncheckedSignedAvailabilityBitfield `scale:"1"`
+	// BackedCandidates represents backed candidates for inclusion in the block.
+	BackedCandidates []parachaintypes.BackedCandidate `scale:"2"`
+	// Disputes represents sets of dispute votes for inclusion.
+	Disputes []parachaintypes.DisputeStatementSet `scale:"3"`
+	// ParentHeader represents the parent block header. Used for checking state proofs.
+	ParentHeader types.Header `scale:"4"`
+}
+
+type blockState interface {
+	GetHeader(common.Hash) (*types.Header, error)
+}
+
+func ProvideInherentData(
+	blockState blockState,
+	overseerCh chan<- any,
+	relayParent common.Hash,
+	inherentData *types.InherentData,
+) error {
+	parachainInherentData, err := createInherentData(blockState, overseerCh, relayParent)
+	if err != nil {
+		return fmt.Errorf("creating parachain inherent data: %w", err)
+	}
+
+	if inherentData == nil {
+		inherentData = types.NewInherentData()
+	}
+
+	err = inherentData.SetInherent(types.Parachn0, parachainInherentData)
+	if err != nil {
+		return fmt.Errorf("setting parachain inherent data: %w", err)
+	}
+
+	return nil
+}
+
+func createInherentData(
+	blockState blockState,
+	overseerCh chan<- any,
+	relayParent common.Hash,
+) (*InherentData, error) {
+	var (
+		parentHeader        *types.Header
+		provisionerInherent *provisioner.ProvisionerInherentData
+		headerErr, provErr  error
+		wg                  sync.WaitGroup
+	)
+
+	wg.Add(2)
+
+	// Fetch parent header concurrently
+	go func() {
+		defer wg.Done()
+		h, err := blockState.GetHeader(relayParent)
+		if err != nil {
+			headerErr = fmt.Errorf("getting header for relay parent %s: %w", relayParent, err)
+			return
+		}
+		if h == nil {
+			headerErr = fmt.Errorf("header for relay parent %s not found", relayParent)
+			return
+		}
+		parentHeader = h
+	}()
+
+	// Fetch provisioner inherent data concurrently
+	go func() {
+		defer wg.Done()
+		provisionerInherent, provErr = waitAndRequestProvisionerInherent(overseerCh, relayParent)
+	}()
+
+	wg.Wait()
+
+	if headerErr != nil {
+		return nil, headerErr
+	}
+
+	if provErr != nil {
+		logger.Errorf("getting provisioner inherent data: %s\n", provErr)
+		return &InherentData{ParentHeader: *parentHeader}, provErr
+	}
+
+	uncheckBitfields := make([]parachaintypes.UncheckedSignedAvailabilityBitfield, 0, len(provisionerInherent.Bitfields))
+	for _, bitfield := range provisionerInherent.Bitfields {
+		uncheckBitfields = append(uncheckBitfields, parachaintypes.UncheckedSignedAvailabilityBitfield(bitfield))
+	}
+
+	return &InherentData{
+		Bitfields:        uncheckBitfields,
+		BackedCandidates: provisionerInherent.BackedCandidates,
+		Disputes:         provisionerInherent.Disputes,
+		ParentHeader:     *parentHeader,
+	}, nil
+}
+
+func waitAndRequestProvisionerInherent(
+	overseerCh chan<- any,
+	relayParent common.Hash,
+) (*provisioner.ProvisionerInherentData, error) {
+	waitForActivation := parachaintypes.WaitForActivation{
+		RelayParent: relayParent,
+		ResponseCh:  make(chan error),
+	}
+
+	overseerCh <- waitForActivation
+	select {
+	case err, ok := <-waitForActivation.ResponseCh:
+		if !ok {
+			return nil, errResponseChannelClosed
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("waiting for leaf activation: %s", err)
+		}
+	case <-time.After(parachaintypes.SubsystemRequestTimeout):
+		return nil, parachaintypes.ErrSubsystemRequestTimeout
+	}
+
+	requestProvisionerInherentData := provisioner.RequestInherentData{
+		RelayParent:             relayParent,
+		ProvisionerInherentData: make(chan provisioner.ProvisionerInherentData),
+	}
+
+	// requesting inherent data after having waited for leaf activation
+	overseerCh <- requestProvisionerInherentData
+	select {
+	case provisionerInherentData, ok := <-requestProvisionerInherentData.ProvisionerInherentData:
+		if !ok {
+			return nil, errResponseChannelClosed
+		}
+		return &provisionerInherentData, nil
+	case <-time.After(parachaintypes.SubsystemRequestTimeout):
+		return nil, parachaintypes.ErrSubsystemRequestTimeout
+	}
+}

--- a/dot/parachain/inherent.go
+++ b/dot/parachain/inherent.go
@@ -60,40 +60,28 @@ func createInherentData(
 	relayParent common.Hash,
 ) (*InherentData, error) {
 	var (
-		parentHeader        *types.Header
 		provisionerInherent *provisioner.ProvisionerInherentData
-		headerErr, provErr  error
+		provErr             error
 		wg                  sync.WaitGroup
 	)
 
-	wg.Add(2)
-
-	// Fetch parent header concurrently
-	go func() {
-		defer wg.Done()
-		h, err := blockState.GetHeader(relayParent)
-		if err != nil {
-			headerErr = fmt.Errorf("getting header for relay parent %s: %w", relayParent, err)
-			return
-		}
-		if h == nil {
-			headerErr = fmt.Errorf("header for relay parent %s not found", relayParent)
-			return
-		}
-		parentHeader = h
-	}()
-
+	wg.Add(1)
 	// Fetch provisioner inherent data concurrently
 	go func() {
 		defer wg.Done()
 		provisionerInherent, provErr = waitAndRequestProvisionerInherent(overseerCh, relayParent)
 	}()
 
-	wg.Wait()
-
-	if headerErr != nil {
-		return nil, headerErr
+	parentHeader, err := blockState.GetHeader(relayParent)
+	if err != nil {
+		return nil, fmt.Errorf("getting header for relay parent %s: %w", relayParent, err)
 	}
+
+	if parentHeader == nil {
+		return nil, fmt.Errorf("header for relay parent %s not found", relayParent)
+	}
+
+	wg.Wait() // wait for the provisioner inherent data to be fetched
 
 	if provErr != nil {
 		logger.Errorf("getting provisioner inherent data: %s\n", provErr)

--- a/dot/parachain/overseer/overseer.go
+++ b/dot/parachain/overseer/overseer.go
@@ -235,6 +235,7 @@ func (o *OverseerSystem) onHeadActivated(blockHash common.Hash) bool {
 	if responseChannels, ok := o.activationExternalListeners[blockHash]; ok {
 		for _, responseCh := range responseChannels {
 			responseCh <- nil
+			close(responseCh)
 		}
 		// leaf got activated
 		delete(o.activationExternalListeners, blockHash)

--- a/dot/parachain/overseer/overseer.go
+++ b/dot/parachain/overseer/overseer.go
@@ -50,6 +50,9 @@ type OverseerSystem struct {
 	blockState   BlockState
 	activeLeaves map[common.Hash]uint32
 
+	//External listeners waiting for a hash to be in the active-leave set.
+	activationExternalListeners map[common.Hash][]chan error
+
 	// block notification channels
 	imported  chan *types.Block
 	finalised chan *types.FinalisationInfo
@@ -197,6 +200,10 @@ func (o *OverseerSystem) processMessages() {
 				}
 				msg.Resp <- rt
 
+			case parachaintypes.WaitForActivation: // external request to wait for activation of a relay parent
+				o.waitForActivation(msg)
+				return
+
 			default:
 				logger.Error("unknown message type")
 			}
@@ -212,6 +219,48 @@ func (o *OverseerSystem) processMessages() {
 			return
 		}
 	}
+}
+
+// onHeadActivated handles a header activation, If the header does not support parachains API, it returns false.
+func (o *OverseerSystem) onHeadActivated(blockHash common.Hash) bool {
+	isSupported, err := o.DoesHeadSupportsParachainConsensus(blockHash)
+	if err != nil {
+		panic(fmt.Sprintf("checking head supports parachain: %s", err.Error()))
+	}
+
+	if !isSupported {
+		return false
+	}
+
+	if responseChannels, ok := o.activationExternalListeners[blockHash]; ok {
+		for _, responseCh := range responseChannels {
+			responseCh <- nil
+		}
+		// leaf got activated
+		delete(o.activationExternalListeners, blockHash)
+	}
+
+	return true
+}
+
+func (o *OverseerSystem) onHeadDeactivated(blockHash common.Hash) {
+	delete(o.activationExternalListeners, blockHash)
+}
+
+// waitForActivation handles an external request to wait for activation of a relay parent.
+func (o *OverseerSystem) waitForActivation(msg parachaintypes.WaitForActivation) {
+	if _, ok := o.activeLeaves[msg.RelayParent]; ok {
+		//Leaf was already ready - answering waitForActivation
+		msg.ResponseCh <- nil
+		return
+	}
+
+	responseChannels, ok := o.activationExternalListeners[msg.RelayParent]
+	if !ok {
+		responseChannels = make([]chan error, 0)
+	}
+	responseChannels = append(responseChannels, msg.ResponseCh)
+	o.activationExternalListeners[msg.RelayParent] = responseChannels
 }
 
 func (o *OverseerSystem) handleBlockEvents() {
@@ -231,31 +280,28 @@ func (o *OverseerSystem) handleBlockEvents() {
 				}
 				return
 			}
-
 			o.activeLeaves[imported.Header.Hash()] = uint32(imported.Header.Number)
-			delete(o.activeLeaves, imported.Header.ParentHash)
 
 			var activeLeavesUpdate parachaintypes.ActiveLeavesUpdateSignal
 
-			supports, err := o.DoesHeadSupportsParachainConsensus(imported.Header.Hash())
-			if err != nil {
-				panic(fmt.Sprintf("checking head supports parachain: %s", err.Error()))
-			}
-
-			if supports {
+			if o.onHeadActivated(imported.Header.Hash()) {
 				activeLeavesUpdate = parachaintypes.ActiveLeavesUpdateSignal{
 					Activated: &parachaintypes.ActivatedLeaf{
 						Hash:   imported.Header.Hash(),
 						Number: uint32(imported.Header.Number),
 					},
-					Deactivated: []common.Hash{imported.Header.ParentHash},
 				}
 			}
+
+			if _, ok := o.activeLeaves[imported.Header.ParentHash]; ok {
+				activeLeavesUpdate.Deactivated = append(activeLeavesUpdate.Deactivated, imported.Header.Hash())
+				o.onHeadDeactivated(imported.Header.ParentHash)
+			}
+			delete(o.activeLeaves, imported.Header.ParentHash)
 
 			if !activeLeavesUpdate.IsEmpty() {
 				o.broadcast(activeLeavesUpdate)
 			}
-
 		case finalised := <-o.finalised:
 			deactivated := make([]common.Hash, 0)
 
@@ -264,6 +310,10 @@ func (o *OverseerSystem) handleBlockEvents() {
 					deactivated = append(deactivated, hash)
 					delete(o.activeLeaves, hash)
 				}
+			}
+
+			for _, hash := range deactivated {
+				o.onHeadDeactivated(hash)
 			}
 
 			o.broadcast(parachaintypes.BlockFinalizedSignal{
@@ -283,6 +333,7 @@ func (o *OverseerSystem) handleBlockEvents() {
 		}
 	}
 }
+
 func (o *OverseerSystem) broadcast(msg any) {
 	for _, overseerToSubSystem := range o.subsystems {
 		overseerToSubSystem <- msg

--- a/dot/parachain/overseer/overseer.go
+++ b/dot/parachain/overseer/overseer.go
@@ -295,7 +295,7 @@ func (o *OverseerSystem) handleBlockEvents() {
 			}
 
 			if _, ok := o.activeLeaves[imported.Header.ParentHash]; ok {
-				activeLeavesUpdate.Deactivated = append(activeLeavesUpdate.Deactivated, imported.Header.Hash())
+				activeLeavesUpdate.Deactivated = append(activeLeavesUpdate.Deactivated, imported.Header.ParentHash)
 				o.onHeadDeactivated(imported.Header.ParentHash)
 			}
 			delete(o.activeLeaves, imported.Header.ParentHash)

--- a/dot/parachain/provisioner/messages/messages.go
+++ b/dot/parachain/provisioner/messages/messages.go
@@ -19,7 +19,7 @@ type RequestInherentData struct {
 }
 
 type ProvisionerInherentData struct {
-	Bitfield         []parachaintypes.CheckedSignedAvailabilityBitfield
+	Bitfields        []parachaintypes.CheckedSignedAvailabilityBitfield
 	BackedCandidates []parachaintypes.BackedCandidate
 	Disputes         []parachaintypes.DisputeStatementSet
 }

--- a/dot/parachain/provisioner/provisioner.go
+++ b/dot/parachain/provisioner/provisioner.go
@@ -207,7 +207,7 @@ func (p *Provisioner) sendInherentData(
 	}
 
 	inherentData := provisionermessages.ProvisionerInherentData{
-		Bitfield:         bitfields,
+		Bitfields:        bitfields,
 		BackedCandidates: candidates,
 		Disputes:         disputes,
 	}

--- a/dot/parachain/provisioner/provisioner_test.go
+++ b/dot/parachain/provisioner/provisioner_test.go
@@ -981,18 +981,18 @@ func TestSendInherentData(t *testing.T) {
 					case inherentData := <-responseSender:
 						var err error
 						// Verify bitfield data
-						if len(inherentData.Bitfield) != len(tc.signedBitfields) {
-							err = fmt.Errorf("expected %d bitfields, got %d", len(tc.signedBitfields), len(inherentData.Bitfield))
+						if len(inherentData.Bitfields) != len(tc.signedBitfields) {
+							err = fmt.Errorf("expected %d bitfields, got %d", len(tc.signedBitfields), len(inherentData.Bitfields))
 						} else if len(tc.signedBitfields) > 0 {
-							if !reflect.DeepEqual(inherentData.Bitfield[0].ValidatorIndex, tc.signedBitfields[0].ValidatorIndex) {
+							if !reflect.DeepEqual(inherentData.Bitfields[0].ValidatorIndex, tc.signedBitfields[0].ValidatorIndex) {
 								err = fmt.Errorf("validator index mismatch: expected %v, got %v",
-									tc.signedBitfields[0].ValidatorIndex, inherentData.Bitfield[0].ValidatorIndex)
-							} else if !reflect.DeepEqual(inherentData.Bitfield[0].Signature, tc.signedBitfields[0].Signature) {
+									tc.signedBitfields[0].ValidatorIndex, inherentData.Bitfields[0].ValidatorIndex)
+							} else if !reflect.DeepEqual(inherentData.Bitfields[0].Signature, tc.signedBitfields[0].Signature) {
 								err = fmt.Errorf("signature mismatch: expected %v, got %v",
-									tc.signedBitfields[0].Signature, inherentData.Bitfield[0].Signature)
-							} else if !reflect.DeepEqual(inherentData.Bitfield[0].Payload, tc.signedBitfields[0].Payload) {
+									tc.signedBitfields[0].Signature, inherentData.Bitfields[0].Signature)
+							} else if !reflect.DeepEqual(inherentData.Bitfields[0].Payload, tc.signedBitfields[0].Payload) {
 								err = fmt.Errorf("payload mismatch: expected %v, got %v",
-									tc.signedBitfields[0].Payload, inherentData.Bitfield[0].Payload)
+									tc.signedBitfields[0].Payload, inherentData.Bitfields[0].Payload)
 							}
 						}
 

--- a/dot/parachain/types/types.go
+++ b/dot/parachain/types/types.go
@@ -1161,3 +1161,9 @@ type DistributeBitfield struct {
 	RelayParent common.Hash
 	Bitfield    UncheckedSignedAvailabilityBitfield
 }
+
+// WaitForActivation is the external request to the overseer to wait for activation of a relay parent.
+type WaitForActivation struct {
+	RelayParent common.Hash
+	ResponseCh  chan error
+}


### PR DESCRIPTION
## Changes
- Implemented the logic for the external overseer message to wait for activation of a relay parent in the overseer.
- Implemented the function to collect and provide parachain inherent data. 

## Tests

<!-- Detail how to run relevant tests to the changes -->

```sh
go test ./dot/parachain/... -timeout 60s
```

## Issues
Closes #4550
Closes #4243 