### PR TITLE
chore(ci): migrate runners to ubuntu-latest, drop macOS build leg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,7 @@ on:
 jobs:
   builds:
     timeout-minutes: 60
-    strategy:
-      matrix:
-        platform: [macos-latest, buildjet-4vcpu-ubuntu-2204]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -63,7 +60,7 @@ jobs:
 
   publish-code-coverage:
     timeout-minutes: 60
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -111,7 +108,7 @@ jobs:
           verbose: true
 
   docker-build-n-push:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ name: checks
 
 jobs:
   linting:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   copyright-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/docker-grandpa.yml
+++ b/.github/workflows/docker-grandpa.yml
@@ -18,7 +18,7 @@ name: docker-grandpa
 
 jobs:
   docker-grandpa-tests:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/.github/workflows/docker-js.yml
+++ b/.github/workflows/docker-js.yml
@@ -18,7 +18,7 @@ name: docker-js
 
 jobs:
   docker-polkadotjs-tests:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/.github/workflows/docker-rpc.yml
+++ b/.github/workflows/docker-rpc.yml
@@ -18,7 +18,7 @@ name: docker-rpc
 
 jobs:
   docker-rpc-tests:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/.github/workflows/docker-stress.yml
+++ b/.github/workflows/docker-stress.yml
@@ -18,7 +18,7 @@ name: docker-stress
 
 jobs:
   docker-stress-tests:
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: "1"
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Deploy docs
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout main
         uses: actions/checkout@v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,7 +5,7 @@ name: fuzz
 jobs:
   fuzz:
     timeout-minutes: 30
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
             github.com/ChainSafe/gossamer/lib/babe,
             github.com/ChainSafe/gossamer/lib/grandpa,
           ]
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/mocks.yml
+++ b/.github/workflows/mocks.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   mocks-check:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
   release:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: Release
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ name: unit-tests
 
 jobs:
   unit-tests:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
@@ -78,7 +78,7 @@ jobs:
           cd ..
 
       - name: Run unit tests
-        run: CI=buildjet go test -coverprofile=coverage.out -covermode=atomic -timeout=15m ./...
+        run: CI=buildjet go test -coverprofile=coverage.out -covermode=atomic -timeout=30m ./...
 
       - name: Trie memory test
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ name: unit-tests
 jobs:
   unit-tests:
     timeout-minutes: 15
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
## Summary
- BuildJet hosted runners are gone, and the org's Warp runners weren't picking up queued jobs either — every PR workflow has been hitting the 24h timeout.
- Switch all `runs-on:` to GitHub-hosted `ubuntu-latest` (free for public repos, no provisioning dependency).
- Drop `macos-latest` from the `build` matrix and collapse the single-platform matrix to a plain `runs-on`.

## Trade-offs
- Three jobs previously sized for 16vcpu (`unit-tests`, `docker-stress`, `docker-rpc`) now run on the standard 2 vCPU / 7 GB runner. They may be slower; revisit with a paid GitHub larger runner if a job consistently bumps into its `timeout-minutes`.
- macOS-specific build breakage will no longer be caught in CI. Restore the leg if gossamer needs to ship to macOS again.

The `CI=buildjet` env var passed to `go test` in `unit-tests.yml` and `integration-tests.yml` is intentionally left alone — it's a signal value read by test code, not a runner reference. Rename in a follow-up if desired.