### PR TITLE
chore(statement-distribution): Simplify an "enum" used in `clusterTracker`

### DIFF
--- a/dot/parachain/statement-distribution/cluster_tracker.go
+++ b/dot/parachain/statement-distribution/cluster_tracker.go
@@ -10,94 +10,32 @@ import (
 	"github.com/ChainSafe/gossamer/lib/common"
 )
 
-// accept signifies that an incoming statement was accepted.
-type accept interface { //nolint:unused
-	isAccept()
-}
+type acceptOrReject byte
 
-// ok means neither the peer nor the originator have apparently exceeded limits.
-// Candidate or statement may already be known.
-type ok struct{}
+const (
+	// ok means neither the peer nor the originator have apparently exceeded limits.
+	// Candidate or statement may already be known.
+	ok acceptOrReject = iota
 
-func (ok) isAccept() {}
+	// withPrejudice means accept the message; the peer hasn't exceeded limits but the originator has.
+	withPrejudice
 
-// / withPrejudice means accept the message; the peer hasn't exceeded limits but the originator has.
-type withPrejudice struct{}
+	// excessiveSeconded means peer sent excessive `Seconded` statements or we attempted to send excessive `Seconded`
+	// statements. The latter indicates a bug on the local node's code.
+	excessiveSeconded
 
-func (withPrejudice) isAccept() {}
+	// notInGroup means sender/target or originator is not in the group.
+	notInGroup
 
-// / rejectIncoming signifies that an incoming statement was rejected.
-type rejectIncoming interface { //nolint:unused
-	isRejectIncoming()
-}
+	// candidateUnknown means the candidate is unknown to us. Only applies to `Valid` statements.
+	candidateUnknown
 
-// excessiveSecondedIncoming means peer sent excessive `Seconded` statements.
-type excessiveSecondedIncoming struct{}
+	// duplicate means the statement is a duplicate.
+	duplicate
 
-func (excessiveSecondedIncoming) isRejectIncoming() {}
-
-// notInGroupIncoming means sender or originator is not in the group.
-type notInGroupIncoming struct{}
-
-func (notInGroupIncoming) isRejectIcoming() {} //nolint:unused
-
-// candidateUnknownIncoming means the candidate is unknown to us. Only applies to `Valid` statements.
-type candidateUnknownIncoming struct{}
-
-func (candidateUnknownIncoming) isRejectIncoming() {}
-
-// duplicateIncoming means the statement is a duplicate.
-type duplicateIncoming struct{}
-
-func (duplicateIncoming) isRejectIncoming() {}
-
-// / rejectOutgoing signifies that an outgoing statement was rejected.
-type rejectOutgoing interface { //nolint:unused
-	isRejectOutgoing()
-}
-
-// candidateUnknownOutgoing means the candidate was unknown. Only applies to `Valid` statements.
-type candidateUnknownOutgoing struct{}
-
-func (candidateUnknownOutgoing) isRejectOutgoing() {}
-
-// excessiveSecondedOutgoing means we attempted to send excessive `Seconded` statements.
-// Indicates a bug on the local node's code.
-type excessiveSecondedOutgoing struct{}
-
-func (excessiveSecondedOutgoing) isRejectOutgoing() {}
-
-// knownOutgoing means the statement was already known to the peer.
-type knownOutgoing struct{}
-
-func (knownOutgoing) isRejectOutgoing() {}
-
-// notInGroupOutgoing means the target or originator are not in the group.
-type notInGroupOutgoing struct{}
-
-func (notInGroupOutgoing) isRejectOutgoing() {}
-
-type acceptOrRejectIncoming interface {
-	isAcceptOrRejectIncoming()
-}
-
-func (ok) isAcceptOrRejectIncoming()                        {}
-func (withPrejudice) isAcceptOrRejectIncoming()             {}
-func (excessiveSecondedIncoming) isAcceptOrRejectIncoming() {}
-func (notInGroupIncoming) isAcceptOrRejectIncoming()        {}
-func (candidateUnknownIncoming) isAcceptOrRejectIncoming()  {}
-func (duplicateIncoming) isAcceptOrRejectIncoming()         {}
-
-type acceptOrRejectOutgoing interface {
-	isAcceptOrRejectOutgoing()
-}
-
-func (ok) isAcceptOrRejectOutgoing()                        {}
-func (withPrejudice) isAcceptOrRejectOutgoing()             {}
-func (candidateUnknownOutgoing) isAcceptOrRejectOutgoing()  {}
-func (excessiveSecondedOutgoing) isAcceptOrRejectOutgoing() {}
-func (knownOutgoing) isAcceptOrRejectOutgoing()             {}
-func (notInGroupOutgoing) isAcceptOrRejectOutgoing()        {}
+	// known means the statement was already known to the peer.
+	known
+)
 
 // knowledge about a candidate
 type knowledge interface {
@@ -214,13 +152,13 @@ func (c *clusterTracker) canReceive(
 	sender parachaintypes.ValidatorIndex,
 	originator parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
-) acceptOrRejectIncoming {
+) acceptOrReject {
 	if !c.isInGroup(sender) || !c.isInGroup(originator) {
-		return notInGroupIncoming{}
+		return notInGroup
 	}
 
 	if c.theySent(sender, specific{statement, originator}) {
-		return duplicateIncoming{}
+		return duplicate
 	}
 
 	switch statement.(type) {
@@ -250,20 +188,20 @@ func (c *clusterTracker) canReceive(
 		}
 
 		if otherSecondedForOrigFromRemote == c.secondingLimit {
-			return excessiveSecondedIncoming{}
+			return excessiveSeconded
 		}
 
 		// at this point, it doesn't seem like the remote has done anything wrong.
 		if c.secondedAlreadyOrWithinLimit(originator, statement.CandidateHash()) {
-			return ok{}
+			return ok
 		} else {
-			return withPrejudice{}
+			return withPrejudice
 		}
 	case *parachaintypes.CompactValid:
 		if !c.knowsCandidate(sender, statement.CandidateHash()) {
-			return candidateUnknownIncoming{}
+			return candidateUnknown
 		}
-		return ok{}
+		return ok
 	default:
 		panic("unreachable")
 	}
@@ -461,13 +399,13 @@ func (c *clusterTracker) canSend(
 	target parachaintypes.ValidatorIndex,
 	originator parachaintypes.ValidatorIndex,
 	statement parachaintypes.CompactStatement,
-) acceptOrRejectOutgoing {
+) acceptOrReject {
 	if !c.isInGroup(target) || !c.isInGroup(originator) {
-		return notInGroupOutgoing{}
+		return notInGroup
 	}
 
 	if c.theyKnowStatement(target, originator, statement) {
-		return knownOutgoing{}
+		return known
 	}
 
 	switch statement.(type) {
@@ -475,14 +413,14 @@ func (c *clusterTracker) canSend(
 		// we send the same `Seconded` statements to all our peers, and only the first `k`
 		// from each originator.
 		if !c.secondedAlreadyOrWithinLimit(originator, statement.CandidateHash()) {
-			return excessiveSecondedOutgoing{}
+			return excessiveSeconded
 		}
-		return ok{}
+		return ok
 	case *parachaintypes.CompactValid:
 		if !c.knowsCandidate(target, statement.CandidateHash()) {
-			return candidateUnknownOutgoing{}
+			return candidateUnknown
 		}
-		return ok{}
+		return ok
 	default:
 		panic("unreachable")
 	}

--- a/dot/parachain/statement-distribution/cluster_tracker_test.go
+++ b/dot/parachain/statement-distribution/cluster_tracker_test.go
@@ -42,7 +42,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.NewCompactSeconded(parachaintypes.CandidateHash{Value: common.Hash{0x1}}),
 			),
-			notInGroupIncoming{},
+			notInGroup,
 		)
 
 		require.Equal(
@@ -52,7 +52,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 				parachaintypes.ValidatorIndex(100),
 				parachaintypes.NewCompactSeconded(parachaintypes.CandidateHash{Value: common.Hash{0x1}}),
 			),
-			notInGroupIncoming{},
+			notInGroup,
 		)
 	})
 
@@ -63,7 +63,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -79,7 +79,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -95,7 +95,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			excessiveSecondedIncoming{},
+			excessiveSeconded,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -111,7 +111,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -127,7 +127,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -143,7 +143,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			withPrejudice{},
+			withPrejudice,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -171,7 +171,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			duplicateIncoming{},
+			duplicate,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -181,7 +181,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			duplicateIncoming{},
+			duplicate,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(200),
@@ -197,7 +197,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			candidateUnknownIncoming{},
+			candidateUnknown,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -219,7 +219,7 @@ func TestClusterTracker_receive_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -252,7 +252,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(5),
@@ -280,7 +280,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			excessiveSecondedOutgoing{},
+			excessiveSeconded,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -290,7 +290,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			excessiveSecondedOutgoing{},
+			excessiveSeconded,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(5),
@@ -312,7 +312,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			knownOutgoing{},
+			known,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -334,7 +334,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			knownOutgoing{},
+			known,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -352,7 +352,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -368,7 +368,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			withPrejudice{},
+			withPrejudice,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(5),
@@ -384,7 +384,7 @@ func TestClusterTracker_send_statements(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(5),
@@ -413,7 +413,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 		// Receive a 'Seconded' statement for candidate A.
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -470,7 +470,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 		// First, send a `Seconded` statement for the candidate.
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(200),
@@ -488,7 +488,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 		// 'Seconded' above.
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(200),
@@ -540,7 +540,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(5),
 				parachaintypes.ValidatorIndex(146),
@@ -614,7 +614,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(200),
 				parachaintypes.ValidatorIndex(5),
@@ -665,7 +665,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 		// First, send a `Seconded` statement for the candidate.
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canSend(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(200),
@@ -682,7 +682,7 @@ func TestClusterTracker_pendingStatementsFor(t *testing.T) {
 		// We have to see the candidate is known by the sender, e.g. we sent them 'Seconded'.
 		require.Equal(
 			t,
-			ok{},
+			ok,
 			tracker.canReceive(
 				parachaintypes.ValidatorIndex(24),
 				parachaintypes.ValidatorIndex(200),


### PR DESCRIPTION
## Changes

The way I modeled `acceptOrReject` was a bit overengineered. I wanted to preserve the distinction between `accept` and `reject` without using errors for the latter. But considering the limited use of this type and the methods that return it, we can just put all values in a simple `const` "enum". That's what this PR does.

## Tests

```sh
go test ./dot/parachain/statement-distribution
```

## Issues

n/a

@P1sar asked for this in a Slack DM.