### PR TITLE
feat(dot/network/shim): implement NetworkPeers.ReportPeer on translation shim type

### DIFF
--- a/dot/network/shim/translation_shim.go
+++ b/dot/network/shim/translation_shim.go
@@ -4,6 +4,7 @@
 package shim
 
 import (
+	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/internal/client/network"
 	gossip "github.com/ChainSafe/gossamer/internal/client/network-gossip"
 	"github.com/ChainSafe/gossamer/internal/client/network/config"
@@ -17,8 +18,7 @@ import (
 
 // TranslationShim implements the gossip.Network and gossip.Syncing interfaces.
 // This shim type provides a bridge between the new Network and Syncing interfaces
-// and the existing Gossamer network implementation. Currently, all methods panic
-// as this is a foundation implementation that will be expanded incrementally.
+// and the existing Gossamer network implementation.
 //
 // The shim is placed in a separate package to avoid circular dependencies between
 // internal/client/network and dot/network packages.
@@ -26,11 +26,13 @@ import (
 // Since both Network and Syncing interfaces have an EventStream method with different
 // return types, we cannot implement both in the same type directly. Instead, we provide
 // two separate types that can be used together.
-type TranslationShim struct{}
+type TranslationShim struct {
+	handler *peerset.Handler
+}
 
 // NewTranslationShim creates a new TranslationShim instance.
-func NewTranslationShim() *TranslationShim {
-	return &TranslationShim{}
+func NewTranslationShim(handler *peerset.Handler) *TranslationShim {
+	return &TranslationShim{handler: handler}
 }
 
 // Compile-time interface check for Network
@@ -57,8 +59,20 @@ func (s *TranslationShim) AddKnownAddress(peerID peerid.PeerID, addr multiaddr.M
 }
 
 // ReportPeer reports a given peer as either beneficial (+) or costly (-).
+// It translates the network types to peerset types and calls the underlying handler.
 func (s *TranslationShim) ReportPeer(peerID peerid.PeerID, costBenefit network.ReputationChange) {
-	panic("ReportPeer: not implemented yet")
+	if s.handler == nil {
+		panic("ReportPeer: handler is nil")
+	}
+
+	// Translate network.ReputationChange to peerset.ReputationChange
+	peersetChange := peerset.ReputationChange{
+		Value:  peerset.Reputation(costBenefit.Value),
+		Reason: costBenefit.Reason,
+	}
+
+	// Translate peerid.PeerID to peer.ID and call the handler
+	s.handler.ReportPeer(peersetChange, peerID.ID)
 }
 
 // PeerReputation gets the reputation of a peer.
@@ -159,9 +173,9 @@ type syncShim struct {
 }
 
 // NewSyncShim creates a new syncShim instance.
-func NewSyncShim() *syncShim {
+func NewSyncShim(handler *peerset.Handler) *syncShim {
 	return &syncShim{
-		TranslationShim: NewTranslationShim(),
+		TranslationShim: NewTranslationShim(handler),
 	}
 }
 

--- a/dot/network/shim/translation_shim.go
+++ b/dot/network/shim/translation_shim.go
@@ -1,0 +1,185 @@
+// Copyright 2025 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package shim
+
+import (
+	"github.com/ChainSafe/gossamer/internal/client/network"
+	gossip "github.com/ChainSafe/gossamer/internal/client/network-gossip"
+	"github.com/ChainSafe/gossamer/internal/client/network/config"
+	"github.com/ChainSafe/gossamer/internal/client/network/event"
+	"github.com/ChainSafe/gossamer/internal/client/network/role"
+	"github.com/ChainSafe/gossamer/internal/client/network/sync"
+	"github.com/ChainSafe/gossamer/internal/client/network/types/multiaddr"
+	peerid "github.com/ChainSafe/gossamer/internal/client/network/types/peer-id"
+	"github.com/ChainSafe/gossamer/lib/common"
+)
+
+// TranslationShim implements the gossip.Network and gossip.Syncing interfaces.
+// This shim type provides a bridge between the new Network and Syncing interfaces
+// and the existing Gossamer network implementation. Currently, all methods panic
+// as this is a foundation implementation that will be expanded incrementally.
+//
+// The shim is placed in a separate package to avoid circular dependencies between
+// internal/client/network and dot/network packages.
+//
+// Since both Network and Syncing interfaces have an EventStream method with different
+// return types, we cannot implement both in the same type directly. Instead, we provide
+// two separate types that can be used together.
+type TranslationShim struct{}
+
+// NewTranslationShim creates a new TranslationShim instance.
+func NewTranslationShim() *TranslationShim {
+	return &TranslationShim{}
+}
+
+// Compile-time interface check for Network
+var _ gossip.Network = (*TranslationShim)(nil)
+
+// Compile-time interface check for Syncing
+var _ gossip.Syncing[common.Hash, uint] = (*syncShim)(nil)
+
+// ===== NetworkPeers Methods =====
+
+// SetAuthorizedPeers sets the authorized peers.
+func (s *TranslationShim) SetAuthorizedPeers(peers map[peerid.PeerID]struct{}) {
+	panic("SetAuthorizedPeers: not implemented yet")
+}
+
+// SetAuthorizedOnly sets the authorized_only flag.
+func (s *TranslationShim) SetAuthorizedOnly(reservedOnly bool) {
+	panic("SetAuthorizedOnly: not implemented yet")
+}
+
+// AddKnownAddress adds an address known to a node.
+func (s *TranslationShim) AddKnownAddress(peerID peerid.PeerID, addr multiaddr.Multiaddr) {
+	panic("AddKnownAddress: not implemented yet")
+}
+
+// ReportPeer reports a given peer as either beneficial (+) or costly (-).
+func (s *TranslationShim) ReportPeer(peerID peerid.PeerID, costBenefit network.ReputationChange) {
+	panic("ReportPeer: not implemented yet")
+}
+
+// PeerReputation gets the reputation of a peer.
+func (s *TranslationShim) PeerReputation(peerID peerid.PeerID) int32 {
+	panic("PeerReputation: not implemented yet")
+}
+
+// DisconnectPeer disconnects from a node as soon as possible.
+func (s *TranslationShim) DisconnectPeer(who peerid.PeerID, protocol network.ProtocolName) {
+	panic("DisconnectPeer: not implemented yet")
+}
+
+// AcceptUnreservedPeers connects to unreserved peers.
+func (s *TranslationShim) AcceptUnreservedPeers() {
+	panic("AcceptUnreservedPeers: not implemented yet")
+}
+
+// DenyUnreservedPeers disconnects from unreserved peers.
+func (s *TranslationShim) DenyUnreservedPeers() {
+	panic("DenyUnreservedPeers: not implemented yet")
+}
+
+// AddReservedPeer adds a PeerID and its MultiAddr as reserved.
+func (s *TranslationShim) AddReservedPeer(peer config.MultiaddrPeerId) error {
+	panic("AddReservedPeer: not implemented yet")
+}
+
+// RemoveReservedPeer removes a PeerID from the list of reserved peers.
+func (s *TranslationShim) RemoveReservedPeer(peerID peerid.PeerID) {
+	panic("RemoveReservedPeer: not implemented yet")
+}
+
+// SetReservedPeers sets the reserved set of a protocol.
+func (s *TranslationShim) SetReservedPeers(
+	protocol network.ProtocolName,
+	peers map[multiaddr.Multiaddr]struct{},
+) error {
+	panic("SetReservedPeers: not implemented yet")
+}
+
+// AddPeersToReservedSet adds peers to a peer set.
+func (s *TranslationShim) AddPeersToReservedSet(
+	protocol network.ProtocolName,
+	peers map[multiaddr.Multiaddr]struct{},
+) error {
+	panic("AddPeersToReservedSet: not implemented yet")
+}
+
+// RemovePeersFromReservedSet removes peers from a peer set.
+func (s *TranslationShim) RemovePeersFromReservedSet(
+	protocol network.ProtocolName,
+	peers []peerid.PeerID,
+) {
+	panic("RemovePeersFromReservedSet: not implemented yet")
+}
+
+// SyncNumConnected returns the number of connected sync peers.
+func (s *TranslationShim) SyncNumConnected() uint {
+	panic("SyncNumConnected: not implemented yet")
+}
+
+// PeerRole attempts to get peer role from handshake.
+func (s *TranslationShim) PeerRole(peerID peerid.PeerID, handshake []byte) *role.ObservedRole {
+	panic("PeerRole: not implemented yet")
+}
+
+// ReservedPeers returns the list of reserved peers.
+func (s *TranslationShim) ReservedPeers() <-chan struct {
+	Peers []peerid.PeerID
+	Error error
+} {
+	panic("ReservedPeers: not implemented yet")
+}
+
+// ===== NetworkEventStream Methods =====
+
+// EventStream returns a stream containing network events.
+func (s *TranslationShim) EventStream(name string) chan event.Event {
+	panic("EventStream (NetworkEventStream): not implemented yet")
+}
+
+// ===== Network Methods =====
+
+// AddSetReserved adds a peer to the reserved set.
+func (s *TranslationShim) AddSetReserved(who peerid.PeerID, protocol network.ProtocolName) {
+	panic("AddSetReserved: not implemented yet")
+}
+
+// RemoveSetReserved removes a peer from the reserved set.
+func (s *TranslationShim) RemoveSetReserved(who peerid.PeerID, protocol network.ProtocolName) {
+	panic("RemoveSetReserved: not implemented yet")
+}
+
+// syncShim implements the gossip.Syncing interface.
+// This is a separate type to avoid method name conflicts with Network.
+type syncShim struct {
+	*TranslationShim
+}
+
+// NewSyncShim creates a new syncShim instance.
+func NewSyncShim() *syncShim {
+	return &syncShim{
+		TranslationShim: NewTranslationShim(),
+	}
+}
+
+// ===== SyncEventStream Methods =====
+
+// EventStream subscribes to syncing related events.
+func (s *syncShim) EventStream(name string) chan sync.SyncEvent {
+	panic("EventStream (SyncEventStream): not implemented yet")
+}
+
+// ===== NetworkBlock Methods =====
+
+// AnnounceBlock announces a block to the network.
+func (s *syncShim) AnnounceBlock(hash common.Hash, data []byte) {
+	panic("AnnounceBlock: not implemented yet")
+}
+
+// NewBestBlockImported informs the network about a new best imported block.
+func (s *syncShim) NewBestBlockImported(hash common.Hash, number uint) {
+	panic("NewBestBlockImported: not implemented yet")
+}

--- a/dot/network/shim/translation_shim_test.go
+++ b/dot/network/shim/translation_shim_test.go
@@ -4,8 +4,11 @@
 package shim
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/ChainSafe/gossamer/dot/peerset"
 	"github.com/ChainSafe/gossamer/internal/client/network"
 	gossip "github.com/ChainSafe/gossamer/internal/client/network-gossip"
 	"github.com/ChainSafe/gossamer/internal/client/network/config"
@@ -21,20 +24,20 @@ func TestTranslationShImplementsInterfaces(t *testing.T) {
 	var _ gossip.Network = (*TranslationShim)(nil)
 	var _ gossip.Syncing[common.Hash, uint] = (*syncShim)(nil)
 
-	require.NotNil(t, NewTranslationShim())
-	require.NotNil(t, NewSyncShim())
+	require.NotNil(t, NewTranslationShim(nil))
+	require.NotNil(t, NewSyncShim(nil))
 }
 
 // TestNewTranslationShim tests the constructor.
 func TestNewTranslationShim(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.NotNil(t, shim)
 	require.IsType(t, &TranslationShim{}, shim)
 }
 
 // TestSetAuthorizedPeers tests that SetAuthorizedPeers panics.
 func TestSetAuthorizedPeers(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.SetAuthorizedPeers(map[peerid.PeerID]struct{}{})
 	})
@@ -42,7 +45,7 @@ func TestSetAuthorizedPeers(t *testing.T) {
 
 // TestSetAuthorizedOnly tests that SetAuthorizedOnly panics.
 func TestSetAuthorizedOnly(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.SetAuthorizedOnly(true)
 	})
@@ -53,7 +56,7 @@ func TestSetAuthorizedOnly(t *testing.T) {
 
 // TestAddKnownAddress tests that AddKnownAddress panics.
 func TestAddKnownAddress(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 	var addr multiaddr.Multiaddr
 
@@ -62,9 +65,9 @@ func TestAddKnownAddress(t *testing.T) {
 	})
 }
 
-// TestReportPeer tests that ReportPeer panics.
-func TestReportPeer(t *testing.T) {
-	shim := NewTranslationShim()
+// TestReportPeerNilHandler tests that ReportPeer panics when handler is nil.
+func TestReportPeerNilHandler(t *testing.T) {
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -72,9 +75,34 @@ func TestReportPeer(t *testing.T) {
 	})
 }
 
+// TestReportPeer tests that ReportPeer correctly translates types and calls the handler.
+func TestReportPeer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cfg := peerset.NewConfigSet(10, 10, false, time.Second)
+	handler, err := peerset.NewPeerSetHandler(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	// Start the handler
+	handler.Start(ctx)
+
+	shim := NewTranslationShim(handler)
+	peerID := peerid.NewRandomPeerID()
+
+	// This should not panic and should successfully call the handler
+	require.NotPanics(t, func() {
+		shim.ReportPeer(peerID, network.ReputationChange{
+			Value:  100,
+			Reason: "test reputation change",
+		})
+	})
+}
+
 // TestPeerReputation tests that PeerReputation panics.
 func TestPeerReputation(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -84,7 +112,7 @@ func TestPeerReputation(t *testing.T) {
 
 // TestDisconnectPeer tests that DisconnectPeer panics.
 func TestDisconnectPeer(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -94,7 +122,7 @@ func TestDisconnectPeer(t *testing.T) {
 
 // TestAcceptUnreservedPeers tests that AcceptUnreservedPeers panics.
 func TestAcceptUnreservedPeers(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.AcceptUnreservedPeers()
 	})
@@ -102,7 +130,7 @@ func TestAcceptUnreservedPeers(t *testing.T) {
 
 // TestDenyUnreservedPeers tests that DenyUnreservedPeers panics.
 func TestDenyUnreservedPeers(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.DenyUnreservedPeers()
 	})
@@ -110,7 +138,7 @@ func TestDenyUnreservedPeers(t *testing.T) {
 
 // TestAddReservedPeer tests that AddReservedPeer panics.
 func TestAddReservedPeer(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.AddReservedPeer(config.MultiaddrPeerId{})
 	})
@@ -118,7 +146,7 @@ func TestAddReservedPeer(t *testing.T) {
 
 // TestRemoveReservedPeer tests that RemoveReservedPeer panics.
 func TestRemoveReservedPeer(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -128,7 +156,7 @@ func TestRemoveReservedPeer(t *testing.T) {
 
 // TestSetReservedPeers tests that SetReservedPeers panics.
 func TestSetReservedPeers(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.SetReservedPeers(network.ProtocolName(""), map[multiaddr.Multiaddr]struct{}{})
 	})
@@ -136,7 +164,7 @@ func TestSetReservedPeers(t *testing.T) {
 
 // TestAddPeersToReservedSet tests that AddPeersToReservedSet panics.
 func TestAddPeersToReservedSet(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.AddPeersToReservedSet(network.ProtocolName(""), map[multiaddr.Multiaddr]struct{}{})
 	})
@@ -144,7 +172,7 @@ func TestAddPeersToReservedSet(t *testing.T) {
 
 // TestRemovePeersFromReservedSet tests that RemovePeersFromReservedSet panics.
 func TestRemovePeersFromReservedSet(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -154,7 +182,7 @@ func TestRemovePeersFromReservedSet(t *testing.T) {
 
 // TestSyncNumConnected tests that SyncNumConnected panics.
 func TestSyncNumConnected(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.SyncNumConnected()
 	})
@@ -162,7 +190,7 @@ func TestSyncNumConnected(t *testing.T) {
 
 // TestPeerRole tests that PeerRole panics.
 func TestPeerRole(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -172,7 +200,7 @@ func TestPeerRole(t *testing.T) {
 
 // TestReservedPeers tests that ReservedPeers panics.
 func TestReservedPeers(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.ReservedPeers()
 	})
@@ -180,7 +208,7 @@ func TestReservedPeers(t *testing.T) {
 
 // TestEventStreamNetwork tests that EventStream (NetworkEventStream) panics.
 func TestEventStreamNetwork(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	require.Panics(t, func() {
 		shim.EventStream("test")
 	})
@@ -188,7 +216,7 @@ func TestEventStreamNetwork(t *testing.T) {
 
 // TestAddSetReserved tests that AddSetReserved panics.
 func TestAddSetReserved(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -198,7 +226,7 @@ func TestAddSetReserved(t *testing.T) {
 
 // TestRemoveSetReserved tests that RemoveSetReserved panics.
 func TestRemoveSetReserved(t *testing.T) {
-	shim := NewTranslationShim()
+	shim := NewTranslationShim(nil)
 	peerID := peerid.NewRandomPeerID()
 
 	require.Panics(t, func() {
@@ -208,14 +236,14 @@ func TestRemoveSetReserved(t *testing.T) {
 
 // TestNewSyncShim tests the syncShim constructor.
 func TestNewSyncShim(t *testing.T) {
-	syncShim := NewSyncShim()
+	syncShim := NewSyncShim(nil)
 	require.NotNil(t, syncShim)
 	require.NotNil(t, syncShim.TranslationShim)
 }
 
 // TestEventStreamSyncShim tests that EventStream (SyncEventStream) panics on syncShim.
 func TestEventStreamSyncShim(t *testing.T) {
-	syncShim := NewSyncShim()
+	syncShim := NewSyncShim(nil)
 	require.Panics(t, func() {
 		syncShim.EventStream("test")
 	})
@@ -223,7 +251,7 @@ func TestEventStreamSyncShim(t *testing.T) {
 
 // TestAnnounceBlockSyncShim tests that AnnounceBlock panics on syncShim.
 func TestAnnounceBlockSyncShim(t *testing.T) {
-	syncShim := NewSyncShim()
+	syncShim := NewSyncShim(nil)
 	hash := common.Hash{}
 
 	require.Panics(t, func() {
@@ -233,7 +261,7 @@ func TestAnnounceBlockSyncShim(t *testing.T) {
 
 // TestNewBestBlockImportedSyncShim tests that NewBestBlockImported panics on syncShim.
 func TestNewBestBlockImportedSyncShim(t *testing.T) {
-	syncShim := NewSyncShim()
+	syncShim := NewSyncShim(nil)
 	hash := common.Hash{}
 
 	require.Panics(t, func() {

--- a/dot/network/shim/translation_shim_test.go
+++ b/dot/network/shim/translation_shim_test.go
@@ -206,14 +206,6 @@ func TestRemoveSetReserved(t *testing.T) {
 	})
 }
 
-// TestEventStreamSync tests that EventStream (SyncEventStream) panics.
-func TestEventStreamSync(t *testing.T) {
-	shim := NewTranslationShim()
-	require.Panics(t, func() {
-		shim.EventStream("test")
-	})
-}
-
 // TestNewSyncShim tests the syncShim constructor.
 func TestNewSyncShim(t *testing.T) {
 	syncShim := NewSyncShim()

--- a/dot/network/shim/translation_shim_test.go
+++ b/dot/network/shim/translation_shim_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 ChainSafe Systems (ON)
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package shim
+
+import (
+	"testing"
+
+	"github.com/ChainSafe/gossamer/internal/client/network"
+	gossip "github.com/ChainSafe/gossamer/internal/client/network-gossip"
+	"github.com/ChainSafe/gossamer/internal/client/network/config"
+	"github.com/ChainSafe/gossamer/internal/client/network/types/multiaddr"
+	peerid "github.com/ChainSafe/gossamer/internal/client/network/types/peer-id"
+	"github.com/ChainSafe/gossamer/lib/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTranslationShImplementsInterfaces verifies that TranslationShim
+// implements the required interfaces at compile time.
+func TestTranslationShImplementsInterfaces(t *testing.T) {
+	var _ gossip.Network = (*TranslationShim)(nil)
+	var _ gossip.Syncing[common.Hash, uint] = (*syncShim)(nil)
+
+	require.NotNil(t, NewTranslationShim())
+	require.NotNil(t, NewSyncShim())
+}
+
+// TestNewTranslationShim tests the constructor.
+func TestNewTranslationShim(t *testing.T) {
+	shim := NewTranslationShim()
+	require.NotNil(t, shim)
+	require.IsType(t, &TranslationShim{}, shim)
+}
+
+// TestSetAuthorizedPeers tests that SetAuthorizedPeers panics.
+func TestSetAuthorizedPeers(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.SetAuthorizedPeers(map[peerid.PeerID]struct{}{})
+	})
+}
+
+// TestSetAuthorizedOnly tests that SetAuthorizedOnly panics.
+func TestSetAuthorizedOnly(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.SetAuthorizedOnly(true)
+	})
+	require.Panics(t, func() {
+		shim.SetAuthorizedOnly(false)
+	})
+}
+
+// TestAddKnownAddress tests that AddKnownAddress panics.
+func TestAddKnownAddress(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+	var addr multiaddr.Multiaddr
+
+	require.Panics(t, func() {
+		shim.AddKnownAddress(peerID, addr)
+	})
+}
+
+// TestReportPeer tests that ReportPeer panics.
+func TestReportPeer(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.ReportPeer(peerID, network.ReputationChange{})
+	})
+}
+
+// TestPeerReputation tests that PeerReputation panics.
+func TestPeerReputation(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.PeerReputation(peerID)
+	})
+}
+
+// TestDisconnectPeer tests that DisconnectPeer panics.
+func TestDisconnectPeer(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.DisconnectPeer(peerID, network.ProtocolName(""))
+	})
+}
+
+// TestAcceptUnreservedPeers tests that AcceptUnreservedPeers panics.
+func TestAcceptUnreservedPeers(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.AcceptUnreservedPeers()
+	})
+}
+
+// TestDenyUnreservedPeers tests that DenyUnreservedPeers panics.
+func TestDenyUnreservedPeers(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.DenyUnreservedPeers()
+	})
+}
+
+// TestAddReservedPeer tests that AddReservedPeer panics.
+func TestAddReservedPeer(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.AddReservedPeer(config.MultiaddrPeerId{})
+	})
+}
+
+// TestRemoveReservedPeer tests that RemoveReservedPeer panics.
+func TestRemoveReservedPeer(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.RemoveReservedPeer(peerID)
+	})
+}
+
+// TestSetReservedPeers tests that SetReservedPeers panics.
+func TestSetReservedPeers(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.SetReservedPeers(network.ProtocolName(""), map[multiaddr.Multiaddr]struct{}{})
+	})
+}
+
+// TestAddPeersToReservedSet tests that AddPeersToReservedSet panics.
+func TestAddPeersToReservedSet(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.AddPeersToReservedSet(network.ProtocolName(""), map[multiaddr.Multiaddr]struct{}{})
+	})
+}
+
+// TestRemovePeersFromReservedSet tests that RemovePeersFromReservedSet panics.
+func TestRemovePeersFromReservedSet(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.RemovePeersFromReservedSet(network.ProtocolName(""), []peerid.PeerID{peerID})
+	})
+}
+
+// TestSyncNumConnected tests that SyncNumConnected panics.
+func TestSyncNumConnected(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.SyncNumConnected()
+	})
+}
+
+// TestPeerRole tests that PeerRole panics.
+func TestPeerRole(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.PeerRole(peerID, []byte{})
+	})
+}
+
+// TestReservedPeers tests that ReservedPeers panics.
+func TestReservedPeers(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.ReservedPeers()
+	})
+}
+
+// TestEventStreamNetwork tests that EventStream (NetworkEventStream) panics.
+func TestEventStreamNetwork(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.EventStream("test")
+	})
+}
+
+// TestAddSetReserved tests that AddSetReserved panics.
+func TestAddSetReserved(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.AddSetReserved(peerID, network.ProtocolName(""))
+	})
+}
+
+// TestRemoveSetReserved tests that RemoveSetReserved panics.
+func TestRemoveSetReserved(t *testing.T) {
+	shim := NewTranslationShim()
+	peerID := peerid.NewRandomPeerID()
+
+	require.Panics(t, func() {
+		shim.RemoveSetReserved(peerID, network.ProtocolName(""))
+	})
+}
+
+// TestEventStreamSync tests that EventStream (SyncEventStream) panics.
+func TestEventStreamSync(t *testing.T) {
+	shim := NewTranslationShim()
+	require.Panics(t, func() {
+		shim.EventStream("test")
+	})
+}
+
+// TestNewSyncShim tests the syncShim constructor.
+func TestNewSyncShim(t *testing.T) {
+	syncShim := NewSyncShim()
+	require.NotNil(t, syncShim)
+	require.NotNil(t, syncShim.TranslationShim)
+}
+
+// TestEventStreamSyncShim tests that EventStream (SyncEventStream) panics on syncShim.
+func TestEventStreamSyncShim(t *testing.T) {
+	syncShim := NewSyncShim()
+	require.Panics(t, func() {
+		syncShim.EventStream("test")
+	})
+}
+
+// TestAnnounceBlockSyncShim tests that AnnounceBlock panics on syncShim.
+func TestAnnounceBlockSyncShim(t *testing.T) {
+	syncShim := NewSyncShim()
+	hash := common.Hash{}
+
+	require.Panics(t, func() {
+		syncShim.AnnounceBlock(hash, []byte{})
+	})
+}
+
+// TestNewBestBlockImportedSyncShim tests that NewBestBlockImported panics on syncShim.
+func TestNewBestBlockImportedSyncShim(t *testing.T) {
+	syncShim := NewSyncShim()
+	hash := common.Hash{}
+
+	require.Panics(t, func() {
+		syncShim.NewBestBlockImported(hash, 0)
+	})
+}


### PR DESCRIPTION
## Changes
- Add `handler` field to `TranslationShim` struct to hold reference to `*peerset.Handler`
- Update `NewTranslationShim` and `NewSyncShim` constructors to accept `*peerset.Handler` parameter
- Implement `ReportPeer` method with type translations:
  - Translate `network.ReputationChange` to `peerset.ReputationChange`
  - Translate `peerid.PeerID` to `peer.ID` via embedded field access
  - Call `peerset.Handler.ReportPeer` to adjust peer reputation
  - Panic if handler is nil (defensive check)
- Add comprehensive unit tests for `ReportPeer` (nil handler and success cases)

## Tests
```sh
go test ./dot/network/shim/... -v
Coverage: 100% for ReportPeer function (exceeds 70% requirement)

Issues
#4799