### PR TITLE
refactor(dot/parachain): rename ValidatorID to ValidatorPublicKey for clarity

### DIFF
--- a/dot/core/mock_runtime_instance_test.go
+++ b/dot/core/mock_runtime_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/availability-distribution/mocks_runtime_test.go
+++ b/dot/parachain/availability-distribution/mocks_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/availability-distribution/session_cache.go
+++ b/dot/parachain/availability-distribution/session_cache.go
@@ -130,8 +130,8 @@ func (c *LRUSessionCache) GetSessionInfo(
 		return nil, err
 	}
 
-	validatorID, ourIndex := parachainutil.SigningKeyAndIndex(sessionInfo.Validators, c.keystore)
-	if validatorID == nil {
+	validatorPublicKey, ourIndex := parachainutil.SigningKeyAndIndex(sessionInfo.Validators, c.keystore)
+	if validatorPublicKey == nil {
 		// This node is not a validator.
 		return nil, nil
 	}

--- a/dot/parachain/availability-distribution/session_cache_test.go
+++ b/dot/parachain/availability-distribution/session_cache_test.go
@@ -412,14 +412,14 @@ func generateKeypairs(t *testing.T, n int) []*sr25519.Keypair {
 	return kps
 }
 
-func validatorIDsFromKeypairs(t *testing.T, kps []*sr25519.Keypair) []parachaintypes.ValidatorID {
+func validatorIDsFromKeypairs(t *testing.T, kps []*sr25519.Keypair) []parachaintypes.ValidatorPublicKey {
 	t.Helper()
 
-	validatorIDs := make([]parachaintypes.ValidatorID, len(kps))
+	validatorPublicKeys := make([]parachaintypes.ValidatorPublicKey, len(kps))
 	for i, kp := range kps {
-		validatorIDs[i] = parachaintypes.ValidatorID(kp.Public().Encode())
+		validatorPublicKeys[i] = parachaintypes.ValidatorPublicKey(kp.Public().Encode())
 	}
-	return validatorIDs
+	return validatorPublicKeys
 }
 
 func generateDiscoveryKeys(t *testing.T, n int) []parachaintypes.AuthorityDiscoveryID {
@@ -438,14 +438,14 @@ func generateDiscoveryKeys(t *testing.T, n int) []parachaintypes.AuthorityDiscov
 func setUpKeystoreMock(
 	t *testing.T,
 	ctrl *gomock.Controller,
-	validatorID parachaintypes.ValidatorID,
+	validatorPublicKey parachaintypes.ValidatorPublicKey,
 	keypair *sr25519.Keypair,
 ) keystore.Keystore {
 	t.Helper()
 
 	ks := NewMockKeystore(ctrl)
 
-	ourPubkey, err := sr25519.NewPublicKey(validatorID[:])
+	ourPubkey, err := sr25519.NewPublicKey(validatorPublicKey[:])
 	require.NoError(t, err)
 
 	ks.EXPECT().
@@ -465,7 +465,7 @@ func setUpRuntimeMock(
 	t *testing.T,
 	ctrl *gomock.Controller,
 	sessionIndex parachaintypes.SessionIndex,
-	validators []parachaintypes.ValidatorID,
+	validators []parachaintypes.ValidatorPublicKey,
 	discoveryKeys []parachaintypes.AuthorityDiscoveryID,
 	validatorGroups [][]parachaintypes.ValidatorIndex,
 	nodeFeatures parachaintypes.BitVec,

--- a/dot/parachain/backing/active_leaves_update_test.go
+++ b/dot/parachain/backing/active_leaves_update_test.go
@@ -116,7 +116,7 @@ func TestProcessActiveLeavesUpdateSignal(t *testing.T) {
 				mockRuntime := NewMockInstance(ctrl)
 				mockBlockState.EXPECT().GetRuntime(gomock.AssignableToTypeOf(common.Hash{})).Return(mockRuntime, nil)
 				mockRuntime.EXPECT().ParachainHostSessionIndexForChild().Return(parachaintypes.SessionIndex(1), nil)
-				mockRuntime.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorID{{1}, {2}, {3}}, nil)
+				mockRuntime.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorPublicKey{{1}, {2}, {3}}, nil)
 				mockRuntime.EXPECT().ParachainHostNodeFeatures().Return(bv, nil)
 				mockRuntime.EXPECT().ParachainHostSessionExecutorParams(gomock.AssignableToTypeOf(parachaintypes.SessionIndex(1))).
 					Return(&parachaintypes.ExecutorParams{}, nil)

--- a/dot/parachain/backing/candidate_backing.go
+++ b/dot/parachain/backing/candidate_backing.go
@@ -101,7 +101,7 @@ type attestingData struct {
 type tableContext struct {
 	validator          *parachaintypes.Validator
 	groups             map[parachaintypes.CoreIndex][]parachaintypes.ValidatorIndex
-	validators         []parachaintypes.ValidatorID
+	validators         []parachaintypes.ValidatorPublicKey
 	disabledValidators []parachaintypes.ValidatorIndex
 }
 
@@ -343,7 +343,7 @@ func (cb *CandidateBacking) handleStatementMessage(
 // and avoid redundant computations.
 type perSessionCache struct {
 	// Cache for storing validators list, retrieved from the runtime.
-	validatorsCache *lrucache.LRUCache[parachaintypes.SessionIndex, []parachaintypes.ValidatorID]
+	validatorsCache *lrucache.LRUCache[parachaintypes.SessionIndex, []parachaintypes.ValidatorPublicKey]
 	// Cache for storing node features, retrieved from the runtime.
 	nodeFeaturesCache *lrucache.LRUCache[parachaintypes.SessionIndex, *parachaintypes.BitVec]
 	// Cache for storing executor parameters, retrieved from the runtime.
@@ -357,7 +357,7 @@ type perSessionCache struct {
 
 func newPerSessionCache(capacity uint) perSessionCache {
 	return perSessionCache{
-		validatorsCache:          lrucache.NewLRUCache[parachaintypes.SessionIndex, []parachaintypes.ValidatorID](capacity),
+		validatorsCache:          lrucache.NewLRUCache[parachaintypes.SessionIndex, []parachaintypes.ValidatorPublicKey](capacity),
 		nodeFeaturesCache:        lrucache.NewLRUCache[parachaintypes.SessionIndex, *parachaintypes.BitVec](capacity),
 		executorParamsCache:      lrucache.NewLRUCache[parachaintypes.SessionIndex, parachaintypes.ExecutorParams](capacity),
 		minimumBackingVotesCache: lrucache.NewLRUCache[parachaintypes.SessionIndex, uint32](capacity),
@@ -370,7 +370,7 @@ func newPerSessionCache(capacity uint) perSessionCache {
 func (cache *perSessionCache) getValidators(
 	sessionIndex parachaintypes.SessionIndex,
 	rt runtime.Instance,
-) ([]parachaintypes.ValidatorID, error) {
+) ([]parachaintypes.ValidatorPublicKey, error) {
 	validators := cache.validatorsCache.Get(sessionIndex)
 	if validators != nil {
 		return validators, nil
@@ -448,7 +448,7 @@ func (cache *perSessionCache) getMinimumBackingVotes(
 // Otherwise, it constructs the mapping, caches it, and then returns it.
 func (cache *perSessionCache) getValidatorToGroup(
 	sessionIndex parachaintypes.SessionIndex,
-	validators []parachaintypes.ValidatorID,
+	validators []parachaintypes.ValidatorPublicKey,
 	validatorGroups [][]parachaintypes.ValidatorIndex,
 ) map[parachaintypes.ValidatorIndex]parachaintypes.GroupIndex {
 	validatorToGroup := cache.validatorToGroupCache.Get(sessionIndex)

--- a/dot/parachain/backing/candidate_backing.go
+++ b/dot/parachain/backing/candidate_backing.go
@@ -357,12 +357,26 @@ type perSessionCache struct {
 
 func newPerSessionCache(capacity uint) perSessionCache {
 	return perSessionCache{
-		validatorsCache:          lrucache.NewLRUCache[parachaintypes.SessionIndex, []parachaintypes.ValidatorPublicKey](capacity),
-		nodeFeaturesCache:        lrucache.NewLRUCache[parachaintypes.SessionIndex, *parachaintypes.BitVec](capacity),
-		executorParamsCache:      lrucache.NewLRUCache[parachaintypes.SessionIndex, parachaintypes.ExecutorParams](capacity),
-		minimumBackingVotesCache: lrucache.NewLRUCache[parachaintypes.SessionIndex, uint32](capacity),
-		validatorToGroupCache: lrucache.NewLRUCache[parachaintypes.SessionIndex,
-			map[parachaintypes.ValidatorIndex]parachaintypes.GroupIndex](capacity),
+		validatorsCache: lrucache.NewLRUCache[
+			parachaintypes.SessionIndex,
+			[]parachaintypes.ValidatorPublicKey,
+		](capacity),
+		nodeFeaturesCache: lrucache.NewLRUCache[
+			parachaintypes.SessionIndex,
+			*parachaintypes.BitVec,
+		](capacity),
+		executorParamsCache: lrucache.NewLRUCache[
+			parachaintypes.SessionIndex,
+			parachaintypes.ExecutorParams,
+		](capacity),
+		minimumBackingVotesCache: lrucache.NewLRUCache[
+			parachaintypes.SessionIndex,
+			uint32,
+		](capacity),
+		validatorToGroupCache: lrucache.NewLRUCache[
+			parachaintypes.SessionIndex,
+			map[parachaintypes.ValidatorIndex]parachaintypes.GroupIndex,
+		](capacity),
 	}
 }
 

--- a/dot/parachain/backing/candidate_backing_test.go
+++ b/dot/parachain/backing/candidate_backing_test.go
@@ -309,7 +309,7 @@ func dummyTableContext(t *testing.T) tableContext {
 			{Index: 2}: {4, 5, 6},
 			{Index: 3}: {7, 8, 9},
 		},
-		validators: []parachaintypes.ValidatorID{
+		validators: []parachaintypes.ValidatorPublicKey{
 			mustHexTo32BArray(t, "0xa262f83b46310770ae8d092147176b8b25e8855bcfbbe701d346b10db0c5385d"),
 			mustHexTo32BArray(t, "0x804b9df571e2b744d65eca2d4c59eb8e4345286c00389d97bfc1d8d13aa6e57e"),
 			mustHexTo32BArray(t, "0x4eb63e4aad805c06dc924e2f19b1dde7faf507e5bb3c1838d6a3cfc10e84fe72"),

--- a/dot/parachain/backing/integration_test.go
+++ b/dot/parachain/backing/integration_test.go
@@ -146,10 +146,10 @@ func newCommittedCandidate(
 }
 
 // parachainValidators returns a list of parachain validator IDs for testing purposes.
-func parachainValidators(t *testing.T, ks keystore.Keystore) []parachaintypes.ValidatorID {
+func parachainValidators(t *testing.T, ks keystore.Keystore) []parachaintypes.ValidatorPublicKey {
 	t.Helper()
 
-	validatorIds := make([]parachaintypes.ValidatorID, 0, 6)
+	validatorPublicKeys := make([]parachaintypes.ValidatorPublicKey, 0, 6)
 
 	keyring, err := keystore.NewSr25519Keyring()
 	require.NoError(t, err)
@@ -164,17 +164,17 @@ func parachainValidators(t *testing.T, ks keystore.Keystore) []parachaintypes.Va
 	}
 
 	for _, kp := range keyPairs {
-		var validatorID parachaintypes.ValidatorID
+		var validatorKey parachaintypes.ValidatorPublicKey
 
 		err := ks.Insert(kp)
 		require.NoError(t, err)
 
 		bytes := kp.Public().Encode()
-		copy(validatorID[:], bytes)
-		validatorIds = append(validatorIds, validatorID)
+		copy(validatorKey[:], bytes)
+		validatorPublicKeys = append(validatorPublicKeys, validatorKey)
 	}
 
-	return validatorIds
+	return validatorPublicKeys
 }
 
 func claimQueue(t *testing.T) parachaintypes.ClaimQueue {

--- a/dot/parachain/backing/mocks_runtime_test.go
+++ b/dot/parachain/backing/mocks_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/backing/per_relay_parent_state.go
+++ b/dot/parachain/backing/per_relay_parent_state.go
@@ -86,12 +86,12 @@ func (cb *CandidateBacking) constructPerRelayParentState(relayParent common.Hash
 
 	var localValidator *parachaintypes.Validator
 
-	validatorID, validatorIndex := parachainutil.SigningKeyAndIndex(validators, cb.Keystore)
-	if validatorID != nil {
+	validatorPublicKey, validatorIndex := parachainutil.SigningKeyAndIndex(validators, cb.Keystore)
+	if validatorPublicKey != nil {
 		//  local node is a validator
 		localValidator = &parachaintypes.Validator{
 			SigningContext: signingContext,
-			Key:            *validatorID,
+			Key:            *validatorPublicKey,
 			Index:          validatorIndex,
 			Disabled:       slices.Contains(disabledValidators, validatorIndex),
 		}

--- a/dot/parachain/bitfield-distribution/bitfield_distribution.go
+++ b/dot/parachain/bitfield-distribution/bitfield_distribution.go
@@ -48,7 +48,9 @@ type perRelayParentData struct {
 	messageReceivedFromPeer map[peer.ID]map[parachaintypes.ValidatorPublicKey]struct{}
 }
 
-func newPerRelayParentData(signingContext parachaintypes.SigningContext, validatorSet []parachaintypes.ValidatorPublicKey,
+func newPerRelayParentData(
+	signingContext parachaintypes.SigningContext,
+	validatorSet []parachaintypes.ValidatorPublicKey,
 ) *perRelayParentData {
 	return &perRelayParentData{
 		signingContext:          signingContext,

--- a/dot/parachain/bitfield-distribution/bitfield_distribution.go
+++ b/dot/parachain/bitfield-distribution/bitfield_distribution.go
@@ -33,29 +33,29 @@ type perRelayParentData struct {
 	signingContext parachaintypes.SigningContext
 
 	// Set of validators for a particular relay parent.
-	validatorsSet []parachaintypes.ValidatorID
+	validatorsSet []parachaintypes.ValidatorPublicKey
 
 	// Set of validators for a particular relay parent for which we
 	// received a valid `BitfieldGossipMessage`.
 	// Also serves as the list of known messages for peers connecting
 	// after bitfield gossips were already received.
-	onePerValidator map[parachaintypes.ValidatorID]*validationprotocol.BitfieldDistributionMessage
+	onePerValidator map[parachaintypes.ValidatorPublicKey]*validationprotocol.BitfieldDistributionMessage
 
 	// Avoid duplicate message transmission to our peers.
-	messageSentToPeer map[peer.ID]map[parachaintypes.ValidatorID]struct{}
+	messageSentToPeer map[peer.ID]map[parachaintypes.ValidatorPublicKey]struct{}
 
 	// Track messages that were already received by a peer to prevent flooding.
-	messageReceivedFromPeer map[peer.ID]map[parachaintypes.ValidatorID]struct{}
+	messageReceivedFromPeer map[peer.ID]map[parachaintypes.ValidatorPublicKey]struct{}
 }
 
-func newPerRelayParentData(signingContext parachaintypes.SigningContext, validatorSet []parachaintypes.ValidatorID,
+func newPerRelayParentData(signingContext parachaintypes.SigningContext, validatorSet []parachaintypes.ValidatorPublicKey,
 ) *perRelayParentData {
 	return &perRelayParentData{
 		signingContext:          signingContext,
 		validatorsSet:           validatorSet,
-		onePerValidator:         make(map[parachaintypes.ValidatorID]*validationprotocol.BitfieldDistributionMessage),
-		messageSentToPeer:       make(map[peer.ID]map[parachaintypes.ValidatorID]struct{}),
-		messageReceivedFromPeer: make(map[peer.ID]map[parachaintypes.ValidatorID]struct{}),
+		onePerValidator:         make(map[parachaintypes.ValidatorPublicKey]*validationprotocol.BitfieldDistributionMessage),
+		messageSentToPeer:       make(map[peer.ID]map[parachaintypes.ValidatorPublicKey]struct{}),
+		messageReceivedFromPeer: make(map[peer.ID]map[parachaintypes.ValidatorPublicKey]struct{}),
 	}
 }
 
@@ -63,7 +63,7 @@ func newPerRelayParentData(signingContext parachaintypes.SigningContext, validat
 // validator is needed by the given peer.
 func (p *perRelayParentData) messageFromValidatorNeededByPeer(
 	peerID peer.ID,
-	signedBy parachaintypes.ValidatorID,
+	signedBy parachaintypes.ValidatorPublicKey,
 ) bool {
 	_, sendToExist := p.messageSentToPeer[peerID][signedBy]
 	_, receiveFromExist := p.messageReceivedFromPeer[peerID][signedBy]
@@ -204,14 +204,14 @@ func (b *BitfieldDistribution) processBitfieldDistributionMessage(msg parachaint
 		logger.Debugf("could not find a validator for index %d", validatorIdx)
 		return nil
 	}
-	validatorID := jobData.validatorsSet[validatorIdx]
+	validatorPublicKey := jobData.validatorsSet[validatorIdx]
 
 	topology := b.topologies.GetTopologyOrFallback(sessionIdx).LocalNeighbours
 
 	requiredRouting := topology.RequiredRoutingByIndex(validatorIdx, true)
 
 	// check the unchecked bitfield message against the validator
-	vpk, err := sr25519.NewPublicKey(validatorID[:])
+	vpk, err := sr25519.NewPublicKey(validatorPublicKey[:])
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func (b *BitfieldDistribution) processBitfieldDistributionMessage(msg parachaint
 	checkedBitfield, err := msg.Bitfield.ToCheck(vpk)
 	if err != nil {
 		return fmt.Errorf("unable to verfy the signed bitfield message against the validator"+
-			": %s, err :%s", validatorID, err)
+			": %s, err :%s", validatorPublicKey, err)
 	}
 
 	// construct the relay message
@@ -228,7 +228,7 @@ func (b *BitfieldDistribution) processBitfieldDistributionMessage(msg parachaint
 		CheckedSignedAvailabilityBitfield: *checkedBitfield,
 	}
 
-	relayMessage(jobData, topology, b.peerViews, validatorID, checkedBitfieldMessage, requiredRouting,
+	relayMessage(jobData, topology, b.peerViews, validatorPublicKey, checkedBitfieldMessage, requiredRouting,
 		b.subSystemToOverseer)
 
 	return nil
@@ -412,14 +412,14 @@ func (b *BitfieldDistribution) processIncomingPeerMessageEvent(event networkbrid
 		return nil
 
 	}
-	validatorID := jobData.validatorsSet[validatorIdx]
+	validatorPublicKey := jobData.validatorsSet[validatorIdx]
 
 	receivedSet := jobData.messageReceivedFromPeer[event.PeerID]
 	if receivedSet == nil {
-		receivedSet = make(map[parachaintypes.ValidatorID]struct{})
-		receivedSet[validatorID] = struct{}{}
+		receivedSet = make(map[parachaintypes.ValidatorPublicKey]struct{})
+		receivedSet[validatorPublicKey] = struct{}{}
 	} else {
-		_, ok := receivedSet[validatorID]
+		_, ok := receivedSet[validatorPublicKey]
 		if ok {
 			logger.Debugf("duplicated message in messageReceivedFromPeer")
 
@@ -432,14 +432,14 @@ func (b *BitfieldDistribution) processIncomingPeerMessageEvent(event networkbrid
 	}
 
 	// compare the bitfield from subsystem state against the incoming signal
-	m, err = jobData.onePerValidator[validatorID].Value()
+	m, err = jobData.onePerValidator[validatorPublicKey].Value()
 	if err != nil {
 		return err
 	}
 	storedBitfield, ok := m.(validationprotocol.UncheckedBitfield)
 	if !ok {
 		return fmt.Errorf("unable to casting the stored BitfieldDistributionMessage in onePerValidator "+
-			"for validatorID %d", validatorID)
+			"for validatorPublicKey %d", validatorPublicKey)
 	}
 	if storedBitfield.UncheckedSignedAvailabilityBitfield.IsEqual(bitfield) {
 		// already received a message for validator
@@ -451,7 +451,7 @@ func (b *BitfieldDistribution) processIncomingPeerMessageEvent(event networkbrid
 	}
 
 	// verify the bitfield data against the validator
-	vpk, err := sr25519.NewPublicKey(validatorID[:])
+	vpk, err := sr25519.NewPublicKey(validatorPublicKey[:])
 	if err != nil {
 		return err
 	}
@@ -478,9 +478,9 @@ func (b *BitfieldDistribution) processIncomingPeerMessageEvent(event networkbrid
 	if err != nil {
 		return err
 	}
-	jobData.onePerValidator[validatorID] = &vdm
+	jobData.onePerValidator[validatorPublicKey] = &vdm
 
-	relayMessage(jobData, topology, b.peerViews, validatorID, message, requiredRouting, b.subSystemToOverseer)
+	relayMessage(jobData, topology, b.peerViews, validatorPublicKey, message, requiredRouting, b.subSystemToOverseer)
 
 	modifyReputation(b.reputation, b.subSystemToOverseer, event.PeerID, util.UnifiedReputationChange{
 		Type:   util.BenefitMinorFirst,
@@ -548,7 +548,7 @@ func relayMessage(
 	jobData *perRelayParentData,
 	topologyNeighbors *grid.GridNeighbours,
 	peers map[peer.ID]*networkbridge.PeerDataViewWithVersion,
-	validatorID parachaintypes.ValidatorID,
+	validatorPublicKey parachaintypes.ValidatorPublicKey,
 	message validationprotocol.CheckedBitfield,
 	requiredRouting grid.RequiredRouting,
 	subsystemToOverSeerChan chan<- any,
@@ -566,7 +566,7 @@ func relayMessage(
 	interestedPeers := make(map[peer.ID]uint32)
 	for peerID, peerData := range peers {
 		if peerData != nil && peerData.View.Contains(relayParent) {
-			if jobData.messageFromValidatorNeededByPeer(peerID, validatorID) {
+			if jobData.messageFromValidatorNeededByPeer(peerID, validatorPublicKey) {
 				needRouting := topologyNeighbors.ShouldRouteToPeer(requiredRouting, peerID)
 				if needRouting {
 					interestedPeers[peerID] = peerData.ProtocolVersion
@@ -582,7 +582,7 @@ func relayMessage(
 
 	// 2. insert the message sent for this peerData into jobData
 	for peerID := range interestedPeers {
-		jobData.messageSentToPeer[peerID] = map[parachaintypes.ValidatorID]struct{}{validatorID: {}}
+		jobData.messageSentToPeer[peerID] = map[parachaintypes.ValidatorPublicKey]struct{}{validatorPublicKey: {}}
 	}
 
 	// 3. send NetworkBridgeTxMessage::SendValidationMessage to all v2 and v3 peers
@@ -658,8 +658,8 @@ func (b *BitfieldDistribution) handlePeerViewChange(
 	for _, hash := range added {
 		jobData := b.perRelayParent[hash]
 		if jobData != nil {
-			for validatorId, message := range jobData.onePerValidator {
-				if jobData.messageFromValidatorNeededByPeer(origin, validatorId) {
+			for validatorPublicKey, message := range jobData.onePerValidator {
+				if jobData.messageFromValidatorNeededByPeer(origin, validatorPublicKey) {
 					v, err := message.Value()
 					if err != nil {
 						logger.Errorf("failed to extract the value from BitfieldDistributionMessage: %s",
@@ -672,7 +672,7 @@ func (b *BitfieldDistribution) handlePeerViewChange(
 							"but got UncheckedBitfield")
 						return
 					}
-					b.sendTrackedGossipMessage(origin, validatorId, bitfield)
+					b.sendTrackedGossipMessage(origin, validatorPublicKey, bitfield)
 				}
 			}
 		}
@@ -682,7 +682,7 @@ func (b *BitfieldDistribution) handlePeerViewChange(
 // sendTrackedGossipMessage sends a gossip message and tracks it in the per relay parent data
 func (b *BitfieldDistribution) sendTrackedGossipMessage(
 	dest peer.ID,
-	validatorId parachaintypes.ValidatorID,
+	validatorPublicKey parachaintypes.ValidatorPublicKey,
 	message validationprotocol.CheckedBitfield,
 ) {
 	jobData := b.perRelayParent[message.Hash]
@@ -698,8 +698,8 @@ func (b *BitfieldDistribution) sendTrackedGossipMessage(
 	}
 
 	if jobData.messageSentToPeer[dest] == nil {
-		jobData.messageSentToPeer[dest] = map[parachaintypes.ValidatorID]struct{}{
-			validatorId: {},
+		jobData.messageSentToPeer[dest] = map[parachaintypes.ValidatorPublicKey]struct{}{
+			validatorPublicKey: {},
 		}
 	}
 
@@ -745,7 +745,7 @@ func modifyReputation(reputation *util.ReputationAggregator, sender chan<- any, 
 // queryBasics queries our validator set and signing context for a particular relay parent
 func (b *BitfieldDistribution) queryBasics(
 	relayParent common.Hash,
-) ([]parachaintypes.ValidatorID, *parachaintypes.SigningContext, error) {
+) ([]parachaintypes.ValidatorPublicKey, *parachaintypes.SigningContext, error) {
 	rt, err := b.blockState.GetRuntime(relayParent)
 	if err != nil {
 		return nil, nil, err

--- a/dot/parachain/bitfield-distribution/bitfield_distribution_test.go
+++ b/dot/parachain/bitfield-distribution/bitfield_distribution_test.go
@@ -36,7 +36,7 @@ func generateDummyPeerID(t *testing.T, bits int) peer.ID {
 }
 
 func TestMessageFromValidatorNeededByPeer(t *testing.T) {
-	validatorSet := []parachaintypes.ValidatorID{
+	validatorSet := []parachaintypes.ValidatorPublicKey{
 		[sr25519.PublicKeyLength]byte{1},
 		[sr25519.PublicKeyLength]byte{2},
 	}
@@ -51,17 +51,17 @@ func TestMessageFromValidatorNeededByPeer(t *testing.T) {
 
 	assert.NotEqual(t, peerA, peerB)
 
-	pretendSent := func(state *perRelayParentData, destPeer peer.ID, signedBy parachaintypes.ValidatorID) bool {
+	pretendSent := func(state *perRelayParentData, destPeer peer.ID, signedBy parachaintypes.ValidatorPublicKey) bool {
 		if state.messageFromValidatorNeededByPeer(destPeer, signedBy) {
-			state.messageSentToPeer[destPeer] = map[parachaintypes.ValidatorID]struct{}{signedBy: {}}
+			state.messageSentToPeer[destPeer] = map[parachaintypes.ValidatorPublicKey]struct{}{signedBy: {}}
 			return true
 		} else {
 			return false
 		}
 	}
 
-	pretendReceive := func(state *perRelayParentData, sourcePeer peer.ID, signedBy parachaintypes.ValidatorID) {
-		state.messageReceivedFromPeer[sourcePeer] = map[parachaintypes.ValidatorID]struct{}{signedBy: {}}
+	pretendReceive := func(state *perRelayParentData, sourcePeer peer.ID, signedBy parachaintypes.ValidatorPublicKey) {
+		state.messageReceivedFromPeer[sourcePeer] = map[parachaintypes.ValidatorPublicKey]struct{}{signedBy: {}}
 	}
 
 	assert.True(t, pretendSent(prpd, peerA, validatorSet[0]))
@@ -251,10 +251,10 @@ func TestBitfieldDistribution_FilterByPeerVersion(t *testing.T) {
 	}
 }
 
-func prepareForValidators() (parachaintypes.ValidatorIndex, []parachaintypes.ValidatorID) {
+func prepareForValidators() (parachaintypes.ValidatorIndex, []parachaintypes.ValidatorPublicKey) {
 	// prepare for the relay message call params
 	validatorIndex := 0
-	validatorSet := []parachaintypes.ValidatorID{
+	validatorSet := []parachaintypes.ValidatorPublicKey{
 		[sr25519.PublicKeyLength]byte{1},
 		[sr25519.PublicKeyLength]byte{2},
 	}
@@ -314,7 +314,7 @@ func TestBitfieldDistribution_RelayMessage_InterestedPeersEmpty(t *testing.T) {
 
 	topologies := grid.NewEmptyGridNeighbours()
 	requiredRouting := grid.RequiredRoutingAll
-	validatorID := jobData.validatorsSet[validatorIndex]
+	validatorPublicKey := jobData.validatorsSet[validatorIndex]
 
 	done := make(chan struct{})
 	go func() {
@@ -331,7 +331,7 @@ func TestBitfieldDistribution_RelayMessage_InterestedPeersEmpty(t *testing.T) {
 	}()
 
 	// call the target method
-	relayMessage(jobData, topologies, b.peerViews, validatorID, message, requiredRouting, b.subSystemToOverseer)
+	relayMessage(jobData, topologies, b.peerViews, validatorPublicKey, message, requiredRouting, b.subSystemToOverseer)
 
 	// wait for the provisionable content checks
 	select {
@@ -397,7 +397,7 @@ func TestBitfieldDistribution_RelayMessage_FilterV2Peers(t *testing.T) {
 
 	topologies := grid.NewEmptyGridNeighbours()
 	requiredRouting := grid.RequiredRoutingAll
-	validatorID := jobData.validatorsSet[validatorIndex]
+	validatorPublicKey := jobData.validatorsSet[validatorIndex]
 
 	done := make(chan struct{})
 	// check the overseer chan message for the SendValidationMessage for V2
@@ -426,7 +426,7 @@ func TestBitfieldDistribution_RelayMessage_FilterV2Peers(t *testing.T) {
 	}()
 
 	// call the target method
-	relayMessage(jobData, topologies, b.peerViews, validatorID, message, requiredRouting, b.subSystemToOverseer)
+	relayMessage(jobData, topologies, b.peerViews, validatorPublicKey, message, requiredRouting, b.subSystemToOverseer)
 
 	// wait for the v2 content SendValidationMessage checks
 	select {
@@ -492,7 +492,7 @@ func TestBitfieldDistribution_RelayMessage_FilterV3Peers(t *testing.T) {
 
 	topologies := grid.NewEmptyGridNeighbours()
 	requiredRouting := grid.RequiredRoutingAll
-	validatorID := jobData.validatorsSet[validatorIndex]
+	validatorPublicKey := jobData.validatorsSet[validatorIndex]
 
 	done := make(chan struct{})
 	// check the overseer chan message for the SendValidationMessage for v3
@@ -521,7 +521,7 @@ func TestBitfieldDistribution_RelayMessage_FilterV3Peers(t *testing.T) {
 	}()
 
 	// call the target method
-	relayMessage(jobData, topologies, b.peerViews, validatorID, message, requiredRouting, b.subSystemToOverseer)
+	relayMessage(jobData, topologies, b.peerViews, validatorPublicKey, message, requiredRouting, b.subSystemToOverseer)
 
 	// wait for the v3 content SendValidationMessage checks
 	select {
@@ -614,8 +614,8 @@ func TestBitfieldDistribution_ProcessBitfieldDistributionMessage_CheckSignedAvai
 	assert.Nil(t, err)
 	aliceKeypair := keyring.Alice().(*sr25519.Keypair)
 
-	validatorSet := []parachaintypes.ValidatorID{
-		parachaintypes.ValidatorID(aliceKeypair.Public().Encode()),
+	validatorSet := []parachaintypes.ValidatorPublicKey{
+		parachaintypes.ValidatorPublicKey(aliceKeypair.Public().Encode()),
 		[sr25519.PublicKeyLength]byte{2},
 	}
 	jobData := newPerRelayParentData(parachaintypes.SigningContext{
@@ -1054,8 +1054,8 @@ func TestBitfieldDistribution_ProcessIncomingPeerMessageEvent_ReceivedSetNotEmpt
 		}),
 	}
 
-	pretendReceive := func(state *perRelayParentData, sourcePeer peer.ID, signedBy parachaintypes.ValidatorID) {
-		state.messageReceivedFromPeer[sourcePeer] = map[parachaintypes.ValidatorID]struct{}{signedBy: {}}
+	pretendReceive := func(state *perRelayParentData, sourcePeer peer.ID, signedBy parachaintypes.ValidatorPublicKey) {
+		state.messageReceivedFromPeer[sourcePeer] = map[parachaintypes.ValidatorPublicKey]struct{}{signedBy: {}}
 	}
 	pretendReceive(jobData, peerA, validatorSet[0])
 
@@ -1103,7 +1103,7 @@ func TestBitfieldDistribution_ProcessIncomingPeerMessageEvent_DuplicatedMessages
 		ParentHash:   common.Hash{0x01},
 	}, validatorSet)
 
-	jobData.onePerValidator = map[parachaintypes.ValidatorID]*validationprotocol.BitfieldDistributionMessage{
+	jobData.onePerValidator = map[parachaintypes.ValidatorPublicKey]*validationprotocol.BitfieldDistributionMessage{
 		validatorSet[validatorIndex]: vb,
 	}
 
@@ -1141,8 +1141,8 @@ func TestBitfieldDistribution_ProcessIncomingPeerMessageEvent_Success(t *testing
 	aliceKeypair := keyring.Alice().(*sr25519.Keypair)
 
 	validatorIndex := 0
-	validatorSet := []parachaintypes.ValidatorID{
-		parachaintypes.ValidatorID(aliceKeypair.Public().Encode()),
+	validatorSet := []parachaintypes.ValidatorPublicKey{
+		parachaintypes.ValidatorPublicKey(aliceKeypair.Public().Encode()),
 		[sr25519.PublicKeyLength]byte{2},
 	}
 
@@ -1195,7 +1195,7 @@ func TestBitfieldDistribution_ProcessIncomingPeerMessageEvent_Success(t *testing
 	err = messageStoredInState.SetValue(storedMessage)
 	assert.Nil(t, err)
 
-	jobData.onePerValidator = map[parachaintypes.ValidatorID]*validationprotocol.BitfieldDistributionMessage{
+	jobData.onePerValidator = map[parachaintypes.ValidatorPublicKey]*validationprotocol.BitfieldDistributionMessage{
 		validatorSet[validatorIndex]: messageStoredInState,
 	}
 
@@ -1696,7 +1696,7 @@ func TestBitfieldDistribution_ProcessActiveLeavesUpdateSignal_QueryParachainHost
 	blockAPIMock := NewMockBlockState(ctrl)
 	runtimeMock := NewMockInstance(ctrl)
 
-	validatorSet := []parachaintypes.ValidatorID{
+	validatorSet := []parachaintypes.ValidatorPublicKey{
 		[sr25519.PublicKeyLength]byte{1},
 		[sr25519.PublicKeyLength]byte{2},
 	}
@@ -1722,7 +1722,7 @@ func TestBitfieldDistribution_ProcessActiveLeavesUpdateSignal_Success(t *testing
 	blockAPIMock := NewMockBlockState(ctrl)
 	runtimeMock := NewMockInstance(ctrl)
 
-	validatorSet := []parachaintypes.ValidatorID{
+	validatorSet := []parachaintypes.ValidatorPublicKey{
 		[sr25519.PublicKeyLength]byte{1},
 		[sr25519.PublicKeyLength]byte{2},
 	}

--- a/dot/parachain/bitfield-distribution/mocks_instance_test.go
+++ b/dot/parachain/bitfield-distribution/mocks_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/bitfield-signing/bitfield_signing.go
+++ b/dot/parachain/bitfield-signing/bitfield_signing.go
@@ -131,8 +131,8 @@ func handleActiveLeavesUpdate(ctx context.Context, b *BitfieldSigning, activated
 		return fmt.Errorf("getting validators: %w", err)
 
 	}
-	validatorID, validatorIndex := parachainutil.SigningKeyAndIndex(validators, b.keystore)
-	if validatorID == nil {
+	validatorPublicKey, validatorIndex := parachainutil.SigningKeyAndIndex(validators, b.keystore)
+	if validatorPublicKey == nil {
 		// skip the logic if not a validator node
 		return nil
 	}
@@ -146,7 +146,7 @@ func handleActiveLeavesUpdate(ctx context.Context, b *BitfieldSigning, activated
 		ParentHash:   relayParent,
 	}
 	validator := parachaintypes.Validator{
-		Key:            *validatorID,
+		Key:            *validatorPublicKey,
 		Index:          validatorIndex,
 		SigningContext: signingContext,
 	}

--- a/dot/parachain/bitfield-signing/bitfield_signing_test.go
+++ b/dot/parachain/bitfield-signing/bitfield_signing_test.go
@@ -219,8 +219,8 @@ func TestProcessActiveLeavesUpdateSignalNotValidator(t *testing.T) {
 
 	blockAPIMock.EXPECT().GetRuntime(common.Hash{1, 2, 3, 4, 5}).Return(runtimeMock, nil).Times(1)
 
-	// validatorIDs is empty
-	runtimeMock.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorID{}, nil).Times(1)
+	// ValidatorPublicKeys is empty
+	runtimeMock.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorPublicKey{}, nil).Times(1)
 
 	// current node is not a validator
 	err = handleActiveLeavesUpdate(context.Background(), testBitfieldSigningSubsystem, testActiveLeaves)
@@ -251,9 +251,9 @@ func TestProcessActiveLeavesUpdateSignalConstructAvailabilityBitfieldError(t *te
 
 	blockAPIMock.EXPECT().GetRuntime(common.Hash{1, 2, 3, 4, 5}).Return(runtimeMock, nil).Times(1)
 
-	// validatorIDs has Alice
-	runtimeMock.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorID{
-		parachaintypes.ValidatorID(aliceKeypair.Public().Encode()),
+	// ValidatorPublicKeys has Alice
+	runtimeMock.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorPublicKey{
+		parachaintypes.ValidatorPublicKey(aliceKeypair.Public().Encode()),
 	}, nil).Times(1)
 
 	runtimeMock.EXPECT().ParachainHostSessionIndexForChild().Return(parachaintypes.SessionIndex(1), nil).Times(1)
@@ -289,9 +289,9 @@ func TestProcessActiveLeavesUpdateSignalSuccess(t *testing.T) {
 
 	blockAPIMock.EXPECT().GetRuntime(common.Hash{1, 2, 3, 4, 5}).Return(runtimeMock, nil).Times(1)
 
-	// validatorIDs has Alice
-	runtimeMock.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorID{
-		parachaintypes.ValidatorID(aliceKeypair.Public().Encode()),
+	// ValidatorPublicKeys has Alice
+	runtimeMock.EXPECT().ParachainHostValidators().Return([]parachaintypes.ValidatorPublicKey{
+		parachaintypes.ValidatorPublicKey(aliceKeypair.Public().Encode()),
 	}, nil).Times(1)
 
 	cores := parachaintypes.NewAvailabilityCores()

--- a/dot/parachain/bitfield-signing/mocks_instance_test.go
+++ b/dot/parachain/bitfield-signing/mocks_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/candidate-validation/mocks_instance_test.go
+++ b/dot/parachain/candidate-validation/mocks_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/collator-protocol/validator-side/validator_side.go
+++ b/dot/parachain/collator-protocol/validator-side/validator_side.go
@@ -303,8 +303,8 @@ func findValidatorGroup(validatorIndex parachaintypes.ValidatorIndex, validatorG
 
 // signingKeyAndIndex finds the first key we can sign with from the given set of validators,
 // if any, and returns it along with the validator index.
-func signingKeyAndIndex(validators []parachaintypes.ValidatorID, ks keystore.Keystore,
-) (*parachaintypes.ValidatorID, parachaintypes.ValidatorIndex) {
+func signingKeyAndIndex(validators []parachaintypes.ValidatorPublicKey, ks keystore.Keystore,
+) (*parachaintypes.ValidatorPublicKey, parachaintypes.ValidatorIndex) {
 	for i, validator := range validators {
 		publicKey, _ := sr25519.NewPublicKey(validator[:])
 		keypair := ks.GetKeypair(publicKey)

--- a/dot/parachain/gossip-support/gossip_support_test.go
+++ b/dot/parachain/gossip-support/gossip_support_test.go
@@ -132,7 +132,7 @@ func TestGetKeyIndexAndUpdateMetrics(t *testing.T) {
 		// than the key index of the current authority
 		sessionInfo := &parachaintypes.SessionInfo{
 			DiscoveryKeys: authorities,
-			Validators:    []parachaintypes.ValidatorID{{0x01}, {0x02}, {0x03}},
+			Validators:    []parachaintypes.ValidatorPublicKey{{0x01}, {0x02}, {0x03}},
 		}
 		keyIdx, err := gs.getKeyIndexAndUpdateMetrics(sessionInfo)
 
@@ -141,7 +141,7 @@ func TestGetKeyIndexAndUpdateMetrics(t *testing.T) {
 
 		// The subset of authorities participating in parachain consensus is less
 		// than the key index of the current authority
-		sessionInfo = &parachaintypes.SessionInfo{DiscoveryKeys: authorities, Validators: []parachaintypes.ValidatorID{{}}}
+		sessionInfo = &parachaintypes.SessionInfo{DiscoveryKeys: authorities, Validators: []parachaintypes.ValidatorPublicKey{{}}}
 		keyIdx, err = gs.getKeyIndexAndUpdateMetrics(sessionInfo)
 
 		assert.Nil(t, err)

--- a/dot/parachain/gossip-support/gossip_support_test.go
+++ b/dot/parachain/gossip-support/gossip_support_test.go
@@ -141,7 +141,12 @@ func TestGetKeyIndexAndUpdateMetrics(t *testing.T) {
 
 		// The subset of authorities participating in parachain consensus is less
 		// than the key index of the current authority
-		sessionInfo = &parachaintypes.SessionInfo{DiscoveryKeys: authorities, Validators: []parachaintypes.ValidatorPublicKey{{}}}
+		sessionInfo = &parachaintypes.SessionInfo{
+			DiscoveryKeys: authorities,
+			Validators: []parachaintypes.ValidatorPublicKey{
+				{},
+			},
+		}
 		keyIdx, err = gs.getKeyIndexAndUpdateMetrics(sessionInfo)
 
 		assert.Nil(t, err)

--- a/dot/parachain/gossip-support/mocks_instance_test.go
+++ b/dot/parachain/gossip-support/mocks_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/network-bridge/messages/tx_overseer_messages.go
+++ b/dot/parachain/network-bridge/messages/tx_overseer_messages.go
@@ -64,7 +64,7 @@ const (
 // `PeerConnected` events from the network bridge.
 type ConnectToValidators struct {
 	// IDs of the validators to connect to.
-	ValidatorIDs []parachaintypes.AuthorityDiscoveryID
+	ValidatorPublicKeys []parachaintypes.AuthorityDiscoveryID
 	// The underlying protocol to use for this request.
 	PeerSet PeerSetType
 	// Sends back the number of `AuthorityDiscoveryId`s which

--- a/dot/parachain/network-bridge/messages/tx_overseer_messages.go
+++ b/dot/parachain/network-bridge/messages/tx_overseer_messages.go
@@ -64,7 +64,7 @@ const (
 // `PeerConnected` events from the network bridge.
 type ConnectToValidators struct {
 	// IDs of the validators to connect to.
-	ValidatorPublicKeys []parachaintypes.AuthorityDiscoveryID
+	ValidatorIDs []parachaintypes.AuthorityDiscoveryID
 	// The underlying protocol to use for this request.
 	PeerSet PeerSetType
 	// Sends back the number of `AuthorityDiscoveryId`s which

--- a/dot/parachain/overseer/mock_runtime_instance_test.go
+++ b/dot/parachain/overseer/mock_runtime_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/prospective-parachains/mocks_instance_test.go
+++ b/dot/parachain/prospective-parachains/mocks_instance_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/provisioner/mocks_runtime_test.go
+++ b/dot/parachain/provisioner/mocks_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/provisioner/test_helper.go
+++ b/dot/parachain/provisioner/test_helper.go
@@ -73,11 +73,11 @@ func signedBitfield(
 	require.NoError(t, err)
 
 	publicKeyBytes := keyPair.Public().Encode()
-	validatorID := parachaintypes.ValidatorID(publicKeyBytes)
+	ValidatorPublicKey := parachaintypes.ValidatorPublicKey(publicKeyBytes)
 
 	validator := parachaintypes.Validator{
 		SigningContext: parachaintypes.SigningContext{},
-		Key:            validatorID,
+		Key:            ValidatorPublicKey,
 	}
 
 	encoded, err := scale.Marshal(field)

--- a/dot/parachain/provisioner/test_helper.go
+++ b/dot/parachain/provisioner/test_helper.go
@@ -73,11 +73,11 @@ func signedBitfield(
 	require.NoError(t, err)
 
 	publicKeyBytes := keyPair.Public().Encode()
-	ValidatorPublicKey := parachaintypes.ValidatorPublicKey(publicKeyBytes)
+	validatorPublicKey := parachaintypes.ValidatorPublicKey(publicKeyBytes)
 
 	validator := parachaintypes.Validator{
 		SigningContext: parachaintypes.SigningContext{},
-		Key:            ValidatorPublicKey,
+		Key:            validatorPublicKey,
 	}
 
 	encoded, err := scale.Marshal(field)

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -160,11 +160,11 @@ func TestStatementVDT_SignAndVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	publicKeyBytes := keyPair.Public().Encode()
-	validatorID := ValidatorID(publicKeyBytes)
+	ValidatorPublicKey := ValidatorPublicKey(publicKeyBytes)
 
 	validator := Validator{
 		SigningContext: signingContext,
-		Key:            validatorID,
+		Key:            ValidatorPublicKey,
 	}
 
 	signedStatement, err := statement.Sign(validator, ks)

--- a/dot/parachain/types/statement_test.go
+++ b/dot/parachain/types/statement_test.go
@@ -160,11 +160,11 @@ func TestStatementVDT_SignAndVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	publicKeyBytes := keyPair.Public().Encode()
-	ValidatorPublicKey := ValidatorPublicKey(publicKeyBytes)
+	validatorPublicKey := ValidatorPublicKey(publicKeyBytes)
 
 	validator := Validator{
 		SigningContext: signingContext,
-		Key:            ValidatorPublicKey,
+		Key:            validatorPublicKey,
 	}
 
 	signedStatement, err := statement.Sign(validator, ks)

--- a/dot/parachain/types/types.go
+++ b/dot/parachain/types/types.go
@@ -23,11 +23,11 @@ import (
 
 // NOTE: https://github.com/ChainSafe/gossamer/pull/3297#discussion_r1214740051
 
-// ValidatorIndex Index of the validator. Used as a lightweight replacement of the `ValidatorId` when appropriate
+// ValidatorIndex Index of the validator. Used as a lightweight replacement of the `ValidatorPublicKey` when appropriate
 type ValidatorIndex uint32
 
-// ValidatorID The public key of a validator.
-type ValidatorID [sr25519.PublicKeyLength]byte
+// ValidatorPublicKey The public key of a validator.
+type ValidatorPublicKey [sr25519.PublicKeyLength]byte
 
 // BlockNumber The block number type.
 type BlockNumber uint32
@@ -446,7 +446,7 @@ type SessionInfo struct {
 	// The amount of sessions to keep for disputes.
 	DisputePeriod SessionIndex `scale:"3"`
 	// Validators in canonical ordering.
-	Validators []ValidatorID `scale:"4"`
+	Validators []ValidatorPublicKey `scale:"4"`
 	// Validators' authority discovery keys for the session in canonical ordering.
 	DiscoveryKeys []AuthorityDiscoveryID `scale:"5"`
 	// The assignment keys for validators.
@@ -1097,7 +1097,7 @@ type CandidateHashAndRelayParent struct {
 // It can be created if the local node is a validator in the context of a particular relay chain block.
 type Validator struct {
 	SigningContext SigningContext
-	Key            ValidatorID
+	Key            ValidatorPublicKey
 	Index          ValidatorIndex
 	Disabled       bool
 }

--- a/dot/parachain/types/types_test.go
+++ b/dot/parachain/types/types_test.go
@@ -45,11 +45,11 @@ func Test_Validators(t *testing.T) {
 	resultBytes, err := common.HexToBytes(resultHex)
 	require.NoError(t, err)
 
-	var validatorIDs []ValidatorID
-	err = scale.Unmarshal(resultBytes, &validatorIDs)
+	var ValidatorPublicKeys []ValidatorPublicKey
+	err = scale.Unmarshal(resultBytes, &ValidatorPublicKeys)
 	require.NoError(t, err)
 
-	expected := []ValidatorID{
+	expected := []ValidatorPublicKey{
 		mustHexTo32BArray(t, "0xa262f83b46310770ae8d092147176b8b25e8855bcfbbe701d346b10db0c5385d"),
 		mustHexTo32BArray(t, "0x804b9df571e2b744d65eca2d4c59eb8e4345286c00389d97bfc1d8d13aa6e57e"),
 		mustHexTo32BArray(t, "0x4eb63e4aad805c06dc924e2f19b1dde7faf507e5bb3c1838d6a3cfc10e84fe72"),
@@ -68,9 +68,9 @@ func Test_Validators(t *testing.T) {
 		mustHexTo32BArray(t, "0x807fa54347a8957ff5ef6c28e2403c83947e5fad4aa805c914df0645a07aab5a"),
 		mustHexTo32BArray(t, "0x4c8e878d7f558ce5086cc37ca0d5964bed54ddd6b15a6663a95fe42e36858936"),
 	}
-	require.Equal(t, expected, validatorIDs)
+	require.Equal(t, expected, ValidatorPublicKeys)
 
-	encoded, err := scale.Marshal(validatorIDs)
+	encoded, err := scale.Marshal(ValidatorPublicKeys)
 	require.NoError(t, err)
 	require.Equal(t, resultHex, common.BytesToHex(encoded))
 }
@@ -193,7 +193,7 @@ func TestSessionInfo(t *testing.T) {
 		RandomSeed: mustHexTo32BArray(t,
 			"0x9a14667dcf973e46392904593e8caf2fb7a57904edbadf1547531657e7a56b5e"),
 		DisputePeriod: 6,
-		Validators: []ValidatorID{
+		Validators: []ValidatorPublicKey{
 			mustHexTo32BArray(t, "0xa262f83b46310770ae8d092147176b8b25e8855bcfbbe701d346b10db0c5385d"),
 			mustHexTo32BArray(t, "0x804b9df571e2b744d65eca2d4c59eb8e4345286c00389d97bfc1d8d13aa6e57e"),
 			mustHexTo32BArray(t, "0x4eb63e4aad805c06dc924e2f19b1dde7faf507e5bb3c1838d6a3cfc10e84fe72"),
@@ -490,11 +490,11 @@ func TestValidator_SignAndVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	publicKeyBytes := keyPair.Public().Encode()
-	validatorID := ValidatorID(publicKeyBytes)
+	ValidatorPublicKey := ValidatorPublicKey(publicKeyBytes)
 
 	validator := Validator{
 		SigningContext: signingContext,
-		Key:            validatorID,
+		Key:            ValidatorPublicKey,
 		Index:          50,
 	}
 

--- a/dot/parachain/util/mock_runtime_test.go
+++ b/dot/parachain/util/mock_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/parachain/util/util.go
+++ b/dot/parachain/util/util.go
@@ -171,9 +171,9 @@ func (r *ReputationAggregator) singleSend(
 // SigningKeyAndIndex finds the first key we can sign with from the given set of validators,
 // if any, and returns it along with the validator index.
 func SigningKeyAndIndex(
-	validators []parachaintypes.ValidatorID,
+	validators []parachaintypes.ValidatorPublicKey,
 	ks keystore.Keystore,
-) (*parachaintypes.ValidatorID, parachaintypes.ValidatorIndex) {
+) (*parachaintypes.ValidatorPublicKey, parachaintypes.ValidatorIndex) {
 	for i, validator := range validators {
 		publicKey, _ := sr25519.NewPublicKey(validator[:])
 		keypair := ks.GetKeypair(publicKey)

--- a/dot/state/mocks_runtime_test.go
+++ b/dot/state/mocks_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/dot/sync/mock_runtime_test.go
+++ b/dot/sync/mock_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/lib/babe/mocks/runtime.go
+++ b/lib/babe/mocks/runtime.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/lib/blocktree/mocks_test.go
+++ b/lib/blocktree/mocks_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/lib/grandpa/mocks_runtime_test.go
+++ b/lib/grandpa/mocks_runtime_test.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/lib/runtime/interface.go
+++ b/lib/runtime/interface.go
@@ -56,7 +56,7 @@ type Instance interface {
 	ParachainHostValidationCode(parachaidID parachaintypes.ParaID, assumption parachaintypes.OccupiedCoreAssumption,
 	) (*parachaintypes.ValidationCode, error)
 	ParachainHostValidationCodeByHash(validationCodeHash common.Hash) (*parachaintypes.ValidationCode, error)
-	ParachainHostValidators() ([]parachaintypes.ValidatorID, error)
+	ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error)
 	ParachainHostValidatorGroups() (*parachaintypes.ValidatorGroups, error)
 	ParachainHostAvailabilityCores() ([]parachaintypes.CoreState, error)
 	ParachainHostCheckValidationOutputs(

--- a/lib/runtime/mocks/mocks.go
+++ b/lib/runtime/mocks/mocks.go
@@ -646,10 +646,10 @@ func (mr *MockInstanceMockRecorder) ParachainHostValidatorGroups() *gomock.Call 
 }
 
 // ParachainHostValidators mocks base method.
-func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (m *MockInstance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ParachainHostValidators")
-	ret0, _ := ret[0].([]parachaintypes.ValidatorID)
+	ret0, _ := ret[0].([]parachaintypes.ValidatorPublicKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/lib/runtime/wazero/instance.go
+++ b/lib/runtime/wazero/instance.go
@@ -1195,19 +1195,19 @@ func (in *Instance) ParachainHostValidationCode(
 
 // ParachainHostValidators returns the validator set at the current state.
 // The specified validators are responsible for backing parachains for the current state.
-func (in *Instance) ParachainHostValidators() ([]parachaintypes.ValidatorID, error) {
+func (in *Instance) ParachainHostValidators() ([]parachaintypes.ValidatorPublicKey, error) {
 	encodedValidators, err := in.Exec(runtime.ParachainHostValidators, []byte{})
 	if err != nil {
 		return nil, fmt.Errorf("exec: %w", err)
 	}
 
-	var validatorIDs []parachaintypes.ValidatorID
-	err = scale.Unmarshal(encodedValidators, &validatorIDs)
+	var validatorPublicKeys []parachaintypes.ValidatorPublicKey
+	err = scale.Unmarshal(encodedValidators, &validatorPublicKeys)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshalling: %w", err)
 	}
 
-	return validatorIDs, nil
+	return validatorPublicKeys, nil
 }
 
 // ParachainHostValidatorGroups returns the validator groups used during the current session.

--- a/lib/runtime/wazero/instance_test.go
+++ b/lib/runtime/wazero/instance_test.go
@@ -1499,7 +1499,7 @@ func TestInstance_ParachainHostValidators(t *testing.T) {
 	response, err := rt.ParachainHostValidators()
 	require.NoError(t, err)
 
-	expected := []parachaintypes.ValidatorID{
+	expected := []parachaintypes.ValidatorPublicKey{
 		mustHexTo32BArray(t, "0xa262f83b46310770ae8d092147176b8b25e8855bcfbbe701d346b10db0c5385d"),
 		mustHexTo32BArray(t, "0x804b9df571e2b744d65eca2d4c59eb8e4345286c00389d97bfc1d8d13aa6e57e"),
 		mustHexTo32BArray(t, "0x4eb63e4aad805c06dc924e2f19b1dde7faf507e5bb3c1838d6a3cfc10e84fe72"),
@@ -1631,7 +1631,7 @@ func TestInstance_ParachainHostSessionInfo(t *testing.T) {
 		ActiveValidatorIndices: []parachaintypes.ValidatorIndex{7, 12, 14, 1, 4, 16, 3, 11, 9, 6, 13, 15, 5, 0, 8, 10, 2},
 		RandomSeed:             mustHexTo32BArray(t, "0x9a14667dcf973e46392904593e8caf2fb7a57904edbadf1547531657e7a56b5e"),
 		DisputePeriod:          6,
-		Validators: []parachaintypes.ValidatorID{
+		Validators: []parachaintypes.ValidatorPublicKey{
 			mustHexTo32BArray(t, "0xa262f83b46310770ae8d092147176b8b25e8855bcfbbe701d346b10db0c5385d"),
 			mustHexTo32BArray(t, "0x804b9df571e2b744d65eca2d4c59eb8e4345286c00389d97bfc1d8d13aa6e57e"),
 			mustHexTo32BArray(t, "0x4eb63e4aad805c06dc924e2f19b1dde7faf507e5bb3c1838d6a3cfc10e84fe72"),


### PR DESCRIPTION
### Changes

This PR renames the `**ValidatorID**` type to `**ValidatorPublicKey**` throughout the parachain subsystem. Previously, `ValidatorID` represented a validator’s public key, which caused ambiguity due to its similarity with `ValidatorIndex`. The new naming improves clarity and correctness.

### Tests

`go test ./dot/parachain/...`  

### Issues

#4552

